### PR TITLE
fix: VW adjust learning rate for boston data example

### DIFF
--- a/notebooks/features/regression/Regression - Vowpal Wabbit vs. LightGBM vs. Linear Regressor.ipynb
+++ b/notebooks/features/regression/Regression - Vowpal Wabbit vs. LightGBM vs. Linear Regressor.ipynb
@@ -224,7 +224,7 @@
    "outputs": [],
    "source": [
     "# Use the same number of iterations as Spark MLlib's Linear Regression (=100)\n",
-    "args = \"--holdout_off --loss_function quantile -l 7 -q :: --power_t 0.3\"\n",
+    "args = \"--holdout_off --loss_function quantile -l 0.5 -q :: --power_t 0.3\"\n",
     "vwr = VowpalWabbitRegressor(labelCol=\"target\", passThroughArgs=args, numPasses=100)\n",
     "\n",
     "# To reduce number of partitions (which will effect performance), use `vw_train_data.repartition(1)`\n",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Update learning rate. @jackgerrits I assume that the defaults maybe changed? Learning rate was 7 and I changed to 0.5 (did a small hyper parameter search). 

## How is this patch tested?

Compared RMSE
