### PR TITLE
fix: Build Developer Docker Image in Pipeline Tasks

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -202,6 +202,23 @@ jobs:
         command: 'push'
         tags: $(version)
     - task: Docker@2
+      displayName: Developer Image Build
+      inputs:
+        containerRegistry: 'mmlspark-mcr-connection-1'
+        repository: 'public/mmlspark/build-developer'
+        command: 'build'
+        buildContext: "."
+        Dockerfile: 'tools/docker/developer/Dockerfile'
+        tags: $(version)
+        arguments: --build-arg MMLSPARK_VERSION=$(version)
+    - task: Docker@2
+      displayName: Developer Image Push
+      inputs:
+        containerRegistry: 'mmlspark-mcr-connection-1'
+        repository: 'public/mmlspark/build-developer'
+        command: 'push'
+        tags: $(version)
+    - task: Docker@2
       condition: startsWith(variables['gittag'], 'v')
       displayName: Release Image Build
       inputs:


### PR DESCRIPTION
# Summary

This change adds building and pushing Developer Docker Image alongside demo and the minimal docker image as part of validation checks

# Tests

None

# Dependency chances

Not Applicable

AB#1750634