### PR TITLE
Log async call duration and include final status in retries exceeded error

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/ComputerVision.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/ComputerVision.scala
@@ -285,11 +285,17 @@ trait BasicAsyncReply extends HasAsyncReply with BasicLogging {
           if (asyncCompletionLogMessagePrefixValue != "") {
             val completedTime = System.nanoTime
             val durationMs = (completedTime - startedTime)/1000000 // seconds -> milli -> micro -> nano
-            logInfo(s"${asyncCompletionLogMessagePrefixValue}:${durationMs}")
+            logInfo(s"${asyncCompletionLogMessagePrefixValue}:true:${durationMs}")
           }
           value
         }
         case Left(lastStatus) => {
+          val asyncCompletionLogMessagePrefixValue = getAsyncCompletionLogMessagePrefix
+          if (asyncCompletionLogMessagePrefixValue != "") {
+            val completedTime = System.nanoTime
+            val durationMs = (completedTime - startedTime)/1000000 // seconds -> milli -> micro -> nano
+            logInfo(s"${asyncCompletionLogMessagePrefixValue}:false:${durationMs}")
+          }
           if (getSuppressMaxRetriesExceededException){
             getRetriesExceededHTTPResponseData(maxTries, lastStatus)
           } else {

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/ComputerVision.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/ComputerVision.scala
@@ -279,23 +279,15 @@ trait BasicAsyncReply extends HasAsyncReply with BasicLogging {
           }
         }
       })
+      val completedTime = System.nanoTime
+      val durationMs = (completedTime - startedTime)/1000000 // seconds -> milli -> micro -> nano
       it match {
         case Right(value) =>{
-          val asyncCompletionLogMessagePrefixValue = getAsyncCompletionLogMessagePrefix
-          if (asyncCompletionLogMessagePrefixValue != "") {
-            val completedTime = System.nanoTime
-            val durationMs = (completedTime - startedTime)/1000000 // seconds -> milli -> micro -> nano
-            logInfo(s"${asyncCompletionLogMessagePrefixValue}:true:${durationMs}")
-          }
+          logInfo(s"Async operation:succeeded=true:${durationMs}")
           value
         }
         case Left(lastStatus) => {
-          val asyncCompletionLogMessagePrefixValue = getAsyncCompletionLogMessagePrefix
-          if (asyncCompletionLogMessagePrefixValue != "") {
-            val completedTime = System.nanoTime
-            val durationMs = (completedTime - startedTime)/1000000 // seconds -> milli -> micro -> nano
-            logInfo(s"${asyncCompletionLogMessagePrefixValue}:false:${durationMs}")
-          }
+          logInfo(s"Async operation:succeeded=false:${durationMs}")
           if (getSuppressMaxRetriesExceededException){
             getRetriesExceededHTTPResponseData(maxTries, lastStatus)
           } else {
@@ -361,23 +353,13 @@ trait HasAsyncReply extends Params {
   def setSuppressMaxRetriesExceededException(value: Boolean): this.type =
       set(suppressMaxRetriesExceededException, value)
 
-  val asyncCompletionLogMessagePrefix = new Param[String](this, "asyncCompletionLogMessagePrefix",
-  "the prefix to use when outputting async completion log messages, or empty string to disable")
-
-  /** @group setParam */
-  def getAsyncCompletionLogMessagePrefix: String = $(asyncCompletionLogMessagePrefix)
-
-  /** @group setParam */
-  def setAsyncCompletionLogMessagePrefix(v: String): this.type = set(asyncCompletionLogMessagePrefix, v)
-
   //scalastyle:off magic.number
   setDefault(
     backoffs -> Array(100, 500, 1000),
     maxPollingRetries -> 1000,
     pollingDelay -> 300,
     initialPollingDelay -> 300,
-    suppressMaxRetriesExceededException -> false,
-    asyncCompletionLogMessagePrefix -> "")
+    suppressMaxRetriesExceededException -> false)
   //scalastyle:on magic.number
 
   protected def queryForResult(key: Option[String],

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/MultivariateAnomalyDetection.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/MultivariateAnomalyDetection.scala
@@ -107,17 +107,15 @@ trait MADHttpRequest extends HasURL with HasSubscriptionKey with BasicAsyncReply
           }
         }
       })
+      val completedTime = System.nanoTime
+      val durationMs = (completedTime - startedTime)/1000000 // seconds -> milli -> micro -> nano
       it match {
         case Right(value) =>{
-          val asyncCompletionLogMessagePrefixValue = getAsyncCompletionLogMessagePrefix
-          if (asyncCompletionLogMessagePrefixValue != "") {
-            val completedTime = System.nanoTime
-            val durationMs = (completedTime - startedTime)/1000000 // seconds -> milli -> micro -> nano
-            logInfo(s"${asyncCompletionLogMessagePrefixValue}:${durationMs}")
-          }
+          logInfo(s"Async operation:succeeded=true:${durationMs}")
           value
         }
         case Left(lastStatus) => {
+          logInfo(s"Async operation:succeeded=false:${durationMs}")
           if (getSuppressMaxRetriesExceededException){
             getRetriesExceededHTTPResponseData(maxTries, lastStatus)
           } else {

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/geospatial/AzureMapsTraits.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/geospatial/AzureMapsTraits.scala
@@ -128,17 +128,15 @@ trait MapsAsyncReply extends BasicAsyncReply with BasicLogging {
           }
         }
       })
+      val completedTime = System.nanoTime
+      val durationMs = (completedTime - startedTime)/1000000 // seconds -> milli -> micro -> nano
       it match {
         case Right(value) =>{
-          val asyncCompletionLogMessagePrefixValue = getAsyncCompletionLogMessagePrefix
-          if (asyncCompletionLogMessagePrefixValue != "") {
-            val completedTime = System.nanoTime
-            val durationMs = (completedTime - startedTime)/1000000 // seconds -> milli -> micro -> nano
-            logInfo(s"${asyncCompletionLogMessagePrefixValue}:${durationMs}")
-          }
+          logInfo(s"Async operation:succeeded=true:${durationMs}")
           value
         }
         case Left(lastStatus) => {
+          logInfo(s"Async operation:succeeded=false:${durationMs}")
           if (getSuppressMaxRetriesExceededException){
             getRetriesExceededHTTPResponseData(maxTries, lastStatus)
           } else {


### PR DESCRIPTION
- Add setAsyncCompletionLogMessagePrefixValue to enable logging of async operations on completion (with duration)
- When reporting the retries exceeded error, include the last retrieved status to aid debugging