### PR TITLE
fix: Abstain from CodeQL for markdown-only changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,9 +14,11 @@ name: "CodeQL"
 on:
   push:
     branches: [ "master" ]
+    paths-ignore: [ "**.md" ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "master" ]
+    paths-ignore: [ "**.md" ]
   schedule:
     - cron: '17 7 * * 3'
 


### PR DESCRIPTION
CodeQL currently running even when only copy/text in a markdown file is changed. e.g. https://github.com/microsoft/SynapseML/pull/1864

This PR adds a filter so CodeQL is only run when non-markdown files are changed.