### PR TITLE
chore: Update isolation-forest to 3.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ val extraDependencies = Seq(
   "com.jcraft" % "jsch" % "0.1.54",
   "org.apache.httpcomponents.client5" % "httpclient5" % "5.1.3",
   "org.apache.httpcomponents" % "httpmime" % "4.5.13",
-  "com.linkedin.isolation-forest" %% "isolation-forest_3.2.0" % "2.0.8"
+  "com.linkedin.isolation-forest" %% "isolation-forest_3.2.0" % "3.0.1"
 ).map(d => d excludeAll (excludes: _*))
 val dependencies = coreDependencies ++ extraDependencies
 


### PR DESCRIPTION
In preparation of the Scala 2.13 update.

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
The Scala 2.13 build requires the new version of isolation-forest: https://github.com/microsoft/SynapseML/pull/1772
I've separated out the update into a separate PR, so that CI can verify that the dependency update itself does not break anything. There's a [change to the API](https://github.com/linkedin/isolation-forest/commit/ec66605459d10930921840b757a9ad153ec991af) contained in the update which doesn't break anything in my local build, but the CI covers more.

## What changes are proposed in this pull request?

To update the `isolation-forest` dependency to the most recent version, which has a Scala 2.13 build.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have run `sbt test:compile` locally to verify that the API change doesn't break Scala code.

## Does this PR change any dependencies?

- [x] Yes. Make sure the dependencies are resolved correctly, and list changes here.
`"com.linkedin.isolation-forest" %% "isolation-forest_3.2.0" % "2.0.8"`  => `"com.linkedin.isolation-forest" %% "isolation-forest_3.2.0" % "3.0.1"`

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No. You can skip this section.
