### PR TITLE
perf: reduce lightgbm prediction time by 20%

### DIFF
--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMClassifier.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMClassifier.scala
@@ -149,11 +149,11 @@ class LightGBMClassificationModel(override val uid: String)
   override def numClasses: Int = getActualNumClasses
 
   override protected def predictRaw(features: Vector): Vector = {
-    Vectors.dense(getModel.score(features, true, true))
+    getModel.score(features, true, true)
   }
 
   override protected def predictProbability(features: Vector): Vector = {
-    Vectors.dense(getModel.score(features, false, true))
+    getModel.score(features, false, true)
   }
 
   override def copy(extra: ParamMap): LightGBMClassificationModel = defaultCopy(extra)

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMModelMethods.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMModelMethods.scala
@@ -23,7 +23,7 @@ trait LightGBMModelMethods extends LightGBMModelParams {
     * @return The local feature importance values.
     */
   def getFeatureShaps(features: Vector): Array[Double] = {
-    getLightGBMBooster.featuresShap(features)
+    getLightGBMBooster.featuresShap(features).toArray
   }
 
   /**
@@ -32,7 +32,7 @@ trait LightGBMModelMethods extends LightGBMModelParams {
     * @return The local feature importance values.
     */
   def getDenseFeatureShaps(features: Array[Double]): Array[Double] = {
-    getLightGBMBooster.featuresShap(Vectors.dense(features))
+    getLightGBMBooster.featuresShap(Vectors.dense(features)).toArray
   }
 
   /**
@@ -43,7 +43,7 @@ trait LightGBMModelMethods extends LightGBMModelParams {
     * @return The local feature importance values.
     */
   def getSparseFeatureShaps(size: Int, indices: Array[Int], values: Array[Double]): Array[Double] = {
-    getLightGBMBooster.featuresShap(Vectors.sparse(size, indices, values))
+    getLightGBMBooster.featuresShap(Vectors.sparse(size, indices, values)).toArray
   }
 
   /**
@@ -52,7 +52,7 @@ trait LightGBMModelMethods extends LightGBMModelParams {
     * @return The predicted leaf index.
     */
   protected def predictLeaf(features: Vector): Vector = {
-    Vectors.dense(getLightGBMBooster.predictLeaf(features))
+    getLightGBMBooster.predictLeaf(features)
   }
 
   /**
@@ -61,6 +61,6 @@ trait LightGBMModelMethods extends LightGBMModelParams {
     * @return The SHAP local feature importance values.
     */
   protected def featuresShap(features: Vector): Vector = {
-    Vectors.dense(getLightGBMBooster.featuresShap(features))
+    getLightGBMBooster.featuresShap(features)
   }
 }

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRanker.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRanker.scala
@@ -131,7 +131,7 @@ class LightGBMRankerModel(override val uid: String)
   }
 
   override def predict(features: Vector): Double = {
-    getModel.score(features, false, false)(0)
+    getModel.scoreValue(features, false, false)
   }
 
   override def copy(extra: ParamMap): LightGBMRankerModel = defaultCopy(extra)

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRegressor.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMRegressor.scala
@@ -110,7 +110,7 @@ class LightGBMRegressionModel(override val uid: String)
   }
 
   override def predict(features: Vector): Double = {
-    getModel.score(features, false, false)(0)
+    getModel.scoreValue(features, false, false)
   }
 
   override def copy(extra: ParamMap): LightGBMRegressionModel = defaultCopy(extra)

--- a/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMUtils.scala
+++ b/src/main/scala/com/microsoft/ml/spark/lightgbm/LightGBMUtils.scala
@@ -40,6 +40,13 @@ object LightGBMUtils {
     }
   }
 
+  def validateJArray(result: Array[Double], component: String): Unit = {
+    if (result == null) {
+      throw new Exception(component + " call failed in LightGBM with error: "
+        + lightgbmlib.LGBM_GetLastError())
+    }
+  }
+
   /** Loads the native shared object binaries lib_lightgbm.so and lib_lightgbm_swig.so
     */
   def initializeNativeLibrary(): Unit = {

--- a/src/test/scala/com/microsoft/ml/spark/lightgbm/split1/VerifyLightGBMClassifier.scala
+++ b/src/test/scala/com/microsoft/ml/spark/lightgbm/split1/VerifyLightGBMClassifier.scala
@@ -258,6 +258,19 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
     assert(modelStr.contains("[lambda_l2: 0.1]") || modelStr.contains("[lambda_l2: 0.5]"))
   }
 
+  test("Performance test for LightGBM Classifier scoring") {
+    val fitModel = baseModel.fit(pimaDF)
+
+    println("Running inferencing test...")
+
+    val t0 = System.nanoTime()
+    (0 to 100).map(i => {
+      fitModel.transform(pimaDF)
+    })
+    val t1 = System.nanoTime()
+    println("Elapsed time: " + (t1 - t0) + "ns")
+  }
+
   test("Verify LightGBM Classifier with batch training") {
     val batches = Array(0, 2, 10)
     batches.foreach(nBatches => assertFitWithoutErrors(baseModel.setNumBatches(nBatches), pimaDF))


### PR DESCRIPTION
perf: reduce lightgbm prediction time by 20%
depends on native changes:
https://github.com/microsoft/LightGBM/pull/3159
In testing, time went from 82159416923ns to 65852779813ns on the pima dataset (test added in PR but num iterations was 10000, not 100 as in PR for performance testing).