### PR TITLE
chore: Adding Action to sync GitHub PRs to WIs

### DIFF
--- a/.github/workflows/ado-pr-to-workitem.yml
+++ b/.github/workflows/ado-pr-to-workitem.yml
@@ -1,0 +1,23 @@
+name: Sync Pull Request to Azure Boards
+
+on:
+  pull_request:
+    types: [opened, edited, closed]
+    branches:
+      - master
+
+jobs:
+  alert:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: mhamilton723/github-actions-pr-to-work-item@master
+      env:
+        ado_token: '${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}'   
+        github_token: '${{ secrets.GH_TOKEN }}'    
+        ado_organization: 'msdata'
+        ado_project: 'A365'
+        ado_wit: 'Task' 
+        ado_new_state: 'To Do'
+        ado_active_state: 'In Progress'
+        ado_close_state: 'Done'
+        ado_area_path: 'A365\\A plus I\\Synapse ML'


### PR DESCRIPTION
This new Action will create Tasks in the destionation AzDO for every PR that is submitted to this repository.