### PR TITLE
fix: Fix reflective class loading in IntelliJ

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/JarLoadingUtils.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/JarLoadingUtils.scala
@@ -8,9 +8,8 @@ import com.microsoft.azure.synapse.ml.codegen.Wrappable
 import java.lang.reflect.Modifier
 import org.sparkproject.guava.reflect.ClassPath
 
-import java.io.{File, InputStreamReader, IOException}
+import java.io.{File, IOException}
 import scala.collection.JavaConverters._
-import scala.collection.mutable.ListBuffer
 import scala.reflect.{ClassTag, classTag}
 
 /** Contains logic for loading classes. */
@@ -115,7 +114,7 @@ object JarLoadingUtils {
         case f if f.isDirectory => findClassesInDirectory(f, packageName + "." + file.getName)
         case f if f.getName.endsWith(".class") =>
           Seq[Class[_]](Class.forName(packageName + '.' + file.getName.substring(0, file.getName.length - 6)))
-        case _ => Seq[Class[_]]() // some other file, just ignore
+        case _ => Seq.empty // some other file, just ignore
       }
     }).flatten.toSeq
   }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/JarLoadingUtils.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/JarLoadingUtils.scala
@@ -8,11 +8,15 @@ import com.microsoft.azure.synapse.ml.codegen.Wrappable
 import java.lang.reflect.Modifier
 import org.sparkproject.guava.reflect.ClassPath
 
+import java.io.{File, InputStreamReader, IOException}
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
 import scala.reflect.{ClassTag, classTag}
 
 /** Contains logic for loading classes. */
 object JarLoadingUtils {
+
+  private var CachedAllClasses: List[Class[_]] = List[Class[_]]()
 
   def className(filename: String): String = {
     if (filename.endsWith(".class")) {
@@ -23,18 +27,24 @@ object JarLoadingUtils {
     }
   }
 
+  import java.io.BufferedReader
+  //import java.util.stream.Collectors
+  //import java.util.Collection
+
+  private def getClassFromName(className: String, packageName: String): Class[_] = {
+    try {
+      Class.forName(packageName + "." + className.substring(0, className.lastIndexOf('.')))
+    }
+    catch {
+      case e: ClassNotFoundException =>
+      null
+      // handle the exception
+    }
+  }
+
   private[ml] val AllClasses = {
-    ClassPath.from(getClass.getClassLoader)
-      .getResources.asScala.toList
-      .map(ri => className(ri.getResourceName))
-      .filter(_.startsWith("com.microsoft.azure.synapse"))
-      .flatMap { cn =>
-        try {
-          Some(Class.forName(cn))
-        } catch {
-          case _: Throwable => None: Option[Class[_]]
-        }
-      }
+    if (CachedAllClasses.isEmpty) CachedAllClasses = getAllClasses
+    CachedAllClasses
   }
 
   private[ml] val WrappableClasses = {
@@ -62,4 +72,85 @@ object JarLoadingUtils {
     },
     jarName)
 
+  /**
+    * Get all relevant classes from the ClassLoader.
+    *
+    * Note that the spark ClassPath utility only works for ClassLoaders derived from UrlClassLoader (which sbt uses).
+    * In IntelliJ, the ClassLoader is not a UrlClassLoader (standard App/Ext/Boot loaders), so in that case
+    * we use a different slower method.
+    *
+    * @return A list of classes in the main package and its modules
+    */
+  private def getAllClasses: List[Class[_]] = {
+    // ClassPath is more performant, so we try that first
+    val urlBasedClasses = ClassPath.from(getClass.getClassLoader)
+      .getResources.asScala.toList
+      .map(ri => className(ri.getResourceName))
+      .filter(_.startsWith("com.microsoft.azure.synapse"))
+      .flatMap { cn =>
+        try {
+          Some(Class.forName(cn))
+        } catch {
+          case _: Throwable => None: Option[Class[_]]
+        }
+      }
+
+    // If the list is empty, likely we are running in IntelliJ, so use a different slower method to list the classes
+    if (!urlBasedClasses.isEmpty) urlBasedClasses else getClassesFromPackage("com.microsoft.azure.synapse")
+  }
+
+  /**
+    * Scans all classes accessible from the context class loader which belong to the given package and subpackages.
+    *
+    * @param packageName The base package
+    * @return The classes
+    * @throws ClassNotFoundException
+    * @throws IOException
+    */
+  @throws[ClassNotFoundException]
+  @throws[IOException]
+  private def getClassesFromPackage(packageName: String): List[Class[_]] = {
+    val classLoader = Thread.currentThread.getContextClassLoader
+    assert(classLoader != null)
+
+    // ClassLoader does not expose a class list (except private vars), so scan the jar files directly
+    val path = packageName.replace('.', '/')
+    val resources = classLoader.getResources(path).asIterator()
+    val dirs = new ListBuffer[File]
+    for (resource <- resources.asScala) {
+      dirs += new File(resource.getFile)
+    }
+
+    val classes = new ListBuffer[Class[_]]
+    for (directory <- dirs) {
+      classes ++= findClassesInDirectory(directory, packageName)
+    }
+    classes.toList
+  }
+
+  /**
+    * Recursive method used to find all classes in a given directory and subdirs.
+    *
+    * @param directory   The base directory
+    * @param packageName The package name for classes found inside the base directory
+    * @return The classes
+    * @throws ClassNotFoundException
+    */
+  @throws[ClassNotFoundException]
+  private def findClassesInDirectory(directory: File, packageName: String): ListBuffer[Class[_]] = {
+    val classes = new ListBuffer[Class[_]]
+    if (directory.exists) {
+      val files = directory.listFiles
+      for (file <- files) {
+        if (file.isDirectory) {
+          assert(!file.getName.contains("."))
+          classes ++= findClassesInDirectory(file, packageName + "." + file.getName)
+        }
+        else if (file.getName.endsWith(".class")) {
+          classes += Class.forName(packageName + '.' + file.getName.substring(0, file.getName.length - 6))
+        }
+      }
+    }
+    classes
+  }
 }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/JarLoadingUtils.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/JarLoadingUtils.scala
@@ -27,21 +27,6 @@ object JarLoadingUtils {
     }
   }
 
