### PR TITLE
Draft PR for LinearDMLEstimator

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/ComputeResidualTransformer.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/ComputeResidualTransformer.scala
@@ -1,0 +1,90 @@
+package com.microsoft.azure.synapse.ml.causal
+
+import com.microsoft.azure.synapse.ml.codegen.Wrappable
+import com.microsoft.azure.synapse.ml.core.schema.SchemaConstants
+import com.microsoft.azure.synapse.ml.logging.BasicLogging
+import org.apache.spark.ml.Transformer
+import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.ml.param._
+import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
+import org.apache.spark.sql.functions.{col, udf}
+import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.types._
+
+protected class ComputeResidualTransformer(override val uid: String) extends Transformer
+  with DefaultParamsWritable
+  with Wrappable
+  with BasicLogging {
+
+  logClass()
+
+  def this() = this(Identifiable.randomUID("ComputeResidualsTransformer"))
+
+  val observedCol = new Param[String](this, "observedCol", "observed data column")
+  def setObservedCol(value: String): this.type = set(param = observedCol, value = value)
+  final def getObservedCol: String = getOrDefault(observedCol)
+
+  val predictedCol = new Param[String](this, "predictedCol", "predicted data column")
+  def setPredictedCol(value: String): this.type = set(param = predictedCol, value = value)
+  final def getPredictedCol: String = getOrDefault(predictedCol)
+
+  val outputCol = new Param[String](this, "outputCol", "output column name")
+  def setOutputCol(value: String): this.type = set(param = outputCol, value = value)
+  final def getOutputCol: String = getOrDefault(outputCol)
+
+  val `class` =
+    new IntParam(
+      this,
+      "class",
+      "probability index value for residual compute, by default it is 1, the second value of probability vector",
+      ParamValidators.gtEq(0))
+  def set$class(value: Int): this.type = set(param = `class`, value = value)
+  final def get$class: Int = $(`class`)
+
+  override def copy(extra: ParamMap): ComputeResidualTransformer = defaultCopy(extra)
+
+  override def transformSchema(schema: StructType): StructType =
+    StructType(
+      schema.fields :+ StructField(
+        name = $(outputCol),
+        dataType = DoubleType,
+        nullable = false
+      )
+    )
+
+  setDefault(outputCol -> "residual", observedCol -> "y", predictedCol -> "yhat", `class` -> 1)
+
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    logTransform[DataFrame]({
+      val outCol  = getOutputCol
+      val obsCol  = getObservedCol
+      val predCol = getPredictedCol
+
+      transformSchema(schema = dataset.schema, logging = true)
+
+      // TO-DO: Validate $(`class`) >= probability size
+      val extract_prob_udf = udf { (label: Double, prob: Vector) =>
+        label - prob($(`class`))
+      }
+
+      val columnsToDrop = Seq(SchemaConstants.SparkRawPredictionColumn, SchemaConstants.SparkProbabilityColumn, SchemaConstants.SparkPredictionColumn)
+
+      if (dataset.schema(predCol).name == SchemaConstants.SparkProbabilityColumn)
+      {
+        // for classifier, we compute residual as "label - probability(1)"
+        dataset.withColumn(
+          colName = outCol,
+          col = extract_prob_udf(col(obsCol), col(predCol))
+        ).drop(columnsToDrop: _*)
+      } else {
+        // for regression, we compute residual as "label - prediction"
+        dataset.withColumn(
+          colName = outCol,
+          col = col(obsCol) - col(predCol)
+        ).drop(columnsToDrop: _*)
+      }
+    })
+  }
+}
+
+object ComputeResidualTransformer extends DefaultParamsReadable[ComputeResidualTransformer]

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/LinearDMLEstimator.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/LinearDMLEstimator.scala
@@ -1,0 +1,283 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.causal
+
+import com.microsoft.azure.synapse.ml.codegen.Wrappable
+import com.microsoft.azure.synapse.ml.train._
+import com.microsoft.azure.synapse.ml.core.schema.SchemaConstants
+import com.microsoft.azure.synapse.ml.featurize.{Featurize, FeaturizeUtilities}
+import com.microsoft.azure.synapse.ml.logging.BasicLogging
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.ml.{Estimator, _}
+import org.apache.spark.ml.classification._
+import org.apache.spark.ml.linalg.DenseVector
+import org.apache.spark.ml.param._
+import org.apache.spark.ml.util._
+import org.apache.spark.sql._
+import org.apache.spark.sql.types._
+import org.apache.spark.ml.regression.{DecisionTreeRegressor, GBTRegressor, GeneralizedLinearRegression, GeneralizedLinearRegressionModel, RandomForestRegressor, Regressor}
+
+
+/** Double ML estimators. The estimator follows the two stage process,
+ *  where a set of nuisance functions are estimated in the first stage in a crossfitting manner
+ *  and a final stage estimates the conditional average treatment effect (CATE) model.
+ *  Our goal is to estimate the constant marginal CATE Theta(X)
+ *
+ *  In this estimator, the CATE is estimated by using the following estimating equations:
+ *  .. math ::
+ *      Y - \\E[Y | X, W] = \\Theta(X) \\cdot (T - \\E[T | X, W]) + \\epsilon
+ *
+ *
+ *  Thus if we estimate the nuisance functions :math:`q(X, W) = \\E[Y | X, W]` and
+ *  :math:`f(X, W)=\\E[T | X, W]` in the first stage, we can estimate the final stage cate for each
+ *  treatment t, by running a regression, minimizing the residual on residual square loss,
+ *  estimating Theta(X) is a final regression problem, regressing tilde{Y} on X and tilde{T})
+ *
+ *  .. math ::
+ *       \\hat{\\theta} = \\arg\\min_{\\Theta}\
+ *       \E_n\\left[ (\\tilde{Y} - \\Theta(X) \\cdot \\tilde{T})^2 \\right]
+ *
+ * Where
+ * `\\tilde{Y}=Y - \\E[Y | X, W]` and :math:`\\tilde{T}=T-\\E[T | X, W]` denotes the
+ * residual outcome and residual treatment.
+ *
+ * The nuisance function :math:`q` is a simple regression problem and user
+ * can use setOutcomeModel to set an arbitrary sparkml regressor that is internally used to solve this regression problem
+ *
+ * The problem of estimating the nuisance function :math:`f` is also a regression problem and user
+ * can use setTreatmentModel to set an arbitrary sparkml regressor that is internally used to solve this regression problem.
+ *
+ * If the init flag `discrete_treatment` is set to `True`, then the treatment model is treated as a classifier.
+ * The input categorical treatment is one-hot encoded (excluding the lexicographically smallest treatment which is used as the baseline)
+ * and the `predict_proba` method of the treatment model classifier is used to residualize the one-hot encoded treatment.
+
+      The final stage is (potentially multi-task) linear regression problem with outcomes the labels
+      :math:`\\tilde{Y}` and regressors the composite features
+      :math:`\\tilde{T}\\otimes \\phi(X) = \\mathtt{vec}(\\tilde{T}\\cdot \\phi(X)^T)`.
+      The :class:`.DML` takes as input parameter
+      ``model_final``, which is any linear sparkml regressor that is internally used to solve this
+      (multi-task) linear regresion problem.
+ */
+//noinspection ScalaStyle
+class LinearDMLEstimator(override val uid: String)
+  extends AutoTrainer[LinearDMLModel]
+  with LinearDMLParams
+  with BasicLogging {
+
+  logClass()
+
+  def this() = this(Identifiable.randomUID("LinearDMLEstimator"))
+
+  override def modelDoc: String = "LinearDML to run"
+
+  setDefault(featuresCol, this.uid + "_features")
+
+  /** Fits the LinearDML model.
+   *
+   * @param dataset The input dataset to train.
+   * @return The trained LinearDML model.
+   */
+  override def fit(dataset: Dataset[_]): LinearDMLModel = {
+    logFit({
+
+      // Step 1 - Train treatment model and compute treatment residual
+      val treatmentClassifier =
+        if (getDiscreteTreatment) {
+          new TrainClassifier().setModel(getTreatmentModel).setLabelCol(getTreatmentCol).setExcludedFeatureCols(Array(getOutcomeCol))
+        } else {
+          new TrainRegressor().setModel(getTreatmentModel).setLabelCol(getTreatmentCol)
+        }
+
+      // get treatment's prediction column, for classifier we use probability column and for regression we use prediction column
+      val treatmentPredictionColName = getTreatmentModel match {
+        case classifier: ProbabilisticClassifier[_, _, _] =>
+          classifier.getProbabilityCol
+        case regressor: Regressor[_, _, _] =>
+          regressor.getPredictionCol
+      }
+
+      // Compute treatment residual
+      val computeTreatmentResiduals =
+        new ComputeResidualTransformer()
+          .setObservedCol(getTreatmentCol)
+          .setPredictedCol(treatmentPredictionColName)
+          .setOutputCol(SchemaConstants.TreatmentResidualColumn)
+
+      // Step 2 - Train outcome model and compute outcome residual
+      val outcomeRegressor = new TrainRegressor().setModel(getOutcomeModel).setLabelCol(getOutcomeCol).setExcludedFeatureCols(Array(getTreatmentCol))
+
+      // get outcome's prediction column, for classifier we use probability column and for regression we use prediction column
+      val outcomePredictionColName = getOutcomeModel match {
+        case classifier: ProbabilisticClassifier[_, _, _] =>
+          classifier.getProbabilityCol
+        case regressor: Regressor[_, _, _] =>
+          regressor.getPredictionCol
+      }
+
+      // Compute outcome residual
+      val computeOutcomeResiduals = new ComputeResidualTransformer()
+        .setObservedCol(getOutcomeCol)
+        .setPredictedCol(outcomePredictionColName)
+        .setOutputCol(SchemaConstants.OutcomeResidualColumn)
+
+      // Execute step 1 and 2 in pipeline
+      val pipelineModel = new Pipeline().setStages(
+        Array(treatmentClassifier, computeTreatmentResiduals, outcomeRegressor, computeOutcomeResiduals,
+        )).fit(dataset)
+
+      // Step 3 - final regression
+      val scoredData = pipelineModel.transform(dataset).select("treatment_residual", "outcome_residual")
+
+      val convertedLabelDataset_finalModel = LinearDMLEstimator.convertRegressorLabel(scoredData, "outcome_residual")
+      val regressor = new GeneralizedLinearRegression().setFamily("gaussian").setLink("identity").setFitIntercept(false)
+
+      val regressor_final = LinearDMLEstimator.getEstimatorWithLabelFeaturesConfigured(regressor, "outcome_residual", getFeaturesCol)
+      val (oneHotEncodeCategoricals_finalModel, numFeatures_finalModel, _) = LinearDMLEstimator.getFeaturizeParams(regressor, getNumFeatures)
+      val featurizer_finalModel = new Featurize()
+        .setOutputCol(getFeaturesCol)
+        .setInputCols(Array("treatment_residual"))
+        .setOneHotEncodeCategoricals(oneHotEncodeCategoricals_finalModel)
+        .setNumFeatures(numFeatures_finalModel)
+
+      val featurized_finalModel = featurizer_finalModel.fit(convertedLabelDataset_finalModel)
+      val processedData_finalModel = featurized_finalModel.transform(convertedLabelDataset_finalModel)
+      processedData_finalModel.cache()
+      val fitFinalModel = regressor_final.fit(processedData_finalModel)
+      processedData_finalModel.unpersist()
+
+      val pipeline_finalModel = new Pipeline().setStages(Array(featurized_finalModel, fitFinalModel)).fit(convertedLabelDataset_finalModel)
+
+      val lrm = pipeline_finalModel.stages.last.asInstanceOf[GeneralizedLinearRegressionModel]
+
+      // compute confidence intervals = slope +/- t * SE Coef
+      val ci_lower = lrm.coefficients(0) - lrm.summary.tValues(0) * lrm.summary.coefficientStandardErrors(0)
+      val ci_higher = lrm.coefficients(0) + lrm.summary.tValues(0) * lrm.summary.coefficientStandardErrors(0)
+
+      new LinearDMLModel()
+        .setATE(lrm.coefficients.asInstanceOf[DenseVector].values)
+        .setCI(Array(ci_lower, ci_higher))
+    })
+  }
+
+  override def copy(extra: ParamMap): Estimator[LinearDMLModel] = {
+    defaultCopy(extra)
+  }
+
+  @DeveloperApi
+  override def transformSchema(schema: StructType): StructType = {
+    LinearDMLEstimator.validateTransformSchema(schema)
+  }
+}
+
+object LinearDMLEstimator extends ComplexParamsReadable[LinearDMLEstimator] {
+
+  def validateTransformSchema(schema: StructType): StructType = {
+    val treatmentSchema = StructType(schema.fields :+ StructField(SchemaConstants.TreatmentResidualColumn, DoubleType))
+    StructType(treatmentSchema.fields :+ StructField(SchemaConstants.OutcomeResidualColumn, DoubleType))
+  }
+
+  def getFeaturizeParams(model: Estimator[_ <: Model[_]], getNumFeatures: Int): (Boolean, Int, Boolean) = {
+    var oneHotEncodeCategoricals = true
+    var modifyInputLayer = false
+    // Create trainer based on the pipeline stage and set the parameters
+
+    val numFeatures: Int = model match {
+      case _: DecisionTreeClassifier | _: GBTClassifier | _: RandomForestClassifier | _: DecisionTreeRegressor | _: GBTRegressor | _: RandomForestRegressor =>
+        oneHotEncodeCategoricals = false
+        FeaturizeUtilities.NumFeaturesTreeOrNNBased
+      case _: MultilayerPerceptronClassifier =>
+        modifyInputLayer = true
+        FeaturizeUtilities.NumFeaturesTreeOrNNBased
+      case _ =>
+        FeaturizeUtilities.NumFeaturesDefault
+    }
+
+    val featuresToHashTo = if (getNumFeatures != 0) {
+      getNumFeatures
+    } else {
+      numFeatures
+    }
+
+    (oneHotEncodeCategoricals, featuresToHashTo, modifyInputLayer)
+  }
+
+  def getEstimatorWithLabelFeaturesConfigured(estimator: Estimator[_ <: Model[_]], labelCol: String, featuresCol: String): Estimator[_ <: Model[_]] = {
+    estimator match {
+      case predictor: Predictor[_, _, _] =>
+        predictor
+          .setLabelCol(labelCol)
+          .setFeaturesCol(featuresCol).asInstanceOf[Estimator[_ <: Model[_]]]
+      case default@defaultType if defaultType.isInstanceOf[Estimator[_ <: Model[_]]] =>
+        // assume label col and features col already set
+        default
+      case _ => throw new Exception("Unsupported learner type " + estimator.getClass.toString)
+    }
+
+  }
+
+  def convertRegressorLabel(dataset: Dataset[_],
+                            labelColumn: String): DataFrame = {
+
+    // TODO: Handle DateType, TimestampType and DecimalType for label
+    // Convert the label column during train to the correct type and drop missings
+    val df_cast = dataset.withColumn(labelColumn,
+      col = dataset.schema(labelColumn).dataType match {
+        case _: IntegerType |
+             _: BooleanType |
+             _: FloatType |
+             _: ByteType |
+             _: LongType |
+             _: ShortType |
+             _: StringType =>
+          dataset(labelColumn).cast(DoubleType)
+        case _: DoubleType =>
+          dataset(labelColumn)
+        case default => throw new Exception("Unknown type: " + default.typeName +
+          ", for label column: " + labelColumn)
+      }
+    ).na.drop(Seq(labelColumn))
+
+
+    // For illegal cast (e.g. an invalid string to double), Spark won't fail and just return null for them. (It's default behavior `spark.sql.ansi.enabled=false`)
+    // So we do a simple count check to ensure casting has no failure
+    if (dataset.count() != df_cast.count()) {
+      throw new Exception("Invalid type: " +
+        "Regressors are not able to train on a string label column when it has invalid value and not able to be converted to numeric: " + labelColumn
+      )
+    }
+
+    df_cast
+  }
+}
+
+/** Model produced by [[LinearDMLEstimator]]. */
+class LinearDMLModel(val uid: String)
+  extends AutoTrainedModel[LinearDMLModel] with Wrappable with BasicLogging {
+  logClass()
+
+  def this() = this(Identifiable.randomUID("LinearDMLModel"))
+
+  val ate = new Param[Array[Double]](this, "cate", "average treatment effect")
+  def getATE: Array[Double] = $(ate)
+  def setATE(v:Array[Double] ): this.type = set(ate, v)
+
+  var ci = new Param[Array[Double]](this, "ci", "treatment effect's confidence interval")
+  def getCI: Array[Double] = $(ci)
+  def setCI(v:Array[Double] ): this.type = set(ci, v)
+
+  override def copy(extra: ParamMap): LinearDMLModel = defaultCopy(extra)
+
+  //scalastyle:off
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    logTransform[DataFrame]({
+      throw new Exception("transform is invalid for LinearDMLEstimator.")
+    })
+  }
+
+  @DeveloperApi
+  override def transformSchema(schema: StructType): StructType =
+    throw new Exception("transform is invalid for LinearDMLEstimator.")
+}
+
+object LinearDMLModel extends ComplexParamsReadable[LinearDMLModel]

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/LinearDMLParams.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/LinearDMLParams.scala
@@ -3,9 +3,9 @@ package com.microsoft.azure.synapse.ml.causal
 import com.microsoft.azure.synapse.ml.core.contracts.HasWeightCol
 import org.apache.spark.ml.classification.{LogisticRegression, ProbabilisticClassifier}
 import org.apache.spark.ml.{Estimator, Model}
