### PR TITLE
docs: update installation guidance of v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ For Spark 3.2 Pools:
   "conf": {
       "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:0.10.0",
       "spark.jars.repositories": "https://mmlspark.azureedge.net/maven",
-      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12",
+      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
       "spark.yarn.user.classpath.first": "true"
   }
 }
@@ -179,7 +179,7 @@ Excluding certain packages from the library may be necessary due to current issu
     "name": "synapseml",
     "conf": {
         "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:0.10.0",
-        "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12"
+        "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind"
     }
 }
 ```

--- a/website/docs/getting_started/installation.md
+++ b/website/docs/getting_started/installation.md
@@ -29,7 +29,7 @@ For Spark3.2 pool:
   "conf": {
       "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:0.10.0",
       "spark.jars.repositories": "https://mmlspark.azureedge.net/maven",
-      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12",
+      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
       "spark.yarn.user.classpath.first": "true"
   }
 }
@@ -111,7 +111,7 @@ Excluding certain packages from the library may be necessary due to current issu
     "conf": {
         # Please use 0.10.0 version for Spark3.2 and 0.9.5-13-d1b51517-SNAPSHOT version for Spark3.1
         "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:0.10.0",
-        "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12"
+        "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind"
     }
 }
 ```
@@ -125,7 +125,7 @@ In Azure Synapse, "spark.yarn.user.classpath.first" should be set to "true" to o
     "conf": {
         # Please use 0.10.0 version for Spark3.2 and 0.9.5-13-d1b51517-SNAPSHOT version for Spark3.1
         "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:0.10.0",
-        "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12",
+        "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
         "spark.yarn.user.classpath.first": "true"
     }
 }

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -290,7 +290,7 @@ function Home() {
   "conf": {
       "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:0.10.0",
       "spark.jars.repositories": "https://mmlspark.azureedge.net/maven",
-      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12",
+      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
       "spark.yarn.user.classpath.first": "true"
   }
 }`}

--- a/website/versioned_docs/version-0.10.0/getting_started/installation.md
+++ b/website/versioned_docs/version-0.10.0/getting_started/installation.md
@@ -29,7 +29,7 @@ For Spark3.2 pool:
   "conf": {
       "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:0.10.0",
       "spark.jars.repositories": "https://mmlspark.azureedge.net/maven",
-      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12",
+      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
       "spark.yarn.user.classpath.first": "true"
   }
 }
@@ -111,7 +111,7 @@ Excluding certain packages from the library may be necessary due to current issu
     "conf": {
         # Please use 0.10.0 version for Spark3.2 and 0.9.5-13-d1b51517-SNAPSHOT version for Spark3.1
         "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:0.10.0",
-        "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12"
+        "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind"
     }
 }
 ```
@@ -125,7 +125,7 @@ In Azure Synapse, "spark.yarn.user.classpath.first" should be set to "true" to o
     "conf": {
         # Please use 0.10.0 version for Spark3.2 and 0.9.5-13-d1b51517-SNAPSHOT version for Spark3.1
         "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:0.10.0",
-        "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12",
+        "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
         "spark.yarn.user.classpath.first": "true"
     }
 }


### PR DESCRIPTION
# Summary

Per testing on Synapse spark3.2 pool, we need to exclude com.fasterxml.jackson.core:jackson-databind package in order to successfully start the spark session.

# Tests

not needed.

# Dependency changes

None.


AB#1890257