### PR TITLE
feat: Upgrade the univariate anomaly detection version to v1.1-preview

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetection.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetection.scala
@@ -101,6 +101,18 @@ abstract class AnomalyDetectorBase(override val uid: String) extends CognitiveSe
 
   def setImputeModeCol(v: String): this.type = setVectorParam(imputeMode, v)
 
+  val imputeFixedValue = new ServiceParam[Double](this, "imputeFixedValue",
+    """
+      |Optional argument, fixed value to use when imputeMode is set to "fixed"
+    """.stripMargin.replace("\n", " ").replace("\r", " "),
+    { _ => true },
+    isRequired = false
+  ) 
+
+  def setImputeFixedValue(v: Double): this.type = setScalarParam(imputeFixedValue, v)
+
+  def setImputeFixedValueCol(v: String): this.type = setVectorParam(imputeFixedValue, v)
+  
   val series = new ServiceParam[Seq[TimeSeriesPoint]](this, "series",
     """
       |Time series data points. Points should be sorted by timestamp in ascending order
@@ -117,6 +129,7 @@ abstract class AnomalyDetectorBase(override val uid: String) extends CognitiveSe
       getValueAny(row, series).asInstanceOf[Seq[Any]].map {
         case tsp: TimeSeriesPoint => tsp
         case r: Row => TimeSeriesPoint(r.getString(0), r.getDouble(1))
+        // TODO imputeMode is string
       },
       getValue(row, granularity),
       getValueOpt(row, maxAnomalyRatio),

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetection.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetection.scala
@@ -107,7 +107,7 @@ abstract class AnomalyDetectorBase(override val uid: String) extends CognitiveSe
     """.stripMargin.replace("\n", " ").replace("\r", " "),
     { _ => true },
     isRequired = false
-  ) 
+  )
 
   def setImputeFixedValue(v: Double): this.type = setScalarParam(imputeFixedValue, v)
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetection.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetection.scala
@@ -135,7 +135,7 @@ abstract class AnomalyDetectorBase(override val uid: String) extends CognitiveSe
       getValueOpt(row, sensitivity),
       getValueOpt(row, customInterval),
       getValueOpt(row, period),
-      getValueOpt(row, imputeMode)
+      getValueOpt(row, imputeMode),
       getValueOpt(row, imputeFixedValue)
     ).toJson.compactPrint))
   }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetection.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetection.scala
@@ -125,7 +125,7 @@ class DetectLastAnomaly(override val uid: String) extends AnomalyDetectorBase(ui
 
   def setSeriesCol(v: String): this.type = setVectorParam(series, v)
 
-  def urlPath: String = "/anomalydetector/v1.0/timeseries/last/detect"
+  def urlPath: String = "/anomalydetector/v1.1-preview.1/timeseries/last/detect"
 
   override def responseDataType: DataType = ADLastResponse.schema
 
@@ -142,7 +142,7 @@ class DetectAnomalies(override val uid: String) extends AnomalyDetectorBase(uid)
 
   def setSeriesCol(v: String): this.type = setVectorParam(series, v)
 
-  def urlPath: String = "/anomalydetector/v1.0/timeseries/entire/detect"
+  def urlPath: String = "/anomalydetector/v1.1-preview.1/timeseries/entire/detect"
 
   override def responseDataType: DataType = ADEntireResponse.schema
 
@@ -238,7 +238,7 @@ class SimpleDetectAnomalies(override val uid: String) extends AnomalyDetectorBas
 
   }
 
-  def urlPath: String = "/anomalydetector/v1.0/timeseries/entire/detect"
+  def urlPath: String = "/anomalydetector/v1.1-preview.1/timeseries/entire/detect"
 
   override def responseDataType: DataType = ADEntireResponse.schema
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetection.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetection.scala
@@ -129,7 +129,6 @@ abstract class AnomalyDetectorBase(override val uid: String) extends CognitiveSe
       getValueAny(row, series).asInstanceOf[Seq[Any]].map {
         case tsp: TimeSeriesPoint => tsp
         case r: Row => TimeSeriesPoint(r.getString(0), r.getDouble(1))
-        // TODO imputeMode is string
       },
       getValue(row, granularity),
       getValueOpt(row, maxAnomalyRatio),

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetection.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetection.scala
@@ -88,6 +88,19 @@ abstract class AnomalyDetectorBase(override val uid: String) extends CognitiveSe
 
   def setPeriodCol(v: String): this.type = setVectorParam(period, v)
 
