### PR TITLE
fix: Remove extraneous "Foo" type from Py codegen

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/codegen/PyCodegen.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/codegen/PyCodegen.scala
@@ -16,8 +16,6 @@ import java.io.File
 
 object PyCodegen {
 
-  type Foo = Estimator[_ <: Model[_]]
-
   import CodeGenUtils._
 
   def generatePythonClasses(conf: CodegenConfig): Unit = {


### PR DESCRIPTION
This type appears to be an artifact from testing/development and has no references in the source.
