### PR TITLE
fix: fix breaking ADB test

### DIFF
--- a/notebooks/features/responsible_ai/Interpretability - Explanation Dashboard.ipynb
+++ b/notebooks/features/responsible_ai/Interpretability - Explanation Dashboard.ipynb
@@ -292,7 +292,8 @@
    },
    "outputs": [],
    "source": [
-    "!pip install --upgrade raiwidgets"
+    "!pip install --upgrade raiwidgets\n",
+    "!pip install itsdangerous==2.0.1"
    ]
   },
   {


### PR DESCRIPTION
Fix breaking ADB test because itsdangerous package has a latest update that remove the deprecated usage of importing json directly.