### PR TITLE
build: Exclude contributors and security markdown docs from build triggers

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -8,6 +8,8 @@ trigger:
   paths:
     exclude:
     - README.md
+    - CONTRIBUTORS.md
+    - SECURITY.md
     - docs/*
     - CODEOWNERS
     - .github


### PR DESCRIPTION
Adding CONTRIBUTORS.md and SECURITY.md to the path exclusion list