### PR TITLE
feat: Add method to get lightgbm native model string directly

### DIFF
--- a/lightgbm/src/main/python/synapse/ml/lightgbm/mixin.py
+++ b/lightgbm/src/main/python/synapse/ml/lightgbm/mixin.py
@@ -13,6 +13,12 @@ class LightGBMModelMixin:
         """
         self._java_obj.saveNativeModel(filename, overwrite)
 
+    def getNativeModel(self):
+        """
+        Get the native model serialized representation as a string.
+        """
+        return self._java_obj.getNativeModel()
+
     def getFeatureImportances(self, importance_type="split"):
         """
         Get the feature importances as a list.  The importance_type can be "split" or "gain".

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMClassifier.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMClassifier.scala
@@ -183,11 +183,6 @@ class LightGBMClassificationModel(override val uid: String)
       udf(predict _).apply(col(getFeaturesCol))
     }
   }
-
-  def saveNativeModel(filename: String, overwrite: Boolean): Unit = {
-    val session = SparkSession.builder().getOrCreate()
-    getModel.saveNativeModel(session, filename, overwrite)
-  }
 }
 
 object LightGBMClassificationModel extends ComplexParamsReadable[LightGBMClassificationModel] {

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMModelMethods.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMModelMethods.scala
@@ -6,6 +6,7 @@ package com.microsoft.azure.synapse.ml.lightgbm
 import com.microsoft.azure.synapse.ml.lightgbm.params.LightGBMModelParams
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.sql.SparkSession
 
 /** Contains common LightGBM model methods across all LightGBM learner types.
   */
@@ -89,6 +90,22 @@ trait LightGBMModelMethods extends LightGBMModelParams with Logging {
     */
   def getBoosterNumClasses(): Int = {
     getLightGBMBooster.numClasses
+  }
+
+  /** Saves the native model serialized representation to file.
+    * @param session The spark session
+    * @param filename The name of the file to save the model to
+    * @param overwrite Whether to overwrite if the file already exists
+    */
+  def saveNativeModel(filename: String, overwrite: Boolean): Unit = {
+    val session = SparkSession.builder().getOrCreate()
+    getModel.saveNativeModel(session, filename, overwrite)
+  }
+
+  /** Gets the native model serialized representation as a string.
+    */
+  def getNativeModel(): String = {
+    getModel.getNativeModel()
   }
 
   /**

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMRanker.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMRanker.scala
@@ -163,11 +163,6 @@ class LightGBMRankerModel(override val uid: String)
   override def copy(extra: ParamMap): LightGBMRankerModel = defaultCopy(extra)
 
   override def numFeatures: Int = getModel.numFeatures
-
-  def saveNativeModel(filename: String, overwrite: Boolean): Unit = {
-    val session = SparkSession.builder().getOrCreate()
-    getModel.saveNativeModel(session, filename, overwrite)
-  }
 }
 
 object LightGBMRankerModel extends ComplexParamsReadable[LightGBMRankerModel] {

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMRegressor.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMRegressor.scala
@@ -132,11 +132,6 @@ class LightGBMRegressionModel(override val uid: String)
   }
 
   override def copy(extra: ParamMap): LightGBMRegressionModel = defaultCopy(extra)
-
-  def saveNativeModel(filename: String, overwrite: Boolean): Unit = {
-    val session = SparkSession.builder().getOrCreate()
-    getModel.saveNativeModel(session, filename, overwrite)
-  }
 }
 
 object LightGBMRegressionModel extends ComplexParamsReadable[LightGBMRegressionModel] {

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/booster/LightGBMBooster.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/booster/LightGBMBooster.scala
@@ -465,6 +465,12 @@ class LightGBMBooster(val trainDataset: Option[LightGBMDataset] = None, val para
     dataset.coalesce(1).write.mode(mode).text(filename)
   }
 
+  /** Gets the native model serialized representation as a string.
+    */
+  def getNativeModel(): String = {
+    modelStr.get
+  }
+
   /** Dumps the native model pointer to file.
     * @param session The spark session
     * @param filename The name of the file to save the model to

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMClassifier.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMClassifier.scala
@@ -745,9 +745,13 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
       val modelPath = targetDir.toString + "/" + outputFileName
       FileUtils.deleteDirectory(new File(modelPath))
       fitModel.saveNativeModel(modelPath, overwrite = true)
+      val retrievedModelStr = fitModel.getNativeModel()
       assert(Files.exists(Paths.get(modelPath)), true)
 
       val oldModelString = fitModel.getModel.modelStr.get
+      // Assert model string is equal when retrieved from booster and getNativeModel API
+      assert(retrievedModelStr == oldModelString)
+
       // Verify model string contains some feature
       colsToVerify.foreach(col => oldModelString.contains(col))
 


### PR DESCRIPTION
# Summary

This PR adds the ability to get the native lightgbm model directly as a string.
This is for the spark version of error analysis, to retrieve the trained surrogate model on errors for traversal in the RAI toolbox:

https://github.com/microsoft/responsible-ai-toolbox/blob/main/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py#L296

For more information on error analysis please see:

https://github.com/microsoft/responsible-ai-toolbox/blob/main/docs/erroranalysis-dashboard-README.md

![image](https://user-images.githubusercontent.com/24683184/169455948-2e0b696f-7196-4b2a-8618-fe59b4359d66.png)

# Tests

I validated that I can get the model string from the LightGBM model.

# Dependency changes

No dependency changes required.

AB#1800563