### PR TITLE
fix: fix flaky translate tests

### DIFF
--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split1/TranslatorSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split1/TranslatorSuite.scala
@@ -249,7 +249,7 @@ class BreakSentenceSuite extends TransformerFuzzing[BreakSentence]
       .withColumn("sentLen", flatten(col("result.sentLen")))
       .select("sentLen").collect()
     val headStr = results.head.getSeq(0).mkString("\n")
-    assert(headStr === "25")
+    assert(headStr === "3")
   }
 
   override def testObjects(): Seq[TestObject[BreakSentence]] =

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split1/TranslatorSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split1/TranslatorSuite.scala
@@ -21,9 +21,9 @@ trait TranslatorUtils extends TestBase {
 
   import spark.implicits._
 
-  lazy val textDf1: DataFrame = Seq(List("Hello, what is your name?")).toDF("text")
+  lazy val textDf1: DataFrame = Seq(List("Bye")).toDF("text")
 
-  lazy val  textDf2: DataFrame = Seq(List("Hello, what is your name?", "Bye")).toDF("text")
+  lazy val  textDf2: DataFrame = Seq(List("Good morning", "Bye")).toDF("text")
 
   lazy val textDf3: DataFrame = Seq(List("This is bullshit.")).toDF("text")
 
@@ -62,7 +62,7 @@ class TranslateSuite extends TransformerFuzzing[Translate]
 
   test("Translate multiple pieces of text with language autodetection") {
     val result1 = getTranslationTextResult(translate.setToLanguage(Seq("zh-Hans")), textDf2).collect()
-    assert(result1(0).getSeq(0).mkString("\n") == "您好，您叫什么名字？\n再见")
+    assert(result1(0).getSeq(0).mkString("\n") == "早上好\n再见")
 
     val translate1: Translate = new Translate()
       .setSubscriptionKey(translatorKey)
@@ -103,13 +103,13 @@ class TranslateSuite extends TransformerFuzzing[Translate]
       .withColumn("transliteration", col("translation.transliteration.text"))
       .withColumn("translation", col("translation.text"))
       .select("translation", "transliteration").collect()
-    assert(results.head.getSeq(0).mkString("\n") === "您好，您叫什么名字？")
-    assert(results.head.getSeq(1).mkString("\n") === "nín hǎo ， nín jiào shén me míng zì ？")
+    assert(results.head.getSeq(0).mkString("\n") === "再见")
+    assert(results.head.getSeq(1).mkString("\n") === "zài jiàn")
   }
 
   test("Translate to multiple languages") {
     val result1 = getTranslationTextResult(translate.setToLanguage(Seq("zh-Hans", "de")), textDf1).collect()
-    assert(result1(0).getSeq(0).mkString("\n") == "您好，您叫什么名字？\nHallo, wie heißt du?")
+    assert(result1(0).getSeq(0).mkString("\n") == "再见\nAuf Wiedersehen")
   }
 
   test("Handle profanity") {
@@ -136,8 +136,8 @@ class TranslateSuite extends TransformerFuzzing[Translate]
       .withColumn("alignment", col("translation.alignment.proj"))
       .withColumn("translation", col("translation.text"))
       .select("translation", "alignment").collect()
-    assert(results.head.getSeq(0).mkString("\n") === "Bonjour, quel est votre nom?")
-    assert(results.head.getSeq(1).mkString("\n") === "0:5-0:7 7:10-9:12 12:13-14:16 15:18-18:22 20:24-24:27")
+    assert(results.head.getSeq(0).mkString("\n") === "Au revoir")
+    assert(results.head.getSeq(1).mkString("\n") === "0:2-0:8")
   }
 
   test("Obtain sentence boundaries") {
@@ -151,9 +151,9 @@ class TranslateSuite extends TransformerFuzzing[Translate]
       .withColumn("transSentLen", flatten(col("translation.sentLen.transSentLen")))
       .withColumn("translation", col("translation.text"))
       .select("translation", "srcSentLen", "transSentLen").collect()
-    assert(results.head.getSeq(0).mkString("\n") === "Bonjour, quel est votre nom?")
-    assert(results.head.getSeq(1).mkString("\n") === "25")
-    assert(results.head.getSeq(2).mkString("\n") === "28")
+    assert(results.head.getSeq(0).mkString("\n") === "Au revoir")
+    assert(results.head.getSeq(1).mkString("\n") === "3")
+    assert(results.head.getSeq(2).mkString("\n") === "9")
   }
 
   test("Translate with dynamic dictionary") {


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

_Briefly describe the changes included in this Pull Request._

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.


AB#1966811