-import org.apache.spark.ml.param.{EstimatorParam, Param, Params}
+import com.microsoft.azure.synapse.ml.param.EstimatorParam
+import org.apache.spark.ml.param.{Param, Params}
 import org.apache.spark.ml.regression.{RandomForestRegressor, Regressor}
-
 
 trait HasTreatmentCol extends Params {
   val treatment = new Param[String](this, "treatment", "treatment column")
@@ -62,7 +62,7 @@ trait LinearDMLParams extends Params with HasTreatmentCol with HasOutcomeCol wit
   }
 
   setDefault(
-    discrete_treatment -> false,
+    discrete_treatment -> true,
     treatmentModel -> new LogisticRegression(),
     outcomeModel -> new RandomForestRegressor()
   )

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/LinearDMLParams.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/LinearDMLParams.scala
@@ -1,0 +1,69 @@
+package com.microsoft.azure.synapse.ml.causal
+
+import com.microsoft.azure.synapse.ml.core.contracts.HasWeightCol
+import org.apache.spark.ml.classification.{LogisticRegression, ProbabilisticClassifier}
+import org.apache.spark.ml.{Estimator, Model}
+import org.apache.spark.ml.param.{EstimatorParam, Param, Params}
+import org.apache.spark.ml.regression.{RandomForestRegressor, Regressor}
+
+
+trait HasTreatmentCol extends Params {
+  val treatment = new Param[String](this, "treatment", "treatment column")
+  def getTreatmentCol: String = $(treatment)
+  def setTreatmentCol(value: String): this.type = set(treatment, value)
+}
+
+trait HasOutcomeCol extends Params {
+  val outcome: Param[String] = new Param[String](this, "outcome", "outcome column")
+  def getOutcomeCol: String = $(outcome)
+  def setOutcomeCol(value: String): this.type = set(outcome, value)
+}
+
+trait LinearDMLParams extends Params with HasTreatmentCol with HasOutcomeCol with HasWeightCol {
+  val discrete_treatment: Param[Boolean] = new Param[Boolean](this, name="discrete_treatment", doc="discrete or continuous treatment")
+  def getDiscreteTreatment: Boolean = $(discrete_treatment)
+  def setDiscreteTreatment(value: Boolean): this.type = set(discrete_treatment, value)
+
+  val treatmentModel = new EstimatorParam(this, "treatmentModel", "treatment model to run")
+  def getTreatmentModel: Estimator[_ <: Model[_]] = $(treatmentModel)
+
+  /** The currently supported classifiers are:
+   * Logistic Regression Classifier
+   * Decision Tree Classifier
+   * Random Forest Classifier
+   * Gradient Boosted Trees Classifier
+   * Naive Bayes Classifier
+   * Multilayer Perceptron Classifier
+   * In addition to any generic learner that inherits from Predictor.
+   */
+  def setTreatmentModel(value: Estimator[_ <: Model[_]]) : this.type = {
+    val isSupportedModel = value match {
+      case regressor: Regressor[_,_,_] =>   true // for continuous treatment
+      case classifier: ProbabilisticClassifier[_, _, _] => true
+      case _ => false
+    }
+    if (!isSupportedModel)  {
+      throw new Exception("LinearDML only support regressor and ProbabilisticClassifier as treatment model")
+    }
+    set(treatmentModel, value)
+  }
+
+  val outcomeModel = new EstimatorParam(this, "outcomeModel", "outcome model to run")
+  def getOutcomeModel: Estimator[_ <: Model[_]] = $(outcomeModel)
+  def setOutcomeModel(value: Estimator[_ <: Model[_]] ) : this.type = {
+    val isSupportedModel = value match {
+      case regressor: Regressor[_,_,_] =>   true // for continuous treatment
+      case _ => false
+    }
+    if (!isSupportedModel)  {
+      throw new Exception("LinearDML only support regressor as outcome model")
+    }
+    set(outcomeModel, value)
+  }
+
+  setDefault(
+    discrete_treatment -> false,
+    treatmentModel -> new LogisticRegression(),
+    outcomeModel -> new RandomForestRegressor()
+  )
+}

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/contracts/Params.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/contracts/Params.scala
@@ -63,9 +63,9 @@ trait HasOutputCols extends Params {
 
 trait HasLabelCol extends Params {
   /** The name of the label column
-    *
-    * @group param
-    */
+   *
+   * @group param
+   */
   val labelCol = new Param[String](this, "labelCol", "The name of the label column")
 
   /** @group setParam */
@@ -204,4 +204,19 @@ trait HasGroupCol extends Params {
 
   /** @group getParam */
   def getGroupCol: String = $(groupCol)
+}
+
+trait HasExcludedFeatureCols extends Params {
+
+  /** The names of the hasExcludedCols
+   *
+   * @group param
+   */
+  val excludedFeatureCols = new StringArrayParam(this, "excludedFeatureCols", "The names of the columns to be excluded from featuring")
+
+  /** @group setParam */
+  def setExcludedFeatureCols(value: Array[String]): this.type = set(excludedFeatureCols, value)
+
+  /** @group getParam */
+  def getExcludedFeatureCols: Array[String] = $(excludedFeatureCols)
 }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/schema/SchemaConstants.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/schema/SchemaConstants.scala
@@ -14,6 +14,9 @@ object SchemaConstants {
   val ScoresColumn              = "scores"
   val ScoredProbabilitiesColumn = "scored_probabilities"
 
+  val TreatmentResidualColumn   = "treatment_residual"
+  val OutcomeResidualColumn     = "outcome_residual"
+
   val ScoreModelPrefix          = "score_model"
   val MMLTag                    = "mml"      // MML metadata tag
   val MLlibTag                  = "ml_attr"  // MLlib metadata tag, see org.apache.spark.ml.attribute.AttributeKeys

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/stages/DropColumns.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/stages/DropColumns.scala
@@ -38,28 +38,28 @@ class DropColumns(val uid: String) extends Transformer with Wrappable with Defau
     */
   override def transform(dataset: Dataset[_]): DataFrame = {
     logTransform[DataFrame]({
-      verifySchema(dataset.schema)
+//      verifySchema(dataset.schema)
       dataset.toDF().drop(getCols: _*)
     })
   }
 
   def transformSchema(schema: StructType): StructType = {
-    verifySchema(schema)
+//    verifySchema(schema)
     val droppedCols = getCols.toSet
     StructType(schema.fields.filter(f => !droppedCols(f.name)))
   }
 
   def copy(extra: ParamMap): DropColumns = defaultCopy(extra)
 
-  private def verifySchema(schema: StructType): Unit = {
-    val providedCols = schema.fields.map(_.name).toSet
-    val invalidCols = getCols.filter(!providedCols(_))
-
-    if (invalidCols.length > 0) {
-      throw new NoSuchElementException(
-        s"DataFrame does not contain specified columns: ${invalidCols.reduce(_ + "," + _)}")
-    }
-
-  }
+//  private def verifySchema(schema: StructType): Unit = {
+//    val providedCols = schema.fields.map(_.name).toSet
+//    val invalidCols = getCols.filter(!providedCols(_))
+//
+//    if (invalidCols.length > 0) {
+//      throw new NoSuchElementException(
+//        s"DataFrame does not contain specified columns: (${invalidCols.reduce(_ + "," + _)}), " +
+//          s"it has columns: (${providedCols.mkString(",")}")
+//    }
+//  }
 
 }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/AutoTrainedModel.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/AutoTrainedModel.scala
@@ -13,7 +13,7 @@ import org.apache.spark.ml.{ComplexParamsWritable, Model, PipelineModel, Transfo
 abstract class AutoTrainedModel[TrainedModel <: Model[TrainedModel]]
   extends Model[TrainedModel] with ComplexParamsWritable with HasLabelCol with HasFeaturesCol{
 
-  private def validate(t: Transformer): Boolean = {
+  def validate(t: Transformer): Boolean = {
     t match {
       case _: PipelineModel => true
       case _ => false

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/AutoTrainer.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/AutoTrainer.scala
@@ -4,7 +4,7 @@
 package com.microsoft.azure.synapse.ml.train
 
 import com.microsoft.azure.synapse.ml.codegen.Wrappable
-import com.microsoft.azure.synapse.ml.core.contracts.{HasFeaturesCol, HasLabelCol}
+import com.microsoft.azure.synapse.ml.core.contracts.{HasExcludedFeatureCols, HasFeaturesCol, HasLabelCol}
 import com.microsoft.azure.synapse.ml.param.EstimatorParam
 import org.apache.spark.ml.param.IntParam
 import org.apache.spark.ml.{ComplexParamsWritable, Estimator, Model}
@@ -12,7 +12,7 @@ import org.apache.spark.ml.{ComplexParamsWritable, Estimator, Model}
 /** Defines common inheritance and parameters across trainers.
   */
 trait AutoTrainer[TrainedModel <: Model[TrainedModel]] extends Estimator[TrainedModel]
-  with HasLabelCol with ComplexParamsWritable with HasFeaturesCol with Wrappable {
+  with HasLabelCol with HasExcludedFeatureCols with ComplexParamsWritable with HasFeaturesCol with Wrappable {
 
   /** Doc for model to run.
     */
@@ -22,7 +22,6 @@ trait AutoTrainer[TrainedModel <: Model[TrainedModel]] extends Estimator[Trained
     * @group param
     */
   val numFeatures = new IntParam(this, "numFeatures", "Number of features to hash to")
-  setDefault(numFeatures -> 0)
 
   /** @group getParam */
   def getNumFeatures: Int = $(numFeatures)
@@ -37,4 +36,7 @@ trait AutoTrainer[TrainedModel <: Model[TrainedModel]] extends Estimator[Trained
   def getModel: Estimator[_ <: Model[_]] = $(model)
   /** @group setParam */
   def setModel(value: Estimator[_ <: Model[_]]): this.type = set(model, value)
+
+
+  setDefault(numFeatures -> 0, excludedFeatureCols -> Array.empty[String])
 }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/TrainClassifier.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/TrainClassifier.scala
@@ -152,7 +152,8 @@ class TrainClassifier(override val uid: String) extends AutoTrainer[TrainedClass
           numFeatures
         }
 
-      val featureColumns = convertedLabelDataset.columns.filter(col => col != getLabelCol).toSeq
+      val nonFeatureColumns = getLabelCol +: getExcludedFeatureCols
+      val featureColumns = convertedLabelDataset.columns.filter(col => !nonFeatureColumns.contains(col)).toSeq
 
       val featurizer = new Featurize()
         .setOutputCol(getFeaturesCol)

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/causal/VerifyResidual.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/causal/VerifyResidual.scala
@@ -1,0 +1,53 @@
+package com.microsoft.azure.synapse.ml.causal
+
+
+import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import org.apache.spark.ml.linalg.DenseVector
+import org.apache.spark.sql.DataFrame
+
+class VerifyResidual extends TestBase {
+
+  val mockLabelColumn = "Label"
+
+  private lazy val mockDataset = spark.createDataFrame(Seq(
+    (0, 2d, 0.50d, true, 0, 0.toByte, 12F),
+    (1, 3d, 0.40d, false, 1, 100.toByte, 30F),
+    (0, 4d, 0.78d, true, 2, 50.toByte, 12F),
+    (1, 5d, 0.12d, false, 3, 0.toByte, 12F),
+    (0, 1d, 0.50d, true, 0, 0.toByte, 30F),
+    (1, 3d, 0.40d, false, 1, 10.toByte, 12F),
+    (0, 3d, 0.78d, false, 2, 0.toByte, 12F),
+    (1, 4d, 0.12d, false, 3, 0.toByte, 12F),
+    (0, 0d, 0.50d, true, 0, 0.toByte, 12F),
+    (1, 2d, 0.40d, false, 1, 127.toByte, 30F),
+    (0, 3d, 0.78d, true, 2, -128.toByte, 12F),
+    (1, 4d, 0.12d, false, 3, 0.toByte, 12F)))
+    .toDF(mockLabelColumn, "col1", "col2", "col3", "col4", "col5", "col6")
+
+  private lazy val expectedDF = spark.createDataFrame(Seq(
+    (0, 2d, 0.50d, true, 0, 0.toByte, 12F,                    1.5),
+    (1, 3d, 0.40d, false, 1, 100.toByte, 30F,                 2.6),
+    (0, 4d, 0.78d,  true, 2, 50.toByte, 12F,   3.2199999999999998),
+    (1, 5d, 0.12d,  false, 3, 0.toByte, 12F,                 4.88),
+    (0, 1d, 0.50d, true, 0, 0.toByte, 30F,                    0.5),
+    (1, 3d, 0.40d, false, 1, 10.toByte, 12F,                  2.6),
+    (0, 3d, 0.78d,  false, 2, 0.toByte, 12F,   2.2199999999999998),
+    (1, 4d, 0.12d,  false, 3, 0.toByte, 12F,                 3.88),
+    (0, 0d, 0.50d,  true, 0, 0.toByte, 12F,                  -0.5),
+    (1, 2d, 0.40d, false, 1, 127.toByte, 30F,                 1.6),
+    (0, 3d, 0.78d,  true, 2, -128.toByte, 12F, 2.2199999999999998),
+    (1, 4d, 0.12d,  false, 3, 0.toByte, 12F,                 3.88)))
+    .toDF(mockLabelColumn, "col1", "col2", "col3", "col4", "col5", "col6", "diff")
+
+
+  test("Compute residual") {
+    val computeResiduals = new ComputeResidualTransformer()
+      .setObservedCol("col1")
+      .setOutputCol("diff")
+      .setPredictedCol("col2")
+
+    var processedDF = computeResiduals.transform(mockDataset)
+
+    assert(verifyResult(expectedDF, processedDF))
+  }
+}

--- a/notebooks/community/aisamples/AIsample - Uplift Modelling.ipynb
+++ b/notebooks/community/aisamples/AIsample - Uplift Modelling.ipynb
@@ -805,7 +805,7 @@
    "metadata": {},
    "source": [
     "### Log and Load Model with MLFlow\n",
-    "Now that we have a trained model, we can save it for later use. Here we use mlflow to log metrics and models, \. We can also use this API to load models for prediction."
+    "Now that we have a trained model, we can save it for later use. Here we use mlflow to log metrics and models. We can also use this API to load models for prediction."
    ]
   },
   {


### PR DESCRIPTION


## What changes are proposed in this pull request?

Add causal inference package and LinearDMLEstimator implementation

## Does this PR change any dependencies?

- [ ] No. 

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] Yes. Make sure you have added samples following below steps.
[Todo: add samples]

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
