### PR TITLE
Adding ado-pr-to-workitem

### DIFF
--- a/.github/workflows/ado-pr-to-workitem.yml
+++ b/.github/workflows/ado-pr-to-workitem.yml
@@ -1,0 +1,23 @@
+name: Sync Pull Request to Azure Boards
+
+on:
+  pull_request_target:
+    types: [opened, edited, closed]
+    branches:
+      - master
+
+jobs:
+  alert:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: riserrad/github-actions-pr-to-work-item@user/riserrad/master/ado_token_issue
+      env:
+        ado_token: '${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}'
+        github_token: '${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}'
+        ado_organization: 'msdata'
+        ado_project: 'A365'
+        ado_wit: 'Task'
+        ado_active_state: 'In Progress'
+        ado_close_state: 'Done'
+        ado_area_path: 'A365\\A plus I\\Synapse ML'
+        debug: false


### PR DESCRIPTION
Adding back the PR -> Work Item integration, now with `pull_request_target`