### PR TITLE
chore: Add GH workflow to label new/reopened issues

### DIFF
--- a/.github/workflows/label-add-triage.yml
+++ b/.github/workflows/label-add-triage.yml
@@ -1,0 +1,17 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Label issues
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+        with:
+          add-labels: "triage"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Summary

Adds a Github workflow to label new/reopened issues with `triage` label. This will help maintainers to know what issues need attention.

# Tests

Workflow will need to be tested once we have this merged to main branch.

# Dependency changes

None.


AB#1889230