### PR TITLE
chore: Add Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+# Description
+
+Please include a summary of the change and/or the issue being fixed. Also include any relavant information, if necessary.
+
+If any dependencies were added, make sure to list them. It is recommended to add a reason for adding this new dependency.
+
+# Test
+
+If it was a feature change or fix, please describe how you tested it. If it does not apply to your change, just add "N/A".
+
+# Before and after
+
+If applicable, provide evidences of your change. For instance, you can add slices of logs or screenshots from before your
+changes/fixes and after it.

--- a/.github/workflows/ado-pr-to-workitem.yml
+++ b/.github/workflows/ado-pr-to-workitem.yml
@@ -10,7 +10,7 @@ jobs:
   alert:
     runs-on: ubuntu-latest
     steps:
-    - uses: riserrad/github-actions-pr-to-work-item@fix-null-replace
+    - uses: riserrad/github-actions-pr-to-work-item@master
       env:
         ado_token: '${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}'   
         github_token: '${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}'    

--- a/.github/workflows/ado-pr-to-workitem.yml
+++ b/.github/workflows/ado-pr-to-workitem.yml
@@ -10,7 +10,7 @@ jobs:
   alert:
     runs-on: ubuntu-latest
     steps:
-    - uses: mhamilton723/github-actions-pr-to-work-item@master
+    - uses: riserrad/github-actions-pr-to-work-item@fix-null-replace
       env:
         ado_token: '${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}'   
         github_token: '${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}'    

--- a/.github/workflows/ado-pr-to-workitem.yml
+++ b/.github/workflows/ado-pr-to-workitem.yml
@@ -10,7 +10,7 @@ jobs:
   alert:
     runs-on: ubuntu-latest
     steps:
-    - uses: riserrad/github-actions-pr-to-work-item@user/riserrad/master/fix-nre-null-pr-desc
+    - uses: mhamilton723/github-actions-pr-to-work-item@master
       env:
         ado_token: '${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}'   
         github_token: '${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}'    

--- a/.github/workflows/ado-pr-to-workitem.yml
+++ b/.github/workflows/ado-pr-to-workitem.yml
@@ -10,7 +10,7 @@ jobs:
   alert:
     runs-on: ubuntu-latest
     steps:
-    - uses: danhellem/github-actions-pr-to-work-item@master
+    - uses: riserrad/github-actions-pr-to-work-item@user/riserrad/master/fix-nre-null-pr-desc
       env:
         ado_token: '${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}'   
         github_token: '${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}'    

--- a/.github/workflows/ado-pr-to-workitem.yml
+++ b/.github/workflows/ado-pr-to-workitem.yml
@@ -10,7 +10,7 @@ jobs:
   alert:
     runs-on: ubuntu-latest
     steps:
-    - uses: riserrad/github-actions-pr-to-work-item@user/riserrad/master/fix-nre-null-pr-desc
+    - uses: danhellem/github-actions-pr-to-work-item@master
       env:
         ado_token: '${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}'   
         github_token: '${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}'    

--- a/.github/workflows/ado-pr-to-workitem.yml
+++ b/.github/workflows/ado-pr-to-workitem.yml
@@ -10,7 +10,7 @@ jobs:
   alert:
     runs-on: ubuntu-latest
     steps:
-    - uses: riserrad/github-actions-pr-to-work-item@master
+    - uses: riserrad/github-actions-pr-to-work-item@user/riserrad/master/fix-nre-null-pr-desc
       env:
         ado_token: '${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}'   
         github_token: '${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}'    


### PR DESCRIPTION
# Description

We do have an integration between GitHub and Azure DevOps that creates Tasks for each new PR submitted to the repo.

This integration currently has an issue to handle PRs that have no description. We're adding this template to stimulate contributors to create PRs with descriptions, minimizing the impact of this active issue, which was reported already.

[Error: Cannot read property 'replace' of null - when PR description is empty](https://github.com/danhellem/github-actions-pr-to-work-item/issues/23)

# Test

I've been extensively testing it in my fork of this repo and validated that this issue happens when the PR has no description/comment.

# Before and after

N/A