### PR TITLE
fix: min_data_in_leaf missing from dataset parameters in lightgbm

### DIFF
--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMBase.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMBase.scala
@@ -267,6 +267,7 @@ trait LightGBMBase[TrainedModel <: Model[TrainedModel]] extends Estimator[Traine
   def getDatasetParams(categoricalIndexes: Array[Int], numThreads: Int): String = {
     val datasetParams = s"max_bin=$getMaxBin is_pre_partition=True " +
       s"bin_construct_sample_cnt=$getBinSampleCount " +
+      s"min_data_in_leaf=$getMinDataInLeaf " +
       s"num_threads=$numThreads " +
       (if (categoricalIndexes.isEmpty) ""
       else s"categorical_feature=${categoricalIndexes.mkString(",")}")


### PR DESCRIPTION
fix performance issue when comparing lightgbm to MPI by adding missing min_data_in_leaf parameter to the set of dataset params used during dataset creation