### PR TITLE
feat: Inject interop with pandas dataframes in _fit and _transform methods

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/CognitiveServiceBase.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/CognitiveServiceBase.scala
@@ -197,7 +197,7 @@ trait HasCustomCogServiceDomain extends Wrappable with HasURL with HasUrlPath {
         |    mlflow_env_configs = get_mlflow_env_config()
         |    self.setAADToken(mlflow_env_configs.driver_aad_token)
         |    self.setInternalEndpoint(mlflow_env_configs.workload_endpoint)
-        |dataset = DataFrame(self._java_obj.transform(dataset._jdf), dataset.sparkSession)""".stripMargin
+        |""".stripMargin + super.pyTransformerInvocation
 
   override def dotnetAdditionalMethods: String = super.dotnetAdditionalMethods + {
     s"""/// <summary>

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/CognitiveServiceBase.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/CognitiveServiceBase.scala
@@ -177,27 +177,27 @@ trait HasCustomCogServiceDomain extends Wrappable with HasURL with HasUrlPath {
   private[ml] def internalServiceType: String = ""
 
   override def pyAdditionalMethods: String = super.pyAdditionalMethods + {
-    """def setCustomServiceName(self, value):
-      |    self._java_obj = self._java_obj.setCustomServiceName(value)
-      |    return self
-      |
-      |def setEndpoint(self, value):
-      |    self._java_obj = self._java_obj.setEndpoint(value)
-      |    return self
-      |
-      |def setInternalEndpoint(self, value):
-      |    self._java_obj = self._java_obj.setInternalEndpoint(value)
-      |    return self
-      |
-      |def _transform(self, dataset: DataFrame) -> DataFrame:
-      |    if running_on_synapse_internal():
-      |        from synapse.ml.mlflow import get_mlflow_env_config
-      |        mlflow_env_configs = get_mlflow_env_config()
-      |        self.setAADToken(mlflow_env_configs.driver_aad_token)
-      |        self.setInternalEndpoint(mlflow_env_configs.workload_endpoint)
-      |    return super()._transform(dataset)
-      |""".stripMargin
+    """|def setCustomServiceName(self, value):
+       |    self._java_obj = self._java_obj.setCustomServiceName(value)
+       |    return self
+       |
+       |def setEndpoint(self, value):
+       |    self._java_obj = self._java_obj.setEndpoint(value)
+       |    return self
+       |
+       |def setInternalEndpoint(self, value):
+       |    self._java_obj = self._java_obj.setInternalEndpoint(value)
+       |    return self
+       |""".stripMargin
   }
+
+  override def pyTransformerInvocation: String =
+    s"""|if running_on_synapse_internal():
+        |    from synapse.ml.mlflow import get_mlflow_env_config
+        |    mlflow_env_configs = get_mlflow_env_config()
+        |    self.setAADToken(mlflow_env_configs.driver_aad_token)
+        |    self.setInternalEndpoint(mlflow_env_configs.workload_endpoint)
+        |dataset = DataFrame(self._java_obj.transform(dataset._jdf), dataset.sparkSession)""".stripMargin
 
   override def dotnetAdditionalMethods: String = super.dotnetAdditionalMethods + {
     s"""/// <summary>

--- a/core/src/main/python/synapse/ml/cyber/feature/indexers.py
+++ b/core/src/main/python/synapse/ml/cyber/feature/indexers.py
@@ -116,6 +116,17 @@ class IdIndexer(Estimator, HasSetInputCol, HasSetOutputCol):
         )
 
     def _fit(self, df: DataFrame) -> IdIndexerModel:
+        def _ensure_spark_df(self, data):
+            if isinstance(data, pd.DataFrame):
+                from pyspark.sql import SparkSession
+
+                spark = SparkSession.builder.getOrCreate()
+                return spark.createDataFrame(data)
+            else:
+                return data
+
+        df = _ensure_spark_df(df)
+
         return IdIndexerModel(
             self.input_col,
             self.partition_key,
@@ -166,4 +177,15 @@ class MultiIndexer(Estimator):
         self.indexers = indexers
 
     def _fit(self, df: DataFrame) -> MultiIndexerModel:
+        def _ensure_spark_df(self, data):
+            if isinstance(data, pd.DataFrame):
+                from pyspark.sql import SparkSession
+
+                spark = SparkSession.builder.getOrCreate()
+                return spark.createDataFrame(data)
+            else:
+                return data
+
+        df = _ensure_spark_df(df)
+
         return MultiIndexerModel([i.fit(df) for i in self.indexers])

--- a/core/src/main/python/synapse/ml/cyber/feature/scalers.py
+++ b/core/src/main/python/synapse/ml/cyber/feature/scalers.py
@@ -154,6 +154,17 @@ class PerPartitionScalarScalerEstimator(
         raise NotImplementedError()
 
     def _fit(self, df: DataFrame) -> PerPartitionScalarScalerModel:
+        def _ensure_spark_df(self, data):
+            if isinstance(data, pd.DataFrame):
+                from pyspark.sql import SparkSession
+
+                spark = SparkSession.builder.getOrCreate()
+                return spark.createDataFrame(data)
+            else:
+                return data
+
+        df = _ensure_spark_df(df)
+
         partition_key = self.partition_key
         apply_on_cols = self._apply_on_cols()
 

--- a/core/src/main/python/synapse/ml/recommendation/RankingTrainValidationSplit.py
+++ b/core/src/main/python/synapse/ml/recommendation/RankingTrainValidationSplit.py
@@ -36,5 +36,16 @@ class RankingTrainValidationSplit(_ValidatorParams, _RankingTrainValidationSplit
         return _java_obj
 
     def _fit(self, dataset):
+        def _ensure_spark_df(self, data):
+            if isinstance(data, pd.DataFrame):
+                from pyspark.sql import SparkSession
+
+                spark = SparkSession.builder.getOrCreate()
+                return spark.createDataFrame(data)
+            else:
+                return data
+
+        df = _ensure_spark_df(df)
+
         model = self._to_java().fit(dataset._jdf)
         return self._create_model(model)

--- a/deep-learning/src/main/python/synapse/ml/dl/DeepTextClassifier.py
+++ b/deep-learning/src/main/python/synapse/ml/dl/DeepTextClassifier.py
@@ -221,6 +221,17 @@ class DeepTextClassifier(TorchEstimator, TextPredictionParams):
         self.setLabelCols([self.getLabelCol()])
 
     def _fit(self, dataset):
+        def _ensure_spark_df(self, data):
+            if isinstance(data, pd.DataFrame):
+                from pyspark.sql import SparkSession
+
+                spark = SparkSession.builder.getOrCreate()
+                return spark.createDataFrame(data)
+            else:
+                return data
+
+        df = _ensure_spark_df(df)
+
         return super()._fit(dataset)
 
     # override this method to provide a correct default backend

--- a/deep-learning/src/main/python/synapse/ml/dl/DeepVisionClassifier.py
+++ b/deep-learning/src/main/python/synapse/ml/dl/DeepVisionClassifier.py
@@ -213,6 +213,17 @@ class DeepVisionClassifier(TorchEstimator, VisionPredictionParams):
         self.setLabelCols([self.getLabelCol()])
 
     def _fit(self, dataset):
+        def _ensure_spark_df(self, data):
+            if isinstance(data, pd.DataFrame):
+                from pyspark.sql import SparkSession
+
+                spark = SparkSession.builder.getOrCreate()
+                return spark.createDataFrame(data)
+            else:
+                return data
+
+        df = _ensure_spark_df(df)
+
         return super()._fit(dataset)
 
     # override this method to provide a correct default backend

--- a/environment.yml
+++ b/environment.yml
@@ -37,3 +37,4 @@ dependencies:
     - Pillow
     - transformers==4.15.0
     - huggingface-hub>=0.8.1
+    - pandas


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

_Briefly describe the changes included in this Pull Request._

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
