### PR TITLE
fix: GridSpace python API not working

### DIFF
--- a/core/src/main/python/synapse/ml/automl/HyperparamBuilder.py
+++ b/core/src/main/python/synapse/ml/automl/HyperparamBuilder.py
@@ -3,7 +3,7 @@
 
 import sys
 
-if sys.version >= '3':
+if sys.version >= "3":
     basestring = str
 
 import pyspark
@@ -11,10 +11,12 @@ from pyspark import SparkContext
 from pyspark.ml.common import inherit_doc
 from pyspark.sql.types import *
 
+
 class HyperparamBuilder(object):
     """
     Specifies the search space for hyperparameters.
     """
+
     def __init__(self):
         ctx = SparkContext.getOrCreate()
         self.jvm = ctx.getOrCreate()._jvm
@@ -39,50 +41,72 @@ class HyperparamBuilder(object):
         """
         return self.hyperparams.items()
 
+
 class DiscreteHyperParam(object):
     """
     Specifies a discrete list of values.
     """
+
     def __init__(self, values, seed=0):
         ctx = SparkContext.getOrCreate()
         self.jvm = ctx.getOrCreate()._jvm
-        self.hyperParam = self.jvm.com.microsoft.azure.synapse.ml.automl.HyperParamUtils.getDiscreteHyperParam(values, seed)
+        self.hyperParam = self.jvm.com.microsoft.azure.synapse.ml.automl.HyperParamUtils.getDiscreteHyperParam(
+            values, seed
+        )
 
     def get(self):
         return self.hyperParam
+
 
 class RangeHyperParam(object):
     """
     Specifies a range of values.
     """
+
     def __init__(self, min, max, seed=0):
         ctx = SparkContext.getOrCreate()
         self.jvm = ctx.getOrCreate()._jvm
-        self.rangeParam = self.jvm.com.microsoft.azure.synapse.ml.automl.HyperParamUtils.getRangeHyperParam(min, max, seed)
+        self.rangeParam = self.jvm.com.microsoft.azure.synapse.ml.automl.HyperParamUtils.getRangeHyperParam(
+            min, max, seed
+        )
 
     def get(self):
         return self.rangeParam
+
 
 class GridSpace(object):
     """
     Specifies a predetermined grid of values to search through.
     """
+
     def __init__(self, paramValues):
         ctx = SparkContext.getOrCreate()
         self.jvm = ctx.getOrCreate()._jvm
-        hyperparamBuilder = self.jvm.com.microsoft.azure.synapse.ml.automl.HyperparamBuilder()
+        hyperparamBuilder = self.jvm.org.apache.spark.ml.tuning.ParamGridBuilder()
         for k, (est, hyperparam) in paramValues:
             javaParam = est._java_obj.getParam(k.name)
-            hyperparamBuilder.addHyperparam(javaParam, hyperparam.get())
+
+            if not isinstance(hyperparam, DiscreteHyperParam):
+                raise ValueError(
+                    "GridSpace only supports DiscreteHyperParam, but hyperparam {} is of type {}".format(
+                        k, type(hyperparam)
+                    )
+                )
+
+            values = hyperparam.get().getValues()
+            hyperparamBuilder.addGrid(javaParam, self.jvm.PythonUtils.toList(values))
+            
         self.gridSpace = self.jvm.com.microsoft.azure.synapse.ml.automl.GridSpace(hyperparamBuilder.build())
 
     def space(self):
         return self.gridSpace
 
+
 class RandomSpace(object):
     """
     Specifies a random streaming range of values to search through.
     """
+
     def __init__(self, paramDistributions):
         ctx = SparkContext.getOrCreate()
         self.jvm = ctx.getOrCreate()._jvm

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/automl/HyperparamBuilder.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/automl/HyperparamBuilder.scala
@@ -5,7 +5,8 @@ package com.microsoft.azure.synapse.ml.automl
 
 import org.apache.spark.ml.param._
 
-import scala.collection.{JavaConverters, mutable}
+import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.util.Random
 
 abstract class RangeHyperParam[T](val min: T, val max: T, val seed: Long) extends Dist[T] {
@@ -77,7 +78,7 @@ object HyperParamUtils {
     * @return A RangeHyperParam matched to the given type for min and max values.
     */
   def getDiscreteHyperParam(values: java.util.ArrayList[_], seed: Long = 0): DiscreteHyperParam[_] = {
-    val valuesList = JavaConverters.asScalaBuffer(values).toList
+    val valuesList = values.asScala.toList
     new DiscreteHyperParam(valuesList, seed)
   }
 }
@@ -90,6 +91,12 @@ class DiscreteHyperParam[T](values: List[T], seed: Long = 0) extends Dist[T] {
     values(random.nextInt(values.length))
   }
 
+  /**
+   * Return the list of values as an java List for py4j side.
+   */
+  def getValues: java.util.List[T] = {
+    values.asJava
+  }
 }
 
 /** Specifies the search space for hyperparameters.


### PR DESCRIPTION
# Summary

GridSpace python API not working:

```python
searchSpace = paramBuilder.build()
gridspace = GridSpace(searchSpace)
```
```
py4j.protocol.Py4JError: An error occurred while calling None.com.microsoft.azure.synapse.ml.automl.GridSpace. Trace:
py4j.Py4JException: Constructor com.microsoft.azure.synapse.ml.automl.GridSpace([class [Lscala.Tuple2;]) does not exist
                at py4j.reflection.ReflectionEngine.getConstructor(ReflectionEngine.java:179)
                at py4j.reflection.ReflectionEngine.getConstructor(ReflectionEngine.java:196)
                at py4j.Gateway.invoke(Gateway.java:237)
                at py4j.commands.ConstructorCommand.invokeConstructor(ConstructorCommand.java:80)
                at py4j.commands.ConstructorCommand.execute(ConstructorCommand.java:69)
                at py4j.GatewayConnection.run(GatewayConnection.java:238)
                at java.lang.Thread.run(Thread.java:748)
```

# Tests

Testing code:
```python
from synapse.ml.lightgbm import LightGBMClassifier
from synapse.ml.automl import *

model = LightGBMClassifier(objective="binary", featuresCol="features", labelCol="Bankrupt?", isUnbalance=True)

searchSpace = (
  HyperparamBuilder()
      .addHyperparam(model, model.learningRate, DiscreteHyperParam([0.001, 0.02]))
      .addHyperparam(model, model.lambdaL1, DiscreteHyperParam([0.01, 1.0]))
      .build()
)

gridSpace = GridSpace(searchSpace)
hypermap = gridSpace.space().paramMaps()
print(hypermap.next())
print(hypermap.next())
print(hypermap.next())
print(hypermap.next())
```

# Dependency chances

None.

AB#1730666