### PR TITLE
fix: Fix building of quadratic parameter in Vowpal Wabbit

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/ParamsStringBuilder.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/ParamsStringBuilder.scala
@@ -70,7 +70,7 @@ class ParamsStringBuilder(parent: Option[Params], prefix: String, delimiter: Str
     this
   }
 
-  /** Add a repeatable parameter name-value pair to the end of the current string (e.g. "-q aa -q bb").
+  /** Add a parameter name-value pair for each array element to the end of the current string (e.g. "-q aa -q bb").
     * @param optionShort Short name of the parameter (only used to check against existing params).
     * @param optionLong Long name of the parameter.  Will be used if it is not already set.
     * @param param The Param object with the value.  Note that if this is not set, nothing will be appended to string.

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/ParamsStringBuilder.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/ParamsStringBuilder.scala
@@ -64,9 +64,30 @@ class ParamsStringBuilder(parent: Option[Params], prefix: String, delimiter: Str
           appendParamListIfNotThere(optionLong, getParamValue(param).get.asInstanceOf[Array[Double]])
         case _: StringArrayParam =>
           appendParamListIfNotThere(optionLong, getParamValue(param).get.asInstanceOf[Array[String]])
-          //for (q <- getParamValue(param).get)  TODO this is the old code for Array[String], but seems wrong
-          //  append(s"$prefix$optionLong$delimiter$q")
         case _ => append(s"$prefix$optionLong$delimiter${getParamValue(param).get}")
+      }
+    }
+    this
+  }
+
+  /** Add a repeatable parameter name-value pair to the end of the current string (e.g. "-q aa -q bb").
+    * @param optionShort Short name of the parameter (only used to check against existing params).
+    * @param optionLong Long name of the parameter.  Will be used if it is not already set.
+    * @param param The Param object with the value.  Note that if this is not set, nothing will be appended to string.
+    */
+  def appendRepeatableParamIfNotThere[T](optionShort: String,
+                                          optionLong: String,
+                                          param: Param[T]): ParamsStringBuilder = {
+    if (getParamValue(param).isDefined)
+    {
+      param match {
+        case _: IntArrayParam =>
+          appendRepeatableParamIfNotThere(optionShort, optionLong, getParamValue(param).get.asInstanceOf[Array[Int]])
+        case _: DoubleArrayParam =>
+          appendRepeatableParamIfNotThere(optionShort, optionLong, getParamValue(param).get.asInstanceOf[Array[Double]])
+        case _: StringArrayParam =>
+          appendRepeatableParamIfNotThere(optionShort, optionLong, getParamValue(param).get.asInstanceOf[Array[String]])
+        case _ => throw new IllegalArgumentException("Repeatable param must be an array")
       }
     }
     this
@@ -104,6 +125,21 @@ class ParamsStringBuilder(parent: Option[Params], prefix: String, delimiter: Str
   def appendParamListIfNotThere[T](name: String, values: Array[T]): ParamsStringBuilder = {
     if (!values.isEmpty && s"$prefix$name".r.findAllIn(sb.result).isEmpty) {
       appendParamList(name, values)
+    }
+    this
+  }
+
+  /** Add a parameter that can be repeated, once for each element in the array (e.g. "-q aa -q bb")
+    * @param optionLong Long name of the parameter.  Will be used if it is not already set.
+    * @param values The Array of values.  Note that if the array is empty, nothing will be appended to string.
+    */
+  def appendRepeatableParamIfNotThere[T](optionShort: String,
+                                         optionLong: String,
+                                         values: Array[T]): ParamsStringBuilder = {
+    for (str <- values) {
+      val shortPair = s"$prefix$optionShort$delimiter$str"
+      val longPair = s"$prefix$optionLong$delimiter$str"
+      if (shortPair.r.findAllIn(sb.result).isEmpty && longPair.r.findAllIn(sb.result).isEmpty) append(longPair)
     }
     this
   }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/core/utils/VerifyParamsStringBuilder.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/core/utils/VerifyParamsStringBuilder.scala
@@ -16,6 +16,8 @@ class VerifyParamsStringBuilder extends TestBase {
       .append("pass_through_flag")
       .append("-short_param=ok")
       .append("-short_param_with_space ok2")
+      .append("repeated_param=p1")
+      .append("rp=p2")
       .appendParamFlagIfNotThere("some_param_flag")
       .appendParamFlagIfNotThere("pass_through_flag") // should not add
       .appendParamListIfNotThere("some_param_list", Array[Int](3, 4, 5))
@@ -24,6 +26,9 @@ class VerifyParamsStringBuilder extends TestBase {
       .appendParamValueIfNotThere("null_param", None) // should not add
       .appendParamValueIfNotThere("some_param", Option(10))
       .appendParamValueIfNotThere("pass_through_param", Option("bad_val")) // should not add
+      .appendRepeatableParamIfNotThere("rp",
+        "repeated_param",
+        Array("p1", "p2", "p3")) // should not add p1 or p2
 
     val expectedStr: String = "pass_through_param=custom" +
       " pass_through_param_with_space custom2" +
@@ -31,9 +36,12 @@ class VerifyParamsStringBuilder extends TestBase {
       " pass_through_flag" +
       " -short_param=ok" +
       " -short_param_with_space ok2" +
+      " repeated_param=p1" +
+      " rp=p2" +
       " some_param_flag" +
       " some_param_list=3,4,5" +
-      " some_param=10"
+      " some_param=10" +
+      " repeated_param=p3"
 
     assert(psb.result == expectedStr)
   }
@@ -85,6 +93,7 @@ class VerifyParamsStringBuilder extends TestBase {
       .appendParamValueIfNotThere("string_array_value", "string_array_value", testParamsContainer.testStringArray)
       .appendParamValueIfNotThere("int_array_value", "int_array_value", testParamsContainer.testIntArray)
       .appendParamValueIfNotThere("double_array_value", "double_array_value", testParamsContainer.testDoubleArray)
+      .appendRepeatableParamIfNotThere("r", "repeated", testParamsContainer.testStringArray)
 
     val expectedStr: String = "--string_value some_string" +
       " --int_value 3" +
@@ -92,7 +101,10 @@ class VerifyParamsStringBuilder extends TestBase {
       " --double_value 3.0" +
       " --string_array_value one,two,three" +
       " --int_array_value 1,2,3" +
-      " --double_array_value 1.0,2.0,3.0"
+      " --double_array_value 1.0,2.0,3.0" +
+      " --repeated one" +
+      " --repeated two" +
+      " --repeated three"
 
     assert(psb.result == expectedStr)
   }
@@ -108,6 +120,7 @@ class VerifyParamsStringBuilder extends TestBase {
       .appendParamValueIfNotThere("string_array_value", "string_array_value", testParamsContainer.testStringArray)
       .appendParamValueIfNotThere("int_array_value", "int_array_value", testParamsContainer.testIntArray)
       .appendParamValueIfNotThere("double_array_value", "double_array_value", testParamsContainer.testDoubleArray)
+      .appendRepeatableParamIfNotThere("r", "repeated", testParamsContainer.testDoubleArray)
 
     val expectedStr: String = "" // Since no parameters were set, they should not have been appended to string
 
@@ -126,6 +139,13 @@ class VerifyParamsStringBuilder extends TestBase {
     assertThrows[IllegalArgumentException] {
       val psb = new ParamsStringBuilder(prefix = "--", delimiter = " ")
         .appendParamValueIfNotThere("string_value", "string_value", testParamsContainer.testString)
+    }
+
+    // Can only pass Array types to appendRepeatableParamIfNotThere
+    testParamsContainer.setString("val")
+    assertThrows[IllegalArgumentException] {
+      val psb = new ParamsStringBuilder(prefix = "--", delimiter = " ")
+        .appendRepeatableParamIfNotThere("s", "string_value", testParamsContainer.testString)
     }
   }
 

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -293,6 +293,7 @@ jobs:
       displayName: 'publish jar package to maven central'
 
 - job: PythonTests
+  timeoutInMinutes: 120
   cancelTimeoutInMinutes: 0
   condition: eq(variables.runTests, 'True')
   pool:

--- a/vw/src/main/scala/com/microsoft/azure/synapse/ml/vw/VowpalWabbitBase.scala
+++ b/vw/src/main/scala/com/microsoft/azure/synapse/ml/vw/VowpalWabbitBase.scala
@@ -490,7 +490,7 @@ trait VowpalWabbitBase extends Wrappable
       .appendParamValueIfNotThere("l1", "l1", l1)
       .appendParamValueIfNotThere("l2", "l2", l2)
       .appendParamValueIfNotThere("ignore", "ignore", ignoreNamespaces)
-      .appendParamValueIfNotThere("q", "quadratic", interactions)
+      .appendRepeatableParamIfNotThere("q", "quadratic", interactions)
       .appendSubclassSpecificParams()
   }
 


### PR DESCRIPTION
# Summary

With the recent parameter refactoring, all Array[T] parameters were converted to build as comma-separated lists (e.g. {"aa", "bb"} => "q=aa,bb").  For Vowpal Wabbit parameter "q", this is a regression.  The parameter should be repeated once for each array element, e.g. "q=aa q=bb".  I added a new appendRepeatableParamIfNotThere method to the ParamsStringBuilder that can handle this special case.

# Tests

Extended existing ParamsStringBuilder tests to include the new appending methods.

# Dependency chances

_If you needed to make any chances to dependencies of this project, please describe them here._