### PR TITLE
fix: fix modelVersion param in TextAnalytics

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/form/FormRecognizer.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/form/FormRecognizer.scala
@@ -4,7 +4,6 @@
 package com.microsoft.azure.synapse.ml.cognitive.form
 
 import com.microsoft.azure.synapse.ml.cognitive._
-import com.microsoft.azure.synapse.ml.cognitive.text.HasModelVersion
 import com.microsoft.azure.synapse.ml.cognitive.vision.{BasicAsyncReply, HasImageInput, ReadLine}
 import com.microsoft.azure.synapse.ml.logging.SynapseMLLogging
 import com.microsoft.azure.synapse.ml.param.ServiceParam
@@ -21,7 +20,7 @@ import spray.json._
 
 abstract class FormRecognizerBase(override val uid: String) extends CognitiveServicesBaseNoHandler(uid)
   with HasCognitiveServiceInput with HasInternalJsonOutputParser with BasicAsyncReply
-  with HasImageInput with HasSetLocation with HasSetLinkedService with HasModelVersion {
+  with HasImageInput with HasSetLocation with HasSetLinkedService {
 
   override protected def prepareEntity: Row => Option[AbstractHttpEntity] = {
     r =>

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/text/TextAnalytics.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/text/TextAnalytics.scala
@@ -65,7 +65,9 @@ trait TextAnalyticsInputParams extends HasServiceParams {
 
 trait HasModelVersion extends HasServiceParams {
   val modelVersion = new ServiceParam[String](
-    this, name = "modelVersion", "Version of the model", isURLParam = true)
+    this, name = "modelVersion", "Version of the model", isURLParam = true) {
+    override val payloadName: String = "model-version"
+  }
 
   def getModelVersion: String = getScalarParam(modelVersion)
 
@@ -136,7 +138,7 @@ private[ml] abstract class TextAnalyticsBaseNoBinding(uid: String)
         None
       } else {
         import TAJSONFormat._
-        val post = new HttpPost(getUrl)
+        val post = new HttpPost(prepareUrl(row))
         getValueOpt(row, subscriptionKey).foreach(post.setHeader("Ocp-Apim-Subscription-Key", _))
         post.setHeader("Content-Type", "application/json")
         val json = TARequest(makeDocuments(row)).toJson.compactPrint
@@ -243,7 +245,7 @@ private[ml] trait HasUnpackedBinding {
 private[ml] abstract class TextAnalyticsBase(uid: String)
   extends TextAnalyticsBaseNoBinding(uid) with HasUnpackedBinding {
 
-    protected def responseBinding: SparkBindings[TAResponse[T]]
+  protected def responseBinding: SparkBindings[TAResponse[T]]
 
   override protected def responseDataType: DataType = responseBinding.schema
 
@@ -412,11 +414,11 @@ class AnalyzeHealthText(override val uid: String)
     super.postprocessResponse(processedResponseOpt.orNull)
   }
 
-/*
-  override private[ml] def dotnetTestValue(v: Seq[TextAnalyzeTask]): String =
-    v.map(x => s"new TextAnalyzeTask(new Dictionary<string, string>" +
-      s"${DotnetWrappableParam.dotnetDefaultRender(x.parameters)})").mkString(",")
-*/
+  /*
+    override private[ml] def dotnetTestValue(v: Seq[TextAnalyzeTask]): String =
+      v.map(x => s"new TextAnalyzeTask(new Dictionary<string, string>" +
+        s"${DotnetWrappableParam.dotnetDefaultRender(x.parameters)})").mkString(",")
+  */
 
   /*
   override def rConstructorLine(v: Seq[TextAnalyzeTask]): String = {

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/text/TextAnalytics.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/text/TextAnalytics.scala
@@ -65,13 +65,11 @@ trait TextAnalyticsInputParams extends HasServiceParams {
 
 trait HasModelVersion extends HasServiceParams {
   val modelVersion = new ServiceParam[String](
-    this, name = "modelVersion", "Version of the model")
+    this, name = "modelVersion", "Version of the model", isURLParam = true)
 
-  def getModelVersion: String = $(modelVersion).left.get
+  def getModelVersion: String = getScalarParam(modelVersion)
 
   def setModelVersion(v: String): this.type = setScalarParam(modelVersion, v)
-
-  def setModelVersionCol(v: String): this.type = setVectorParam(modelVersion, v)
 
   setDefault(
     modelVersion -> Left("latest")

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/text/TextAnalyticsSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/text/TextAnalyticsSuite.scala
@@ -41,7 +41,8 @@ class LanguageDetectorSuite extends TATestBase[LanguageDetector] {
     "Hello World",
     "Bonjour tout le monde",
     "La carretera estaba atascada. Había mucho tráfico el día de ayer.",
-    ":) :( :D"
+    ":) :( :D",
+    "日本国（にほんこく、にっぽんこく、英: Japan）、または日本（にほん、にっぽん）は、東アジアに位置する民主制国家 [1]。首都は東京都[注 2][2][3]。"
   ).toDF("text")
 
   override def model: LanguageDetector = new LanguageDetector()
@@ -56,6 +57,19 @@ class LanguageDetectorSuite extends TATestBase[LanguageDetector] {
     assert(langs(1) == "French")
   }
 
+  def versionModel: LanguageDetector = new LanguageDetector()
+    .setSubscriptionKey(textKey)
+    .setLocation(textApiLocation)
+    .setModelVersion("2021-11-20")
+    .setOutputCol("output")
+
+  test("Set Model Version"){
+    val results = prepResults(versionModel.transform(df))
+    val langs = results.map(_.get.document.get.detectedLanguage.get.name)
+    assert(langs.head == "English")
+    assert(langs(1) == "French")
+    assert(langs(4) == "Japan")
+  }
   override def reader: MLReadable[_] = LanguageDetector
 
   override def testObjects(): Seq[TestObject[LanguageDetector]] =

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/text/TextAnalyticsSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/text/TextAnalyticsSuite.scala
@@ -68,7 +68,7 @@ class LanguageDetectorSuite extends TATestBase[LanguageDetector] {
     val langs = results.map(_.get.document.get.detectedLanguage.get.name)
     assert(langs.head == "English")
     assert(langs(1) == "French")
-    assert(langs(4) == "Japan")
+    assert(langs(4) == "Japanese")
   }
   override def reader: MLReadable[_] = LanguageDetector
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

_Briefly describe the changes included in this Pull Request._

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
