### PR TITLE
fix: update website doc of Spark3.1 version installation on Synapase

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -273,7 +273,7 @@ function Home() {
 {
   "name": "synapseml",
   "conf": {
-      "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:0.9.4",
+      "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:0.9.5-13-d1b51517-SNAPSHOT",
       "spark.jars.repositories": "https://mmlspark.azureedge.net/maven",
       "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12",
       "spark.yarn.user.classpath.first": "true"
@@ -300,9 +300,9 @@ function Home() {
                   SynapseML can be conveniently installed on existing Spark
                   clusters via the --packages option, examples:
                   <CodeSnippet
-                    snippet={`spark-shell --packages com.microsoft.azure:synapseml_2.12:0.9.4 # Please use 0.9.4 version for Spark3.1 and 0.9.5 version for Spark3.2
-pyspark --packages com.microsoft.azure:synapseml_2.12:0.9.4
-spark-submit --packages com.microsoft.azure:synapseml_2.12:0.9.4 MyApp.jar `}
+                    snippet={`spark-shell --packages com.microsoft.azure:synapseml_2.12:0.9.5 # Please use 0.9.5 version for Spark3.2 and 0.9.5-13-d1b51517-SNAPSHOT version for Spark3.1
+pyspark --packages com.microsoft.azure:synapseml_2.12:0.9.5
+spark-submit --packages com.microsoft.azure:synapseml_2.12:0.9.5 MyApp.jar `}
                     lang="bash"
                   ></CodeSnippet>
                   This can be used in other Spark contexts too. For example, you
@@ -330,7 +330,7 @@ spark-submit --packages com.microsoft.azure:synapseml_2.12:0.9.4 MyApp.jar `}
                     <p>For the coordinates:</p>
                     Spark 3.1 Cluster:
                     <CodeSnippet
-                      snippet={`com.microsoft.azure:synapseml_2.12:0.9.4`}
+                      snippet={`com.microsoft.azure:synapseml_2.12:0.9.5-13-d1b51517-SNAPSHOT`}
                       lang="bash"
                     ></CodeSnippet>
                     Spark 3.2 Cluster:
@@ -391,7 +391,7 @@ spark-submit --packages com.microsoft.azure:synapseml_2.12:0.9.4 MyApp.jar `}
                   <CodeSnippet
                     snippet={`import pyspark
 spark = pyspark.sql.SparkSession.builder.appName("MyApp")
-        .config("spark.jars.packages", "com.microsoft.azure:synapseml_2.12:0.9.4") # Please use 0.9.4 version for Spark3.1 and 0.9.5 version for Spark3.2
+        .config("spark.jars.packages", "com.microsoft.azure:synapseml_2.12:0.9.5") # Please use 0.9.5 version for Spark3.2 and 0.9.5-13-d1b51517-SNAPSHOT version for Spark3.1
         .config("spark.jars.repositories", "https://mmlspark.azureedge.net/maven")
         .getOrCreate()
 import synapse.ml`}
@@ -403,7 +403,7 @@ import synapse.ml`}
                   following lines to your build.sbt:
                   <CodeSnippet
                     snippet={`resolvers += "SynapseML" at "https://mmlspark.azureedge.net/maven"
-libraryDependencies += "com.microsoft.azure" %% "synapseml" % "0.9.4" // Please use 0.9.4 version for Spark3.1 and 0.9.5 version for Spark3.2`}
+libraryDependencies += "com.microsoft.azure" %% "synapseml_2.12" % "0.9.5" // Please use 0.9.5 version for Spark3.2 and 0.9.5-13-d1b51517-SNAPSHOT version for Spark3.1`}
                     lang="jsx"
                   ></CodeSnippet>
                 </TabItem>


### PR DESCRIPTION
Update website homepage installation guidance's Spark3.1 version of SynapseML, we use version 0.9.5-13-d1b51517-SNAPSHOT for now that includes latest features.

Tested UI rendering.