### PR TITLE
fix: chunksize parameter incorrectly specified during data copy

### DIFF
--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMBase.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMBase.scala
@@ -313,7 +313,6 @@ trait LightGBMBase[TrainedModel <: Model[TrainedModel]] extends Estimator[Traine
     val execNumThreads =
       if (getUseSingleDatasetMode) get(numThreads).getOrElse(numTasksPerExec - 1)
       else getNumThreads
-
     ExecutionParams(getChunkSize, getMatrixType, execNumThreads, getUseSingleDatasetMode)
   }
 

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMUtils.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMUtils.scala
@@ -170,25 +170,4 @@ object LightGBMUtils {
     val taskId = ctx.taskAttemptId()
     taskId
   }
-
-  def getNumRowsForChunksArray(numRows: Int, chunkSize: Int): SWIGTYPE_p_int = {
-    val leftoverChunk = numRows % chunkSize
-    val numChunks = if (leftoverChunk > 0) {
-      Math.floorDiv(numRows, chunkSize) + 1
-    }else{
-      Math.floorDiv(numRows, chunkSize)
-    }
-    val numRowsForChunks = lightgbmlib.new_intArray(numChunks)
-    (0 until numChunks).foreach({ index: Int =>
-      if (index == numChunks - 1 && leftoverChunk > 0) {
-        lightgbmlib.intArray_setitem(numRowsForChunks, index, leftoverChunk)
-      } else {
-        lightgbmlib.intArray_setitem(numRowsForChunks, index, chunkSize)
-      }
-    })
-    numRowsForChunks
-  }
-
-
-
 }

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/swig/SwigUtils.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/swig/SwigUtils.scala
@@ -24,6 +24,8 @@ abstract class ChunkedArray[T]() {
 
   def getLastChunkAddCount: Long
 
+  def getChunkSize: Long
+
   def getAddCount: Long
 
   def getItem(chunk: Long, inChunkIdx: Long, default: T): T
@@ -46,6 +48,8 @@ class FloatChunkedArray(array: floatChunkedArray) extends ChunkedArray[Float] {
   def getChunksCount: Long = array.get_chunks_count()
 
   def getLastChunkAddCount: Long = array.get_last_chunk_add_count()
+
+  def getChunkSize: Long = array.get_chunk_size()
 
   def getAddCount: Long = array.get_add_count()
 
@@ -75,6 +79,8 @@ class DoubleChunkedArray(array: doubleChunkedArray) extends ChunkedArray[Double]
 
   def getLastChunkAddCount: Long = array.get_last_chunk_add_count()
 
+  def getChunkSize: Long = array.get_chunk_size()
+
   def getAddCount: Long = array.get_add_count()
 
   def getItem(chunk: Long, inChunkIdx: Long, default: Double): Double =
@@ -102,6 +108,8 @@ class IntChunkedArray(array: int32ChunkedArray) extends ChunkedArray[Int] {
   def getChunksCount: Long = array.get_chunks_count()
 
   def getLastChunkAddCount: Long = array.get_last_chunk_add_count()
+
+  def getChunkSize: Long = array.get_chunk_size()
 
   def getAddCount: Long = array.get_add_count()
 


### PR DESCRIPTION
# Summary

This PR fixes the chunksize being incorrectly specified during data copy in single dataset mode.  This PR should resolve the user issue: https://github.com/microsoft/SynapseML/issues/1478

Specifically, the chunk size for the features array was actually specified to be ```num_cols * default_chunksize```, hence using just the default chunksize is incorrect during the data copy operation.  The PR uses the chunksize retrieved from the array directly.

Also, this PR removes the unused method ```getNumRowsForChunksArray```.

# Tests

A test was added to validate that specifying different chunk size values should not have any impact on the model metrics.  The chunk size is only for copying data and should not have any impact on the model's accuracy.

# Dependency changes

There are no dependency changes in this PR.

AB#1761413