### PR TITLE
docs: add explanation dashboard integration example notebook

### DIFF
--- a/notebooks/Interpretability - Explanation Dashboard.ipynb
+++ b/notebooks/Interpretability - Explanation Dashboard.ipynb
@@ -1,0 +1,430 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "inputWidgets": {},
+     "nuid": "4a463c67-7543-42d2-a116-e70e8451b09b",
+     "showTitle": false,
+     "title": ""
+    }
+   },
+   "source": [
+    "## Interpretability - Explanation Dashboard\n",
+    "\n",
+    "In this example, similar to the \"Interpretability - Tabular SHAP explainer\" notebook, we use Kernel SHAP to explain a tabular classification model built from the Adults Census dataset and then visualize the explanation in the ExplanationDashboard from https://github.com/microsoft/responsible-ai-widgets.\n",
+    "\n",
+    "First we import the packages and define some UDFs we will need later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "inputWidgets": {},
+     "nuid": "bf0fdfc2-97b2-48e4-b3d9-794b0cb3da67",
+     "showTitle": false,
+     "title": ""
+    },
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import pyspark\n",
+    "from synapse.ml.explainers import *\n",
+    "from pyspark.ml import Pipeline\n",
+    "from pyspark.ml.classification import LogisticRegression\n",
+    "from pyspark.ml.feature import StringIndexer, OneHotEncoder, VectorAssembler\n",
+    "from pyspark.sql.types import *\n",
+    "from pyspark.sql.functions import *\n",
+    "import pandas as pd\n",
+    "\n",
+    "vec_access = udf(lambda v, i: float(v[i]), FloatType())\n",
+    "vec2array = udf(lambda vec: vec.toArray().tolist(), ArrayType(FloatType()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "inputWidgets": {},
+     "nuid": "ae47e1f9-0672-47ed-94de-10970e1b14b5",
+     "showTitle": false,
+     "title": ""
+    }
+   },
+   "source": [
+    "Now let's read the data and train a simple binary classification model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "inputWidgets": {},
+     "nuid": "58807448-d8e0-4818-adc8-27536d561fb3",
+     "showTitle": false,
+     "title": ""
+    },
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "df = spark.read.parquet(\"wasbs://publicwasb@mmlspark.blob.core.windows.net/AdultCensusIncome.parquet\")\n",
+    "\n",
+    "labelIndexer = StringIndexer(inputCol=\"income\", outputCol=\"label\", stringOrderType=\"alphabetAsc\").fit(df)\n",
+    "print(\"Label index assigment: \" + str(set(zip(labelIndexer.labels, [0, 1]))))\n",
+    "\n",
+    "training = labelIndexer.transform(df)\n",
+    "display(training)\n",
+    "categorical_features = [\n",
+    "    \"workclass\",\n",
+    "    \"education\",\n",
+    "    \"marital-status\",\n",
+    "    \"occupation\",\n",
+    "    \"relationship\",\n",
+    "    \"race\",\n",
+    "    \"sex\",\n",
+    "    \"native-country\",\n",
+    "]\n",
+    "categorical_features_idx = [col + \"_idx\" for col in categorical_features]\n",
+    "categorical_features_enc = [col + \"_enc\" for col in categorical_features]\n",
+    "numeric_features = [\"age\", \"education-num\", \"capital-gain\", \"capital-loss\", \"hours-per-week\"]\n",
+    "\n",
+    "strIndexer = StringIndexer(inputCols=categorical_features, outputCols=categorical_features_idx)\n",
+    "onehotEnc = OneHotEncoder(inputCols=categorical_features_idx, outputCols=categorical_features_enc)\n",
+    "vectAssem = VectorAssembler(inputCols=categorical_features_enc + numeric_features, outputCol=\"features\")\n",
+    "lr = LogisticRegression(featuresCol=\"features\", labelCol=\"label\", weightCol=\"fnlwgt\")\n",
+    "pipeline = Pipeline(stages=[strIndexer, onehotEnc, vectAssem, lr])\n",
+    "model = pipeline.fit(training)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "inputWidgets": {},
+     "nuid": "f617f9a4-7e67-43f8-8fa9-92680b635b3d",
+     "showTitle": false,
+     "title": ""
+    }
+   },
+   "source": [
+    "After the model is trained, we randomly select some observations to be explained."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "inputWidgets": {},
+     "nuid": "f55757a6-6204-4f64-a91e-65bfbacf62bc",
+     "showTitle": false,
+     "title": ""
+    },
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "explain_instances = model.transform(training).orderBy(rand()).limit(5).repartition(200).cache()\n",
+    "display(explain_instances)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "inputWidgets": {},
+     "nuid": "48a0c8ee-8e36-4bd3-9a04-eded6d2c8894",
+     "showTitle": false,
+     "title": ""
+    }
+   },
+   "source": [
+    "We create a TabularSHAP explainer, set the input columns to all the features the model takes, specify the model and the target output column we are trying to explain. In this case, we are trying to explain the \"probability\" output which is a vector of length 2, and we are only looking at class 1 probability. Specify targetClasses to `[0, 1]` if you want to explain class 0 and 1 probability at the same time. Finally we sample 100 rows from the training data for background data, which is used for integrating out features in Kernel SHAP."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "inputWidgets": {},
+     "nuid": "7e097552-e617-4e1c-a085-b66eca5bcb69",
+     "showTitle": false,
+     "title": ""
+    },
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "shap = TabularSHAP(\n",
+    "    inputCols=categorical_features + numeric_features,\n",
+    "    outputCol=\"shapValues\",\n",
+    "    numSamples=5000,\n",
+    "    model=model,\n",
+    "    targetCol=\"probability\",\n",
+    "    targetClasses=[1],\n",
+    "    backgroundData=training.orderBy(rand()).limit(100).cache(),\n",
+    ")\n",
+    "\n",
+    "shap_df = shap.transform(explain_instances)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "inputWidgets": {},
+     "nuid": "6933b52b-7d46-4210-810a-f984b76dd4a2",
+     "showTitle": false,
+     "title": ""
+    }
+   },
+   "source": [
+    "Once we have the resulting dataframe, we extract the class 1 probability of the model output, the SHAP values for the target class, the original features and the true label. Then we convert it to a pandas dataframe for visisualization.\n",
+    "For each observation, the first element in the SHAP values vector is the base value (the mean output of the background dataset), and each of the following element is the SHAP values for each feature."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "inputWidgets": {},
+     "nuid": "05e01f98-e44c-46c9-a8ae-26ba892f85b3",
+     "showTitle": false,
+     "title": ""
+    },
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "shaps = (\n",
+    "    shap_df.withColumn(\"probability\", vec_access(col(\"probability\"), lit(1)))\n",
+    "    .withColumn(\"shapValues\", vec2array(col(\"shapValues\").getItem(0)))\n",
+    "    .select([\"shapValues\", \"probability\", \"label\"] + categorical_features + numeric_features)\n",
+    ")\n",
+    "\n",
+    "shaps_local = shaps.toPandas()\n",
+    "shaps_local.sort_values(\"probability\", ascending=False, inplace=True, ignore_index=True)\n",
+    "pd.set_option(\"display.max_colwidth\", None)\n",
+    "shaps_local"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "inputWidgets": {},
+     "nuid": "f9317a27-900a-4d1d-9e9f-9fe906eae75c",
+     "showTitle": false,
+     "title": ""
+    }
+   },
+   "source": [
+    "We can visualize the explanation in the [interpret-community format](https://github.com/interpretml/interpret-community) in the ExplanationDashboard from https://github.com/microsoft/responsible-ai-widgets/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "inputWidgets": {},
+     "nuid": "c9b4c03e-eac8-4314-a6c2-0a451525e6a4",
+     "showTitle": false,
+     "title": ""
+    },
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "features = categorical_features + numeric_features\n",
+    "features_with_base = [\"Base\"] + features\n",
+    "\n",
+    "rows = shaps_local.shape[0]\n",
+    "\n",
+    "local_importance_values = shaps_local[['shapValues']]\n",
+    "eval_data = shaps_local[features]\n",
+    "true_y = np.array(shaps_local[['label']])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "list_local_importance_values = local_importance_values.values.tolist()\n",
+    "converted_importance_values = []\n",
+    "bias = []\n",
+    "for classarray in list_local_importance_values:\n",
+    "    for rowarray in classarray:\n",
+    "        converted_list = rowarray.tolist()\n",
+    "        bias.append(converted_list[0])\n",
+    "        # remove the bias from local importance values\n",
+    "        del converted_list[0]\n",
+    "        converted_importance_values.append(converted_list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When running Synapse Analytics, please follow instructions here [Package management - Azure Synapse Analytics | Microsoft Docs](https://docs.microsoft.com/en-us/azure/synapse-analytics/spark/apache-spark-azure-portal-add-libraries) to install [\"raiwidgets\"](https://pypi.org/project/raiwidgets/) and [\"interpret-community\"](https://pypi.org/project/interpret-community/) packages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade raiwidgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade interpret-community"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from interpret_community.adapter import ExplanationAdapter\n",
+    "adapter = ExplanationAdapter(features, classification=True)\n",
+    "global_explanation = adapter.create_global(converted_importance_values, eval_data, expected_values=bias)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# view the global importance values\n",
+    "global_explanation.global_importance_values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# view the local importance values\n",
+    "global_explanation.local_importance_values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "class wrapper(object):\n",
+    "  def __init__(self, model):\n",
+    "    self.model = model\n",
+    "  \n",
+    "  def predict(self, data):\n",
+    "    sparkdata = spark.createDataFrame(data)\n",
+    "    return model.transform(sparkdata).select('prediction').toPandas().values.flatten().tolist()\n",
+    "  \n",
+    "  def predict_proba(self, data):\n",
+    "    sparkdata = spark.createDataFrame(data)\n",
+    "    prediction = model.transform(sparkdata).select('probability').toPandas().values.flatten().tolist()\n",
+    "    proba_list = [vector.values.tolist() for vector in prediction]\n",
+    "    return proba_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# view the explanation in the ExplanationDashboard\n",
+    "from raiwidgets import ExplanationDashboard\n",
+    "ExplanationDashboard(global_explanation, wrapper(model), dataset=eval_data, true_y=true_y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "inputWidgets": {},
+     "nuid": "8f22fceb-0fc0-4a86-a0ca-2a7b47b4795a",
+     "showTitle": false,
+     "title": ""
+    }
+   },
+   "source": [
+    "Your results will look like:\n",
+    "\n",
+    "<img src=\"https://mmlspark.blob.core.windows.net/graphics/rai-dashboard.png\" style=\"float: right;\"/>"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "dashboards": [],
+   "language": "python",
+   "notebookMetadata": {
+    "pythonIndentUnit": 2
+   },
+   "notebookName": "Interpretability - Tabular SHAP explainer",
+   "notebookOrigID": 4343954975413564,
+   "widgets": {}
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Using this PR and creating a new notebook instead of updating an existing notebook: https://github.com/microsoft/SynapseML/pull/1228

Closing the other PR based on comments.

======== Description from previous PR:

This PR integrates the RAI widgets with the SHAP interpretability notebook.
Specifically, it demonstrates how to create an [interpret-community style explanation](https://github.com/interpretml/interpret-community) from the local importance values, which can then be visualized in the ExplanationDashboard widget locally and optionally uploaded to AzureML.

In a near-term future TODO, the ExplanationAdapter can be integrated directly into the SHAP explainer with explain_local and explain_global APIs, so the explainer can output the explanation directly.

Please add this image in the examples URL which demonstrates how the ExplanationDashboard will look like after passing the interpret-community explanation to it:

![ExplanationDashboard](https://user-images.githubusercontent.com/24683184/138751795-18ffee08-c03e-4f1f-99de-129c62a0f170.png)

