### PR TITLE
feat: Add LightGBM streaming execution mode

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/ClusterUtil.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/ClusterUtil.scala
@@ -7,6 +7,7 @@ import java.net.InetAddress
 import org.apache.http.conn.util.InetAddressUtils
 import org.apache.spark.SparkContext
 import org.apache.spark.injections.BlockManagerUtils
+import org.apache.spark.sql.functions.typedLit
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.slf4j.Logger
 
@@ -45,7 +46,7 @@ object ClusterUtil {
     */
   def getNumRowsPerPartition(df: DataFrame, labelCol: String): Array[Long] = {
     val indexedRowCounts: Array[(Int, Long)] = df
-      .select(labelCol)
+      .select(typedLit(0.toByte))
       .rdd
       .mapPartitionsWithIndex({case (i,rows) => Iterator((i,rows.size.toLong))}, true)
       .collect()

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/core/test/benchmarks/Benchmarks.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/core/test/benchmarks/Benchmarks.scala
@@ -35,8 +35,10 @@ object Benchmark {
 trait Benchmarks extends TestBase {
 
   lazy val resourcesDirectory = new File(getClass.getResource("/").toURI)
-  lazy val oldBenchmarkFile = new File(new File(resourcesDirectory, "benchmarks"), s"benchmarks_${this}.csv")
-  lazy val newBenchmarkFile = new File(new File(resourcesDirectory, "new_benchmarks"), s"new_benchmarks_${this}.csv")
+  lazy val oldBenchmarkFile = new File(new File(resourcesDirectory, "benchmarks"),
+                                 s"benchmarks_$this.csv")
+  lazy val newBenchmarkFile = new File(new File(resourcesDirectory, "new_benchmarks"),
+                                 s"new_benchmarks_$this.csv")
   lazy val newBenchmarks: ListBuffer[Benchmark] = ListBuffer[Benchmark]()
 
   def addBenchmark(name: String,
@@ -96,8 +98,8 @@ trait Benchmarks extends TestBase {
     writeCSV(newBenchmarks, newBenchmarkFile)
 
     val oldBenchmarks = spark.read
-      .option("header", true)
-      .option("inferSchema", true)
+      .option("header", value = true)
+      .option("inferSchema", value = true)
       .csv(oldBenchmarkFile.getAbsolutePath)
       .collect().map(Benchmark.fromRow)
     val newMap = newBenchmarks.map(bm => (bm.name, bm)).toMap

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/StreamingPartitionTask.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/StreamingPartitionTask.scala
@@ -1,0 +1,424 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm
+
+import com.microsoft.azure.synapse.ml.lightgbm.dataset.{LightGBMDataset, SampledData}
+import com.microsoft.azure.synapse.ml.lightgbm.swig._
+import com.microsoft.ml.lightgbm._
+import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
+import org.apache.spark.ml.linalg.{DenseVector, SparseVector}
+import org.apache.spark.sql._
+import org.apache.spark.sql.types.StructType
+
+import scala.annotation.tailrec
+import scala.language.existentials
+
+case class StreamingState(ctx: PartitionTaskContext,
+                          dataset: LightGBMDataset,
+                          threadIndex: Int) {
+  val trainingCtx: TrainingContext = ctx.trainingCtx
+  val columnParams: ColumnParams = trainingCtx.columnParams
+  val schema: StructType = trainingCtx.schema
+  val numCols: Int = trainingCtx.numCols
+  val numInitScoreClasses: Int = trainingCtx.numInitScoreClasses
+  val microBatchSize: Int = trainingCtx.microBatchSize
+
+  val isSparse: Boolean = ctx.sharedState.isSparse.get
+  val isDense: Boolean = !isSparse
+  val hasWeights: Boolean = trainingCtx.hasWeights
+  val hasInitialScores: Boolean = trainingCtx.hasInitialScores
+  val hasGroups: Boolean = trainingCtx.hasGroups
+
+  /* Buffers for holding micro-batch data */
+
+  // dense data
+  lazy val featureDataBuffer: DoubleSwigArray = new DoubleSwigArray(microBatchSize * numCols)
+
+  // sparse data
+  lazy val indptrBuffer: LongSwigArray = new LongSwigArray(microBatchSize + 1)
+  lazy val indicesBuffer: IntSwigArray = new IntSwigArray(microBatchSize * numCols) // allocate max space
+  lazy val valBuffer: DoubleSwigArray = new DoubleSwigArray(microBatchSize * numCols) // allocate max space
+
+  // metadata
+  val labelBuffer: FloatSwigArray = new FloatSwigArray(microBatchSize)
+  lazy val weightBuffer: FloatSwigArray = new FloatSwigArray(microBatchSize)
+  lazy val initScoreBuffer: DoubleSwigArray = new DoubleSwigArray(microBatchSize * numInitScoreClasses)
+  lazy val groupBuffer: IntSwigArray = new IntSwigArray(microBatchSize)
+
+  val datasetPointer: SWIGTYPE_p_void = dataset.datasetPtr
+  val featureDataPtr: SWIGTYPE_p_void  =
+    if (isSparse) null  // scalastyle:ignore null
+    else lightgbmlib.double_to_voidp_ptr(featureDataBuffer.array)
+  val indptrPtr: SWIGTYPE_p_void  =
+    if (isDense) null  // scalastyle:ignore null
+    else lightgbmlib.int64_t_to_voidp_ptr(indptrBuffer.array)
+  val indicesPtr: SWIGTYPE_p_int  =
+    if (isDense) null  // scalastyle:ignore null
+    else indicesBuffer.array
+  val valPtr: SWIGTYPE_p_void  =
+    if (isDense) null  // scalastyle:ignore null
+    else lightgbmlib.double_to_voidp_ptr(valBuffer.array)
+
+  val labelPtr: SWIGTYPE_p_float = labelBuffer.array
+  val weightPtr: SWIGTYPE_p_float =
+    if (hasWeights) weightBuffer.array
+    else null  // scalastyle:ignore null
+  val initScorePtr: SWIGTYPE_p_double =
+    if (hasInitialScores) initScoreBuffer.array
+    else null  // scalastyle:ignore null
+  val groupPtr: SWIGTYPE_p_int =
+    if (hasGroups) groupBuffer.array
+    else null  // scalastyle:ignore null
+
+  val featureIndex: Int = schema.fieldIndex(columnParams.featuresColumn)
+  val labelIndex: Int = schema.fieldIndex(columnParams.labelColumn)
+  val weightIndex: Int = if (hasWeights) schema.fieldIndex(columnParams.weightColumn.get) else 0
+  val initScoreIndex: Int = if (hasInitialScores) schema.fieldIndex(columnParams.initScoreColumn.get) else 0
+  val groupIndex: Int = if (hasGroups) schema.fieldIndex(columnParams.groupColumn.get) else 0
+
+  if (isSparse) indptrBuffer.setItem(0, 0)  // every micro-batch starts with index 0
+
+  def delete(): Unit = {
+    // Delete all the temporary micro-batch marshaling buffers
+    if (isDense) lightgbmlib.delete_doubleArray(featureDataBuffer.array)
+    else {
+      lightgbmlib.delete_int64_tp(indptrBuffer.array)
+      lightgbmlib.delete_intArray(indicesBuffer.array)
+      lightgbmlib.delete_doubleArray(valBuffer.array)
+    }
+
+    lightgbmlib.delete_floatArray(labelBuffer.array)
+    if (hasWeights) lightgbmlib.delete_floatArray(weightBuffer.array)
+    if (hasInitialScores) lightgbmlib.delete_doubleArray(initScoreBuffer.array)
+    if (hasGroups) lightgbmlib.delete_intArray(groupBuffer.array)
+  }
+}
+
+/**
+  * Class for handling the execution of streaming-based Tasks on workers for each partition.
+  */
+class StreamingPartitionTask extends BasePartitionTask {
+  override protected def initializeInternal(ctx: TrainingContext,
+                                            shouldExecuteTraining: Boolean,
+                                            isEmptyPartition: Boolean): Unit = {
+    // Streaming always uses 1 Dataset per executor, so we need to add to synchronization stop for helpers
+    if (!shouldExecuteTraining && !isEmptyPartition) ctx.sharedState().incrementDataPrepDoneSignal(log)
+
+    // First dataset to reach here calculates the validation Dataset if needed
+    if (ctx.hasValidationData) {
+      ctx.sharedState().linkValidationDatasetWorker()
+    }
+  }
+
+  protected def preparePartitionDataInternal(ctx: PartitionTaskContext,
+                                             inputRows: Iterator[Row]): PartitionDataState = {
+    // If this is the task that will execute training, first create the empty Dataset from sampled data
+    if (ctx.shouldExecuteTraining) {
+      ctx.sharedState.datasetState.streamingDataset = Option(createSharedExecutorDataset(ctx))
+      ctx.sharedState.helperStartSignal.countDown()
+    } else {
+      // This must be a task that just loads data and exits, so wait for the shared Dataset to be created
+      ctx.sharedState.helperStartSignal.await()
+    }
+
+    // Make sure isSparse is set with a value and get an adjusted iterator (might have had to sample)
+    val rowIterator = determineMatrixType(ctx, inputRows)
+
+    insertRowsIntoTrainingDataset(ctx, rowIterator)
+
+    // Now handle validation data, which comes from a broadcast-ed hardcoded array
+    if (ctx.shouldCalcValidationDataset) {
+      log.info(s"DEBUG Creating validation dataset in task ${ctx.taskId} partition ${ctx.partitionId}")
+      ctx.sharedState.validationDatasetState.streamingDataset = Option(generateOptValidationDataset(ctx))
+      log.info(s"DEBUG Done Creating validation dataset in task ${ctx.taskId} partition ${ctx.partitionId}")
+    }
+
+    // streaming does not use data state (it stores intermediate results in the context shared state),
+    // so just return a stub
+    PartitionDataState(None, None)
+  }
+
+  protected def getTrainingDatasetInternal(ctx: PartitionTaskContext,
+                                           dataState: PartitionDataState): LightGBMDataset = {
+    val dataset = ctx.sharedState.datasetState.streamingDataset.get
+    LightGBMUtils.validate(lightgbmlib.LGBM_DatasetMarkFinished(dataset.datasetPtr), "Dataset mark finished")
+    dataset
+  }
+
+  protected def getValidationDatasetInternal(ctx: PartitionTaskContext,
+                                           dataState: PartitionDataState,
+                                           referenceDataset: LightGBMDataset): LightGBMDataset = {
+    // We have already calculated and finished the validation Dataset in the preparation stage
+    ctx.sharedState.validationDatasetState.streamingDataset.get
+  }
+
+  private def generateOptValidationDataset(ctx: PartitionTaskContext): LightGBMDataset = {
+    val validationData = ctx.trainingCtx.validationData.get.value
+
+    val validationDataset = createSharedValidationDataset(ctx, validationData.length)
+
+    insertRowsIntoDataset(
+      ctx,
+      validationDataset,
+      validationData.toIterator,
+      0,
+      validationData.length,
+      0)
+
+    // Complete the dataset here since we only add data to it once
+    LightGBMUtils.validate(lightgbmlib.LGBM_DatasetMarkFinished(validationDataset.datasetPtr),
+      "Dataset mark finished")
+    validationDataset
+  }
+
+  private def insertRowsIntoTrainingDataset(ctx: PartitionTaskContext, inputRows: Iterator[Row]): Unit = {
+    val partitionRowCount = ctx.trainingCtx.partitionCounts.get(ctx.partitionId).toInt
+    val partitionRowOffset = ctx.streamingPartitionOffset
+    val isSparse = ctx.sharedState.isSparse.get
+    log.info(s"Inserting rows into training Dataset from partition ${ctx.partitionId}, " +
+      s"size $partitionRowCount, offset: $partitionRowOffset, sparse: $isSparse, threadId: ${ctx.threadIndex}")
+    val dataset = ctx.sharedState.datasetState.streamingDataset.get
+
+    val stopIndex = partitionRowOffset + partitionRowCount
+    insertRowsIntoDataset(ctx, dataset, inputRows, partitionRowOffset, stopIndex, ctx.threadIndex)
+
+    log.info(s"Part ${ctx.partitionId}: inserted $partitionRowCount partition ${ctx.partitionId} " +
+      s"rows into shared training dataset at offset $partitionRowOffset")
+  }
+
+  private def insertRowsIntoDataset(ctx: PartitionTaskContext,
+                                    dataset: LightGBMDataset,
+                                    inputRows: Iterator[Row],
+                                    startIndex: Int,
+                                    stopIndex: Int,
+                                    threadIndex: Int): Unit = {
+    val state = StreamingState(ctx, dataset, threadIndex)
+    try {
+      if (ctx.sharedState.isSparse.get)
+        pushSparseMicroBatches(state, inputRows, startIndex, stopIndex)
+      else
+        pushDenseMicroBatches(state, inputRows, startIndex, stopIndex)
+    } finally {
+      log.info(s"Deleting state from ${ctx.taskId}, part ${ctx.partitionId}") // DEBUG TODO remove
+      state.delete()
+    }
+  }
+
+  @tailrec
+  private def pushDenseMicroBatches(state: StreamingState,
+                                    inputRows: Iterator[Row],
+                                    startIndex: Int,
+                                    stopIndex: Int): Unit = {
+    // Account for stopping early due to partial micro-batch
+    val maxBatchSize = Math.min(state.microBatchSize, stopIndex - startIndex)
+    val count =
+      if (maxBatchSize == 0) 0
+      else loadOneDenseMicroBatchBuffer(state, inputRows, 0, maxBatchSize)
+    if (count > 0) {
+      log.info(s"Part ${state.ctx.partitionId}: Pushing $count dense rows at $startIndex, will stop at $stopIndex")
+      if (state.hasInitialScores && state.microBatchSize != count && state.numInitScoreClasses > 1) {
+        log.info(s"Part ${state.ctx.partitionId}: Adjusting $count initial scores")
+        (1 until state.numInitScoreClasses).foreach { i =>
+          (0 until count).foreach { j => {
+            val score = state.initScoreBuffer.getItem(i * state.microBatchSize + j)
+            state.initScoreBuffer.setItem(i * count + j, score)}}
+        }
+      }
+      LightGBMUtils.validate(lightgbmlib.LGBM_DatasetPushRowsWithMetadata(
+        state.datasetPointer,
+        lightgbmlib.double_to_voidp_ptr(state.featureDataBuffer.array), // DEBUG TODO put back state.featureDataPtr,
+        lightgbmlibConstants.C_API_DTYPE_FLOAT64,
+        count,
+        state.numCols,
+        startIndex,
+        state.labelPtr,
+        state.weightPtr,
+        state.initScorePtr,
+        state.groupPtr,
+        state.threadIndex), "Dataset push dense micro-batch")
+
+      // might be more rows, so continue with tail recursion at next index
+      pushDenseMicroBatches(state, inputRows, startIndex + count, stopIndex)
+    }
+  }
+
+  @tailrec
+  private def pushSparseMicroBatches(state: StreamingState,
+                                     inputRows: Iterator[Row],
+                                     startIndex: Int,
+                                     stopIndex: Int): Unit = {
+    // Account for stopping early due to partial micro-batch
+    val maxBatchSize = Math.min(state.microBatchSize, stopIndex - startIndex)
+    val (microBatchRowCount: Int, microBatchElementCount: Int) =
+      if (maxBatchSize == 0) (0, 0)
+      else loadOneSparseMicroBatchBuffer(state, inputRows, 0, 0, maxBatchSize)
+    if (microBatchRowCount > 0) {
+      // If we have only a partial micro-batch, and we have multi-class initial scores (i.e. numClass > 1),
+      // we need to re-coalesce the data since it was stored column-wise based on original microBatchSize
+      if (state.hasInitialScores && state.microBatchSize != microBatchRowCount && state.numInitScoreClasses > 1) {
+        (1 until state.numInitScoreClasses).foreach { i =>  // TODO make this shared
+          (0 until microBatchRowCount).foreach { j => {
+            val score = state.initScoreBuffer.getItem(i * state.microBatchSize + j)
+            state.initScoreBuffer.setItem(i * microBatchRowCount + j, score)}}
+        }
+      }
+      LightGBMUtils.validate(lightgbmlib.LGBM_DatasetPushRowsByCSRWithMetadata(
+        state.datasetPointer,
+        state.indptrPtr,
+        lightgbmlibConstants.C_API_DTYPE_INT64,
+        state.indicesPtr,
+        state.valPtr,
+        lightgbmlibConstants.C_API_DTYPE_FLOAT64,
+        microBatchRowCount + 1,
+        microBatchElementCount,
+        startIndex,
+        state.labelPtr,
+        state.weightPtr,
+        state.initScorePtr,
+        state.groupPtr,
+        state.threadIndex), "Dataset push CSR micro-batch")
+
+      // might be more rows, so continue with tail recursion at next index
+      pushSparseMicroBatches(state, inputRows, startIndex + microBatchRowCount, stopIndex)
+    } else {
+      log.info(s"LightGBM pushed $startIndex in partition ${state.ctx.partitionId}")
+    }
+  }
+
+  @tailrec
+  private def loadOneDenseMicroBatchBuffer(state: StreamingState,
+                                           inputRows: Iterator[Row],
+                                           currentCount: Int,
+                                           maxBatchCount: Int): Int = {
+    if (inputRows.hasNext && currentCount < maxBatchCount) {
+      val row = inputRows.next()
+      // Each row might be either sparse or dense, so convert to overall dense format
+      row.getAs[Any](state.featureIndex) match {
+        case dense: DenseVector => dense.values.zipWithIndex.foreach { case (x, i) =>
+          state.featureDataBuffer.setItem(currentCount * state.numCols + i, x) }
+        case sparse: SparseVector => sparse.toArray.zipWithIndex.foreach { case (x, i) =>
+          state.featureDataBuffer.setItem(currentCount * state.numCols + i, x) }
+      }
+
+      loadOneMetadataRow(state, row, currentCount)
+
+      // We have not reached the end of the micro-batch or Rows, so continue with tail recursion
+      loadOneDenseMicroBatchBuffer(state, inputRows, currentCount + 1, maxBatchCount)
+    } else currentCount
+  }
+
+  @tailrec
+  private def loadOneSparseMicroBatchBuffer(state: StreamingState,
+                                            inputRows: Iterator[Row],
+                                            batchRowCount: Int,
+                                            elementCount: Int,
+                                            maxBatchCount: Int): (Int, Int) = {
+    if (inputRows.hasNext && batchRowCount < maxBatchCount) {
+      val row = inputRows.next()
+      // Each row might be either sparse or dense, so convert to overall sparse format
+      val sparseVector = row.getAs[Any](state.featureIndex) match {
+        case dense: DenseVector => dense.toSparse
+        case sparse: SparseVector => sparse
+        case _ => throw new Exception(row.getAs[Any](state.featureIndex).toString)
+      }
+
+      /* DEBUG TODO log.info(s"Iterator row $batchRowCount count: ${sparseVector.values.length}")
+      (0 until sparseVector.values.length).foreach(i => {
+        log.info(s"  index ${sparseVector.indices(i)} value ${sparseVector.values(i)}")
+      }) */
+      val rowElementCount = sparseVector.values.length
+      val endIndex = rowElementCount + elementCount
+      sparseVector.values.zipWithIndex.foreach { case (value, i) =>
+        state.valBuffer.setItem(elementCount + i, value) }
+      sparseVector.indices.zipWithIndex.foreach { case (index, i) =>
+        state.indicesBuffer.setItem(elementCount + i, index) }
+      state.indptrBuffer.setItem(batchRowCount + 1, endIndex)
+
+      loadOneMetadataRow(state, row, batchRowCount)
+
+      // We have not reached the end of the micro-batch or Rows, so continue with tail recursion
+      loadOneSparseMicroBatchBuffer(state, inputRows, batchRowCount + 1, endIndex, maxBatchCount)
+    } else (batchRowCount, elementCount)
+  }
+
+  private def loadOneMetadataRow(state: StreamingState, row: Row, index: Int): Unit = {
+    state.labelBuffer.setItem(index, row.getDouble(state.labelIndex).toFloat)
+    if (state.hasWeights) state.weightBuffer.setItem(index, row.getDouble(state.weightIndex).toFloat)
+    if (state.hasGroups) state.groupBuffer.setItem(index, row.getAs[Int](state.groupIndex))
+
+    // Initial scores are passed in column-based format, where the score for each class is contiguous
+    if (state.hasInitialScores) {
+      if (row.schema(state.initScoreIndex).dataType == VectorType) // TODO cache bool?
+        row.getAs[DenseVector](state.initScoreIndex).values.zipWithIndex.foreach {
+          case (value, i) => state.initScoreBuffer.setItem(index + state.microBatchSize * i, value) }
+      else
+        state.initScoreBuffer.setItem(index, row.getDouble(state.initScoreIndex))
+    }
+  }
+
+  private def createSharedExecutorDataset(ctx: PartitionTaskContext): LightGBMDataset = {
+    // The sample data is broadcast from Spark, so retrieve it
+    ctx.measures.markSamplingStart()
+    val numRows = ctx.executorRowCount
+    val sampledRowData = ctx.trainingCtx.broadcastedSampleData.get.value
+
+    // create properly formatted sampled data
+    log.info(s"Creating sample data with ${sampledRowData.length} samples")
+    val datasetVoidPtr = lightgbmlib.voidpp_handle()
+    val sampledData: SampledData = new SampledData(sampledRowData.length, ctx.trainingCtx.numCols)
+    try {
+      sampledRowData.zipWithIndex.foreach(rowAndIndex =>
+        sampledData.pushRow(rowAndIndex._1, rowAndIndex._2, ctx.trainingCtx.columnParams.featuresColumn))
+      ctx.measures.markSamplingStop()
+
+      // Convert byte array to native memory
+      log.info(s"Creating empty dense training dataset with $numRows rows, config:${ctx.trainingCtx.datasetParams}")
+      // Generate the dataset for features
+      val datasetVoidPtr = lightgbmlib.voidpp_handle()
+      LightGBMUtils.validate(lightgbmlib.LGBM_DatasetCreateFromSampledColumn(
+        sampledData.getSampleData,
+        sampledData.getSampleIndices,
+        ctx.trainingCtx.numCols,
+        sampledData.getRowCounts,
+        sampledData.numRows,
+        numRows,
+        ctx.trainingCtx.datasetParams,
+        datasetVoidPtr), "Dataset create")
+
+      val datasetPtr: SWIGTYPE_p_void = lightgbmlib.voidpp_value(datasetVoidPtr)
+      LightGBMUtils.validate(lightgbmlib.LGBM_DatasetInitStreaming(datasetPtr,
+                                                                   ctx.trainingCtx.hasWeightsAsInt,
+                                                                   ctx.trainingCtx.hasInitialScoresAsInt,
+                                                                   ctx.trainingCtx.hasGroupsAsInt,
+                                                                   ctx.trainingCtx.trainingParams.getNumClass,
+                                                                   ctx.executorPartitionCount),
+                             "LGBM_DatasetInitStreaming")
+
+      val dataset = new LightGBMDataset(datasetPtr)
+      dataset.setFeatureNames(ctx.trainingCtx.featureNames, ctx.trainingCtx.numCols)
+      dataset
+    } finally {
+      sampledData.delete()
+      lightgbmlib.delete_voidpp(datasetVoidPtr)
+    }
+  }
+
+  private def createSharedValidationDataset(ctx: PartitionTaskContext, rowCount: Int): LightGBMDataset = {
+    val pointer = lightgbmlib.voidpp_handle()
+    val reference = ctx.sharedState.datasetState.streamingDataset.get.datasetPtr
+    LightGBMUtils.validate(
+      lightgbmlib.LGBM_DatasetCreateByReference(reference, rowCount, pointer),
+      "Dataset create from reference")
+
+    val datasetPtr = lightgbmlib.voidpp_value(pointer)
+    LightGBMUtils.validate(
+      lightgbmlib.LGBM_DatasetSetWaitForManualFinish(datasetPtr, 1),
+      "Dataset LGBM_DatasetSetWaitForManualFinish")
+
+    lightgbmlib.delete_voidpp(pointer)
+    val dataset = new LightGBMDataset(datasetPtr)
+    dataset.setFeatureNames(ctx.trainingCtx.featureNames, ctx.trainingCtx.numCols)
+    dataset
+  }
+}

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/TrainUtils.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/TrainUtils.scala
@@ -76,7 +76,7 @@ private object TrainUtils extends Serializable {
 
   def updateOneIteration(state: PartitionTaskTrainingState, log: Logger): Unit = {
     try {
-      log.debug("LightGBM running iteration: " + state.iteration)
+      log.info(s"LightGBM task starting iteration ${state.iteration}")
       val fobj = state.ctx.trainingParams.objectiveParams.fobj
       if (fobj.isDefined) {
         val (gradient, hessian) = fobj.get.getGradient(
@@ -107,7 +107,6 @@ private object TrainUtils extends Serializable {
         state.learningRate = newLearningRate
       }
 
-      log.info(s"LightGBM task starting iteration ${state.iteration}")
       updateOneIteration(state, log)
 
       val trainEvalResults: Option[Map[String, Double]] =

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/dataset/SampledData.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/dataset/SampledData.scala
@@ -1,0 +1,96 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm.dataset
+
+import org.apache.spark.ml.linalg.{DenseVector, SparseVector}
+import org.apache.spark.sql.Row
+import com.microsoft.azure.synapse.ml.lightgbm.swig._
+import com.microsoft.ml.lightgbm._
+
+/** SampledData: Encapsulates the sampled data need to initialize a LightGBM dataset.
+  * .
+  * LightGBM expects sampled data to be an array of vectors, where each feature column
+  * has a sparse representation of non-zero values (i.e. indexes and data vector). It also needs
+  * a #features sized array of element count per feature to know how long each column is.
+  * .
+  * Since we create sampled data as a self-contained set with ONLY sampled data and nothing else,
+  * the indexes are trivial (0 until #elements). We don't need to maintain original raw indexes. LightGBM
+  * only uses this data to get distributions, and does not care about raw row indexes.
+  * .
+  * This class manages keeping all the indexing in sync so callers can just push rows of data into it
+  * and retrieve the resulting pointers at the end.
+  * .
+  * Note: sample data row count is not expected to exceed max(Int), so we index with Ints.
+  */
+class SampledData(val numRows: Int, val numCols: Int) {
+
+  // Allocate full arrays for each feature column, but we will push only non-zero values and
+  // keep track of actual counts in rowCounts array
+  val sampleData = new DoublePointerSwigArray(numCols)
+  val sampleIndexes = new IntPointerSwigArray(numCols)
+  val rowCounts = new IntSwigArray(numCols)
+
+  // Initialize column vectors (might move some of this to inside XPointerSwigArray)
+  (0 until numCols).foreach(col => {
+    rowCounts.setItem(col, 0) // Initialize as 0-rowCount columns
+
+    sampleData.setItem(col, new DoubleSwigArray(numRows))
+    sampleIndexes.setItem(col, new IntSwigArray(numRows))
+  })
+
+  // Store non-zero elements in arrays given a feature value row
+  def pushRow(rowData: Row, index: Int, featureColName: String): Unit = {
+    val data = rowData.getAs[Any](featureColName)
+    data match {
+      case sparse: SparseVector => pushRow(sparse, index)
+      case dense: DenseVector => pushRow(dense, index)
+      case _ => throw new IllegalArgumentException("Unknown row data type to push")
+    }
+  }
+
+  // Store non-zero elements in arrays given a dense feature value row
+  def pushRow(rowData: DenseVector, index: Int): Unit = pushRow(rowData.values, index)
+
+  // Store non-zero elements in arrays given a dense feature value array
+  def pushRow(rowData: Array[Double], index: Int): Unit = {
+    require(rowData.length <= numCols, s"Row is too large for sample data.  size should be $numCols" +
+                                     s", but is ${rowData.length}")
+    (0 until numCols).foreach(col => pushRowElementIfNotZero(col, rowData(col), index))
+  }
+
+  // Store non-zero elements in arrays given a sparse feature value row
+  def pushRow(rowData: SparseVector, index: Int): Unit = {
+    require(rowData.size <= numCols, s"Row is too large for sample data.  size should be $numCols" +
+                                     s", but is ${rowData.size}")
+    (0 until rowData.numActives).foreach(i =>
+      pushRowElementIfNotZero(rowData.indices(i), rowData.values(i), index))
+  }
+
+  def pushRowElementIfNotZero(col: Int, value: Double, index: Int): Unit = {
+    if (value != 0.0) {
+      val nextIndex = rowCounts.getItem(col)
+      sampleData.pushElement(col, nextIndex, value)
+      sampleIndexes.pushElement(col, nextIndex, index)
+      rowCounts.setItem(col, nextIndex + 1) // increment row count
+    }
+  }
+
+  def getSampleData: SWIGTYPE_p_p_double = {
+    sampleData.array
+  }
+
+  def getSampleIndices: SWIGTYPE_p_p_int = {
+    sampleIndexes.array
+  }
+
+  def getRowCounts: SWIGTYPE_p_int = {
+    rowCounts.array
+  }
+
+  def delete(): Unit = {
+    sampleData.delete()
+    sampleIndexes.delete()
+    rowCounts.delete()
+  }
+}

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/BaseTrainParams.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/BaseTrainParams.scala
@@ -20,6 +20,8 @@ abstract class BaseTrainParams extends Serializable {
   def seedParams: SeedParams
   def categoricalParams: CategoricalParams
 
+  def getNumClass: Int = 1
+
   override def toString: String = {
     // Note: passing `isProvideTrainingMetric` to LightGBM as a config parameter won't work,
     // Fetch and print training metrics in `TrainUtils.scala` through JNI.

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/ClassifierTrainParams.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/ClassifierTrainParams.scala
@@ -23,6 +23,8 @@ case class ClassifierTrainParams(passThroughArgs: Option[String],
                                  numClass: Int = 1) extends BaseTrainParams {
   val isBinary: Boolean = objectiveParams.objective == LightGBMConstants.BinaryObjective
 
+  override def getNumClass(): Int = { numClass }
+
   override def appendSpecializedParams(sb: ParamsStringBuilder): ParamsStringBuilder =
   {
     sb.appendParamValueIfNotThere("num_class", if (!isBinary) Option(numClass) else None)

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/LightGBMParams.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/LightGBMParams.scala
@@ -66,7 +66,7 @@ trait LightGBMExecutionParams extends Wrappable {
 
   val microBatchSize = new IntParam(this, "microBatchSize",
     "Specify how many elements are sent in a streaming micro-batch.")
-  setDefault(microBatchSize -> 1)
+  setDefault(microBatchSize -> 100)
   def getMicroBatchSize: Int = $(microBatchSize)
   def setMicroBatchSize(value: Int): this.type = set(microBatchSize, value)
 

--- a/lightgbm/src/test/resources/log4j.properties
+++ b/lightgbm/src/test/resources/log4j.properties
@@ -5,4 +5,6 @@ log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss} %-5p %c{1}:%L - %m%n
 
 log4j.rootLogger=WARN, stdout
 log4j.logger.org.apache.spark=WARN, stdout
+log4j.additivity.org.apache.spark=false
 log4j.logger.com.microsoft=INFO, stdout
+log4j.additivity.com.microsoft=false

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMCommon.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMCommon.scala
@@ -5,12 +5,29 @@ package com.microsoft.azure.synapse.ml.lightgbm.split1
 
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 import com.microsoft.azure.synapse.ml.lightgbm._
-import com.microsoft.azure.synapse.ml.lightgbm.dataset.{ChunkedArrayUtils, LightGBMDataset}
-import com.microsoft.azure.synapse.ml.lightgbm.swig.{DoubleChunkedArray, DoubleSwigArray, SwigUtils}
+import com.microsoft.azure.synapse.ml.lightgbm.dataset.{ChunkedArrayUtils, SampledData}
+import com.microsoft.azure.synapse.ml.lightgbm.swig.{DoubleChunkedArray, DoubleSwigArray, IntSwigArray, SwigUtils}
+import com.microsoft.ml.lightgbm.{SWIGTYPE_p_p_void, SWIGTYPE_p_void, lightgbmlib}
+import org.apache.spark.ml.linalg.{DenseVector, SparseVector}
+import org.apache.spark.sql.DataFrame
 
 // scalastyle:off magic.number
 /** Tests to validate general functionality of LightGBM module. */
-class VerifyLightGBMCommon extends TestBase {
+class VerifyLightGBMCommon extends TestBase with LightGBMTestUtils {
+  lazy val taskDF: DataFrame = loadBinary("task.train.csv", "TaskFailed10").cache()
+  lazy val pimaDF: DataFrame = loadBinary("PimaIndian.csv", "Diabetes mellitus").cache()
+
+  lazy val baseModel: LightGBMClassifier = new LightGBMClassifier()
+    .setFeaturesCol(featuresCol)
+    .setRawPredictionCol(rawPredCol)
+    .setDefaultListenPort(getAndIncrementPort())
+    .setNumLeaves(5)
+    .setNumIterations(10)
+    .setObjective("binary")
+    .setLabelCol(labelCol)
+    .setLeafPredictionCol(leafPredCol)
+    .setFeaturesShapCol(featuresShapCol)
+    .setExecutionMode("streaming")
 
   test("Verify chunked array transpose simple") {
     Array(10, 100).foreach(chunkSize => {
@@ -72,6 +89,215 @@ class VerifyLightGBMCommon extends TestBase {
       assert(array.zipWithIndex.forall(pair => pair._1 == expectedArray(pair._2)))
     } finally {
       transposedArray.delete()
+    }
+  }
+
+  test("Verify sample data creation") {
+    LightGBMUtils.initializeNativeLibrary()
+    val Array(train, _) = pimaDF.randomSplit(Array(0.8, 0.2), seed)
+
+    val numRows = 100
+    val sampledRowData = train.take(numRows)
+    val featureData = sampledRowData(0).getAs[Any](featuresCol)
+    val numCols = featureData match {
+      case sparse: SparseVector => sparse.size
+      case dense: DenseVector => dense.size
+      case _ => throw new IllegalArgumentException("Unknown row data type to push")
+    }
+
+    val sampledData: SampledData = new SampledData(sampledRowData.length, numCols)
+    sampledRowData.zipWithIndex.foreach(rowWithIndex =>
+      sampledData.pushRow(rowWithIndex._1, rowWithIndex._2, featuresCol))
+
+    val rowCounts: IntSwigArray = sampledData.rowCounts
+    (0 until numCols).foreach(col => {
+      val rowCount = rowCounts.getItem(col)
+      println(s"Row counts for col $col: $rowCount")
+      val values = sampledData.sampleData.getItem(col)
+      val indexes = sampledData.sampleIndexes.getItem(col)
+      (0 until rowCount).foreach(i => println(s"  Index: ${indexes.getItem(i)}, val: ${values.getItem(i)}"))
+    })
+
+    var datasetVoidPtr:SWIGTYPE_p_p_void = null
+    try {
+      println("Creating dataset")
+      datasetVoidPtr = lightgbmlib.voidpp_handle()
+      val resultCode = lightgbmlib.LGBM_DatasetCreateFromSampledColumn(
+        sampledData.getSampleData,
+        sampledData.getSampleIndices,
+        numCols,
+        sampledData.getRowCounts,
+        numRows,
+        numRows,
+        s"max_bin=255 bin_construct_sample_cnt=$numRows min_data_in_leaf=1 num_threads=3",
+        datasetVoidPtr)
+      println(s"Result code for LGBM_DatasetCreateFromSampledColumn: $resultCode")
+    } finally {
+      sampledData.delete()
+
+      val datasetPtr: SWIGTYPE_p_void = lightgbmlib.voidpp_value(datasetVoidPtr)
+      LightGBMUtils.validate(lightgbmlib.LGBM_DatasetFree(datasetPtr), "Dataset LGBM_DatasetFree")
+
+      lightgbmlib.delete_voidpp(datasetVoidPtr)
+    }
+  }
+
+  test("Verify performance measures") {
+    val Array(train, _) = taskDF.randomSplit(Array(0.8, 0.2), seed)
+    // TODO How does this make fresh copy?
+    val measuredModel = baseModel
+      .setUseSingleDatasetMode(false)
+      .setExecutionMode("streaming")
+      .setMatrixType("sparse")
+      .setMicroBatchSize(100)
+    val _ = measuredModel.fit(train)
+    val measuresOpt =  measuredModel.getPerformanceMeasures
+
+    assert(measuresOpt.isDefined)
+    val measures = measuresOpt.get
+    val totalTime = measures.totalTime
+    assert(totalTime > 0)
+    println(s"Total time: $totalTime")
+    val columnStatisticsTime = measures.columnStatisticsTime()
+    assert(columnStatisticsTime > 0)
+    println(s"Column statistics time: $columnStatisticsTime")
+    val rowStatisticsTime = measures.rowStatisticsTime()
+    println(s"Row statistics time: $rowStatisticsTime")
+    val trainingTime = measures.trainingTime()
+    assert(trainingTime > 0)
+    println(s"Training time: $trainingTime")
+
+    println("")
+    val rowCountTime = measures.rowCountTime()
+    println(s"Row count time: $rowCountTime")
+    val sampleTime = measures.samplingTime()
+    println(s"Sample time: $sampleTime")
+
+    println("")
+    val taskTimes = measures.taskTotalTimes()
+    assert(taskTimes.nonEmpty)
+    taskTimes.foreach(t => assert(t > 0))
+    println(s"Task total times: ${taskTimes.mkString(",")}")
+    val taskDataPreparationTimes = measures.taskDataPreparationTimes()
+    assert(taskDataPreparationTimes.nonEmpty)
+    taskDataPreparationTimes.foreach(t => assert(t > 0))
+    println(s"Task data preparation times: ${taskDataPreparationTimes.mkString(",")}")
+    val taskDatasetCreationTimes = measures.taskDatasetCreationTimes()
+    assert(taskDatasetCreationTimes.nonEmpty)
+    assert(taskDatasetCreationTimes.sum > 0)
+    println(s"Task dataset creation times: ${taskDatasetCreationTimes.mkString(",")}")
+    val taskTrainingIterationTimes = measures.taskTrainingIterationTimes()
+    assert(taskTrainingIterationTimes.nonEmpty)
+    // TODO assert(taskTrainingIterationTimes.sum > 0)
+    println(s"Task training iteration times: ${taskTrainingIterationTimes.mkString(",")}")
+
+    val tasks = measures.getTaskMeasures
+    val activeTasks = tasks.filter(t => t.isActiveTrainingTask).map(t => t.partitionId)
+    println(s"Active task ids: ${activeTasks.mkString(",")}")
+
+    // TODO verify all diff measures that are 0 by default
+  }
+
+  test("Performance testing") {
+    // modify this test for getting some simple performance measures
+    val dataset = taskDF
+    val measurementCount = 1
+    val executionModes = Array("bulk")  // streaming, bulk
+    val microBatchSizes = Array(4000) // 1, 2, 4, 8, 16, 32, 100, 1000)
+    val matrixTypes = Array("dense")  // dense, sparse, auto
+    val useSingleDatasetModes = Array(true)
+
+    executionModes.foreach(executionMode => {
+      matrixTypes.foreach(matrixType => {
+        microBatchSizes.foreach(microBatchSize => {
+          useSingleDatasetModes.foreach(useSingleDataset => {
+            println(s"*********************************************************************************************")
+            println(s"**** Start ExecutionMode: $executionMode, MatrixType: $matrixType, " +
+              s"useSingleDataset: $useSingleDataset, MicroBatchSize: $microBatchSize")
+            measurePerformance(dataset, measurementCount, executionMode, microBatchSize, matrixType, useSingleDataset)
+            println(s"**** Done ExecutionMode: $executionMode, MatrixType: $matrixType, " +
+              s"useSingleDataset: $useSingleDataset, MicroBatchSize: $microBatchSize")
+            println(s"*********************************************************************************************")
+          })
+        })
+      })
+    })
+  }
+
+  def measurePerformance(df: DataFrame,
+                         measurementCount: Int,
+                         executionMode: String,
+                         microBatchSize: Int,
+                         matrixType: String,
+                         useSingleDataset: Boolean): Unit = {
+    val Array(train, _) = df.randomSplit(Array(0.8, 0.2), seed)
+    val measurements = Array.ofDim[InstrumentationMeasures](measurementCount)
+
+    (0 until measurementCount).foreach(i => {
+      println(s"** Start Measurement $i")
+
+      val measuredModel = baseModel
+        .setUseSingleDatasetMode(useSingleDataset)
+        .setExecutionMode(executionMode)
+        .setMatrixType(matrixType)
+        .setMicroBatchSize(microBatchSize)
+
+      val _ = measuredModel.fit(train)
+      measurements(i) = measuredModel.getPerformanceMeasures.get
+      println(s"Total time, ${measurements(i).totalTime}")
+      println(s"Column statistics, ${measurements(i).columnStatisticsTime}")
+      println(s"Row statistics time, ${measurements(i).rowStatisticsTime}")
+      println(s"Row count time, ${measurements(i).rowCountTime()}")
+      println(s"Sampling time, ${measurements(i).samplingTime()}")
+      println(s"Training time, ${measurements(i).trainingTime}")
+      println(s"Overhead time, ${measurements(i).overheadTime}")
+      println(s"Task total times, ${measurements(i).taskTotalTimes.mkString(",")}")
+      println(s"Task overhead times, ${measurements(i).taskOverheadTimes().mkString(",")}")
+      println(s"Task initialization times, ${measurements(i).taskInitializationTimes().mkString(",")}")
+      println(s"Task library initialization times, ${measurements(i).taskLibraryInitializationTimes().mkString(",")}")
+      println(s"Task network initialization times, ${measurements(i).taskNetworkInitializationTimes().mkString(",")}")
+      println(s"Task data preparation times, ${measurements(i).taskDataPreparationTimes.mkString(",")}")
+      println(s"Task dataset wait times, ${measurements(i).taskWaitTimes().mkString(",")}")
+      println(s"Task dataset creation times, ${measurements(i).taskDatasetCreationTimes.mkString(",")}")
+      println(s"Task training iteration times, ${measurements(i).taskTrainingIterationTimes.mkString(",")}")
+      println(s"Task cleanup times, ${measurements(i).taskCleanupTimes().mkString(",")}")
+      println(s"** Completed Measurement $i")
+    })
+    println(s"***** Averaged results for $measurementCount runs")
+    var median = getMedian(measurements.map(m => m.totalTime))
+    println(s"Median Total time, $median")
+    median = getMedian(measurements.map(m => m.columnStatisticsTime))
+    println(s"Median Column statistics, $median")
+    median = getMedian(measurements.map(m => m.rowCountTime()))
+    println(s"Median Row count time, $median")
+    median = getMedian(measurements.map(m => m.samplingTime()))
+    println(s"Median Sampling time, $median")
+    median = getMedian(measurements.map(m => m.rowStatisticsTime()))
+    println(s"Median Row statistics time, $median")
+    median = getMedian(measurements.map(m => m.trainingTime))
+    println(s"Median Training time, $median")
+    median = getMedian(measurements.map(m => m.overheadTime))
+    println(s"Median Overhead time, $median")
+    var medianMax = getMedian(measurements.map(m => m.taskTotalTimes.max))
+    println(s"Median-max Task total times, $medianMax")
+    medianMax = getMedian(measurements.map(m => m.taskOverheadTimes().max))
+    println(s"Median-max Task overhead times, $medianMax")
+    medianMax = getMedian(measurements.map(m => m.taskInitializationTimes().max))
+    println(s"Median-max Task initialization times, $medianMax")
+    medianMax = getMedian(measurements.map(m => m.taskDataPreparationTimes.max))
+    println(s"Median-max Task data preparation times, $medianMax")
+    medianMax = getMedian(measurements.map(m => m.taskDatasetCreationTimes.max))
+    println(s"Median-max Task dataset creation times, $medianMax")
+    medianMax = getMedian(measurements.map(m => m.taskTrainingIterationTimes.max))
+    println(s"Median-max Task training iteration times, $medianMax")
+  }
+
+  def getMedian[T: Ordering](seq: Seq[T])(implicit conv: T => Float, f: Fractional[Float]): Float = {
+    val sortedSeq = seq.sorted
+    if (seq.size % 2 == 1) sortedSeq(sortedSeq.size / 2)  else {
+      val (up, down) = sortedSeq.splitAt(seq.size / 2)
+      import f._
+      (conv(up.last) + conv(down.head)) / fromInt(2)
     }
   }
 }


### PR DESCRIPTION
# Summary

Add the streaming execution mode to LightGBM wrapper.  This mode uses almost no memory on top of what LightGBM needs to execute.

# Tests

Tests will be modified to run in both bulk and streaming mode before checkin.  Before this PR was pushed, LightGBMClassifier tests were all passing for streaming mode (the bulk of the tests).
There are also some new tests just for streaming components and instrumentation in Common.

# Dependency changes

This PR cannot be checked in without corresponding changes in native LightGBM library, or pointing to custom upload.  https://github.com/microsoft/LightGBM/pull/5299
