### PR TITLE
fix: lightgbm default params should not be specified if optional

### DIFF
--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMClassifier.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMClassifier.scala
@@ -47,13 +47,13 @@ class LightGBMClassifier(override val uid: String)
     val actualNumClasses = getNumClasses(dataset)
     val categoricalIndexes = getCategoricalIndexes(dataset.schema(getFeaturesCol))
     val modelStr = if (getModelString == null || getModelString.isEmpty) None else get(modelString)
-    ClassifierTrainParams(getParallelism, getTopK, getNumIterations, getLearningRate, getNumLeaves, getMaxBin,
-      getBinSampleCount, getBaggingFraction, getPosBaggingFraction, getNegBaggingFraction,
-      getBaggingFreq, getBaggingSeed, getEarlyStoppingRound, getImprovementTolerance,
-      getFeatureFraction, getMaxDepth, getMinSumHessianInLeaf, numTasks, modelStr,
+    ClassifierTrainParams(getParallelism, get(topK), getNumIterations, getLearningRate,
+      get(numLeaves), get(maxBin), get(binSampleCount), get(baggingFraction), get(posBaggingFraction),
+      get(negBaggingFraction), get(baggingFreq), get(baggingSeed), getEarlyStoppingRound, getImprovementTolerance,
+      get(featureFraction), get(maxDepth), get(minSumHessianInLeaf), numTasks, modelStr,
       getIsUnbalance, getVerbosity, categoricalIndexes, actualNumClasses, getBoostFromAverage,
-      getBoostingType, getLambdaL1, getLambdaL2, getIsProvideTrainingMetric,
-      getMetric, getMinGainToSplit, getMaxDeltaStep, getMaxBinByFeature, getMinDataInLeaf, getSlotNames,
+      getBoostingType, get(lambdaL1), get(lambdaL2), get(isProvideTrainingMetric),
+      get(metric), get(minGainToSplit), get(maxDeltaStep), getMaxBinByFeature, get(minDataInLeaf), getSlotNames,
       getDelegate, getDartParams, getExecutionParams, getObjectiveParams)
   }
 

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMRanker.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMRanker.scala
@@ -53,13 +53,13 @@ class LightGBMRanker(override val uid: String)
   def getTrainParams(numTasks: Int, dataset: Dataset[_], numTasksPerExec: Int): TrainParams = {
     val categoricalIndexes = getCategoricalIndexes(dataset.schema(getFeaturesCol))
     val modelStr = if (getModelString == null || getModelString.isEmpty) None else get(modelString)
-    RankerTrainParams(getParallelism, getTopK, getNumIterations, getLearningRate, getNumLeaves,
-      getMaxBin, getBinSampleCount, getBaggingFraction, getPosBaggingFraction, getNegBaggingFraction,
-      getBaggingFreq, getBaggingSeed, getEarlyStoppingRound, getImprovementTolerance,
-      getFeatureFraction, getMaxDepth, getMinSumHessianInLeaf, numTasks, modelStr,
-      getVerbosity, categoricalIndexes, getBoostingType, getLambdaL1, getLambdaL2, getMaxPosition, getLabelGain,
-      getIsProvideTrainingMetric, getMetric, getEvalAt, getMinGainToSplit, getMaxDeltaStep,
-      getMaxBinByFeature, getMinDataInLeaf, getSlotNames, getDelegate, getDartParams,
+    RankerTrainParams(getParallelism, get(topK), getNumIterations, getLearningRate,
+      get(numLeaves), get(maxBin), get(binSampleCount), get(baggingFraction), get(posBaggingFraction),
+      get(negBaggingFraction), get(baggingFreq), get(baggingSeed), getEarlyStoppingRound, getImprovementTolerance,
+      get(featureFraction), get(maxDepth), get(minSumHessianInLeaf), numTasks, modelStr,
+      getVerbosity, categoricalIndexes, getBoostingType, get(lambdaL1), get(lambdaL2), getMaxPosition, getLabelGain,
+      get(isProvideTrainingMetric), get(metric), getEvalAt, get(minGainToSplit), get(maxDeltaStep),
+      getMaxBinByFeature, get(minDataInLeaf), getSlotNames, getDelegate, getDartParams,
       getExecutionParams, getObjectiveParams)
   }
 

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMRegressor.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMRegressor.scala
@@ -61,12 +61,15 @@ class LightGBMRegressor(override val uid: String)
   def getTrainParams(numTasks: Int, dataset: Dataset[_], numTasksPerExec: Int): TrainParams = {
     val categoricalIndexes = getCategoricalIndexes(dataset.schema(getFeaturesCol))
     val modelStr = if (getModelString == null || getModelString.isEmpty) None else get(modelString)
-    RegressorTrainParams(getParallelism, getTopK, getNumIterations, getLearningRate, getNumLeaves,
-      getAlpha, getTweedieVariancePower, getMaxBin, getBinSampleCount, getBaggingFraction, getPosBaggingFraction,
-      getNegBaggingFraction, getBaggingFreq, getBaggingSeed, getEarlyStoppingRound, getImprovementTolerance,
-      getFeatureFraction, getMaxDepth, getMinSumHessianInLeaf, numTasks, modelStr, getVerbosity, categoricalIndexes,
-      getBoostFromAverage, getBoostingType, getLambdaL1, getLambdaL2, getIsProvideTrainingMetric, getMetric,
-      getMinGainToSplit, getMaxDeltaStep, getMaxBinByFeature, getMinDataInLeaf, getSlotNames, getDelegate,
+    RegressorTrainParams(getParallelism, get(topK), getNumIterations, getLearningRate,
+      get(numLeaves), getAlpha, getTweedieVariancePower,
+      get(maxBin), get(binSampleCount), get(baggingFraction), get(posBaggingFraction),
+      get(negBaggingFraction), get(baggingFreq), get(baggingSeed), getEarlyStoppingRound, getImprovementTolerance,
+      get(featureFraction), get(maxDepth), get(minSumHessianInLeaf),
+      numTasks, modelStr, getVerbosity, categoricalIndexes,
+      getBoostFromAverage, getBoostingType, get(lambdaL1), get(lambdaL2), get(isProvideTrainingMetric),
+      get(metric), get(minGainToSplit), get(maxDeltaStep),
+      getMaxBinByFeature, get(minDataInLeaf), getSlotNames, getDelegate,
       getDartParams, getExecutionParams, getObjectiveParams)
   }
 

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/TrainUtils.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/TrainUtils.scala
@@ -114,13 +114,14 @@ private object TrainUtils extends Serializable {
 
       isFinished = updateOneIteration(trainParams, booster, log, iters)
 
-      val trainEvalResults: Option[Map[String, Double]] = if (trainParams.isProvideTrainingMetric && !isFinished) {
-        val evalResults: Array[(String, Double)] = booster.getEvalResults(evalNames, 0)
-        evalResults.foreach { case (evalName: String, score: Double) => log.info(s"Train $evalName=$score") }
-        Option(Map(evalResults:_*))
-      } else {
-        None
-      }
+      val trainEvalResults: Option[Map[String, Double]] =
+        if (trainParams.isProvideTrainingMetric.getOrElse(false) && !isFinished) {
+          val evalResults: Array[(String, Double)] = booster.getEvalResults(evalNames, 0)
+          evalResults.foreach { case (evalName: String, score: Double) => log.info(s"Train $evalName=$score") }
+          Option(Map(evalResults:_*))
+        } else {
+          None
+        }
 
       val validEvalResults: Option[Map[String, Double]] = if (hasValid && !isFinished) {
         val evalResults: Array[(String, Double)] = booster.getEvalResults(evalNames, 1)

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/TrainParams.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/TrainParams.scala
@@ -9,53 +9,69 @@ import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMConstants, LightGBMDeleg
   */
 abstract class TrainParams extends Serializable {
   def parallelism: String
-  def topK: Int
+  def boostingType: String
+  def numMachines: Int
+  def verbosity: Int
+  def topK: Option[Int]
   def numIterations: Int
   def learningRate: Double
-  def numLeaves: Int
-  def maxBin: Int
-  def binSampleCount: Int
-  def baggingFraction: Double
-  def posBaggingFraction: Double
-  def negBaggingFraction: Double
-  def baggingFreq: Int
-  def baggingSeed: Int
+  def numLeaves: Option[Int]
+  def maxBin: Option[Int]
+  def binSampleCount: Option[Int]
+  def baggingFraction: Option[Double]
+  def posBaggingFraction: Option[Double]
+  def negBaggingFraction: Option[Double]
+  def baggingFreq: Option[Int]
+  def baggingSeed: Option[Int]
   def earlyStoppingRound: Int
   def improvementTolerance: Double
-  def featureFraction: Double
-  def maxDepth: Int
-  def minSumHessianInLeaf: Double
-  def numMachines: Int
+  def featureFraction: Option[Double]
+  def maxDepth: Option[Int]
+  def minSumHessianInLeaf: Option[Double]
   def modelString: Option[String]
-  def verbosity: Int
   def categoricalFeatures: Array[Int]
-  def boostingType: String
-  def lambdaL1: Double
-  def lambdaL2: Double
-  def isProvideTrainingMetric: Boolean
-  def metric: String
-  def minGainToSplit: Double
-  def maxDeltaStep: Double
+  def lambdaL1: Option[Double]
+  def lambdaL2: Option[Double]
+  def isProvideTrainingMetric: Option[Boolean]
+  def metric: Option[String]
+  def minGainToSplit: Option[Double]
+  def maxDeltaStep: Option[Double]
   def maxBinByFeature: Array[Int]
-  def minDataInLeaf: Int
+  def minDataInLeaf: Option[Int]
   def featureNames: Array[String]
   def delegate: Option[LightGBMDelegate]
   def dartModeParams: DartModeParams
   def executionParams: ExecutionParams
   def objectiveParams: ObjectiveParams
 
+  def paramToString[T](paramName: String, paramValueOpt: Option[T]): String = {
+    paramValueOpt match {
+      case Some(paramValue) => s"$paramName=$paramValue"
+      case None => ""
+    }
+  }
+
+  def paramsToString(paramNamesToValues: Array[(String, Option[_])]): String = {
+    paramNamesToValues.map {
+      case (paramName: String, paramValue: Option[_]) => paramToString(paramName, paramValue)
+    }.mkString(" ")
+  }
+
   override def toString: String = {
     // Since passing `isProvideTrainingMetric` to LightGBM as a config parameter won't work,
     // let's fetch and print training metrics in `TrainUtils.scala` through JNI.
-    s"is_pre_partition=True boosting_type=$boostingType tree_learner=$parallelism top_k=$topK " +
-      s"num_iterations=$numIterations learning_rate=$learningRate num_leaves=$numLeaves " +
-      s"max_bin=$maxBin bagging_fraction=$baggingFraction pos_bagging_fraction=$posBaggingFraction " +
-      s"neg_bagging_fraction=$negBaggingFraction bagging_freq=$baggingFreq " +
-      s"bagging_seed=$baggingSeed early_stopping_round=$earlyStoppingRound " +
-      s"feature_fraction=$featureFraction max_depth=$maxDepth min_sum_hessian_in_leaf=$minSumHessianInLeaf " +
-      s"num_machines=$numMachines verbosity=$verbosity " +
-      s"lambda_l1=$lambdaL1 lambda_l2=$lambdaL2 metric=$metric min_gain_to_split=$minGainToSplit " +
-      s"max_delta_step=$maxDeltaStep min_data_in_leaf=$minDataInLeaf ${objectiveParams.toString()} " +
+    s"is_pre_partition=True boosting_type=$boostingType tree_learner=$parallelism " +
+      paramsToString(Array(("top_k", topK), ("num_leaves", numLeaves), ("max_bin", maxBin),
+        ("bagging_fraction", baggingFraction), ("pos_bagging_fraction", posBaggingFraction),
+        ("neg_bagging_fraction", negBaggingFraction), ("bagging_freq", baggingFreq),
+        ("bagging_seed", baggingSeed), ("feature_fraction", featureFraction), ("max_depth", maxDepth),
+        ("min_sum_hessian_in_leaf", minSumHessianInLeaf), ("lambda_l1", lambdaL1),
+        ("lambda_l2", lambdaL2), ("metric", metric), ("min_gain_to_split", minGainToSplit),
+        ("max_delta_step", maxDeltaStep), ("min_data_in_leaf", minDataInLeaf)
+      )) +
+      s" num_iterations=$numIterations learning_rate=$learningRate " +
+      s" num_machines=$numMachines verbosity=$verbosity ${objectiveParams.toString()} " +
+      s" early_stopping_round=$earlyStoppingRound " +
       (if (categoricalFeatures.isEmpty) "" else s"categorical_feature=${categoricalFeatures.mkString(",")} ") +
       (if (maxBinByFeature.isEmpty) "" else s"max_bin_by_feature=${maxBinByFeature.mkString(",")} ") +
       (if (boostingType == "dart") s"${dartModeParams.toString()} " else "") +
@@ -65,44 +81,92 @@ abstract class TrainParams extends Serializable {
 
 /** Defines the Booster parameters passed to the LightGBM classifier.
   */
-case class ClassifierTrainParams(parallelism: String, topK: Int, numIterations: Int, learningRate: Double,
-                                 numLeaves: Int, maxBin: Int, binSampleCount: Int,
-                                 baggingFraction: Double, posBaggingFraction: Double, negBaggingFraction: Double,
-                                 baggingFreq: Int, baggingSeed: Int, earlyStoppingRound: Int,
-                                 improvementTolerance: Double, featureFraction: Double,
-                                 maxDepth: Int, minSumHessianInLeaf: Double,
-                                 numMachines: Int, modelString: Option[String], isUnbalance: Boolean,
-                                 verbosity: Int, categoricalFeatures: Array[Int], numClass: Int,
-                                 boostFromAverage: Boolean, boostingType: String, lambdaL1: Double, lambdaL2: Double,
-                                 isProvideTrainingMetric: Boolean, metric: String, minGainToSplit: Double,
-                                 maxDeltaStep: Double, maxBinByFeature: Array[Int], minDataInLeaf: Int,
-                                 featureNames: Array[String], delegate: Option[LightGBMDelegate],
-                                 dartModeParams: DartModeParams, executionParams: ExecutionParams,
+case class ClassifierTrainParams(parallelism: String,
+                                 topK: Option[Int],
+                                 numIterations: Int,
+                                 learningRate: Double,
+                                 numLeaves: Option[Int],
+                                 maxBin: Option[Int],
+                                 binSampleCount: Option[Int],
+                                 baggingFraction: Option[Double],
+                                 posBaggingFraction: Option[Double],
+                                 negBaggingFraction: Option[Double],
+                                 baggingFreq: Option[Int],
+                                 baggingSeed: Option[Int],
+                                 earlyStoppingRound: Int,
+                                 improvementTolerance: Double,
+                                 featureFraction: Option[Double],
+                                 maxDepth: Option[Int],
+                                 minSumHessianInLeaf: Option[Double],
+                                 numMachines: Int,
+                                 modelString: Option[String],
+                                 isUnbalance: Boolean,
+                                 verbosity: Int,
+                                 categoricalFeatures: Array[Int],
+                                 numClass: Int,
+                                 boostFromAverage: Boolean,
+                                 boostingType: String,
+                                 lambdaL1: Option[Double],
+                                 lambdaL2: Option[Double],
+                                 isProvideTrainingMetric: Option[Boolean],
+                                 metric: Option[String],
+                                 minGainToSplit: Option[Double],
+                                 maxDeltaStep: Option[Double],
+                                 maxBinByFeature: Array[Int],
+                                 minDataInLeaf: Option[Int],
+                                 featureNames: Array[String],
+                                 delegate: Option[LightGBMDelegate],
+                                 dartModeParams: DartModeParams,
+                                 executionParams: ExecutionParams,
                                  objectiveParams: ObjectiveParams)
   extends TrainParams {
   override def toString: String = {
     val extraStr =
       if (objectiveParams.objective != LightGBMConstants.BinaryObjective) s"num_class=$numClass"
       else s"is_unbalance=${isUnbalance.toString}"
-    s"metric=$metric boost_from_average=${boostFromAverage.toString} ${super.toString()} $extraStr"
+    s"boost_from_average=${boostFromAverage.toString} ${super.toString()} $extraStr"
   }
 }
 
 /** Defines the Booster parameters passed to the LightGBM regressor.
   */
-case class RegressorTrainParams(parallelism: String, topK: Int, numIterations: Int, learningRate: Double,
-                                numLeaves: Int, alpha: Double, tweedieVariancePower: Double, maxBin: Int,
-                                binSampleCount: Int, baggingFraction: Double, posBaggingFraction: Double,
-                                negBaggingFraction: Double, baggingFreq: Int, baggingSeed: Int,
-                                earlyStoppingRound: Int, improvementTolerance: Double, featureFraction: Double,
-                                maxDepth: Int, minSumHessianInLeaf: Double, numMachines: Int,
-                                modelString: Option[String], verbosity: Int,
-                                categoricalFeatures: Array[Int], boostFromAverage: Boolean,
-                                boostingType: String, lambdaL1: Double, lambdaL2: Double,
-                                isProvideTrainingMetric: Boolean, metric: String, minGainToSplit: Double,
-                                maxDeltaStep: Double, maxBinByFeature: Array[Int], minDataInLeaf: Int,
-                                featureNames: Array[String], delegate: Option[LightGBMDelegate],
-                                dartModeParams: DartModeParams, executionParams: ExecutionParams,
+case class RegressorTrainParams(parallelism: String,
+                                topK: Option[Int],
+                                numIterations: Int,
+                                learningRate: Double,
+                                numLeaves: Option[Int],
+                                alpha: Double,
+                                tweedieVariancePower: Double,
+                                maxBin: Option[Int],
+                                binSampleCount: Option[Int],
+                                baggingFraction: Option[Double],
+                                posBaggingFraction: Option[Double],
+                                negBaggingFraction: Option[Double],
+                                baggingFreq: Option[Int],
+                                baggingSeed: Option[Int],
+                                earlyStoppingRound: Int,
+                                improvementTolerance: Double,
+                                featureFraction: Option[Double],
+                                maxDepth: Option[Int],
+                                minSumHessianInLeaf: Option[Double],
+                                numMachines: Int,
+                                modelString: Option[String],
+                                verbosity: Int,
+                                categoricalFeatures: Array[Int],
+                                boostFromAverage: Boolean,
+                                boostingType: String,
+                                lambdaL1: Option[Double],
+                                lambdaL2: Option[Double],
+                                isProvideTrainingMetric: Option[Boolean],
+                                metric: Option[String],
+                                minGainToSplit: Option[Double],
+                                maxDeltaStep: Option[Double],
+                                maxBinByFeature: Array[Int],
+                                minDataInLeaf: Option[Int],
+                                featureNames: Array[String],
+                                delegate: Option[LightGBMDelegate],
+                                dartModeParams: DartModeParams,
+                                executionParams: ExecutionParams,
                                 objectiveParams: ObjectiveParams)
   extends TrainParams {
   override def toString: String = {
@@ -113,19 +177,43 @@ case class RegressorTrainParams(parallelism: String, topK: Int, numIterations: I
 
 /** Defines the Booster parameters passed to the LightGBM ranker.
   */
-case class RankerTrainParams(parallelism: String, topK: Int, numIterations: Int, learningRate: Double,
-                             numLeaves: Int, maxBin: Int, binSampleCount: Int, baggingFraction: Double,
-                             posBaggingFraction: Double, negBaggingFraction: Double, baggingFreq: Int,
-                             baggingSeed: Int, earlyStoppingRound: Int, improvementTolerance: Double,
-                             featureFraction: Double, maxDepth: Int, minSumHessianInLeaf: Double, numMachines: Int,
-                             modelString: Option[String], verbosity: Int,
-                             categoricalFeatures: Array[Int], boostingType: String,
-                             lambdaL1: Double, lambdaL2: Double, maxPosition: Int,
-                             labelGain: Array[Double], isProvideTrainingMetric: Boolean,
-                             metric: String, evalAt: Array[Int], minGainToSplit: Double,
-                             maxDeltaStep: Double, maxBinByFeature: Array[Int], minDataInLeaf: Int,
-                             featureNames: Array[String], delegate: Option[LightGBMDelegate],
-                             dartModeParams: DartModeParams, executionParams: ExecutionParams,
+case class RankerTrainParams(parallelism: String,
+                             topK: Option[Int],
+                             numIterations: Int,
+                             learningRate: Double,
+                             numLeaves: Option[Int],
+                             maxBin: Option[Int],
+                             binSampleCount: Option[Int],
+                             baggingFraction: Option[Double],
+                             posBaggingFraction: Option[Double],
+                             negBaggingFraction: Option[Double],
+                             baggingFreq: Option[Int],
+                             baggingSeed: Option[Int],
+                             earlyStoppingRound: Int,
+                             improvementTolerance: Double,
+                             featureFraction: Option[Double],
+                             maxDepth: Option[Int],
+                             minSumHessianInLeaf: Option[Double],
+                             numMachines: Int,
+                             modelString: Option[String],
+                             verbosity: Int,
+                             categoricalFeatures: Array[Int],
+                             boostingType: String,
+                             lambdaL1: Option[Double],
+                             lambdaL2: Option[Double],
+                             maxPosition: Int,
+                             labelGain: Array[Double],
+                             isProvideTrainingMetric: Option[Boolean],
+                             metric: Option[String],
+                             evalAt: Array[Int],
+                             minGainToSplit: Option[Double],
+                             maxDeltaStep: Option[Double],
+                             maxBinByFeature: Array[Int],
+                             minDataInLeaf: Option[Int],
+                             featureNames: Array[String],
+                             delegate: Option[LightGBMDelegate],
+                             dartModeParams: DartModeParams,
+                             executionParams: ExecutionParams,
                              objectiveParams: ObjectiveParams)
   extends TrainParams {
   override def toString: String = {


### PR DESCRIPTION
Default params should not be specified if optional.
This PR fixes this issue by only passing the optional parameters to native lightgbm if they are explicitly specified.
Update: I thought this might be the cause of some issues with min_data_in_leaf and min_sum_hessian_in_lead but it doesn't seem to be the case. Regardless this seems like a good change to have, as we can't guarantee that specifying all possible parameters directly to lightgbm will lead to consistent behavior.