### PR TITLE
feat: Add SpeakerEmotionInference transformer for generating SSML t…

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/ComputerVision.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/ComputerVision.scala
@@ -444,7 +444,7 @@ object GenerateThumbnails extends ComplexParamsReadable[GenerateThumbnails] with
 class GenerateThumbnails(override val uid: String)
   extends CognitiveServicesBase(uid) with HasImageInput
     with HasWidth with HasHeight with HasSmartCropping
-    with HasInternalJsonOutputParser with HasCognitiveServiceInput with HasSetLocation with BasicLogging
+    with HasCognitiveServiceInput with HasSetLocation with BasicLogging
     with HasSetLinkedService {
   logClass()
 
@@ -453,8 +453,6 @@ class GenerateThumbnails(override val uid: String)
   override protected def getInternalOutputParser(schema: StructType): HTTPOutputParser = {
     new CustomOutputParser().setUDF({ r: HTTPResponseData => r.entity.map(_.content).orNull })
   }
-
-  override def responseDataType: DataType = BinaryType
 
   def urlPath: String = "/vision/v2.0/generateThumbnail"
 }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/SpeakerEmotionInference.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/SpeakerEmotionInference.scala
@@ -29,8 +29,7 @@ class SpeakerEmotionInference(override val uid: String)
   setDefault(
     locale -> Left("en-US"),
     voiceName -> Left("en-US-JennyNeural"),
-    text -> Left(this.uid + "_input"),
-  )
+    text -> Left(this.uid + "_text"))
 
   def urlPath: String = "cognitiveservices/v1"
 
