### PR TITLE
feat: add aad auth for openAI

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/openai/OpenAI.scala
@@ -3,10 +3,11 @@
 
 package com.microsoft.azure.synapse.ml.cognitive.openai
 
-import com.microsoft.azure.synapse.ml.codegen.{GenerationUtils, Wrappable}
-import com.microsoft.azure.synapse.ml.cognitive.{CognitiveServicesBase, HasCognitiveServiceInput,
-  HasInternalJsonOutputParser, HasServiceParams}
-import com.microsoft.azure.synapse.ml.io.http._
+import com.microsoft.azure.synapse.ml.codegen.GenerationUtils
+import com.microsoft.azure.synapse.ml.cognitive.{
+  CognitiveServicesBase, HasCognitiveServiceInput,
+  HasInternalJsonOutputParser, HasServiceParams
+}
 import com.microsoft.azure.synapse.ml.logging.SynapseMLLogging
 import com.microsoft.azure.synapse.ml.param.AnyJsonFormat.anyFormat
 import com.microsoft.azure.synapse.ml.param.ServiceParam
@@ -19,21 +20,6 @@ import spray.json.DefaultJsonProtocol._
 import spray.json._
 
 import scala.language.existentials
-
-
-trait HasSetServiceName extends Wrappable with HasURL {
-  override def pyAdditionalMethods: String = super.pyAdditionalMethods + {
-    """
-      |def setServiceName(self, value):
-      |    self._java_obj = self._java_obj.setServiceName(value)
-      |    return self
-      |""".stripMargin
-  }
-
-  def setServiceName(v: String): this.type = {
-    setUrl(s"https://${v}.openai.azure.com/")
-  }
-}
 
 trait HasPrompt extends HasServiceParams {
   val prompt: ServiceParam[String] = new ServiceParam[String](
@@ -135,7 +121,7 @@ trait HasMaxTokens extends HasServiceParams {
 }
 
 trait HasOpenAIParams extends HasServiceParams
-  with HasSetServiceName with HasPrompt  with HasBatchPrompt with HasIndexPrompt with HasBatchIndexPrompt
+  with HasPrompt with HasBatchPrompt with HasIndexPrompt with HasBatchIndexPrompt
   with HasAPIVersion with HasDeploymentName with HasMaxTokens {
 
   val temperature: ServiceParam[Double] = new ServiceParam[Double](
@@ -318,6 +304,10 @@ class OpenAICompletion(override val uid: String) extends CognitiveServicesBase(u
   def this() = this(Identifiable.randomUID("OpenAPICompletion"))
 
   def urlPath: String = ""
+
+  override def setCustomServiceName(v: String): this.type = {
+    setUrl(s"https://$v.openai.azure.com/" + urlPath.stripPrefix("/"))
+  }
 
   override protected def prepareUrlRoot: Row => String = { row =>
     s"${getUrl}openai/deployments/${getValue(row, deploymentName)}/completions"

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/openai/OpenAISuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/cognitive/openai/OpenAISuite.scala
@@ -6,6 +6,7 @@ package com.microsoft.azure.synapse.ml.cognitive.openai
 import com.microsoft.azure.synapse.ml.Secrets
 import com.microsoft.azure.synapse.ml.core.test.base.Flaky
 import com.microsoft.azure.synapse.ml.core.test.fuzzing.{TestObject, TransformerFuzzing}
+import com.microsoft.azure.synapse.ml.nbtest.SynapseUtilities.getAccessToken
 import org.apache.spark.ml.util.MLReadable
 import org.apache.spark.sql.{DataFrame, Row}
 import org.scalactic.Equality
@@ -23,7 +24,7 @@ class OpenAICompletionSuite extends TransformerFuzzing[OpenAICompletion] with Op
     .setSubscriptionKey(openAIAPIKey)
     .setDeploymentName("text-davinci-001")
     .setModel("text-davinci-003")
-    .setServiceName(openAIServiceName)
+    .setCustomServiceName(openAIServiceName)
     .setMaxTokens(20)
     .setLogProbs(5)
     .setPromptCol("prompt")
@@ -68,6 +69,23 @@ class OpenAICompletionSuite extends TransformerFuzzing[OpenAICompletion] with Op
     testCompletion(promptCompletion, promptDF)
   }
 
+  test("Basic usage with AAD auth") {
+    val aadToken = getAccessToken(Secrets.ServicePrincipalClientId,
+      Secrets.ServiceConnectionSecret,
+      "https://cognitiveservices.azure.com/")
+    val completion = new OpenAICompletion()
+      .setAADToken(aadToken)
+      .setDeploymentName("text-davinci-001")
+      .setModel("text-davinci-003")
+      .setCustomServiceName(openAIServiceName)
+      .setMaxTokens(20)
+      .setLogProbs(5)
+      .setPromptCol("prompt")
+      .setOutputCol("out")
+
+    testCompletion(completion, promptDF)
+  }
+
   ignore("Batch Prompt") {
     testCompletion(batchPromptCompletion, batchPromptDF)
   }
@@ -92,7 +110,7 @@ class OpenAICompletionSuite extends TransformerFuzzing[OpenAICompletion] with Op
     new OpenAICompletion()
       .setSubscriptionKey(openAIAPIKey)
       .setDeploymentName("text-davinci-001")
-      .setServiceName(openAIServiceName)
+      .setCustomServiceName(openAIServiceName)
       .setMaxTokens(20)
       .setLogProbs(5)
       .setOutputCol("out")


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

_Briefly describe the changes included in this Pull Request._

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
