### PR TITLE
fix: add retry to reduce flakiness

### DIFF
--- a/notebooks/features/geospatial_services/GeospatialServices - Flooding Risk.ipynb
+++ b/notebooks/features/geospatial_services/GeospatialServices - Flooding Risk.ipynb
@@ -78,7 +78,7 @@
     "if user_data_response.status_code > 201:\n",
     "  raise ValueError(f\"Unknown response status code {user_data_response.status_code}:: Error: {user_data_response.content}\")\n",
     "\n",
-    "user_data_id = json.loads(requests.get(user_data_response.content))['udid']"
+    "user_data_id = json.loads(user_data_response.content)['udid']"
    ]
   },
   {

--- a/notebooks/features/geospatial_services/GeospatialServices - Flooding Risk.ipynb
+++ b/notebooks/features/geospatial_services/GeospatialServices - Flooding Risk.ipynb
@@ -66,7 +66,19 @@
     "\n",
     "# Once the above operation returns a HTTP 201, get the user_data_id of the flood plains data, you uploaded to your map account.\n",
     "user_data_id_resource_url = resource['resourceLocation']\n",
-    "user_data_id = json.loads(requests.get(f'{user_data_id_resource_url}&subscription-key={azureMapsKey}').content)['udid']"
+    "user_data_response = requests.get(f'{user_data_id_resource_url}&subscription-key={azureMapsKey}')\n",
+    "\n",
+    "for _ in range(20):\n",
+    "  if user_data_response.status_code == 201:\n",
+    "    break\n",
+    "  else:\n",
+    "    time.sleep(5) # wait for a few seconds\n",
+    "    user_data_response = requests.get(f'{user_data_id_resource_url}&subscription-key={azureMapsKey}')\n",
+    "\n",
+    "if user_data_response.status_code > 201:\n",
+    "  raise ValueError(f\"Unknown response status code {user_data_response.status_code}:: Error: {user_data_response.content}\")\n",
+    "\n",
+    "user_data_id = json.loads(requests.get(user_data_response.content))['udid']"
    ]
   },
   {


### PR DESCRIPTION
# Summary
- The `GET` flood-line user-data in the `GeospatialServices-FloodingRisk` notebook can be flaky sometimes.
Adding simple retry
# Tests
N/A
# Dependency chances
N/A