### PR TITLE
docs: add MLFlow in ai sample time series forecasting

### DIFF
--- a/notebooks/community/aisamples/AIsample - Time Series Forecasting.ipynb
+++ b/notebooks/community/aisamples/AIsample - Time Series Forecasting.ipynb
@@ -398,6 +398,58 @@
             "source": [
                 "display(df_p)"
             ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## Step 4: Log and Load Model with MLFlow\n",
+                "We can now store the trained model for later use."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# setup mlflow\n",
+                "import mlflow\n",
+                "import trident.mlflow\n",
+                "from trident.mlflow import get_sds_url\n",
+                "\n",
+                "EXPERIMENT_NAME = \"aisample-timeseries\"\n",
+                "\n",
+                "mlflow.set_tracking_uri(get_sds_url())\n",
+                "mlflow.set_registry_uri(get_sds_url())\n",
+                "mlflow.set_experiment(EXPERIMENT_NAME)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# log the model and parameters\n",
+                "model_name = f\"{EXPERIMENT_NAME}-prophet\"\n",
+                "with mlflow.start_run() as run:\n",
+                "    mlflow.prophet.log_model(m, model_name, registered_model_name=model_name)\n",
+                "    mlflow.log_params({\"seasonality_mode\": \"multiplicative\", \"mcmc_samples\": 1000})\n",
+                "    model_uri = f\"runs:/{run.info.run_id}/{model_name}\"\n",
+                "    print(\"Model saved in run %s\" % run.info.run_id)\n",
+                "    print(f\"Model URI: {model_uri}\")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# load the model back\n",
+                "loaded_model = mlflow.prophet.load_model(model_uri)"
+            ]
         }
     ],
     "metadata": {


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

None

## What changes are proposed in this pull request?

Add MLFlow logging and loading to Time Series Forecasting sample notebook

## How is this patch tested?

- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [x] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.


AB#1966880