### PR TITLE
Turning sensitive AzDO data into secret

### DIFF
--- a/.github/workflows/ado-integration.yml
+++ b/.github/workflows/ado-integration.yml
@@ -13,9 +13,9 @@ jobs:
         env:
           ado_token: "${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}"
           github_token: "${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}"
-          ado_organization: "msdata"
-          ado_project: "A365"
-          ado_area_path: "A365\\A plus I\\Synapse ML"
+          ado_organization: "${{ secrets.ADO_ORGANIZATION }}"
+          ado_project: "${{ secrets.ADO_PROJECT }}"
+          ado_area_path: "${{ secrets.ADO_AREA_PATH }}"
           ado_wit: "Task"
           ado_new_state: "To Do"
           ado_active_state: "In Progress"

--- a/.github/workflows/ado-pr-to-workitem.yml
+++ b/.github/workflows/ado-pr-to-workitem.yml
@@ -14,10 +14,9 @@ jobs:
       env:
         ado_token: '${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}'
         github_token: '${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}'
-        ado_organization: 'msdata'
-        ado_project: 'A365'
+        ado_organization: '${{ secrets.ADO_ORGANIZATION }}'
+        ado_project: '${{ secrets.ADO_PROJECT }}'
         ado_wit: 'Task'
         ado_active_state: 'In Progress'
         ado_close_state: 'Done'
-        ado_area_path: 'A365\\A plus I\\Synapse ML'
-        debug: false
+        ado_area_path: '${{ secrets.ADO_AREA_PATH }}'


### PR DESCRIPTION
Some internal AzDO information might be sensitive, so I turned them into secrets.

This also makes things easier if any of these change in the future.