-  import java.io.BufferedReader
-  //import java.util.stream.Collectors
-  //import java.util.Collection
-
-  private def getClassFromName(className: String, packageName: String): Class[_] = {
-    try {
-      Class.forName(packageName + "." + className.substring(0, className.lastIndexOf('.')))
-    }
-    catch {
-      case e: ClassNotFoundException =>
-      null
-      // handle the exception
-    }
-  }
-
   private[ml] val AllClasses = {
     if (CachedAllClasses.isEmpty) CachedAllClasses = getAllClasses
     CachedAllClasses

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/swig/SwigUtils.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/swig/SwigUtils.scala
@@ -31,8 +31,8 @@ abstract class ChunkedArray[T]() {
   def add(value: T): Unit
 }
 
-object floatChunkedArray {
-  def apply(size: Long): floatChunkedArray = {
+object FloatChunkedArray {
+  private def apply(size: Long): floatChunkedArray = {
     if (size <= 0) {
       throw new IllegalArgumentException("Chunked array size must be greater than zero")
     }
@@ -41,7 +41,7 @@ object floatChunkedArray {
 }
 
 class FloatChunkedArray(array: floatChunkedArray) extends ChunkedArray[Float] {
-  def this(size: Long) = this(floatChunkedArray(size))
+  def this(size: Long) = this(FloatChunkedArray(size))
 
   def getChunksCount: Long = array.get_chunks_count()
 
@@ -59,8 +59,8 @@ class FloatChunkedArray(array: floatChunkedArray) extends ChunkedArray[Float] {
   def coalesceTo(floatSwigArray: FloatSwigArray): Unit = array.coalesce_to(floatSwigArray.array)
 }
 
-object doubleChunkedArray {
-  def apply(size: Long): doubleChunkedArray = {
+object DoubleChunkedArray {
+  private def apply(size: Long): doubleChunkedArray = {
     if (size <= 0) {
       throw new IllegalArgumentException("Chunked array size must be greater than zero")
     }
@@ -69,7 +69,7 @@ object doubleChunkedArray {
 }
 
 class DoubleChunkedArray(array: doubleChunkedArray) extends ChunkedArray[Double] {
-  def this(size: Long) = this(doubleChunkedArray(size))
+  def this(size: Long) = this(DoubleChunkedArray(size))
 
   def getChunksCount: Long = array.get_chunks_count()
 
@@ -87,8 +87,8 @@ class DoubleChunkedArray(array: doubleChunkedArray) extends ChunkedArray[Double]
   def coalesceTo(doubleSwigArray: DoubleSwigArray): Unit = array.coalesce_to(doubleSwigArray.array)
 }
 
-object int32ChunkedArray {
-  def apply(size: Long): int32ChunkedArray = {
+object IntChunkedArray {
+  private def apply(size: Long): int32ChunkedArray = {
     if (size <= 0) {
       throw new IllegalArgumentException("Chunked array size must be greater than zero")
     }
@@ -97,7 +97,7 @@ object int32ChunkedArray {
 }
 
 class IntChunkedArray(array: int32ChunkedArray) extends ChunkedArray[Int] {
-  def this(size: Long) = this(int32ChunkedArray(size))
+  def this(size: Long) = this(IntChunkedArray(size))
 
   def getChunksCount: Long = array.get_chunks_count()
 


### PR DESCRIPTION
# Summary

Some tests rely on the ability to reflect all classes in the synpaseml package (e.g. to filter to a set of all classes derived from a particular parent class).  The current implementation uses ClassPath.from() from a spark utility package.  However, this utility only works for ClassLoaders derived from UrlClassLoader (not well documented limitation).  In the context of sbt, this is true, so things work in pipelines and such. In IntelliJ, the ClassLoaders are the standard App/Ext/Boot trio, which are not, so any test using this pathway fails since ClassPath.from() returns an empty list.  

This PR adds a double check so that if the reflected class list from ClassPath comes back empty, it falls back to a manual lookup. This lookup is slower, so the choice was to not replace it, but instead add a path that should only run when a test is run from inside IntelliJ.  Caching was added so the lookup is only done once in either case.

# Tests

Some tests that were failing before in IntelliJ now work (used first FuzzingTest as a canary).  Due to the nature of the fix, there is no way to test this in the pipelines since they use sbt.

# Dependency chances

N/A