### PR TITLE
fix: Fix useSingleDataset mode single class initial scores

### DIFF
--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/dataset/DatasetAggregator.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/dataset/DatasetAggregator.scala
@@ -290,7 +290,7 @@ private[lightgbm] abstract class BaseAggregatedColumns(val chunkSize: Int) exten
   def addInitialScores(chunkedCols: BaseChunkedColumns, startIndex: Long): Unit = {
     // Optimize for single class, which does not need transposing
     chunkedCols.initScores.foreach(chunkedArray => if (getRowCount == getInitScoreCount)
-      chunkedArray.coalesceTo(initScores.get)
+      ChunkedArrayUtils.copyChunkedArray(chunkedArray, initScores.get, startIndex)
     else {
       log.info(s"DEBUG: cols: ${getInitScoreCount/getRowCount} rows: $getRowCount, startIndex: $startIndex")
       ChunkedArrayUtils.insertTransposedChunkedArray(

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMClassifier.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMClassifier.scala
@@ -176,13 +176,16 @@ class VerifyLightGBMClassifier extends Benchmarks with EstimatorFuzzing[LightGBM
   }
 
   test("Verify LightGBM Classifier continued training with initial score") {
-    val convertUDF = udf((vector: DenseVector) => vector(1))
-    val scoredDF1 = baseModel.fit(pimaDF).transform(pimaDF)
-    val df2 = scoredDF1.withColumn(initScoreCol, convertUDF(col(rawPredCol)))
-      .drop(predCol, rawPredCol, probCol, leafPredCol, featuresShapCol)
-    val scoredDF2 = baseModel.setInitScoreCol(initScoreCol).fit(df2).transform(df2)
+    // test each useSingleDatasetMode mode since the paths differ slightly
+    Array(true, false).foreach(mode => {
+      val convertUDF = udf((vector: DenseVector) => vector(1))
+      val scoredDF1 = baseModel.setUseSingleDatasetMode(mode).fit(pimaDF).transform(pimaDF)
+      val df2 = scoredDF1.withColumn(initScoreCol, convertUDF(col(rawPredCol)))
+        .drop(predCol, rawPredCol, probCol, leafPredCol, featuresShapCol)
+      val scoredDF2 = baseModel.setUseSingleDatasetMode(mode).setInitScoreCol(initScoreCol).fit(df2).transform(df2)
 
-    assertBinaryImprovement(scoredDF1, scoredDF2)
+      assertBinaryImprovement(scoredDF1, scoredDF2)
+    })
   }
 
   test("Verify LightGBM Multiclass Classifier with vector initial score") {


### PR DESCRIPTION
# Summary

In a recent PR to fix multi-class initial scores (https://github.com/microsoft/SynapseML/pull/1526), a bug was introduced that broke single-class initial scores for useSingleDatasetMode == true.  The bug is non-deterministic from the standpoint of model improvement, so it was not detected by the existing tests (fails only sporadically).

Basically, in the previous PR, a method was extracted that used the non-useSingleDataset mode way of adding initial data, but coalesceTo cannot be used to insert in the middle of an array at a startIndex.  The fix was to simply use the appropriate way to insert scores for a shared dataset.

# Tests

Added coverage for both useSingleDatasetMode == true and useSingleDatasetMode == false to existing test.

# Dependency changes

N/A


AB#1867252