### PR TITLE
fix: performance issue in interpretability notebooks

### DIFF
--- a/notebooks/Interpretability - Explanation Dashboard.ipynb
+++ b/notebooks/Interpretability - Explanation Dashboard.ipynb
@@ -169,7 +169,7 @@
     "    model=model,\n",
     "    targetCol=\"probability\",\n",
     "    targetClasses=[1],\n",
-    "    backgroundData=training.orderBy(rand()).limit(100).cache(),\n",
+    "    backgroundData=broadcast(training.orderBy(rand()).limit(100).cache()),\n",
     ")\n",
     "\n",
     "shap_df = shap.transform(explain_instances)\n"

--- a/notebooks/Interpretability - Tabular SHAP explainer.ipynb
+++ b/notebooks/Interpretability - Tabular SHAP explainer.ipynb
@@ -165,7 +165,7 @@
     "    model=model,\n",
     "    targetCol=\"probability\",\n",
     "    targetClasses=[1],\n",
-    "    backgroundData=training.orderBy(rand()).limit(100).cache(),\n",
+    "    backgroundData=broadcast(training.orderBy(rand()).limit(100).cache()),\n",
     ")\n",
     "\n",
     "shap_df = shap.transform(explain_instances)\n"


### PR DESCRIPTION
In the notebook, the background data should be broadcasted. When the `explain_instances` dataframe (observations to be explained) is in a mid range (50 to 100-ish), Spark will use a unexpected type of join plan, and messes up with the parallelization of the Kernel SHAP sampler, thus creating a performance bottleneck. Broadcasting the background dataset makes Spark respect the partitioning of the `explain_instances` dataframe.

These two notebooks both explain only 5 data points, so the performance bottleneck is not obvious. However, if we change 5 to 50, it becomes obvious. But if we further change it 500, Spark uses the intended join plan, and the bottleneck is not triggered.

I thought about forcing the broadcast inside the explainer, but this may create unexpected effect for other scenarios, so I'm hesitant to do so.