### PR TITLE
docs: integrate RAI widgets into the interpretability notebook

### DIFF
--- a/notebooks/Interpretability - Tabular SHAP explainer.ipynb
+++ b/notebooks/Interpretability - Tabular SHAP explainer.ipynb
@@ -27,7 +27,8 @@
      "nuid": "bf0fdfc2-97b2-48e4-b3d9-794b0cb3da67",
      "showTitle": false,
      "title": ""
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -67,7 +68,8 @@
      "nuid": "58807448-d8e0-4818-adc8-27536d561fb3",
      "showTitle": false,
      "title": ""
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -123,7 +125,8 @@
      "nuid": "f55757a6-6204-4f64-a91e-65bfbacf62bc",
      "showTitle": false,
      "title": ""
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -154,7 +157,8 @@
      "nuid": "7e097552-e617-4e1c-a085-b66eca5bcb69",
      "showTitle": false,
      "title": ""
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -195,7 +199,8 @@
      "nuid": "05e01f98-e44c-46c9-a8ae-26ba892f85b3",
      "showTitle": false,
      "title": ""
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -234,7 +239,8 @@
      "nuid": "c9b4c03e-eac8-4314-a6c2-0a451525e6a4",
      "showTitle": false,
      "title": ""
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -285,6 +291,187 @@
     "\n",
     "<img src=\"https://mmlspark.blob.core.windows.net/graphics/explainers/tabular-shap.png\" style=\"float: right;\"/>"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Integration with interpret-community from InterpretML and responsible-ai-widgets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also visualization the explanation in the [interpret-community format](https://github.com/interpretml/interpret-community) in the ExplanationDashboard from https://github.com/microsoft/responsible-ai-widgets/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "local_importance_values = shaps.select('shapValues').toPandas()\n",
+    "eval_data = shaps.select(features).toPandas()\n",
+    "true_y = np.array(shaps.select('label').toPandas())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list_local_importance_values = local_importance_values.values.tolist()\n",
+    "converted_importance_values = []\n",
+    "bias = []\n",
+    "for classarray in list_local_importance_values:\n",
+    "  for rowarray in classarray:\n",
+    "    converted_list = rowarray.tolist()\n",
+    "    bias.append(converted_list[0])\n",
+    "    # remove the bias from local importance values\n",
+    "    del converted_list[0]\n",
+    "    converted_importance_values.append(converted_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade raiwidgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade interpret-community"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from interpret_community.adapter import ExplanationAdapter\n",
+    "adapter = ExplanationAdapter(features, classification=True)\n",
+    "global_explanation = adapter.create_global(converted_importance_values, eval_data, expected_values=bias)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# view the global importance values\n",
+    "global_explanation.global_importance_values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# view the local importance values\n",
+    "global_explanation.local_importance_values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# you can upload the explanation to your AzureML workspace using the ExplanationClient\n",
+    "# note for this you need to have azureml-sdk installed and have a workspace\n",
+    "\n",
+    "# import os\n",
+    "# subscription_id = os.getenv(\"SUBSCRIPTION_ID\", default=\"a75ae43f-9f72-4699-ba66-d3a173cfe082\")\n",
+    "# resource_group = os.getenv(\"RESOURCE_GROUP\", default=\"ilmatrg\")\n",
+    "# workspace_name = os.getenv(\"WORKSPACE_NAME\", default=\"ilmatworkspace\")\n",
+    "# workspace_region = os.getenv(\"WORKSPACE_REGION\", default=\"eastus2\")\n",
+    "\n",
+    "# from azureml.core import Workspace\n",
+    "\n",
+    "# try:\n",
+    "#     ws = Workspace(subscription_id = subscription_id, resource_group = resource_group, workspace_name = workspace_name)\n",
+    "#     # write the details of the workspace to a configuration file to the notebook library\n",
+    "#     ws.write_config()\n",
+    "#     print(\"Workspace configuration succeeded. Skip the workspace creation steps below\")\n",
+    "# except:\n",
+    "#     print(\"Workspace not accessible. Change your parameters or create a new workspace below\")\n",
+    "\n",
+    "# from azureml.interpret import ExplanationClient\n",
+    "# from azureml.core import Experiment\n",
+    "\n",
+    "# experiment_name = 'synapseml-integration'\n",
+    "# experiment = Experiment(ws, experiment_name)\n",
+    "# run = experiment.start_logging()\n",
+    "# client = ExplanationClient.from_run(run)\n",
+    "\n",
+    "# client.upload_model_explanation(global_explanation, comment='global explanation: all features')\n",
+    "# run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "class wrapper(object):\n",
+    "  def __init__(self, model):\n",
+    "    self.model = model\n",
+    "  \n",
+    "  def predict(self, data):\n",
+    "    sparkdata = spark.createDataFrame(data)\n",
+    "    prediction = model.transform(sparkdata).select('probability').toPandas().values.flatten().tolist()\n",
+    "    prediction_list = [vector.values.tolist() for vector in prediction]\n",
+    "    return prediction_list\n",
+    "  \n",
+    "  def predict_proba(self, data):\n",
+    "    sparkdata = spark.createDataFrame(data)\n",
+    "    return model.transform(sparkdata).select('prediction').toPandas().values.flatten().tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# view the explanation in the ExplanationDashboard\n",
+    "from raiwidgets import ExplanationDashboard\n",
+    "ExplanationDashboard(global_explanation, wrapper(model), dataset=eval_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Your results will look like:\n",
+    "\n",
+    "<img src=\"https://mmlspark.blob.core.windows.net/graphics/explainers/ExplanationDashboard.png\" style=\"float: right;\"/>"
+   ]
   }
  ],
  "metadata": {
@@ -313,7 +500,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR integrates the RAI widgets with the SHAP interpretability notebook.
Specifically, it demonstrates how to create an [interpret-community style explanation](https://github.com/interpretml/interpret-community) from the local importance values, which can then be visualized in the ExplanationDashboard widget locally and optionally uploaded to AzureML.

In a near-term future TODO, the ExplanationAdapter can be integrated directly into the SHAP explainer with explain_local and explain_global APIs, so the explainer can output the explanation directly.

Please add this image in the examples URL which demonstrates how the ExplanationDashboard will look like after passing the interpret-community explanation to it:

![ExplanationDashboard](https://user-images.githubusercontent.com/24683184/138751795-18ffee08-c03e-4f1f-99de-129c62a0f170.png)

