### PR TITLE
small tweaks

### DIFF
--- a/.github/workflows/clean-acr.yml
+++ b/.github/workflows/clean-acr.yml
@@ -12,8 +12,10 @@ name: Clean ACR
 # The secret has an expiration date (currently 11/20/2024), so it will need to be renewed at some point.
 
 on:
-  schedule:
-    - cron: "0 1 * * 0" # every sunday at 1am
+  workflow_dispatch:
+
+#  schedule:
+#    - cron: "0 1 * * 0" # every sunday at 1am
 
 # Use workflow_dispatch in place of schedule for debugging.
 # You can trigger the workflow in the 'Actions' tab in github.

--- a/.github/workflows/clean-acr.yml
+++ b/.github/workflows/clean-acr.yml
@@ -11,17 +11,15 @@ name: Clean ACR
 # It is backed up in the mmlspark-keys vault by secret clean-acr-github-actions-info.
 # The secret has an expiration date (currently 11/20/2024), so it will need to be renewed at some point.
 
-on:
-  workflow_dispatch:
-
+#on:
 #  schedule:
 #    - cron: "0 1 * * 0" # every sunday at 1am
 
 # Use workflow_dispatch in place of schedule for debugging.
 # You can trigger the workflow in the 'Actions' tab in github.
 # Apparently, this file must be in the master branch to get the 'Run workflow' button.
-#on:
-#  workflow_dispatch:
+on:
+  workflow_dispatch:
    
 jobs:
   clean-acr:

--- a/.github/workflows/scripts/clean-acr.py
+++ b/.github/workflows/scripts/clean-acr.py
@@ -1,9 +1,7 @@
 import os
 import json
 from azure.storage.blob import BlobClient
-from azure.identity import DefaultAzureCredential
 import sys
-import subprocess
 from azure.keyvault.secrets import SecretClient
 from azure.identity import DefaultAzureCredential
 
@@ -14,10 +12,12 @@ run this if sas expires and place result in keyvault under secret name
  IMPORT_SAS=?$(az storage container generate-sas \
    --name acrbackup \
    --account-name mmlspark \
-   --expiry 2023-01-01 \
+   --expiry 2024-01-01 \
    --permissions rawdl \
    --https-only \
-   --output tsv)
+   --output tsv \
+   --auth-mode key \
+   --account-key <key>)
    echo $IMPORT_SAS
 """
 
@@ -50,8 +50,10 @@ for repo in repos:
             conn_string, container_name=container, blob_name=target_blob
         ).exists()
         if not backup_exists:
+            blob_hash = str(abs(hash(target_blob)))
             result = os.system(
-                f"az acr pipeline-run create --resource-group {rg} --registry {acr} --pipeline {pipeline} --name {str(abs(hash(target_blob)))} --pipeline-type export --storage-blob {target_blob} -a {image}"
+                f"az acr pipeline-run create --resource-group {rg} --registry {acr} --pipeline {pipeline} "
+                + "--name {blob_hash} --pipeline-type export --storage-blob {target_blob} -a {image}"
             )
             assert result == 0
             print(f"Transferred {target_blob}")


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?
Updated expiry for sas token. Also update sas generation to include access key, and a couple style fixes
Also switched to workflow_dispatch trigger for testing. I don't see any other way to test.

## How is this patch tested?
Not yet tested. See above. Will revert to scheduled runs after testing.

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [x] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
