### PR TITLE
fix: fix databricks test

### DIFF
--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/DatabricksUtilities.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/DatabricksUtilities.scala
@@ -51,7 +51,7 @@ object DatabricksUtilities {
     Map("pypi" -> Map("package" -> "bs4")),
     Map("pypi" -> Map("package" -> "plotly")),
     Map("pypi" -> Map("package" -> "Pillow")),
-    Map("pypi" -> Map("package" -> "onnxmltools")),
+    Map("pypi" -> Map("package" -> "onnxmltools==1.7.0")),
     Map("pypi" -> Map("package" -> "lightgbm")),
     Map("pypi" -> Map("package" -> "mlflow"))
   ).toJson.compactPrint


### PR DESCRIPTION
# Summary

Fix breaking onnx notebook in databricks e2e test. onnxmltools released a new version and the dependency on onnxruntime contains errors.

# Tests

Ran dbx tests.

# Dependency changes

None.

AB#1826714