### PR TITLE
chore: add secret scanning infrastructure

### DIFF
--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/Secrets.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/Secrets.scala
@@ -59,5 +59,7 @@ object Secrets {
   lazy val MADTestStorageKey: String = getSecret("madtest-storage-key")
   lazy val MADTestSASToken: String = getSecret("madtest-sas-token")
 
+  lazy val SecretRegexpFile: String = getSecret("secret-regexp-file")
+
   lazy val AzureMapsKey: String = getSecret("azuremaps-api-key")
 }

--- a/src/test/scala/com/microsoft/azure/synapse/ml/core/test/fuzzing/FuzzingTest.scala
+++ b/src/test/scala/com/microsoft/azure/synapse/ml/core/test/fuzzing/FuzzingTest.scala
@@ -3,15 +3,24 @@
 
 package com.microsoft.azure.synapse.ml.core.test.fuzzing
 
+import com.microsoft.azure.synapse.ml.Secrets
+import com.microsoft.azure.synapse.ml.build.BuildInfo
 import com.microsoft.azure.synapse.ml.core.contracts.{HasFeaturesCol, HasInputCol, HasLabelCol, HasOutputCol}
+import com.microsoft.azure.synapse.ml.core.env.StreamUtilities.using
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 import com.microsoft.azure.synapse.ml.core.utils.JarLoadingUtils
 import org.apache.spark.ml._
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.util.{MLReadable, MLWritable}
 
+import java.io.File
+import java.nio.file.{FileSystems, Files}
+import scala.collection.JavaConverters._
 import java.lang.reflect.ParameterizedType
+import java.nio.charset.MalformedInputException
 import scala.language.existentials
+import scala.io.Source
+import scala.util.matching.Regex
 
 /** Tests to validate fuzzing of modules. */
 class FuzzingTest extends TestBase {
@@ -312,6 +321,56 @@ class FuzzingTest extends TestBase {
         }
       }
     }
+  }
+
+  test("Scan codebase for secrets") {
+    val excludedFiles = List(
+      ".png",
+      ".jpg",
+      ".jpeg")
+    val excludedDirs = List(
+      ".git",
+      ".idea",
+      "target",
+      ".docusaurus",
+      "node_modules",
+      s"website${File.separator}build"
+    )
+
+    val regexps: List[Regex] = using(Source.fromURL(Secrets.SecretRegexpFile)) { s =>
+      s.getLines().toList.map(_.r)
+    }.get
+
+    val allFiles = Files.walk(BuildInfo.baseDirectory.getParentFile.toPath)
+      .iterator().asScala.map(_.toFile)
+      .filterNot(f => excludedDirs.exists(dir => f.toString.contains(dir)))
+      .toList
+
+    val nameIssues = allFiles.flatMap {
+      case f if regexps.flatMap(_.findFirstMatchIn(f.toString)).nonEmpty =>
+        Some(s"Bad file name: ${f.toString}")
+      case _ =>
+        None
+    }
+    val contentsIssue = allFiles.filter(_.isFile)
+      .filterNot(f => excludedFiles.exists(end => f.toString.endsWith(end)))
+      .flatMap { f =>
+        println(f)
+        try {
+          val lines = using(Source.fromFile(f)) { s => s.getLines().toList }.get
+          lines.zipWithIndex.flatMap { case (l, i) =>
+            if (regexps.flatMap(_.findFirstMatchIn(l)).nonEmpty) {
+              Some(s"Line $i of file ${f.toString} contains secrets")
+            } else {
+              None
+            }
+          }
+        } catch {
+          case _: MalformedInputException => List()
+        }
+      }
+    val allIssues = nameIssues ++ contentsIssue
+    assert(allIssues.isEmpty, allIssues.mkString("\n"))
   }
 
   private def assertOrLog(condition: Boolean, hint: String = "",


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

_Briefly describe the changes included in this Pull Request._

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