@@ -38,8 +37,7 @@ class SpeakerEmotionInference(override val uid: String)
 
   protected val additionalHeaders: Map[String, String] = Map[String, String](
     ("X-Microsoft-OutputFormat", "textanalytics-json"),
-    ("Content-Type", "application/ssml+xml")
-  )
+    ("Content-Type", "application/ssml+xml"))
 
   override protected def inputFunc(schema: StructType): Row => Option[HttpRequestBase] = super.inputFunc(schema)
     .andThen(r => r.map(r => {
@@ -126,8 +124,8 @@ trait HasVoiceNameCol extends HasServiceParams {
 
 trait HasTextCol extends HasServiceParams {
   val text = new ServiceParam[String](this,
-    "input",
-    s"The text input to annotate with inferred emotion",
+    "text",
+    s"The text to annotate with inferred emotion",
     isRequired = true)
 
   def setText(v: String): this.type = setScalarParam(text, v)

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/SpeakerEmotionInference.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/SpeakerEmotionInference.scala
@@ -1,0 +1,136 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.cognitive
+
+import com.microsoft.azure.synapse.ml.logging.BasicLogging
+import com.microsoft.azure.synapse.ml.param.ServiceParam
+import com.microsoft.azure.synapse.ml.stages.Lambda
+import org.apache.http.client.methods.HttpRequestBase
+import org.apache.http.entity.{AbstractHttpEntity, StringEntity}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.ml.{ComplexParamsReadable, NamespaceInjections, PipelineModel, Transformer}
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.types.{DataType, StringType, StructType}
+import spray.json.DefaultJsonProtocol.StringJsonFormat
+
+object SpeakerEmotionInference extends ComplexParamsReadable[SpeakerEmotionInference] with Serializable
+
+class SpeakerEmotionInference(override val uid: String)
+  extends CognitiveServicesBase(uid)
+    with HasLocaleCol with HasVoiceNameCol with HasTextCol with HasSetLocation
+    with HasCognitiveServiceInput with HasInternalJsonOutputParser with BasicLogging {
+  logClass()
+
+  def this() = this(Identifiable.randomUID(classOf[SpeakerEmotionInference].getSimpleName))
+
+  setDefault(
+    locale -> Left("en-US"),
+    voiceName -> Left("en-US-JennyNeural"),
+    text -> Left(this.uid + "_input"),
+  )
+
+  def urlPath: String = "cognitiveservices/v1"
+
+  override protected def responseDataType: DataType = SpeakerEmotionInferenceResponse.schema
+
+  protected val additionalHeaders: Map[String, String] = Map[String, String](
+    ("X-Microsoft-OutputFormat", "textanalytics-json"),
+    ("Content-Type", "application/ssml+xml")
+  )
+
+  override protected def inputFunc(schema: StructType): Row => Option[HttpRequestBase] = super.inputFunc(schema)
+    .andThen(r => r.map(r => {
+      additionalHeaders.foreach(header => r.setHeader(header._1, header._2))
+      r
+    }))
+
+  override def setLocation(v: String): this.type = {
+    val domain = getLocationDomain(v)
+    setUrl(s"https://$v.tts.speech.microsoft.$domain/cognitiveservices/v1")
+  }
+
+  override protected def prepareEntity: Row => Option[AbstractHttpEntity] = { row =>
+    val body: String =
+      s"<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xmlns:mstts='https://www.w3.org/2001/mstts'" +
+        s" xml:lang='en-US'><voice name='Microsoft Server Speech Text to Speech Voice (en-US, JennyNeural)'>" +
+        s"<mstts:task name ='RoleStyle'/>${getValue(row, text)}</voice></speak>"
+    Some(new StringEntity(body))
+  }
+
+  private[cognitive] def formatSSML(content: String,
+                                    lang: String,
+                                    voice: String,
+                                    response: SpeakerEmotionInferenceResponse): String = {
+    // Create a sequence containing all of the non-speech text (text outside of quotes)
+    // Then zip that with the sequence of all speech text, wrapping speech text in an express-as tag
+    val speechBounds = response.Conversations.unzip(c => (c.Begin, c.End))
+    val nonSpeechEnds = speechBounds._1 ++ Seq(content.length)
+    val nonSpeechBegins = Seq(0) ++ speechBounds._2
+    val nonSpeechText = (nonSpeechBegins).zip(nonSpeechEnds).map(pair => content.substring(pair._1, pair._2))
+    val speechText = response.Conversations.map(c => {
+      s"<mstts:express-as role='${c.Role}' style='${c.Style}'>${c.Content}</mstts:express-as>"
+    }) ++ Seq("")
+    val innerText = nonSpeechText.zip(speechText).map(pair => pair._1 + pair._2).reduce(_ + _)
+
+    "<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xmlns:mstts='https://www.w3.org/2001/mstts' " +
+      s"xml:lang='${lang}'><voice name='${voice}'>${innerText}</voice></speak>\n"
+  }
+
+  protected override def getInternalTransformer(schema: StructType): PipelineModel = {
+    val internalTransformer = super.getInternalTransformer(schema)
+    NamespaceInjections.pipelineModel(stages = Array[Transformer](
+      internalTransformer,
+      new Lambda().setTransform(ds => {
+        val converter = SpeakerEmotionInferenceResponse.makeFromRowConverter
+        val newSchema = schema.add(getErrorCol, SpeakerEmotionInferenceError.schema).add(getOutputCol, StringType)
+        ds.toDF().map(row => {
+          val ssml = formatSSML(
+            getValue(row, text),
+            getValue(row, locale),
+            getValue(row, voiceName),
+            converter(row.getAs[Row](row.fieldIndex(getOutputCol)))
+          )
+          new GenericRowWithSchema((row.toSeq.dropRight(1) ++ Seq(ssml)).toArray, newSchema): Row
+        })(RowEncoder({
+          newSchema
+        }))
+      })
+    ))
+  }
+}
+
+trait HasLocaleCol extends HasServiceParams {
+  val locale = new ServiceParam[String](this,
+    "locale",
+    s"The locale of the input text",
+    isRequired = true)
+
+  def setLocale(v: String): this.type = setScalarParam(locale, v)
+
+  def setLocaleCol(v: String): this.type = setVectorParam(locale, v)
+}
+
+trait HasVoiceNameCol extends HasServiceParams {
+  val voiceName = new ServiceParam[String](this,
+    "voiceName",
+    s"The name of the voice used for synthesis",
+    isRequired = true)
+
+  def setVoiceName(v: String): this.type = setScalarParam(voiceName, v)
+
+  def setVoiceNameCol(v: String): this.type = setVectorParam(voiceName, v)
+}
+
+trait HasTextCol extends HasServiceParams {
+  val text = new ServiceParam[String](this,
+    "input",
+    s"The text input to annotate with inferred emotion",
+    isRequired = true)
+
+  def setText(v: String): this.type = setScalarParam(text, v)
+
+  def setTextCol(v: String): this.type = setVectorParam(text, v)
+}

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/SpeechSchemas.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/SpeechSchemas.scala
@@ -59,7 +59,6 @@ object SpeechFormat extends DefaultJsonProtocol {
     jsonFormat9(TranscriptionResponse.apply)
   implicit val TranscriptionParticipantFormat: RootJsonFormat[TranscriptionParticipant] =
     jsonFormat3(TranscriptionParticipant.apply)
-
 }
 
 object SpeechSynthesisError extends SparkBindings[SpeechSynthesisError] {
@@ -69,3 +68,19 @@ object SpeechSynthesisError extends SparkBindings[SpeechSynthesisError] {
 }
 
 case class SpeechSynthesisError(errorCode: String, errorDetails: String, errorReason: String)
+
+object SpeakerEmotionInferenceError extends SparkBindings[SpeakerEmotionInferenceError]
+
+case class SpeakerEmotionInferenceError(errorCode: String, errorDetails: String)
+
+case class SSMLConversation(Begin: Int,
+                            End: Int,
+                            Content: String,
+                            Role: String,
+                            Style: String)
+
+object SSMLConversation extends SparkBindings[SSMLConversation]
+
+case class SpeakerEmotionInferenceResponse(IsValid: Boolean, Conversations: Seq[SSMLConversation])
+
+object SpeakerEmotionInferenceResponse extends SparkBindings[SpeakerEmotionInferenceResponse]

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/TextToSpeech.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/TextToSpeech.scala
@@ -7,8 +7,10 @@ import com.microsoft.azure.synapse.ml.core.env.StreamUtilities.using
 import com.microsoft.azure.synapse.ml.io.http.{HasErrorCol, HasURL}
 import com.microsoft.azure.synapse.ml.logging.BasicLogging
 import com.microsoft.azure.synapse.ml.param.ServiceParam
-import com.microsoft.cognitiveservices.speech.{SpeechConfig, SpeechSynthesisCancellationDetails,
-  SpeechSynthesisOutputFormat, SpeechSynthesizer}
+import com.microsoft.cognitiveservices.speech.{
+  SpeechConfig, SpeechSynthesisCancellationDetails,
+  SpeechSynthesisOutputFormat, SpeechSynthesisResult, SpeechSynthesizer
+}
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.io.{IOUtils => HUtils}
 import org.apache.spark.ml.param.{Param, ParamMap}
@@ -62,7 +64,6 @@ class TextToSpeech(override val uid: String)
     s"The locale of the input text",
     isRequired = true)
 
-
   def setLocale(v: String): this.type = setScalarParam(locale, v)
 
   def setLocaleCol(v: String): this.type = setVectorParam(locale, v)
@@ -106,6 +107,20 @@ class TextToSpeech(override val uid: String)
 
   def getOutputFileCol: String = $(outputFileCol)
 
+  val useSSML = new ServiceParam[Boolean](this,
+    "useSSML",
+    s"whether to interpret the provided text input as SSML (Speech Synthesis Markup Language). " +
+      "The default value is false.",
+    isRequired = false)
+
+  def setUseSSML(v: Boolean): this.type = setScalarParam(useSSML, v)
+
+  def setUseSSMLCol(v: String): this.type = setVectorParam(useSSML, v)
+
+  def speechGenerator(synth: SpeechSynthesizer, shouldUseSSML: Boolean, txt: String): SpeechSynthesisResult = {
+    if (shouldUseSSML) synth.SpeakSsml(txt) else synth.SpeakText(txt)
+  }
+
   override def transform(dataset: Dataset[_]): DataFrame = {
     val hconf = new SerializableConfiguration(dataset.sparkSession.sparkContext.hadoopConfiguration)
     val toRow = SpeechSynthesisError.makeToRowConverter
@@ -117,7 +132,7 @@ class TextToSpeech(override val uid: String)
           config.setSpeechSynthesisOutputFormat(SpeechSynthesisOutputFormat.valueOf(format)))
 
         val (errorOpt, data) = using(new SpeechSynthesizer(config, null)) { synth =>  //scalastyle:ignore null
-          val res = synth.SpeakText(getValue(row, text))
+          val res = speechGenerator(synth, getValueOpt(row, useSSML).getOrElse(false), getValueOpt(row, text).getOrElse(""))
           val error = if (res.getReason.name() == "SynthesizingAudioCompleted") {
             None
           } else {

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/TextToSpeech.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/TextToSpeech.scala
@@ -131,8 +131,9 @@ class TextToSpeech(override val uid: String)
         getValueOpt(row, outputFormat).foreach(format =>
           config.setSpeechSynthesisOutputFormat(SpeechSynthesisOutputFormat.valueOf(format)))
 
-        val (errorOpt, data) = using(new SpeechSynthesizer(config, null)) { synth =>  //scalastyle:ignore null
-          val res = speechGenerator(synth, getValueOpt(row, useSSML).getOrElse(false), getValueOpt(row, text).getOrElse(""))
+        val (errorOpt, data) = using(new SpeechSynthesizer(config, null)) { synth => //scalastyle:ignore null
+          val res = speechGenerator(synth, getValueOpt(row, useSSML)
+            .getOrElse(false), getValueOpt(row, text).getOrElse(""))
           val error = if (res.getReason.name() == "SynthesizingAudioCompleted") {
             None
           } else {

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split1/ComputerVisionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split1/ComputerVisionSuite.scala
@@ -3,7 +3,6 @@
 
 package com.microsoft.azure.synapse.ml.cognitive.split1
 
-import com.microsoft.azure.synapse.ml.Secrets
 import com.microsoft.azure.synapse.ml.cognitive._
 import com.microsoft.azure.synapse.ml.core.spark.FluentAPI._
 import com.microsoft.azure.synapse.ml.core.test.base.{Flaky, TestBase}
@@ -13,10 +12,6 @@ import org.apache.spark.ml.util.MLReadable
 import org.apache.spark.sql.functions.{col, typedLit}
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.scalactic.Equality
-
-trait CognitiveKey {
-  lazy val cognitiveKey: String = sys.env.getOrElse("COGNITIVE_API_KEY", Secrets.CognitiveApiKey)
-}
 
 trait OCRUtils extends TestBase {
 

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split2/SearchWriterSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split2/SearchWriterSuite.scala
@@ -5,7 +5,6 @@ package com.microsoft.azure.synapse.ml.cognitive.split2
 
 import com.microsoft.azure.synapse.ml.Secrets
 import com.microsoft.azure.synapse.ml.cognitive._
-import com.microsoft.azure.synapse.ml.cognitive.split1.CognitiveKey
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 import com.microsoft.azure.synapse.ml.core.test.fuzzing.{TestObject, TransformerFuzzing}
 import com.microsoft.azure.synapse.ml.io.http.RESTHelpers._

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split2/SpeakerEmotionInferenceSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split2/SpeakerEmotionInferenceSuite.scala
@@ -44,8 +44,7 @@ class SpeakerEmotionInferenceSuite extends TransformerFuzzing[SpeakerEmotionInfe
       "<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' " +
         "xmlns:mstts='https://www.w3.org/2001/mstts' xml:lang='en-US'><voice name='en-US-JennyNeural'>" +
         "<mstts:express-as role='female' style='calm'>\"This is an example of a sentence with unmatched quotes,\"" +
-        "</mstts:express-as> she said.\"</voice></speak>\n"),
-  )
+        "</mstts:express-as> she said.\"</voice></speak>\n"))
 
   lazy val df: DataFrame = testData.map(e => e._1).toSeq.toDF("text")
 
@@ -102,8 +101,7 @@ class SpeakerEmotionInferenceSuite extends TransformerFuzzing[SpeakerEmotionInfe
         """xmlns:mstts='https://www.w3.org/2001/mstts' xml:lang='en-US'>""" +
         """<voice name='en-US-JennyNeural'><mstts:express-as role='male' style='calm'>"A"""" +
         """</mstts:express-as><mstts:express-as role='male' style='calm'>"B"</mstts:express-as>""" +
-        """<mstts:express-as role='male' style='calm'>"C"</mstts:express-as></voice></speak>""" + "\n")),
-  )
+        """<mstts:express-as role='male' style='calm'>"C"</mstts:express-as></voice></speak>""" + "\n")))
 
   test("formatSSML") {
     ssmlFormatTestData.map(test => {

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split2/SpeakerEmotionInferenceSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split2/SpeakerEmotionInferenceSuite.scala
@@ -1,0 +1,152 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.cognitive.split2
+
+import com.microsoft.azure.synapse.ml.cognitive._
+import com.microsoft.azure.synapse.ml.core.test.fuzzing.{TestObject, TransformerFuzzing}
+import org.apache.spark.ml.util.MLReadable
+import org.apache.spark.sql.DataFrame
+
+import java.io.File
+
+class SpeakerEmotionInferenceSuite extends TransformerFuzzing[SpeakerEmotionInference] with CognitiveKey {
+
+  import spark.implicits._
+
+  lazy val saveDir: File = tmpDir.toFile
+
+  def ssmlGenerator: SpeakerEmotionInference = new SpeakerEmotionInference()
+    .setLocation("eastus")
+    .setSubscriptionKey(cognitiveKey)
+    .setLocale("en-US")
+    .setVoiceName("en-US-JennyNeural")
+    .setTextCol("text")
+    .setOutputCol("ssml")
+
+  val testData: Map[String, String] = Map[String, String](
+    ("\"A\" \"B\" \"C\"",
+      "<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xmlns:mstts='https://www.w3.org/2001/mstts' " +
+        "xml:lang='en-US'><voice name='en-US-JennyNeural'>" +
+        "<mstts:express-as role='male' style='calm'>\"A\"</mstts:express-as> " +
+        "<mstts:express-as role='male' style='calm'>\"B\"</mstts:express-as> " +
+        "<mstts:express-as role='male' style='calm'>\"C\"</mstts:express-as></voice></speak>\n"),
+    ("\"I'm shouting excitedly!\" she shouted excitedly.",
+      "<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' " +
+        "xmlns:mstts='https://www.w3.org/2001/mstts' xml:lang='en-US'><voice name='en-US-JennyNeural'>" +
+        "<mstts:express-as role='female' style='cheerful'>\"I'm shouting excitedly!\"</mstts:express-as> she shouted " +
+        "excitedly.</voice></speak>\n"),
+    ("This text has no quotes in it, so isValid should be false",
+      "<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' " +
+        "xmlns:mstts='https://www.w3.org/2001/mstts' xml:lang='en-US'><voice name='en-US-JennyNeural'>" +
+        "This text has no quotes in it, so isValid should be false</voice></speak>\n"),
+    ("\"This is an example of a sentence with unmatched quotes,\" she said.\"",
+      "<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' " +
+        "xmlns:mstts='https://www.w3.org/2001/mstts' xml:lang='en-US'><voice name='en-US-JennyNeural'>" +
+        "<mstts:express-as role='female' style='calm'>\"This is an example of a sentence with unmatched quotes,\"" +
+        "</mstts:express-as> she said.\"</voice></speak>\n"),
+  )
+
+  lazy val df: DataFrame = testData.map(e => e._1).toSeq.toDF("text")
+
+  test("basic") {
+    val transformed = ssmlGenerator.transform(df)
+    transformed.show(truncate = false)
+    transformed.collect().map(row => {
+      val actual = testData.get(row.getString(0)).getOrElse("")
+      val expected = row.getString(2)
+      assert(actual.equals(expected))
+    })
+  }
+
+  test("arbitrary df size") {
+    val bigDF = Seq(("A", "B", "C", "Hello")).toDF("A", "B", "C", "text")
+    ssmlGenerator.transform(bigDF).collect().map(
+      row => {
+        val actual = row.getString(5)
+        val expected =
+          """<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' """ +
+            """xmlns:mstts='https://www.w3.org/2001/mstts' xml:lang='en-US'><voice name='en-US-JennyNeural'>""" +
+            s"""Hello</voice></speak>\n"""
+        assert(actual.equals(expected))
+      })
+  }
+
+  val ssmlFormatTestData = Map[(String, SpeakerEmotionInferenceResponse), String](
+    ((""""A", "B", "C"""", SpeakerEmotionInferenceResponse(true, Seq(
+      SSMLConversation(0, 3, """"A"""", "male", "calm"),
+      SSMLConversation(5, 8, """"B"""", "male", "calm"),
+      SSMLConversation(10, 13, """"C"""", "male", "calm"),
+    ))) ->
+      ("""<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' """ +
+        """xmlns:mstts='https://www.w3.org/2001/mstts' xml:lang='en-US'><voice name='en-US-JennyNeural'>""" +
+        """<mstts:express-as role='male' style='calm'>"A"</mstts:express-as>, """ +
+        """<mstts:express-as role='male' style='calm'>"B"</mstts:express-as>, """ +
+        """<mstts:express-as role='male' style='calm'>"C"</mstts:express-as></voice></speak>""" + "\n")),
+    (("""Z"A"Z"B"Z"C"Z""", SpeakerEmotionInferenceResponse(true, Seq(
+      SSMLConversation(1, 4, """"A"""", "male", "calm"),
+      SSMLConversation(5, 8, """"B"""", "male", "calm"),
+      SSMLConversation(9, 12, """"C"""", "male", "calm"),
+    ))) ->
+      ("""<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' """ +
+        """xmlns:mstts='https://www.w3.org/2001/mstts' xml:lang='en-US'><voice name='en-US-JennyNeural'>Z""" +
+        """<mstts:express-as role='male' style='calm'>"A"</mstts:express-as>Z<mstts:express-as role='male' """ +
+        """style='calm'>"B"</mstts:express-as>Z<mstts:express-as role='male' style='calm'>"C"""" +
+        """</mstts:express-as>Z</voice></speak>""" + "\n")),
+    ((""""A""B""C"""", SpeakerEmotionInferenceResponse(true, Seq(
+      SSMLConversation(0, 3, """"A"""", "male", "calm"),
+      SSMLConversation(3, 6, """"B"""", "male", "calm"),
+      SSMLConversation(6, 9, """"C"""", "male", "calm"),
+    ))) ->
+      ("""<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' """ +
+        """xmlns:mstts='https://www.w3.org/2001/mstts' xml:lang='en-US'>""" +
+        """<voice name='en-US-JennyNeural'><mstts:express-as role='male' style='calm'>"A"""" +
+        """</mstts:express-as><mstts:express-as role='male' style='calm'>"B"</mstts:express-as>""" +
+        """<mstts:express-as role='male' style='calm'>"C"</mstts:express-as></voice></speak>""" + "\n")),
+  )
+
+  test("formatSSML") {
+    ssmlFormatTestData.map(test => {
+      val result = ssmlGenerator.formatSSML(
+        test._1._1,
+        "en-US",
+        "en-US-JennyNeural",
+        test._1._2)
+      assertResult(test._2)(result)
+    })
+  }
+
+  def tts: TextToSpeech = new TextToSpeech()
+    .setUseSSML(true)
+    .setLocation("eastus")
+    .setSubscriptionKey(cognitiveKey)
+    .setTextCol("ssml")
+    .setOutputFileCol("filename")
+
+  lazy val synthesisDF: DataFrame = Seq(
+    ("Hello world this is some sample text",
+      new File(saveDir, "test1.mp3").getAbsolutePath),
+    (""""Hi, how are you?" she said.""",
+      new File(saveDir, "test2.mp3").getAbsolutePath),
+    ("""She was terrified and said. "This is how I sound right now."""",
+      new File(saveDir, "test3.mp3").getAbsolutePath),
+    (""""I'm really excited!" she said, excitedly.""",
+      new File(saveDir, "test4.mp3").getAbsolutePath),
+    ("""She screamed "Hi," and followed up with "how are you?" before reaching for the baseball.""",
+      new File(saveDir, "test5.mp3").getAbsolutePath),
+  ).toDF("text", "filename")
+
+  test("integration with TTS") {
+    val ssmlDF = ssmlGenerator.transform(synthesisDF)
+    ssmlDF.collect()
+    val resultDF = tts.transform(ssmlDF)
+    resultDF.collect()
+      .map(row => row.getAs[String]("filename"))
+      .foreach(filename => assert(new File(filename).length() > 20))
+  }
+
+  override def testObjects(): Seq[TestObject[SpeakerEmotionInference]] =
+    Seq(new TestObject(ssmlGenerator, df))
+
+  override def reader: MLReadable[_] = SpeakerEmotionInference
+}

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split2/SpeakerEmotionInferenceSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split2/SpeakerEmotionInferenceSuite.scala
@@ -75,8 +75,7 @@ class SpeakerEmotionInferenceSuite extends TransformerFuzzing[SpeakerEmotionInfe
     ((""""A", "B", "C"""", SpeakerEmotionInferenceResponse(true, Seq(
       SSMLConversation(0, 3, """"A"""", "male", "calm"),
       SSMLConversation(5, 8, """"B"""", "male", "calm"),
-      SSMLConversation(10, 13, """"C"""", "male", "calm"),
-    ))) ->
+      SSMLConversation(10, 13, """"C"""", "male", "calm")))) ->
       ("""<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' """ +
         """xmlns:mstts='https://www.w3.org/2001/mstts' xml:lang='en-US'><voice name='en-US-JennyNeural'>""" +
         """<mstts:express-as role='male' style='calm'>"A"</mstts:express-as>, """ +
@@ -85,8 +84,7 @@ class SpeakerEmotionInferenceSuite extends TransformerFuzzing[SpeakerEmotionInfe
     (("""Z"A"Z"B"Z"C"Z""", SpeakerEmotionInferenceResponse(true, Seq(
       SSMLConversation(1, 4, """"A"""", "male", "calm"),
       SSMLConversation(5, 8, """"B"""", "male", "calm"),
-      SSMLConversation(9, 12, """"C"""", "male", "calm"),
-    ))) ->
+      SSMLConversation(9, 12, """"C"""", "male", "calm")))) ->
       ("""<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' """ +
         """xmlns:mstts='https://www.w3.org/2001/mstts' xml:lang='en-US'><voice name='en-US-JennyNeural'>Z""" +
         """<mstts:express-as role='male' style='calm'>"A"</mstts:express-as>Z<mstts:express-as role='male' """ +
@@ -95,8 +93,7 @@ class SpeakerEmotionInferenceSuite extends TransformerFuzzing[SpeakerEmotionInfe
     ((""""A""B""C"""", SpeakerEmotionInferenceResponse(true, Seq(
       SSMLConversation(0, 3, """"A"""", "male", "calm"),
       SSMLConversation(3, 6, """"B"""", "male", "calm"),
-      SSMLConversation(6, 9, """"C"""", "male", "calm"),
-    ))) ->
+      SSMLConversation(6, 9, """"C"""", "male", "calm")))) ->
       ("""<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' """ +
         """xmlns:mstts='https://www.w3.org/2001/mstts' xml:lang='en-US'>""" +
         """<voice name='en-US-JennyNeural'><mstts:express-as role='male' style='calm'>"A"""" +
@@ -131,8 +128,7 @@ class SpeakerEmotionInferenceSuite extends TransformerFuzzing[SpeakerEmotionInfe
     (""""I'm really excited!" she said, excitedly.""",
       new File(saveDir, "test4.mp3").getAbsolutePath),
     ("""She screamed "Hi," and followed up with "how are you?" before reaching for the baseball.""",
-      new File(saveDir, "test5.mp3").getAbsolutePath),
-  ).toDF("text", "filename")
+      new File(saveDir, "test5.mp3").getAbsolutePath)).toDF("text", "filename")
 
   test("integration with TTS") {
     val ssmlDF = ssmlGenerator.transform(synthesisDF)

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split2/SpeechToTextSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split2/SpeechToTextSuite.scala
@@ -3,7 +3,7 @@
 
 package com.microsoft.azure.synapse.ml.cognitive.split2
 
-import com.microsoft.azure.synapse.ml.cognitive.split1.CognitiveKey
+import com.microsoft.azure.synapse.ml.cognitive._
 import com.microsoft.azure.synapse.ml.cognitive.{SpeechResponse, SpeechToText}
 import com.microsoft.azure.synapse.ml.core.test.fuzzing.{TestObject, TransformerFuzzing}
 import org.apache.commons.compress.utils.IOUtils

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split3/SpeechToTextSDKSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/split3/SpeechToTextSDKSuite.scala
@@ -5,7 +5,6 @@ package com.microsoft.azure.synapse.ml.cognitive.split3
 
 import com.microsoft.azure.synapse.ml.Secrets
 import com.microsoft.azure.synapse.ml.cognitive._
-import com.microsoft.azure.synapse.ml.cognitive.split1.CognitiveKey
 import com.microsoft.azure.synapse.ml.core.env.StreamUtilities
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 import com.microsoft.azure.synapse.ml.core.test.fuzzing.{TestObject, TransformerFuzzing}

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/test/CognitiveServicesCommon.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/test/CognitiveServicesCommon.scala
@@ -1,3 +1,6 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
 package com.microsoft.azure.synapse.ml.cognitive
 
 import com.microsoft.azure.synapse.ml.Secrets

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/test/CognitiveServicesCommon.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/test/CognitiveServicesCommon.scala
@@ -1,0 +1,7 @@
+package com.microsoft.azure.synapse.ml.cognitive
+
+import com.microsoft.azure.synapse.ml.Secrets
+
+trait CognitiveKey {
+  lazy val cognitiveKey = sys.env.getOrElse("COGNITIVE_API_KEY", Secrets.CognitiveApiKey)
+}

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/Parsers.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/Parsers.scala
@@ -193,7 +193,6 @@ class JSONOutputParser(val uid: String) extends HTTPOutputParser with ComplexPar
       val stringEntityCol = HTTPSchema.entity_to_string(col(getInputCol + ".entity"))
       val parsed = dataset.toDF.withColumn(getOutputCol,
         from_json(stringEntityCol, getDataType, Map("charset" -> "UTF-8")))
-
       getPostProcessor.map(_
         .setInputCol(getOutputCol)
         .setOutputCol(getOutputCol)

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/core/test/base/TestBase.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/core/test/base/TestBase.scala
@@ -186,8 +186,8 @@ abstract class TestBase extends AnyFunSuite with BeforeAndAfterEachTestData with
 
   protected override def afterAll(): Unit = {
     logTime(s"Suite $this", suiteElapsed, 10000)
-    if (tmpDirCreated) {
-      FileUtils.forceDelete(tmpDir.toFile)
+    if (tmpDirCreated && tmpDir.toFile.exists) {
+        FileUtils.forceDelete(tmpDir.toFile)
     }
   }
 

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/core/test/fuzzing/Fuzzing.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/core/test/fuzzing/Fuzzing.scala
@@ -659,7 +659,7 @@ trait SerializationFuzzing[S <: PipelineStage with MLWritable] extends TestBase 
       f.mkdir()
       f.toString
     } else {
-      Files.createTempDirectory("SavedModels-").toString
+      tmpDir.toString
     }
   }
 

--- a/deep-learning/src/test/scala/com/microsoft/azure/synapse/ml/downloader/DownloaderSuite.scala
+++ b/deep-learning/src/test/scala/com/microsoft/azure/synapse/ml/downloader/DownloaderSuite.scala
@@ -8,14 +8,13 @@ import com.microsoft.azure.synapse.ml.core.utils.FaultToleranceUtils
 import org.apache.commons.io.FileUtils
 
 import java.io.File
-import java.nio.file.Files
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.Duration
 import scala.util.Random
 
 class DownloaderSuite extends TestBase {
 
-  lazy val saveDir = Files.createTempDirectory("Models-").toFile
+  lazy val saveDir = tmpDir.toFile
   lazy val d = new ModelDownloader(spark, saveDir.toURI)
 
   test("retry utility should catch flakiness"){


### PR DESCRIPTION
…o augment TTS requests

## Related Issues/PRs

## What changes are proposed in this pull request?

Added a transformer to augment text to speech requests by calling the speech service to generate SSML for given text. The generated SSML may include style annotations for dialogue within the text so the specified text will be read with an emotional tone more accurate to the content of the text. 

## How is this patch tested?

- [X] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [X] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [] No. You can skip this section.
- [X] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.

AB#2000521
