### PR TITLE
fix: Fix DML regression bug, should remove both treatment and outcome colu…

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/DoubleMLEstimator.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/DoubleMLEstimator.scala
@@ -193,8 +193,12 @@ class DoubleMLEstimator(override val uid: String)
     val treatmentResidualVecCol = DatasetExtensions.findUnusedColumnName("treatmentResidualVec", dataset)
 
     def calculateResiduals(train: Dataset[_], test: Dataset[_]): DataFrame = {
-      val treatmentModel = treatmentEstimator.setInputCols(train.columns.filterNot(_ == getOutcomeCol)).fit(train)
-      val outcomeModel = outcomeEstimator.setInputCols(train.columns.filterNot(_ == getTreatmentCol)).fit(train)
+      val treatmentModel = treatmentEstimator.setInputCols(
+        train.columns.filterNot(Array(getTreatmentCol, getOutcomeCol).contains)
+      ).fit(train)
+      val outcomeModel = outcomeEstimator.setInputCols(
+        train.columns.filterNot(Array(getOutcomeCol, getTreatmentCol).contains)
+      ).fit(train)
 
       val treatmentResidual =
         new ResidualTransformer()

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/TrainClassifier.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/TrainClassifier.scala
@@ -156,7 +156,11 @@ class TrainClassifier(override val uid: String) extends AutoTrainer[TrainedClass
         }
 
       val nonFeatureColumns = getLabelCol
-      val featureColumns = convertedLabelDataset.columns.filterNot(nonFeatureColumns.contains)
+      val featureColumns = if (isDefined(inputCols)) {
+        getInputCols
+      } else {
+        convertedLabelDataset.columns.filterNot(nonFeatureColumns.contains)
+      }
 
       val featurizer = new Featurize()
         .setOutputCol(getFeaturesCol)

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/TrainRegressor.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/TrainRegressor.scala
@@ -93,7 +93,11 @@ class TrainRegressor(override val uid: String) extends AutoTrainer[TrainedRegres
       ).na.drop(Seq(labelColumn))
 
       val nonFeatureColumns = getLabelCol
-      val featureColumns = convertedLabelDataset.columns.filterNot(nonFeatureColumns.contains)
+      val featureColumns = if (isDefined(inputCols)) {
+        getInputCols
+      } else {
+        convertedLabelDataset.columns.filterNot(nonFeatureColumns.contains)
+      }
 
       val featurizer = new Featurize()
         .setOutputCol(getFeaturesCol)


### PR DESCRIPTION
Fix DML regression bug, should remove both treatment and outcome columns as features

## Related Issues/PRs
#1715

## What changes are proposed in this pull request?
The issue is from commit 237472d3d5446d1fb0f20aaad3d2791412a8524d in PR #1715, and it makes ATE value negative.
In this commit I removed HasExcludeFeatureCols and use HasInputCols, when setting InputCols for treatment and outcome estimator, I excluded partner's column (e.g., outcome column for treatment estimator), but forgot to exclude their own label column (e.g., treatment column is treatment estimator label column)


## How is this patch tested?
test with sample notebook