### PR TITLE
docs: Add audiobook generation example

### DIFF
--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/DatabricksUtilities.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/DatabricksUtilities.scala
@@ -391,9 +391,10 @@ abstract class DatabricksTestHelper extends TestBase {
       assert(isClusterActive(clusterId))
     }
 
+    Thread.sleep(1000) // Ensure cluster is not overwhelmed
     println("Installing libraries")
     installLibraries(clusterId, libraries)
-    tryWithRetries(Seq.fill(60 * 3)(1000).toArray) { () =>
+    tryWithRetries(Seq.fill(60 * 6)(1000).toArray) { () =>
       assert(areLibrariesInstalled(clusterId))
     }
 

--- a/notebooks/features/cognitive_services/CognitiveServices - Create Audiobooks.ipynb
+++ b/notebooks/features/cognitive_services/CognitiveServices - Create Audiobooks.ipynb
@@ -1,0 +1,314 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Create Audiobooks using Neural Speech to Text"
+   ],
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "showTitle": false,
+     "cellMetadata": {},
+     "nuid": "389e4a78-19aa-4c3f-9b7a-92e81f088168",
+     "inputWidgets": {},
+     "title": ""
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Step 1: Load libraries and add service information"
+   ],
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "showTitle": false,
+     "cellMetadata": {},
+     "nuid": "f320d6af-b255-4cb5-b60b-da840760713e",
+     "inputWidgets": {},
+     "title": ""
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "from synapse.ml.core.platform import *\n",
+    "\n",
+    "# Bootstrap Spark Session\n",
+    "spark = SparkSession.builder.getOrCreate()\n",
+    "if running_on_synapse():\n",
+    "    from notebookutils import mssparkutils\n",
+    "    from notebookutils.visualization import display\n",
+    "\n",
+    "# Fill this in with your cognitive service information\n",
+    "service_key = find_secret(\n",
+    "    \"cognitive-api-key\"\n",
+    ")  # Replace this line with a string like service_key = \"dddjnbdkw9329\"\n",
+    "service_loc = \"eastus\"\n",
+    "\n",
+    "storage_container = \"audiobooks\"\n",
+    "storage_key = find_secret(\"madtest-storage-key\")\n",
+    "storage_account = \"anomalydetectiontest\""
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "showTitle": false,
+     "cellMetadata": {},
+     "nuid": "ab422610-0438-4ca4-bd16-b45e90125294",
+     "inputWidgets": {},
+     "title": ""
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Step 2: Attach the storage account to hold the audio files"
+   ],
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "showTitle": false,
+     "cellMetadata": {},
+     "nuid": "10c83d0e-998f-4d72-a351-4ffab15f662c",
+     "inputWidgets": {},
+     "title": ""
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "spark_key_setting = f\"fs.azure.account.key.{storage_account}.blob.core.windows.net\"\n",
+    "spark.sparkContext._jsc.hadoopConfiguration().set(spark_key_setting, storage_key)"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "showTitle": false,
+     "cellMetadata": {},
+     "nuid": "55b83038-e907-4101-a914-0a32825a9d03",
+     "inputWidgets": {},
+     "title": ""
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "import os"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": false,
+     "outputs_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "import os\n",
+    "from os.path import exists, join\n",
+    "\n",
+    "mount_path = f\"wasbs://{storage_container}@{storage_account}.blob.core.windows.net/\"\n",
+    "if running_on_synapse():\n",
+    "    mount_dir = join(\"/synfs\", mssparkutils.env.getJobId(), storage_container)\n",
+    "    if not exists(mount_dir):\n",
+    "        mssparkutils.fs.mount(\n",
+    "            mount_path, f\"/{storage_container}\", {\"accountKey\": storage_key}\n",
+    "        )\n",
+    "elif running_on_databricks():\n",
+    "    if not exists(f\"/dbfs/mnt/{storage_container}\"):\n",
+    "        dbutils.fs.mount(\n",
+    "            source=mount_path,\n",
+    "            mount_point=f\"/mnt/{storage_container}\",\n",
+    "            extra_configs={spark_key_setting: storage_key},\n",
+    "        )"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "showTitle": false,
+     "cellMetadata": {},
+     "nuid": "625c7b1d-4034-4df2-b919-3775ac9c271c",
+     "inputWidgets": {},
+     "title": ""
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Step 3: Read in text data"
+   ],
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "showTitle": false,
+     "cellMetadata": {},
+     "nuid": "381c3af7-e0e8-4a29-ae88-467e86a0e717",
+     "inputWidgets": {},
+     "title": ""
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "from pyspark.sql.functions import udf\n",
+    "\n",
+    "\n",
+    "@udf\n",
+    "def make_audio_filename(part):\n",
+    "    return f\"wasbs://{storage_container}@{storage_account}.blob.core.windows.net/alice_in_wonderland/part_{part}.wav\"\n",
+    "\n",
+    "\n",
+    "df = (\n",
+    "    spark.read.parquet(\n",
+    "        \"wasbs://publicwasb@mmlspark.blob.core.windows.net/alice_in_wonderland.parquet\"\n",
+    "    )\n",
+    "    .repartition(10)\n",
+    "    .withColumn(\"filename\", make_audio_filename(\"part\"))\n",
+    ")\n",
+    "\n",
+    "display(df)"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "showTitle": false,
+     "cellMetadata": {},
+     "nuid": "56c8ebab-567f-4c1d-a2ea-1aeb5aefcf1e",
+     "inputWidgets": {},
+     "title": ""
+    },
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Step 4: Synthesize audio from text\n",
+    "\n",
+    "<div>\n",
+    "<img src=\"https://marhamilresearch4.blob.core.windows.net/gutenberg-public/Notebook/NeuralTTS_hero.jpeg\" width=\"500\" />\n",
+    "</div>"
+   ],
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "showTitle": false,
+     "cellMetadata": {},
+     "nuid": "9fcb4305-a6d4-4f48-ac6f-cf4f863c7f5f",
+     "inputWidgets": {},
+     "title": ""
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "from synapse.ml.cognitive import TextToSpeech\n",
+    "\n",
+    "tts = (\n",
+    "    TextToSpeech()\n",
+    "    .setSubscriptionKey(service_key)\n",
+    "    .setTextCol(\"text\")\n",
+    "    .setLocation(service_loc)\n",
+    "    .setErrorCol(\"error\")\n",
+    "    .setVoiceName(\"en-US-SteffanNeural\")\n",
+    "    .setOutputFileCol(\"filename\")\n",
+    ")\n",
+    "\n",
+    "audio = tts.transform(df).cache()\n",
+    "display(audio)"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "showTitle": false,
+     "cellMetadata": {},
+     "nuid": "2730c8cd-616a-4258-909d-912ea66d6446",
+     "inputWidgets": {},
+     "title": ""
+    },
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Step 5: Listen to an audio file"
+   ],
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "showTitle": false,
+     "cellMetadata": {},
+     "nuid": "157a368a-d80b-4bf8-a5cb-c1f266be2f00",
+     "inputWidgets": {},
+     "title": ""
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "from IPython.display import Audio\n",
+    "\n",
+    "\n",
+    "def get_audio_file(num):\n",
+    "    if running_on_databricks():\n",
+    "        return f\"/dbfs/mnt/{storage_container}/alice_in_wonderland/part_{num}.wav\"\n",
+    "    else:\n",
+    "        return join(mount_dir, f\"alice_in_wonderland/part_{num}.wav\")\n",
+    "\n",
+    "\n",
+    "Audio(filename=get_audio_file(1))"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "showTitle": false,
+     "cellMetadata": {},
+     "nuid": "7a0ad60f-5511-42ba-9882-e93f474f85e9",
+     "inputWidgets": {},
+     "title": ""
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "language": "Python",
+   "display_name": "Synapse PySpark"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "kernel_info": {
+   "name": "synapse_pyspark"
+  },
+  "save_output": true,
+  "synapse_widget": {
+   "version": "0.1",
+   "state": {}
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

_Briefly describe the changes included in this Pull Request._

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
