### PR TITLE
fix: KernelSHAP throws error when the key type in the ZipMap output is LongType

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/explainers/SharedParams.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/explainers/SharedParams.scala
@@ -177,7 +177,7 @@ trait HasExplainTarget extends Params with CanValidateSchema {
         SlicerFunctions.vectorSlicer(col(getTargetCol), col(targetClassesCol))
       case ArrayType(elementType: NumericType, _) =>
         SlicerFunctions.arraySlicer(elementType)(col(getTargetCol), col(targetClassesCol))
-      case MapType(_: IntegerType, valueType: NumericType, _) =>
+      case MapType(_: IntegerType | LongType | ShortType | ByteType, valueType: NumericType, _) =>
         SlicerFunctions.mapSlicer(valueType)(col(getTargetCol), col(targetClassesCol))
       case other =>
         throw new IllegalArgumentException(

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/explainers/split1/HasExplainTargetSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/explainers/split1/HasExplainTargetSuite.scala
@@ -13,8 +13,14 @@ class HasExplainTargetSuite extends TestBase {
     import spark.implicits._
 
     val df = Seq(
-      (Array(1, 2, 3), Vectors.dense(1, 2, 3), Map(0 -> 1f, 1 -> 2f, 2 -> 3f), Array(0, 2))
-    ) toDF("label1", "label2", "label3", "targets")
+      (
+        Array(1, 2, 3),
+        Vectors.dense(1, 2, 3),
+        Map(0 -> 1f, 1 -> 2f, 2 -> 3f),
+        Map(0L -> 1f, 1L -> 3f, 2L -> 5f),
+        Array(0, 2)
+      )
+    ) toDF("label1", "label2", "label3", "label4", "targets")
 
     // array of Int
     val target1 = LIME.vector
@@ -39,5 +45,13 @@ class HasExplainTargetSuite extends TestBase {
 
     val Tuple1(v3) = df.select(target3).as[Tuple1[Vector]].head
     assert(v3 == Vectors.dense(1d, 3d))
+
+    // Map of Long -> Float
+    val target4 = LocalExplainer.LIME.vector
+      .setTargetCol("label4")
+      .extractTarget(df.schema, "targets")
+
+    val Tuple1(v4) = df.select(target4).as[Tuple1[Vector]].head
+    assert(v4 == Vectors.dense(1d, 5d))
   }
 }


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
NA

## What changes are proposed in this pull request?

KernelSHAP throws error when the key in the ZipMap output of an ONNX model is of LongType. Adding more type checks to make sure all IntegralTypes can be supported as key type. IntegralType itself is private so I cannot use that type itself.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [x] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.


AB#1988985