### PR TITLE
fix: Upgrading Onnx-protobuf version to overcome the assembly usage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -404,7 +404,7 @@ lazy val deepLearning = (project in file("deep-learning"))
   .dependsOn(core % "test->test;compile->compile", opencv % "test->test;compile->compile")
   .settings(settings ++ Seq(
     libraryDependencies ++= Seq(
-      "com.microsoft.azure" % "onnx-protobuf_2.12" % "0.9.1" classifier "assembly",
+      "com.microsoft.azure" % "onnx-protobuf_2.12" % "0.9.3",
       "com.microsoft.onnxruntime" % "onnxruntime_gpu" % "1.8.1"
     ),
     name := "synapseml-deep-learning"


### PR DESCRIPTION
## What changes are proposed in this pull request?
Upgrading the Onnx version which has the shaded classes in a regular jar and avoids the classifier need.

## How is this patch tested?
Tested using Databricks spark3.3 cluster
![image](https://user-images.githubusercontent.com/98137159/221600484-42ebe4cd-5b2f-4578-aa2b-bca662e8436f.png)
![image](https://user-images.githubusercontent.com/98137159/221600561-11fc4e60-ca25-42ae-a2cb-629baeabe6db.png)

