### PR TITLE
feat: Add the `descriptionExcludes` parameter to `AnalyzeImage`

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/ComputerVision.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/ComputerVision.scala
@@ -485,10 +485,7 @@ class AnalyzeImage(override val uid: String)
 
   val details = new ServiceParam[Seq[String]](
     this, "details", "what visual feature types to return",
-    {
-      case Left(seq) => seq.forall(Set("Celebrities", "Landmarks"))
-      case _ => true
-    },
+    { _ => true},
     isURLParam = true,
     toValueString = { seq => seq.mkString(",") }
   )
@@ -500,6 +497,21 @@ class AnalyzeImage(override val uid: String)
   def setDetails(v: Seq[String]): this.type = setScalarParam(details, v)
 
   def setDetailsCol(v: String): this.type = setVectorParam(details, v)
+
+  val descriptionExclude = new ServiceParam[Seq[String]](
+    this, "descriptionExclude", "Whether to exclude certain parts of the model in the description",
+    { _ => true},
+    isURLParam = true,
+    toValueString = { seq => seq.mkString(",") }
+  )
+
+  def getDescriptionExclude: Seq[String] = getScalarParam(descriptionExclude)
+
+  def getDescriptionExcludeCol: String = getVectorParam(descriptionExclude)
+
+  def setDescriptionExclude(v: Seq[String]): this.type = setScalarParam(descriptionExclude, v)
+
+  def setDescriptionExcludeCol(v: String): this.type = setVectorParam(descriptionExclude, v)
 
   val language = new ServiceParam[String](
     this, "language", "the language of the response (en if none given)", isURLParam = true

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split1/ComputerVisionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split1/ComputerVisionSuite.scala
@@ -101,26 +101,22 @@ class AnalyzeImageSuite extends TransformerFuzzing[AnalyzeImage] with CognitiveK
     .setSubscriptionKey(cognitiveKey)
     .setLocation("eastus")
     .setOutputCol("features")
-
-  lazy val ai: AnalyzeImage = baseAI
-    .setImageUrlCol("url")
     .setLanguageCol("language")
     .setVisualFeatures(
-      Seq("Categories", "Tags", "Description", "Faces", "ImageType", "Color", "Adult", "Objects", "Brands"))
+      Seq("Categories", "Tags", "Description", "Faces", "ImageType", "Color", "Adult", "Objects", "Brands")
+    )
     .setDetails(Seq("Celebrities", "Landmarks"))
+
+  def ai: AnalyzeImage = baseAI
+    .setImageUrlCol("url")
 
   lazy val bytesDF: DataFrame = BingImageSearch
     .downloadFromUrls("url", "imageBytes", 4, 10000)
     .transform(df)
     .drop("url")
 
-  lazy val bytesAI: AnalyzeImage = baseAI
+  def bytesAI: AnalyzeImage = baseAI
     .setImageBytesCol("imageBytes")
-    .setLanguageCol("language")
-    .setVisualFeatures(
-      Seq("Categories", "Tags", "Description", "Faces", "ImageType", "Color", "Adult", "Objects", "Brands")
-    )
-    .setDetails(Seq("Celebrities", "Landmarks"))
 
   test("full parametrization") {
     val row = (Seq("Categories"), "en", Seq("Celebrities"),
@@ -258,6 +254,7 @@ class ReadImageSuite extends TransformerFuzzing[ReadImage]
     def prep(df: DataFrame) = {
       df.select("url", "ocr.analyzeResult.readResults")
     }
+
     super.assertDFEq(prep(df1), prep(df2))(eq)
   }
 


### PR DESCRIPTION
Allows one to use AnalyzeImage in a privacy compliant way