### PR TITLE
fix: task displayName for minimal Dockerfile

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -185,7 +185,7 @@ jobs:
         command: 'push'
         tags: $(version)
     - task: Docker@2
-      displayName: Minimal Image Build + Push
+      displayName: Minimal Image Build
       inputs:
         containerRegistry: 'mmlspark-mcr-connection-1'
         repository: 'public/mmlspark/build-minimal'
@@ -195,7 +195,7 @@ jobs:
         tags: $(version)
         arguments: --build-arg MMLSPARK_VERSION=$(version)
     - task: Docker@2
-      displayName: Minimal Image Build + Push
+      displayName: Minimal Image Push
       inputs:
         containerRegistry: 'mmlspark-mcr-connection-1'
         repository: 'public/mmlspark/build-minimal'


### PR DESCRIPTION
# Summary

There are two tasks for build-ing and push-ing minimal Docker Image. They both are incorrectly named the same as "Minimal Image Build + Push" -- fixing the confusion here.

![image](https://user-images.githubusercontent.com/33642858/163651608-265a0b56-7cce-4827-afd8-201ed8880f4a.png)


# Tests

N/A

# Dependency chances

None.

N/A