### PR TITLE
feat: Support gray scale images in `toNDArray`

### DIFF
--- a/opencv/src/main/python/synapse/ml/opencv/ImageTransformer.py
+++ b/opencv/src/main/python/synapse/ml/opencv/ImageTransformer.py
@@ -43,6 +43,10 @@ def toNDArray(image):
     Returns:
         array: The image as a 1-dimensional array
     """
+    if image.nChannels == 1:
+        return np.asarray(image.data, dtype=np.uint8).reshape(
+            (image.height, image.width, 1))
+    
     return np.asarray(image.data, dtype=np.uint8).reshape(
         (image.height, image.width, 3),
     )[:, :, (2, 1, 0)]

--- a/opencv/src/main/python/synapse/ml/opencv/ImageTransformer.py
+++ b/opencv/src/main/python/synapse/ml/opencv/ImageTransformer.py
@@ -47,6 +47,7 @@ def toNDArray(image):
         return np.asarray(image.data, dtype=np.uint8).reshape(
             (image.height, image.width, 1)
         )
+     
     return np.asarray(image.data, dtype=np.uint8).reshape(
         (image.height, image.width, 3),
     )[:, :, (2, 1, 0)]

--- a/opencv/src/main/python/synapse/ml/opencv/ImageTransformer.py
+++ b/opencv/src/main/python/synapse/ml/opencv/ImageTransformer.py
@@ -47,7 +47,6 @@ def toNDArray(image):
         return np.asarray(image.data, dtype=np.uint8).reshape(
             (image.height, image.width, 1)
         )
-    
     return np.asarray(image.data, dtype=np.uint8).reshape(
         (image.height, image.width, 3),
     )[:, :, (2, 1, 0)]

--- a/opencv/src/main/python/synapse/ml/opencv/ImageTransformer.py
+++ b/opencv/src/main/python/synapse/ml/opencv/ImageTransformer.py
@@ -45,7 +45,8 @@ def toNDArray(image):
     """
     if image.nChannels == 1:
         return np.asarray(image.data, dtype=np.uint8).reshape(
-            (image.height, image.width, 1))
+            (image.height, image.width, 1)
+        )
     
     return np.asarray(image.data, dtype=np.uint8).reshape(
         (image.height, image.width, 3),

--- a/opencv/src/main/python/synapse/ml/opencv/ImageTransformer.py
+++ b/opencv/src/main/python/synapse/ml/opencv/ImageTransformer.py
@@ -47,7 +47,7 @@ def toNDArray(image):
         return np.asarray(image.data, dtype=np.uint8).reshape(
             (image.height, image.width, 1)
         )
-     
+
     return np.asarray(image.data, dtype=np.uint8).reshape(
         (image.height, image.width, 3),
     )[:, :, (2, 1, 0)]


### PR DESCRIPTION
Changed `toNDArray` method to also support converting gray scale images to numpy arrays for further transformations on those arrays.

AB#1909273