### PR TITLE
fix: lazily creating a tempdir in NativeLoader

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/env/NativeLoader.java
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/env/NativeLoader.java
@@ -27,14 +27,21 @@ import java.nio.file.Files;
  * */
 public class NativeLoader implements Serializable {
 
-    private String resourcesPath;
+    private final String resourcesPath;
     private Boolean extractionDone = false;
-    private File tempDir;
+    private File tempDir = null;
 
-    public NativeLoader(String topLevelResourcesPath) throws IOException {
+    private File getOrCreateTempDir() throws IOException {
+        if (tempDir == null) {
+            tempDir = Files.createTempDirectory("mml-natives").toFile();
+            tempDir.deleteOnExit();
+        }
+
+        return tempDir;
+    }
+
+    public NativeLoader(String topLevelResourcesPath) {
         this.resourcesPath = getResourcesPath(topLevelResourcesPath);
-        tempDir = Files.createTempDirectory("mml-natives").toFile();
-        tempDir.deleteOnExit();
     }
 
     /**
@@ -56,7 +63,7 @@ public class NativeLoader implements Serializable {
                 libName = System.mapLibraryName(libName);
                 extractNativeLibraries(libName);
                 // Try to load library from extracted native resources
-                System.load(tempDir.getAbsolutePath() + File.separator + libName);
+                System.load(getOrCreateTempDir().getAbsolutePath() + File.separator + libName);
             }
             catch (Exception ee) {
                 throw new UnsatisfiedLinkError(String.format(
@@ -106,7 +113,7 @@ public class NativeLoader implements Serializable {
 
     private void extractResourceFromPath(String libName, String prefix) throws IOException {
 
-        File temp = new File(tempDir.getPath() + File.separator + libName);
+        File temp = new File(getOrCreateTempDir().getPath() + File.separator + libName);
         temp.createNewFile();
         temp.deleteOnExit();
 


### PR DESCRIPTION
This pr is recreated. origin pr is https://github.com/microsoft/SynapseML/pull/945

---
When predicting with a lightgbm model, there are so many lightgbm's so files on runtime.
It made failure on allocating memory on tmpfs in my application.

So, I tried to use java.library.path that has already "so" files.
When trying this approach, I found that it is possible to create so many /tmp/mml-nativesXXXX directories. Though, copied "so" files were not used.

Therefore, this pr is created to create lazily tempdir in NativeLoader to using getOrCreateTempDir() instead of making it in class's initializer.