### PR TITLE
Various improvements for TextAnalyze

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/ComputerVision.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/ComputerVision.scala
@@ -231,7 +231,7 @@ trait BasicAsyncReply extends HasAsyncReply {
 
   private def getRetriesExceededHTTPResponseData(maxTries: Int) = {
     val headers = Array[HeaderData]()
-    val errorResponseString = "{\"error\": { \"code\": \"418\", \"message\": \"" + 
+    val errorResponseString = "{\"error\": { \"code\": \"418\", \"message\": \"" +
           s"SynapseML: Querying for results did not complete within ${maxTries} tries" + "\"}}";
     val errorResponse = errorResponseString.getBytes()
     val entityData = EntityData(
@@ -283,8 +283,8 @@ trait BasicAsyncReply extends HasAsyncReply {
       response
     }
   }
-  
-  protected def modifyPollingURI(originalURI : URI) : URI = { originalURI }
+
+  protected def modifyPollingURI(originalURI: URI): URI = { originalURI }
 }
 
 trait HasAsyncReply extends Params {
@@ -333,7 +333,8 @@ trait HasAsyncReply extends Params {
   def getSuppressMaxRetriesExceededException: Boolean = $(suppressMaxRetriesExceededException)
 
   /** @group setParam */
-  def setSuppressMaxRetriesExceededException(value: Boolean): this.type = set(suppressMaxRetriesExceededException, value)
+  def setSuppressMaxRetriesExceededException(value: Boolean): this.type =
+      set(suppressMaxRetriesExceededException, value)
 
 
   //scalastyle:off magic.number
@@ -351,9 +352,6 @@ trait HasAsyncReply extends Params {
 
   protected def handlingFunc(client: CloseableHttpClient,
                              request: HTTPRequestData): HTTPResponseData
-
-  
-
 }
 
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/ComputerVision.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/ComputerVision.scala
@@ -254,7 +254,8 @@ trait BasicAsyncReply extends HasAsyncReply {
                              request: HTTPRequestData): HTTPResponseData = {
     val response = HandlingUtils.advanced(getBackoffs: _*)(client, request)
     if (response != null && response.statusLine.statusCode == 202) {
-      val location = new URI(response.headers.filter(_.name.toLowerCase() == "operation-location").head.value)
+      val originalLocation = new URI(response.headers.filter(_.name.toLowerCase() == "operation-location").head.value)
+      val location = modifyPollingURI(originalLocation)
       val maxTries = getMaxPollingRetries
       val key = request.headers.find(_.name == "Ocp-Apim-Subscription-Key").map(_.value)
       blocking {
@@ -282,6 +283,8 @@ trait BasicAsyncReply extends HasAsyncReply {
       response
     }
   }
+  
+  protected def modifyPollingURI(originalURI : URI) : URI = { originalURI }
 }
 
 trait HasAsyncReply extends Params {

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/ComputerVision.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/ComputerVision.scala
@@ -13,6 +13,7 @@ import org.apache.http.client.methods.{HttpEntityEnclosingRequestBase, HttpGet, 
 import org.apache.http.entity.{AbstractHttpEntity, ByteArrayEntity, ContentType, StringEntity}
 import org.apache.http.impl.client.CloseableHttpClient
 import org.apache.spark.injections.UDFUtils
+import org.apache.spark.internal.{Logging => SparkLogging}
 import org.apache.spark.ml.ComplexParamsReadable
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.util._
@@ -228,6 +229,27 @@ trait BasicAsyncReply extends HasAsyncReply {
     }
   }
 
+  private def getRetriesExceededHTTPResponseData(maxTries: Int) = {
+    val headers = Array[HeaderData]()
+    val errorResponseString = "{\"error\": { \"code\": \"418\", \"message\": \"" + 
+          s"SynapseML: Querying for results did not complete within ${maxTries} tries" + "\"}}";
+    val errorResponse = errorResponseString.getBytes()
+    val entityData = EntityData(
+      errorResponse,
+      None,
+      Some(errorResponse.length.toLong),
+      Some(HeaderData("Content-Type", "application/json")),
+      false,
+      false,
+      false)
+    val statusLineData = StatusLineData(
+      ProtocolVersionData("1.1", 1, 1),
+      418,
+      s"SynapseML: Querying for results did not complete within $maxTries tries")
+    new HTTPResponseData(headers, Some(entityData), statusLineData, "en-us")
+
+  }
+
   protected def handlingFunc(client: CloseableHttpClient,
                              request: HTTPRequestData): HTTPResponseData = {
     val response = HandlingUtils.advanced(getBackoffs: _*)(client, request)
@@ -238,7 +260,7 @@ trait BasicAsyncReply extends HasAsyncReply {
       blocking {
         Thread.sleep(getInitialPollingDelay.toLong)
       }
-      val it = (0 to maxTries).toIterator.flatMap { _ =>
+      val it = (0 to maxTries).toIterator.flatMap { i =>
         queryForResult(key, client, location).orElse({
           blocking {
             Thread.sleep(getPollingDelay.toLong)
@@ -249,8 +271,12 @@ trait BasicAsyncReply extends HasAsyncReply {
       if (it.hasNext) {
         it.next()
       } else {
-        throw new TimeoutException(
-          s"Querying for results did not complete within $maxTries tries")
+        if (getSuppressMaxRetriesExceededException){
+          getRetriesExceededHTTPResponseData(maxTries)
+        } else {
+          throw new TimeoutException(
+            s"Querying for results did not complete within $maxTries tries")
+        }
       }
     } else {
       response
@@ -295,8 +321,25 @@ trait HasAsyncReply extends Params {
   /** @group setParam */
   def setInitialPollingDelay(value: Int): this.type = set(initialPollingDelay, value)
 
+  val suppressMaxRetriesExceededException: BooleanParam = new BooleanParam(
+    this,
+    "suppressMaxRetriesExceededException",
+    "set true to suppress the maxumimum retries exception and report in the error column")
+
+  /** @group getParam */
+  def getSuppressMaxRetriesExceededException: Boolean = $(suppressMaxRetriesExceededException)
+
+  /** @group setParam */
+  def setSuppressMaxRetriesExceededException(value: Boolean): this.type = set(suppressMaxRetriesExceededException, value)
+
+
   //scalastyle:off magic.number
-  setDefault(backoffs -> Array(100, 500, 1000), maxPollingRetries -> 1000, pollingDelay -> 300, initialPollingDelay -> 300)
+  setDefault(
+    backoffs -> Array(100, 500, 1000),
+    maxPollingRetries -> 1000,
+    pollingDelay -> 300,
+    initialPollingDelay -> 300,
+    suppressMaxRetriesExceededException -> false)
   //scalastyle:on magic.number
 
   protected def queryForResult(key: Option[String],
@@ -305,6 +348,8 @@ trait HasAsyncReply extends Params {
 
   protected def handlingFunc(client: CloseableHttpClient,
                              request: HTTPRequestData): HTTPResponseData
+
+  
 
 }
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/TextAnalytics.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/TextAnalytics.scala
@@ -483,7 +483,7 @@ class TextAnalyze(override val uid: String) extends TextAnalyticsBase(uid)
 
   override protected def prepareEntity: Row => Option[AbstractHttpEntity] = { _ => None }
 
-  override protected def modifyPollingURI(originalURI: URI) : URI = {
+  override protected def modifyPollingURI(originalURI: URI): URI = {
     // async API allows up to 25 results to be submitted in a batch, but defaults to 20 results per page
     // Add $top=25 to force the full batch in the response
     val originalQuery = originalURI.getQuery()
@@ -585,7 +585,8 @@ class TextAnalyze(override val uid: String) extends TextAnalyticsBase(uid)
         val succeededTask = taskNames.map(name => tasks.getAs[Seq[GenericRowWithSchema]](name))
           .filter(r => r != null)
           .flatten
-          .filter(r => r.getAs[String]("state") == "succeeded") // only consider tasks that succeeded to handle 'partiallycompleted' requests
+          // only consider tasks that succeeded to handle 'partiallycompleted' requests
+          .filter(r => r.getAs[String]("state") == "succeeded")
           .head
         val results = succeededTask.getAs[GenericRowWithSchema]("results")
         val docCount = results.getAs[Seq[GenericRowWithSchema]]("documents").size


### PR DESCRIPTION
This PR contains the output from various rounds of performance testing with `TextAnalyze`

- fix #1307  - add `$top=25` to polling location to force a full maximum batch size of results from the polling endpoint
- fix handling of result data to tolerate incomplete results and add `partiallycompleted` as a terminal state to process
- add `setSuppressMaxRetriesExceededException` to allow consumers to get an error in the error column when a request reaches the maximum polling limit if they prefer that to failing a Spark task
- add `setInitialPollingDelay` option to allow a delay before the initial polling request for async API. When it is known that a request can take a certain time, this allows fine-tuning to reduce the number of requests being made