### PR TITLE
fix: fix translator endpoint and update all endpoints for gov regions

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/CognitiveServiceBase.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/CognitiveServiceBase.scala
@@ -276,7 +276,7 @@ trait HasSetLinkedServiceUsingLocation extends HasSetLinkedService with HasSetLo
   }
 }
 
-trait HasSetLocation extends Wrappable with HasURL with HasUrlPath {
+trait HasSetLocation extends Wrappable with HasURL with HasUrlPath with DomainHelper {
   override def pyAdditionalMethods: String = super.pyAdditionalMethods + {
     """
       |def setLocation(self, value):
@@ -298,8 +298,24 @@ trait HasSetLocation extends Wrappable with HasURL with HasUrlPath {
        |""".stripMargin
   }
 
+
   def setLocation(v: String): this.type = {
-    setUrl(s"https://$v.api.cognitive.microsoft.com/" + urlPath)
+    val domain = getLocationDomain(v)
+    setUrl(s"https://$v.api.cognitive.microsoft.$domain/" + urlPath)
+  }
+}
+
+trait DomainHelper {
+
+  protected def getLocationDomain(location: String): String = {
+    val usGovRegions = Array("usgovarizona", "usgovvirginia")
+    val cnVianet = Array("chinaeast2", "chinanorth")
+    val domain = location match {
+      case v if usGovRegions.contains(v) => "us"
+      case v if cnVianet.contains(v) => "cn"
+      case _ => "com"
+    }
+    domain
   }
 }
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/DocumentTranslator.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/DocumentTranslator.scala
@@ -49,7 +49,8 @@ object DocumentTranslator extends ComplexParamsReadable[DocumentTranslator]
 
 class DocumentTranslator(override val uid: String) extends CognitiveServicesBaseNoHandler(uid)
   with HasInternalJsonOutputParser with HasCognitiveServiceInput with HasServiceName
-  with Wrappable with DocumentTranslatorAsyncReply with BasicLogging with HasSetLinkedService {
+  with Wrappable with DocumentTranslatorAsyncReply with BasicLogging with HasSetLinkedService
+  with DomainHelper {
 
   import TranslatorJsonProtocol._
 
@@ -151,7 +152,8 @@ class DocumentTranslator(override val uid: String) extends CognitiveServicesBase
 
   override def setServiceName(v: String): this.type = {
     super.setServiceName(v)
-    setUrl(s"https://$getServiceName.cognitiveservices.azure.com/" + urlPath)
+    val domain = getLocationDomain(v)
+    setUrl(s"https://$getServiceName.cognitiveservices.azure.$domain/" + urlPath)
   }
 
   def urlPath: String = "/translator/text/batch/v1.0/batches"

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/SpeechToText.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/SpeechToText.scala
@@ -26,8 +26,10 @@ class SpeechToText(override val uid: String) extends CognitiveServicesBase(uid)
 
   def this() = this(Identifiable.randomUID("SpeechToText"))
 
-  override def setLocation(v: String): this.type =
-    setUrl(s"https://$v.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1")
+  override def setLocation(v: String): this.type = {
+    val domain = getLocationDomain(v)
+    setUrl(s"https://$v.stt.speech.microsoft.$domain/speech/recognition/conversation/cognitiveservices/v1")
+  }
 
   def urlPath: String = "/speech/recognition/conversation/cognitiveservices/v1"
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/TextTranslator.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/TextTranslator.scala
@@ -196,7 +196,7 @@ abstract class TextTranslatorBase(override val uid: String) extends CognitiveSer
 
   override def setLocation(v: String): this.type = {
     setSubscriptionRegion(v)
-    setUrl("https://api.cognitive.microsofttranslator.com/" + urlPath)
+    super.setLocation(v)
   }
 
 }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/TextTranslator.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/TextTranslator.scala
@@ -196,7 +196,8 @@ abstract class TextTranslatorBase(override val uid: String) extends CognitiveSer
 
   override def setLocation(v: String): this.type = {
     setSubscriptionRegion(v)
-    super.setLocation(v)
+    val domain = getLocationDomain(v)
+    setUrl(s"https://api.cognitive.microsofttranslator.$domain/" + urlPath)
   }
 
 }


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
No issues. There was a related IcM ticket.

## What changes are proposed in this pull request?

For gov regions the cog service endpoint is different.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [x] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.


AB#1937420