### PR TITLE
chore: Fix path for notebook test files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,8 @@ node_modules/
 .Rproj.user
 
 # Notebook Test Files
-/notebooks/*.py
-/notebooks/*.txt
+/notebooks/**/*.py
+/notebooks/**/*.txt
 
 # R output
 *.Rout


### PR DESCRIPTION
# Summary
Fixes relative path where notebook test files (*.py & *.txt) that are generated as a part of code compilation that should be ignored by git as these are runtime generated files that should not be checked in. 

# Tests

Made sure that with the changes, even after running `sbt setup` the notebook/**/*.py files don't show up on `git status` as untracked files that confuses the end user.

`sbt setup && git status` WITHOUT these changes:

```
 git status
On branch foobar
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   .gitignore

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        notebooks/features/classification/Classification - Adult Census with Vowpal Wabbit.py
        notebooks/features/classification/Classification - Adult Census.py
        notebooks/features/classification/Classification - Before and After SynapseML.py
        notebooks/features/classification/Classification - Twitter Sentiment with Vowpal Wabbit.py
        notebooks/features/classification/ClassificationAdultCensus.py
        ...
```

`sbt setup && git status` WITH these changes:

```
$ git status
On branch user/ppruthi/foobar
nothing to commit, working tree clean
```

# Dependency chances
None

AB#1758124