### PR TITLE
fix: lightgbm getting stuck when empty partition is chosen as the main worker in singleDatasetMode

### DIFF
--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/SharedState.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/SharedState.scala
@@ -83,7 +83,6 @@ class SharedDatasetState(columnParams: ColumnParams,
 class SharedState(columnParams: ColumnParams,
                   schema: StructType,
                   trainParams: BaseTrainParams) {
-  val mainExecutorWorker: Long = LightGBMUtils.getTaskId
   val useSingleDataset: Boolean = trainParams.executionParams.useSingleDatasetMode
   val chunkSize: Int = trainParams.executionParams.chunkSize
   val matrixType: String = trainParams.executionParams.matrixType
@@ -92,12 +91,23 @@ class SharedState(columnParams: ColumnParams,
   val validationDatasetState: SharedDatasetState = new SharedDatasetState(columnParams, schema, trainParams, this)
 
   @volatile var isSparse: Option[Boolean] = None
+  @volatile var mainExecutorWorker: Option[Long] = None
 
   def linkIsSparse(isSparse: Boolean): Unit = {
     if (this.isSparse.isEmpty) {
       this.synchronized {
         if (this.isSparse.isEmpty) {
           this.isSparse = Some(isSparse)
+        }
+      }
+    }
+  }
+
+  def linkMainExecutorWorker(): Unit = {
+    if (this.mainExecutorWorker.isEmpty) {
+      this.synchronized {
+        if (this.mainExecutorWorker.isEmpty) {
+          this.mainExecutorWorker = Some(LightGBMUtils.getTaskId)
         }
       }
     }

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/TaskTrainingMethods.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/TaskTrainingMethods.scala
@@ -14,16 +14,13 @@ object TaskTrainingMethods {
     * Otherwise, returns true for all tasks.
     * @param trainParams The training parameters.
     * @param log The logger.
+    * @param sharedState The shared state.
     * @return Whether the current task is enabled.
     */
   def isWorkerEnabled(trainParams: BaseTrainParams, log: Logger, sharedState: SharedState): Boolean = {
     if (trainParams.executionParams.useSingleDatasetMode) {
       // Find all workers in current JVM
-      val mainExecutorWorker = sharedState.mainExecutorWorker
-      val myTaskId = LightGBMUtils.getTaskId
-      val isMainWorker = mainExecutorWorker == myTaskId
-      log.info(s"Using singleDatasetMode.  " +
-        s"Is main worker: ${isMainWorker} for task id: ${myTaskId} and main task id: ${mainExecutorWorker}")
+      val isMainWorker = isCurrentTaskMainWorker(log, sharedState)
       sharedState.incrementArrayProcessedSignal(log)
       if (!isMainWorker) {
         sharedState.incrementDoneSignal(log)
@@ -32,6 +29,21 @@ object TaskTrainingMethods {
     } else {
       true
     }
+  }
+
+  /** Determines if the current task is the main worker in the current JVM.
+    *
+    * @param log The logger.
+    * @param sharedState The shared state.
+    * @return True if the current task in the main worker, false otherwise.
+    */
+  def isCurrentTaskMainWorker(log: Logger, sharedState: SharedState): Boolean = {
+    val mainExecutorWorker = sharedState.mainExecutorWorker.get
+    val myTaskId = LightGBMUtils.getTaskId
+    val isMainWorker = mainExecutorWorker == myTaskId
+    log.info(s"Using singleDatasetMode.  " +
+      s"Is main worker: ${isMainWorker} for task id: ${myTaskId} and main task id: ${mainExecutorWorker}")
+    isMainWorker
   }
 
   def prepareDatasets(inputRows: Iterator[Row],


### PR DESCRIPTION
# Summary

Lightgbm can get stuck when SingleDatasetMode is enabled and if an empty partition is, by random chance, chosen as the main worker in the executor.
The fix is to only allow non-empty partitions to be chosen as the main worker.

# Tests

Run the test "Verify LightGBM Classifier won't get stuck on empty partitions" in the file:
https://github.com/microsoft/SynapseML/blob/master/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMClassifier.scala#L610
many times, by random chance it will often get stuck after several runs.

# Dependency chances

No dependency changes.