### PR TITLE
fix: fix deepVision param updates

### DIFF
--- a/deep-learning/src/main/python/synapse/ml/dl/DeepVisionClassifier.py
+++ b/deep-learning/src/main/python/synapse/ml/dl/DeepVisionClassifier.py
@@ -142,23 +142,6 @@ class DeepVisionClassifier(TorchEstimator, PredictionParams):
         kwargs = self._kwargs
         self._set(**kwargs)
 
-        self._update_input_shapes()
-        self._update_cols()
-        self._update_transformation_fn()
-
-        model = LitDeepVisionModel(
-            backbone=self.getBackbone(),
-            additional_layers_to_train=self.getAdditionalLayersToTrain(),
-            num_classes=self.getNumClasses(),
-            input_shape=self.getInputShapes()[0],
-            optimizer_name=self.getOptimizerName(),
-            loss_name=self.getLossName(),
-            label_col=self.getLabelCol(),
-            image_col=self.getImageCol(),
-            dropout_aux=self.getDropoutAUX(),
-        )
-        self._set(model=model)
-
     def setBackbone(self, value):
         return self._set(backbone=value)
 
@@ -213,6 +196,24 @@ class DeepVisionClassifier(TorchEstimator, PredictionParams):
         self.setLabelCols([self.getLabelCol()])
 
     def _fit(self, dataset):
+
+        self._update_input_shapes()
+        self._update_cols()
+        self._update_transformation_fn()
+
+        model = LitDeepVisionModel(
+            backbone=self.getBackbone(),
+            additional_layers_to_train=self.getAdditionalLayersToTrain(),
+            num_classes=self.getNumClasses(),
+            input_shape=self.getInputShapes()[0],
+            optimizer_name=self.getOptimizerName(),
+            loss_name=self.getLossName(),
+            label_col=self.getLabelCol(),
+            image_col=self.getImageCol(),
+            dropout_aux=self.getDropoutAUX(),
+        )
+        self._set(model=model)
+
         return super()._fit(dataset)
 
     # override this method to provide a correct default backend

--- a/deep-learning/src/main/python/synapse/ml/dl/DeepVisionModel.py
+++ b/deep-learning/src/main/python/synapse/ml/dl/DeepVisionModel.py
@@ -116,7 +116,7 @@ class DeepVisionModel(TorchModel, PredictionParams):
     def _transform(self, df):
         self._update_transform_fn()
         self._update_cols()
-        
+
         output_df = super()._transform(df)
         argmax = udf(lambda v: float(np.argmax(v)), returnType=DoubleType())
         pred_df = output_df.withColumn(

--- a/deep-learning/src/main/python/synapse/ml/dl/DeepVisionModel.py
+++ b/deep-learning/src/main/python/synapse/ml/dl/DeepVisionModel.py
@@ -56,8 +56,6 @@ class DeepVisionModel(TorchModel, PredictionParams):
 
         kwargs = self._kwargs
         self._set(**kwargs)
-        self._update_transform_fn()
-        self._update_cols()
 
     def setTransformFn(self, value):
         return self._set(transform_fn=value)
@@ -116,6 +114,9 @@ class DeepVisionModel(TorchModel, PredictionParams):
         return None
 
     def _transform(self, df):
+        self._update_transform_fn()
+        self._update_cols()
+        
         output_df = super()._transform(df)
         argmax = udf(lambda v: float(np.argmax(v)), returnType=DoubleType())
         pred_df = output_df.withColumn(

--- a/deep-learning/src/main/python/synapse/ml/dl/LitDeepVisionModel.py
+++ b/deep-learning/src/main/python/synapse/ml/dl/LitDeepVisionModel.py
@@ -118,17 +118,18 @@ class LitDeepVisionModel(pl.LightningModule):
 
         # The Lightning checkpoint also saves the arguments passed into the LightningModule init
         # under the "hyper_parameters" key in the checkpoint.
-        self.save_hyperparameters(
-            "backbone",
-            "additional_layers_to_train",
-            "num_classes",
-            "input_shape",
-            "optimizer_name",
-            "loss_name",
-            "label_col",
-            "image_col",
-            "dropout_aux",
-        )
+        # TODO: Add this back after upgrading pytorch_lightning to a version that includes fix
+        # self.save_hyperparameters(
+        #     "backbone",
+        #     "additional_layers_to_train",
+        #     "num_classes",
+        #     "input_shape",
+        #     "optimizer_name",
+        #     "loss_name",
+        #     "label_col",
+        #     "image_col",
+        #     "dropout_aux",
+        # )
 
     def _check_params(self):
         # TORCHVISION


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

_Briefly describe the changes included in this Pull Request._

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
