### PR TITLE
perf: improve lightgbm training performance 4x-10x by setting num_threads to be cores-1 by default for single dataset mode

### DIFF
--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMBase.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMBase.scala
@@ -247,8 +247,12 @@ trait LightGBMBase[TrainedModel <: Model[TrainedModel]] extends Estimator[Traine
     *
     * @return ExecutionParams object containing parameters related to LightGBM execution.
     */
-  protected def getExecutionParams: ExecutionParams = {
-    ExecutionParams(getChunkSize, getMatrixType, getNumThreads, getUseSingleDatasetMode)
+  protected def getExecutionParams(numTasksPerExec: Int): ExecutionParams = {
+    val execNumThreads =
+      if (getUseSingleDatasetMode) get(numThreads).getOrElse(numTasksPerExec - 1)
+      else getNumThreads
+
+    ExecutionParams(getChunkSize, getMatrixType, execNumThreads, getUseSingleDatasetMode)
   }
 
   protected def getColumnParams: ColumnParams = {

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMClassifier.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMClassifier.scala
@@ -54,7 +54,7 @@ class LightGBMClassifier(override val uid: String)
       getIsUnbalance, getVerbosity, categoricalIndexes, actualNumClasses, getBoostFromAverage,
       getBoostingType, get(lambdaL1), get(lambdaL2), get(isProvideTrainingMetric),
       get(metric), get(minGainToSplit), get(maxDeltaStep), getMaxBinByFeature, get(minDataInLeaf), getSlotNames,
-      getDelegate, getDartParams, getExecutionParams, getObjectiveParams)
+      getDelegate, getDartParams, getExecutionParams(numTasksPerExec), getObjectiveParams)
   }
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMClassificationModel = {

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMRanker.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMRanker.scala
@@ -60,7 +60,7 @@ class LightGBMRanker(override val uid: String)
       getVerbosity, categoricalIndexes, getBoostingType, get(lambdaL1), get(lambdaL2), getMaxPosition, getLabelGain,
       get(isProvideTrainingMetric), get(metric), getEvalAt, get(minGainToSplit), get(maxDeltaStep),
       getMaxBinByFeature, get(minDataInLeaf), getSlotNames, getDelegate, getDartParams,
-      getExecutionParams, getObjectiveParams)
+      getExecutionParams(numTasksPerExec), getObjectiveParams)
   }
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMRankerModel = {

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMRegressor.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMRegressor.scala
@@ -70,7 +70,7 @@ class LightGBMRegressor(override val uid: String)
       getBoostFromAverage, getBoostingType, get(lambdaL1), get(lambdaL2), get(isProvideTrainingMetric),
       get(metric), get(minGainToSplit), get(maxDeltaStep),
       getMaxBinByFeature, get(minDataInLeaf), getSlotNames, getDelegate,
-      getDartParams, getExecutionParams, getObjectiveParams)
+      getDartParams, getExecutionParams(numTasksPerExec), getObjectiveParams)
   }
 
   def getModel(trainParams: TrainParams, lightGBMBooster: LightGBMBooster): LightGBMRegressionModel = {


### PR DESCRIPTION
In benchmarking, it was discovered that lightgbm training time could be reduced 4X-10X by setting the num_threads to be equal to the # of machine cores - 1 for the single dataset mode (which is now the default mode).
This actually was already suggested in the lightgbm docs:
https://lightgbm.readthedocs.io/en/latest/Parameters.html#num_threads
>>> for distributed learning, do not use all CPU cores because this will cause poor performance for the network communication

Poor network communication can lead to very slow training execution time.

On one scenario with a 37 GB dataset on disk with parameters:
```learning_rate = 0.1, num_leaves = 768, num_trees = 1000, min_data_in_leaf = 15000, max_bin = 512```
the training time without setting num_threads was 5.5 hours, while setting num_threads to (number of machine cores)-1 reduced the training time to 1.2 hours.  The change in performance will vary depending on the parameters used.

This PR sets the distributed lightgbm number of threads by default to be (num cores)-1  if the parameter is not specified by the user.  The user can still override the parameter.
