### PR TITLE
fix: missing org.json4s when saving model

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,8 @@ val extraDependencies = Seq(
   "com.jcraft" % "jsch" % "0.1.54",
   "org.apache.httpcomponents" % "httpclient" % "4.5.6",
   "org.apache.httpcomponents" % "httpmime" % "4.5.6",
-  "com.linkedin.isolation-forest" %% "isolation-forest_3.2.0" % "2.0.8"
+  "com.linkedin.isolation-forest" %% "isolation-forest_3.2.0" % "2.0.8",
+  "org.json4s" %% "json4s-native" % "4.0.3"
 ).map(d => d excludeAll (excludes: _*))
 val dependencies = coreDependencies ++ extraDependencies
 


### PR DESCRIPTION
Apache Spark 3.1
Python 3.8
Scala 2.12.10
Java 1.8.0_282

<img width="556" alt="image" src="https://user-images.githubusercontent.com/9027725/150451919-5a5c4af9-2899-46f6-bf46-8a8e959905f5.png">

The above error was encountered while trying to save LightGBM on Azure Synapse.