### PR TITLE
fix: Fix validation data creation for useSingleDataset mode

### DIFF
--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMBase.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMBase.scala
@@ -410,12 +410,14 @@ trait LightGBMBase[TrainedModel <: Model[TrainedModel]] extends Estimator[Traine
       trainParams.generalParams.categoricalFeatures,
       trainParams.executionParams.numThreads)
     beforeGenerateTrainDataset(batchIndex, columnParams, schema, log, trainParams)
+    log.info(s"DEBUG Generation training set")
     val trainDataset = generateDataset(aggregatedColumns, None, schema, datasetParams)
     try {
       afterGenerateTrainDataset(batchIndex, columnParams, schema, log, trainParams)
 
       val validDatasetOpt = validationData.map { vd =>
         beforeGenerateValidDataset(batchIndex, columnParams, schema, log, trainParams)
+        log.info(s"DEBUG Generation validation set, ${vd.getRowCount}")
         val out = generateDataset(vd, Some(trainDataset), schema, datasetParams)
         afterGenerateValidDataset(batchIndex, columnParams, schema, log, trainParams)
         out
@@ -480,6 +482,7 @@ trait LightGBMBase[TrainedModel <: Model[TrainedModel]] extends Estimator[Traine
           // If worker enabled, initialize the network ring of communication
           networkInit(nodes, localListenPort, log, LightGBMConstants.NetworkRetries, LightGBMConstants.InitialDelay)
           if (useSingleDatasetMode) sharedState.doneSignal.await()
+          log.info(s"DEBUG hasValidation data: ${validationData.isDefined}")
           translate(batchIndex, aggregatedValidationColumns, trainParams, returnBooster, schema, aggregatedColumns)
         } else {
           log.info("Helper task finished processing rows")

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/SharedState.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/SharedState.scala
@@ -15,6 +15,7 @@ import java.util.concurrent.CountDownLatch
 class SharedDatasetState(columnParams: ColumnParams,
                          schema: StructType,
                          trainParams: BaseTrainParams,
+                         isForValidation: Boolean,
                          sharedState: SharedState) {
   val chunkSize: Int = trainParams.executionParams.chunkSize
   val useSingleDataset: Boolean = trainParams.executionParams.useSingleDatasetMode
@@ -46,12 +47,22 @@ class SharedDatasetState(columnParams: ColumnParams,
       if (useSingleDataset) sparseAggregatedColumns
       else new SparseAggregatedColumns(chunkSize)
     }
-    aggregatedColumns.incrementCount(ts)
+    // For the validation Dataset in useSingleDataset mode, we only want 1 copy of the data (otherwise
+    // every partition appends the same broadcast-ed data). That one copy will be made by the main execution worker.
+    val mergeRows =
+      if (!isForValidation) true
+      else !useSingleDataset || sharedState.mainExecutorWorker.get == LightGBMUtils.getTaskId
+    if (mergeRows)
+    {
+      aggregatedColumns.incrementCount(ts)
+    }
     if (useSingleDataset) {
       arrayProcessedSignal.countDown()
       arrayProcessedSignal.await()
     }
-    aggregatedColumns.addRows(ts)
+    if (mergeRows) {
+      aggregatedColumns.addRows(ts)
+    }
     ts.release()
     aggregatedColumns
   }
@@ -87,8 +98,18 @@ class SharedState(columnParams: ColumnParams,
   val chunkSize: Int = trainParams.executionParams.chunkSize
   val matrixType: String = trainParams.executionParams.matrixType
 
-  val datasetState: SharedDatasetState = new SharedDatasetState(columnParams, schema, trainParams, this)
-  val validationDatasetState: SharedDatasetState = new SharedDatasetState(columnParams, schema, trainParams, this)
+  val datasetState: SharedDatasetState = new SharedDatasetState(
+    columnParams,
+    schema,
+    trainParams,
+    isForValidation = false,
+    this)
+  val validationDatasetState: SharedDatasetState = new SharedDatasetState(
+    columnParams,
+    schema,
+    trainParams,
+    isForValidation = true,
+    this)
 
   @volatile var isSparse: Option[Boolean] = None
   @volatile var mainExecutorWorker: Option[Long] = None

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/dataset/DatasetAggregator.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/dataset/DatasetAggregator.scala
@@ -437,12 +437,12 @@ private[lightgbm] abstract class BaseSparseAggregatedColumns(chunkSize: Int)
   def getIndexPointers: IntSwigArray = indexPointers
 
   override def cleanup(): Unit = {
-    labels.delete()
+    if (labels != null) labels.delete()
     weights.foreach(_.delete())
     initScores.foreach(_.delete())
-    values.delete()
-    indexes.delete()
-    indexPointers.delete()
+    if (values != null) values.delete()
+    if (indexes != null) indexes.delete()
+    if (indexPointers != null) indexPointers.delete()
   }
 
   private def indexPointerArrayIncrement(indptrArray: SWIGTYPE_p_int): Unit = {


### PR DESCRIPTION
# Summary

Fix validation Dataset creation in useSingleDataset mode.  Due to shared code with the regular training Dataset, every partition tries to merge its data with the "single" executor Dataset.  But for validation data, there is only 1 array of data, so this ends up duplicating it.  This causes 2 problems:
1. Extra pressure for OOM errors
2. If not every executor has the same # of partitions, then the validation Dataset is different length on each executor, causing errors.

# Tests

The existing validation Dataset tests still pass.

# Dependency changes

_If you needed to make any changes to dependencies of this project, please describe them here._