### PR TITLE
feat: word level timing information for Speech to Text

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/speech/SpeechSchemas.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/speech/SpeechSchemas.scala
@@ -7,10 +7,13 @@ import com.microsoft.azure.synapse.ml.core.schema.SparkBindings
 import com.microsoft.cognitiveservices.speech.SpeechSynthesisCancellationDetails
 import spray.json.{DefaultJsonProtocol, RootJsonFormat}
 
+case class Word(Duration: Long, Offset: Long, Word: String)
+
 case class DetailedSpeechResponse(Confidence: Double,
                                   Lexical: String,
                                   ITN: String,
                                   MaskedITN: String,
+                                  Words: Option[Seq[Word]],
                                   Display: String)
 
 trait SharedSpeechFields {
@@ -52,8 +55,10 @@ object TranscriptionResponse extends SparkBindings[TranscriptionResponse]
 case class TranscriptionParticipant(name: String, language: String, signature: String)
 
 object SpeechFormat extends DefaultJsonProtocol {
+  implicit val WordFormat: RootJsonFormat[Word] =
+    jsonFormat3(Word.apply)
   implicit val DetailedSpeechResponseFormat: RootJsonFormat[DetailedSpeechResponse] =
-    jsonFormat5(DetailedSpeechResponse.apply)
+    jsonFormat6(DetailedSpeechResponse.apply)
   implicit val SpeechResponseFormat: RootJsonFormat[SpeechResponse] = jsonFormat6(SpeechResponse.apply)
   implicit val TranscriptionResponseFormat: RootJsonFormat[TranscriptionResponse] =
     jsonFormat9(TranscriptionResponse.apply)

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/speech/SpeechToTextSDKSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/speech/SpeechToTextSDKSuite.scala
@@ -33,7 +33,9 @@ trait SpeechToTextSDKSuiteBase extends TestBase with CognitiveKey with CustomSpe
   val uri = new URI(s"https://$region.api.cognitive.microsoft.com/sts/v1.0/issuetoken")
   val language = "en-us"
   val profanity = "masked"
+  val wordLevelTimestamps = false
   val format = "simple"
+
 
   val streamUrl = "http://qthttp.apple.com.edgesuite.net/1010qwoeiuryfg/sl.m3u8"
 
@@ -82,8 +84,7 @@ trait SpeechToTextSDKSuiteBase extends TestBase with CognitiveKey with CustomSpe
   def speechTest(format: String, audioBytes: Array[Byte], expectedText: String): Assertion = {
     val resultArray = sdk.inputStreamToText(
       new ByteArrayInputStream(audioBytes),
-      "wav",
-      uri, cognitiveKey, profanity, language, format, None, Seq())
+      "wav", uri, cognitiveKey, profanity, wordLevelTimestamps, language, format, None, Seq())
     val result = speechArrayToText(resultArray.toSeq)
     if (format == "simple") {
       resultArray.foreach { rp =>
@@ -170,6 +171,13 @@ class SpeechToTextSDKSuite extends TransformerFuzzing[SpeechToTextSDK] with Spee
     speechTest("detailed", bytes1, text1)
   }
 
+  test("Word level timing") {
+    val resultSeq = extractResults(
+      sdk.setFormat("detailed").setWordLevelTimestamps(true).transform(audioDf1),
+      sdk.getStreamIntermediateResults)
+    assert(resultSeq.head.NBest.get.head.Words.get.length > 1)
+  }
+
   ignore("Detailed audioBytesToText 2") {
     speechTest("detailed", bytes2, text2)
   }
@@ -248,7 +256,7 @@ class SpeechToTextSDKSuite extends TransformerFuzzing[SpeechToTextSDK] with Spee
         .toDF("audio")
       dfTest(
         "detailed",
-        uriDf, text4,verbose=true, sdk = sdk2, threshold = .6)
+        uriDf, text4, verbose = true, sdk = sdk2, threshold = .6)
     }
   }
 

--- a/notebooks/features/cognitive_services/CognitiveServices - Create a Multilingual Search Engine from Forms.ipynb
+++ b/notebooks/features/cognitive_services/CognitiveServices - Create a Multilingual Search Engine from Forms.ipynb
@@ -23,7 +23,7 @@
     "\n",
     "search_key = find_secret(\"azure-search-key\")\n",
     "search_service = \"mmlspark-azure-search\"\n",
-    "search_index = \"form-demo-index\""
+    "search_index = \"form-demo-index-2\""
    ]
   },
   {


### PR DESCRIPTION

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

_Briefly describe the changes included in this Pull Request._

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
