### PR TITLE
feat: add pre-commit support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-added-large-files
+
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    -   id: black
+    -   id: black-jupyter

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@
 # Required to auto-format python code
 black==22.3.0
 black[jupyter]==22.3.0
+pre-commit==2.19.0


### PR DESCRIPTION
# Summary

Adds `pre-commit` configuration for general linting / formatting of python & markdown files. Once we install pre-commit locally, this check would
- check for any code style issues, AND
- fix them
before a `git commit` completes
For more information, please read: [pre-commit docs](https://pre-commit.com/)

THIS DOES NOT FORMAT / CHECK SCALA CODE

# Tests

None

# Dependency changes

pre-commit python package

AB#1834318