### PR TITLE
fix: make style check verbose

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -47,7 +47,7 @@ jobs:
     - script: pip install -r requirements.txt
       displayName: 'Install requirements'
     - bash: |
-        black --check .
+        black --diff --color . && black --check -q .
       displayName: 'Python Style Check'
 
 - job: Publish


### PR DESCRIPTION
# Summary

Style check currently fails without any verbosity on what line(s) need fixing. The developer will have no idea on what line(s) to fix unless he/she runs the black tool locally. Given we can show this on our checks in the pipeline, that would be useful for the developer.

# Tests
With verbosity: [ADO Pipeline link](https://msdata.visualstudio.com/A365/_build/results?buildId=65190468&view=logs&jobId=3f85e25b-fb23-5eb7-8385-51966a33df73&j=3f85e25b-fb23-5eb7-8385-51966a33df73&t=7a397729-aae9-5f53-8015-ab5fa5af6899)
Without verbosity: [ADO Pipeline link](https://msdata.visualstudio.com/A365/_build/results?buildId=65185618&view=logs&jobId=3f85e25b-fb23-5eb7-8385-51966a33df73&j=3f85e25b-fb23-5eb7-8385-51966a33df73&t=7a397729-aae9-5f53-8015-ab5fa5af6899)

# Dependency changes
None

AB#1832624