### PR TITLE
Add config to Text Api location

### DIFF
--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split1/TextAnalyticsSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split1/TextAnalyticsSuite.scala
@@ -16,8 +16,11 @@ import org.apache.spark.sql.{DataFrame, Row}
 trait TextKey {
   lazy val textKey = sys.env.getOrElse("TEXT_API_KEY", Secrets.CognitiveApiKey)
 }
+trait TextApiLocation {
+  lazy val textApiLocation = sys.env.getOrElse("TEXT_API_LOCATION", "eastus")
+}
 
-class LanguageDetectorSuite extends TransformerFuzzing[LanguageDetectorV2] with TextKey {
+class LanguageDetectorSuite extends TransformerFuzzing[LanguageDetectorV2] with TextKey with TextApiLocation {
 
   import spark.implicits._
 
@@ -30,7 +33,7 @@ class LanguageDetectorSuite extends TransformerFuzzing[LanguageDetectorV2] with 
 
   lazy val detector: LanguageDetectorV2 = new LanguageDetectorV2()
     .setSubscriptionKey(textKey)
-    .setUrl("https://eastus.api.cognitive.microsoft.com/text/analytics/v2.0/languages")
+    .setUrl(s"https://$textApiLocation.api.cognitive.microsoft.com/text/analytics/v2.0/languages")
     .setTextCol("text2")
     .setOutputCol("replies")
 
@@ -70,7 +73,7 @@ class LanguageDetectorSuite extends TransformerFuzzing[LanguageDetectorV2] with 
   override def reader: MLReadable[_] = LanguageDetectorV2
 }
 
-class LanguageDetectorV3Suite extends TransformerFuzzing[LanguageDetector] with TextKey {
+class LanguageDetectorV3Suite extends TransformerFuzzing[LanguageDetector] with TextKey with TextApiLocation {
 
   import spark.implicits._
 
@@ -83,7 +86,7 @@ class LanguageDetectorV3Suite extends TransformerFuzzing[LanguageDetector] with 
 
   lazy val detector: LanguageDetector = new LanguageDetector()
     .setSubscriptionKey(textKey)
-    .setUrl("https://eastus.api.cognitive.microsoft.com/text/analytics/v3.0/languages")
+    .setUrl(s"https://$textApiLocation.api.cognitive.microsoft.com/text/analytics/v3.0/languages")
     .setOutputCol("replies")
 
   test("Basic Usage") {
@@ -102,7 +105,7 @@ class LanguageDetectorV3Suite extends TransformerFuzzing[LanguageDetector] with 
   override def reader: MLReadable[_] = LanguageDetector
 }
 
-class EntityDetectorSuite extends TransformerFuzzing[EntityDetectorV2] with TextKey {
+class EntityDetectorSuite extends TransformerFuzzing[EntityDetectorV2] with TextKey with TextApiLocation {
 
   import spark.implicits._
 
@@ -113,7 +116,7 @@ class EntityDetectorSuite extends TransformerFuzzing[EntityDetectorV2] with Text
 
   lazy val detector: EntityDetectorV2 = new EntityDetectorV2()
     .setSubscriptionKey(textKey)
-    .setUrl("https://eastus.api.cognitive.microsoft.com/text/analytics/v2.0/entities")
+    .setUrl(s"https://$textApiLocation.api.cognitive.microsoft.com/text/analytics/v2.0/entities")
     .setLanguage("en")
     .setOutputCol("replies")
 
@@ -163,7 +166,7 @@ class EntityDetectorSuiteV3 extends TransformerFuzzing[EntityDetector] with Text
   override def reader: MLReadable[_] = EntityDetector
 }
 
-trait TextSentimentBaseSuite extends TestBase with TextKey {
+trait TextSentimentBaseSuite extends TestBase with TextKey with TextApiLocation {
   import spark.implicits._
 
   lazy val df: DataFrame = Seq(
@@ -219,7 +222,7 @@ class TextSentimentSuite extends TransformerFuzzing[TextSentimentV2] with TextSe
 
   lazy val t: TextSentimentV2 = new TextSentimentV2()
     .setSubscriptionKey(textKey)
-    .setUrl("https://eastus.api.cognitive.microsoft.com/text/analytics/v2.0/sentiment")
+    .setUrl(s"https://$textApiLocation.api.cognitive.microsoft.com/text/analytics/v2.0/sentiment")
     .setLanguageCol("lang")
     .setOutputCol("replies")
 
@@ -251,7 +254,7 @@ class TextSentimentSuite extends TransformerFuzzing[TextSentimentV2] with TextSe
   override def reader: MLReadable[_] = TextSentimentV2
 }
 
-class KeyPhraseExtractorSuite extends TransformerFuzzing[KeyPhraseExtractorV2] with TextKey {
+class KeyPhraseExtractorSuite extends TransformerFuzzing[KeyPhraseExtractorV2] with TextKey with TextApiLocation {
 
   import spark.implicits._
 
@@ -264,7 +267,7 @@ class KeyPhraseExtractorSuite extends TransformerFuzzing[KeyPhraseExtractorV2] w
 
   lazy val t: KeyPhraseExtractorV2 = new KeyPhraseExtractorV2()
     .setSubscriptionKey(textKey)
-    .setUrl("https://eastus.api.cognitive.microsoft.com/text/analytics/v2.0/keyPhrases")
+    .setUrl(s"https://$textApiLocation.api.cognitive.microsoft.com/text/analytics/v2.0/keyPhrases")
     .setLanguageCol("lang")
     .setOutputCol("replies")
 
@@ -285,7 +288,7 @@ class KeyPhraseExtractorSuite extends TransformerFuzzing[KeyPhraseExtractorV2] w
   override def reader: MLReadable[_] = KeyPhraseExtractorV2
 }
 
-class KeyPhraseExtractorV3Suite extends TransformerFuzzing[KeyPhraseExtractor] with TextKey {
+class KeyPhraseExtractorV3Suite extends TransformerFuzzing[KeyPhraseExtractor] with TextKey with TextApiLocation {
 
   import spark.implicits._
 
@@ -298,7 +301,7 @@ class KeyPhraseExtractorV3Suite extends TransformerFuzzing[KeyPhraseExtractor] w
 
   lazy val t: KeyPhraseExtractor = new KeyPhraseExtractor()
     .setSubscriptionKey(textKey)
-    .setUrl("https://eastus.api.cognitive.microsoft.com/text/analytics/v3.0/keyPhrases")
+    .setUrl(s"https://$textApiLocation.api.cognitive.microsoft.com/text/analytics/v3.0/keyPhrases")
     .setLanguageCol("lang")
     .setOutputCol("replies")
 
@@ -319,7 +322,7 @@ class KeyPhraseExtractorV3Suite extends TransformerFuzzing[KeyPhraseExtractor] w
   override def reader: MLReadable[_] = KeyPhraseExtractor
 }
 
-class NERSuite extends TransformerFuzzing[NERV2] with TextKey {
+class NERSuite extends TransformerFuzzing[NERV2] with TextKey with TextApiLocation {
   import spark.implicits._
 
   lazy val df: DataFrame = Seq(
@@ -329,7 +332,7 @@ class NERSuite extends TransformerFuzzing[NERV2] with TextKey {
 
   lazy val n: NERV2 = new NERV2()
     .setSubscriptionKey(textKey)
-    .setLocation("eastus")
+    .setLocation(textApiLocation)
     .setLanguage("en")
     .setOutputCol("response")
 
@@ -358,7 +361,7 @@ class NERSuite extends TransformerFuzzing[NERV2] with TextKey {
   override def reader: MLReadable[_] = NERV2
 }
 
-class NERSuiteV3 extends TransformerFuzzing[NER] with TextKey {
+class NERSuiteV3 extends TransformerFuzzing[NER] with TextKey with TextApiLocation {
   import spark.implicits._
 
   lazy val df: DataFrame = Seq(
@@ -368,7 +371,7 @@ class NERSuiteV3 extends TransformerFuzzing[NER] with TextKey {
 
   lazy val n: NER = new NER()
     .setSubscriptionKey(textKey)
-    .setLocation("eastus")
+    .setLocation(textApiLocation)
     .setLanguage("en")
     .setOutputCol("response")
 
@@ -397,7 +400,7 @@ class NERSuiteV3 extends TransformerFuzzing[NER] with TextKey {
   override def reader: MLReadable[_] = NER
 }
 
-class PIISuiteV3 extends TransformerFuzzing[PII] with TextKey {
+class PIISuiteV3 extends TransformerFuzzing[PII] with TextKey with TextApiLocation {
   import spark.implicits._
 
   lazy val df: DataFrame = Seq(
@@ -409,7 +412,7 @@ class PIISuiteV3 extends TransformerFuzzing[PII] with TextKey {
 
   lazy val n: PII = new PII()
     .setSubscriptionKey(textKey)
-    .setLocation("eastus")
+    .setLocation(textApiLocation)
     .setLanguage("en")
     .setOutputCol("response")
 

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split1/TextAnalyticsSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split1/TextAnalyticsSuite.scala
@@ -13,14 +13,12 @@ import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{DataFrame, Row}
 
-trait TextKey {
+trait TextEndpoint {
   lazy val textKey = sys.env.getOrElse("TEXT_API_KEY", Secrets.CognitiveApiKey)
-}
-trait TextApiLocation {
   lazy val textApiLocation = sys.env.getOrElse("TEXT_API_LOCATION", "eastus")
 }
 
-class LanguageDetectorSuite extends TransformerFuzzing[LanguageDetectorV2] with TextKey with TextApiLocation {
+class LanguageDetectorSuite extends TransformerFuzzing[LanguageDetectorV2] with TextEndpoint {
 
   import spark.implicits._
 
@@ -73,7 +71,7 @@ class LanguageDetectorSuite extends TransformerFuzzing[LanguageDetectorV2] with 
   override def reader: MLReadable[_] = LanguageDetectorV2
 }
 
-class LanguageDetectorV3Suite extends TransformerFuzzing[LanguageDetector] with TextKey with TextApiLocation {
+class LanguageDetectorV3Suite extends TransformerFuzzing[LanguageDetector] with TextEndpoint {
 
   import spark.implicits._
 
@@ -105,7 +103,7 @@ class LanguageDetectorV3Suite extends TransformerFuzzing[LanguageDetector] with 
   override def reader: MLReadable[_] = LanguageDetector
 }
 
-class EntityDetectorSuite extends TransformerFuzzing[EntityDetectorV2] with TextKey with TextApiLocation {
+class EntityDetectorSuite extends TransformerFuzzing[EntityDetectorV2] with TextEndpoint {
 
   import spark.implicits._
 
@@ -135,7 +133,7 @@ class EntityDetectorSuite extends TransformerFuzzing[EntityDetectorV2] with Text
   override def reader: MLReadable[_] = EntityDetectorV2
 }
 
-class EntityDetectorSuiteV3 extends TransformerFuzzing[EntityDetector] with TextKey {
+class EntityDetectorSuiteV3 extends TransformerFuzzing[EntityDetector] with TextEndpoint {
 
   import spark.implicits._
 
@@ -166,7 +164,7 @@ class EntityDetectorSuiteV3 extends TransformerFuzzing[EntityDetector] with Text
   override def reader: MLReadable[_] = EntityDetector
 }
 
-trait TextSentimentBaseSuite extends TestBase with TextKey with TextApiLocation {
+trait TextSentimentBaseSuite extends TestBase with TextEndpoint {
   import spark.implicits._
 
   lazy val df: DataFrame = Seq(
@@ -254,7 +252,7 @@ class TextSentimentSuite extends TransformerFuzzing[TextSentimentV2] with TextSe
   override def reader: MLReadable[_] = TextSentimentV2
 }
 
-class KeyPhraseExtractorSuite extends TransformerFuzzing[KeyPhraseExtractorV2] with TextKey with TextApiLocation {
+class KeyPhraseExtractorSuite extends TransformerFuzzing[KeyPhraseExtractorV2] with TextEndpoint {
 
   import spark.implicits._
 
@@ -288,7 +286,7 @@ class KeyPhraseExtractorSuite extends TransformerFuzzing[KeyPhraseExtractorV2] w
   override def reader: MLReadable[_] = KeyPhraseExtractorV2
 }
 
-class KeyPhraseExtractorV3Suite extends TransformerFuzzing[KeyPhraseExtractor] with TextKey with TextApiLocation {
+class KeyPhraseExtractorV3Suite extends TransformerFuzzing[KeyPhraseExtractor] with TextEndpoint {
 
   import spark.implicits._
 
@@ -322,7 +320,7 @@ class KeyPhraseExtractorV3Suite extends TransformerFuzzing[KeyPhraseExtractor] w
   override def reader: MLReadable[_] = KeyPhraseExtractor
 }
 
-class NERSuite extends TransformerFuzzing[NERV2] with TextKey with TextApiLocation {
+class NERSuite extends TransformerFuzzing[NERV2] with TextEndpoint {
   import spark.implicits._
 
   lazy val df: DataFrame = Seq(
@@ -361,7 +359,7 @@ class NERSuite extends TransformerFuzzing[NERV2] with TextKey with TextApiLocati
   override def reader: MLReadable[_] = NERV2
 }
 
-class NERSuiteV3 extends TransformerFuzzing[NER] with TextKey with TextApiLocation {
+class NERSuiteV3 extends TransformerFuzzing[NER] with TextEndpoint {
   import spark.implicits._
 
   lazy val df: DataFrame = Seq(
@@ -400,7 +398,7 @@ class NERSuiteV3 extends TransformerFuzzing[NER] with TextKey with TextApiLocati
   override def reader: MLReadable[_] = NER
 }
 
-class PIISuiteV3 extends TransformerFuzzing[PII] with TextKey with TextApiLocation {
+class PIISuiteV3 extends TransformerFuzzing[PII] with TextEndpoint {
   import spark.implicits._
 
   lazy val df: DataFrame = Seq(


### PR DESCRIPTION
Adds `TEXT_API_LOCATION` environment variable (defaults to `eastus`) to allow overriding the Cognitive Services, alongside the existing `TEXT_API_KEY`.