### PR TITLE
feat: add maxNumClasses param to LightGBMClassifier for multi-class

### DIFF
--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMClassifier.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMClassifier.scala
@@ -53,7 +53,8 @@ class LightGBMClassifier(override val uid: String)
       getExecutionParams(numTasksPerExec),
       getObjectiveParams,
       getSeedParams,
-      getCategoricalParams)
+      getCategoricalParams,
+      getNumClass)
   }
 
   override protected def addCustomTrainParams(params: BaseTrainParams, dataset: Dataset[_]): BaseTrainParams = {
@@ -63,7 +64,8 @@ class LightGBMClassifier(override val uid: String)
      */
     val classifierParams = params.asInstanceOf[ClassifierTrainParams]
     if (classifierParams.isBinary) params
-    else classifierParams.setNumClass(getNumClasses(dataset))
+    else if (classifierParams.getNumClass() != 1) params // multi classfication and already set number of classes
+    else classifierParams.setNumClass(getNumClasses(dataset)) // infering the actual numClasses from the dataset
   }
 
   def getModel(trainParams: BaseTrainParams, lightGBMBooster: LightGBMBooster): LightGBMClassificationModel = {

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMClassifier.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMClassifier.scala
@@ -53,8 +53,7 @@ class LightGBMClassifier(override val uid: String)
       getExecutionParams(numTasksPerExec),
       getObjectiveParams,
       getSeedParams,
-      getCategoricalParams,
-      getNumClass)
+      getCategoricalParams)
   }
 
   override protected def addCustomTrainParams(params: BaseTrainParams, dataset: Dataset[_]): BaseTrainParams = {
@@ -64,8 +63,7 @@ class LightGBMClassifier(override val uid: String)
      */
     val classifierParams = params.asInstanceOf[ClassifierTrainParams]
     if (classifierParams.isBinary) params
-    else if (classifierParams.getNumClass() != 1) params // multi classfication and already set number of classes
-    else classifierParams.setNumClass(getNumClasses(dataset)) // infering the actual numClasses from the dataset
+    else classifierParams.setNumClass(getNumClasses(dataset, getMaxNumClasses))
   }
 
   def getModel(trainParams: BaseTrainParams, lightGBMBooster: LightGBMBooster): LightGBMClassificationModel = {

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/LightGBMParams.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/LightGBMParams.scala
@@ -606,6 +606,12 @@ trait LightGBMParams extends Wrappable
   def getMinDataInLeaf: Int = $(minDataInLeaf)
   def setMinDataInLeaf(value: Int): this.type = set(minDataInLeaf, value)
 
+  val numClass = new IntParam(this, "numClass",
+    "Number of classes for multi-class classification. Defaults to binary.")
+  setDefault(numClass -> 1)
+  def getNumClass: Int = $(numClass)
+  def setNumClass(value: Int): this.type = set(numClass, value)
+
   var delegate: Option[LightGBMDelegate] = None
   def getDelegate: Option[LightGBMDelegate] = delegate
   def setDelegate(delegate: LightGBMDelegate): this.type = {

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/LightGBMParams.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/LightGBMParams.scala
@@ -606,11 +606,11 @@ trait LightGBMParams extends Wrappable
   def getMinDataInLeaf: Int = $(minDataInLeaf)
   def setMinDataInLeaf(value: Int): this.type = set(minDataInLeaf, value)
 
-  val numClass = new IntParam(this, "numClass",
-    "Number of classes for multi-class classification. Defaults to binary.")
-  setDefault(numClass -> 1)
-  def getNumClass: Int = $(numClass)
-  def setNumClass(value: Int): this.type = set(numClass, value)
+  val maxNumClasses = new IntParam(this, "maxNumClasses",
+    "Number of max classes to infer numClass in multi-class classification.")
+  setDefault(maxNumClasses -> 100)
+  def getMaxNumClasses: Int = $(maxNumClasses)
+  def setMaxNumClasses(value: Int): this.type = set(maxNumClasses, value)
 
   var delegate: Option[LightGBMDelegate] = None
   def getDelegate: Option[LightGBMDelegate] = delegate


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

## What changes are proposed in this pull request?

Add maxNumClasses param to LightGBMClassifier. Now, In multiclassfication problem, the number of classes is inferred by using  getNumClasses(spark ml) in addCustomTrainParams. In getNumClasses, maxNumClasses's default is 100. So, It is hard to use datasets that have the number of classes over 100. 

```scala
protected def getNumClasses(dataset: Dataset[_], maxNumClasses: Int = 100): Int
```

To support these datasets, maxNumClasses param is added to LightGBMClassifier.


## How is this patch tested?
It is tested in unittest cases that have cases for multiclassfication.

## Does this PR change any dependencies?

- [x] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