+  val imputeMode = new ServiceParam[String](this, "imputeMode",
+    """
+      |Optional argument, impute mode of a time series.
+      |Possible values: auto, previous, linear, fixed, zero, notFill
+    """.stripMargin.replace("\n", " ").replace("\r", " "),
+    { _ => true },
+    isRequired = false
+  )
+
+  def setImputeMode(v: String): this.type = setScalarParam(imputeMode, v)
+
+  def setImputeModeCol(v: String): this.type = setVectorParam(imputeMode, v)
+
   val series = new ServiceParam[Seq[TimeSeriesPoint]](this, "series",
     """
       |Time series data points. Points should be sorted by timestamp in ascending order
@@ -109,7 +122,8 @@ abstract class AnomalyDetectorBase(override val uid: String) extends CognitiveSe
       getValueOpt(row, maxAnomalyRatio),
       getValueOpt(row, sensitivity),
       getValueOpt(row, customInterval),
-      getValueOpt(row, period)
+      getValueOpt(row, period),
+      getValueOpt(row, imputeMode)
     ).toJson.compactPrint))
   }
 }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetection.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetection.scala
@@ -112,7 +112,7 @@ abstract class AnomalyDetectorBase(override val uid: String) extends CognitiveSe
   def setImputeFixedValue(v: Double): this.type = setScalarParam(imputeFixedValue, v)
 
   def setImputeFixedValueCol(v: String): this.type = setVectorParam(imputeFixedValue, v)
-  
+
   val series = new ServiceParam[Seq[TimeSeriesPoint]](this, "series",
     """
       |Time series data points. Points should be sorted by timestamp in ascending order
@@ -137,6 +137,7 @@ abstract class AnomalyDetectorBase(override val uid: String) extends CognitiveSe
       getValueOpt(row, customInterval),
       getValueOpt(row, period),
       getValueOpt(row, imputeMode)
+      getValueOpt(row, imputeFixedValue)
     ).toJson.compactPrint))
   }
 }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetectorSchemas.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetectorSchemas.scala
@@ -17,7 +17,8 @@ case class ADRequest(series: Seq[TimeSeriesPoint],
                      sensitivity: Option[Int],
                      customInterval: Option[Int],
                      period: Option[Int],
-                     imputeMode: Option[String])
+                     imputeMode: Option[String],
+                     imputeFixedValue: Option[Double])
 
 object ADRequest extends SparkBindings[ADRequest]
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetectorSchemas.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetectorSchemas.scala
@@ -16,7 +16,8 @@ case class ADRequest(series: Seq[TimeSeriesPoint],
                      maxAnomalyRatio: Option[Double],
                      sensitivity: Option[Int],
                      customInterval: Option[Int],
-                     period: Option[Int])
+                     period: Option[Int],
+                     imputeMode: Option[String])
 
 object ADRequest extends SparkBindings[ADRequest]
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetectorSchemas.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetectorSchemas.scala
@@ -27,7 +27,8 @@ case class ADLastResponse(isAnomaly: Boolean,
                           expectedValue: Double,
                           upperMargin: Double,
                           lowerMargin: Double,
-                          suggestedWindow: Int)
+                          suggestedWindow: Int,
+                          severity: Double)
 
 object ADLastResponse extends SparkBindings[ADLastResponse]
 
@@ -37,7 +38,8 @@ case class ADSingleResponse(isAnomaly: Boolean,
                             period: Int,
                             expectedValue: Double,
                             upperMargin: Double,
-                            lowerMargin: Double)
+                            lowerMargin: Double,
+                            severity: Double)
 
 object ADSingleResponse extends SparkBindings[ADSingleResponse]
 
@@ -47,13 +49,14 @@ case class ADEntireResponse(isAnomaly: Seq[Boolean],
                             period: Int,
                             expectedValues: Seq[Double],
                             upperMargins: Seq[Double],
-                            lowerMargins: Seq[Double]) {
+                            lowerMargins: Seq[Double],
+                            severity: Seq[Double]) {
 
   def explode: Seq[ADSingleResponse] = {
     isAnomaly.indices.map { i =>
       ADSingleResponse(
         isAnomaly(i), isPositiveAnomaly(i), isNegativeAnomaly(i),
-        period, expectedValues(i), upperMargins(i), lowerMargins(i)
+        period, expectedValues(i), upperMargins(i), lowerMargins(i), severity(i)
       )
     }
   }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetectorSchemas.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/AnomalyDetectorSchemas.scala
@@ -68,5 +68,5 @@ object ADEntireResponse extends SparkBindings[ADEntireResponse]
 
 object AnomalyDetectorProtocol {
   implicit val TspEnc: RootJsonFormat[TimeSeriesPoint] = jsonFormat2(TimeSeriesPoint.apply)
-  implicit val AdreqEnc: RootJsonFormat[ADRequest] = jsonFormat6(ADRequest.apply)
+  implicit val AdreqEnc: RootJsonFormat[ADRequest] = jsonFormat8(ADRequest.apply)
 }


### PR DESCRIPTION
This PR upgrades the version of the univariate anomaly detection API endpoint to `v1.1-preview.1` to add support for an optional parameter `imputeMode` in the input, and expect severity scores in the output.