### PR TITLE
fix: DML run get timeout if big dataset has more feature columns (Workaround Synapse Spark optimizer issue)

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/DoubleMLEstimator.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/DoubleMLEstimator.scala
@@ -232,9 +232,7 @@ class DoubleMLEstimator(override val uid: String)
 
       val df1 = treatmentPipeline.transform(test).cache
       val df2 = outcomePipeline.transform(df1).cache
-      df1.unpersist()
       val transformed = treatmentResidualVA.transform(df2)
-      df2.unpersist()
       transformed
     }
 

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/DoubleMLEstimator.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/DoubleMLEstimator.scala
@@ -232,7 +232,9 @@ class DoubleMLEstimator(override val uid: String)
 
       val df1 = treatmentPipeline.transform(test).cache
       val df2 = outcomePipeline.transform(df1).cache
+      df1.unpersist()
       val transformed = treatmentResidualVA.transform(df2)
+      df2.unpersist()
       transformed
     }
 

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/DoubleMLEstimator.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/DoubleMLEstimator.scala
@@ -118,7 +118,7 @@ class DoubleMLEstimator(override val uid: String)
               Some(oneAte)
             } catch {
               case ex: Throwable =>
-                log.info(s"ATE calculation got exception on iteration $index with the redrew sample data. " +
+                log.warn(s"ATE calculation got exception on iteration $index with the redrew sample data. " +
                   s"Exception details: $ex")
                 None
             }
@@ -193,14 +193,12 @@ class DoubleMLEstimator(override val uid: String)
 
     def calculateResiduals(train: Dataset[_], test: Dataset[_]): DataFrame = {
       val treatmentModel = treatmentEstimator.setInputCols(
-        train.columns.filterNot(Array(getTreatmentCol, getOutcomeCol,
-//          treatmentResidualPredictionColName, outcomeResidualPredictionColName
+        train.columns.filterNot(Array(getTreatmentCol, getOutcomeCol
         ).contains)
       )
 
       val outcomeModel = outcomeEstimator.setInputCols(
-        train.columns.filterNot(Array(getOutcomeCol, getTreatmentCol,
-//          treatmentResidualPredictionColName, outcomeResidualPredictionColName
+        train.columns.filterNot(Array(getOutcomeCol, getTreatmentCol
         ).contains)
       )
 

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/ResidualTransformer.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/ResidualTransformer.scala
@@ -15,6 +15,8 @@ import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.{BooleanType, DoubleType, IntegerType, LongType, NumericType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Dataset}
 
+import java.util.Calendar
+
 /** Compute the differences between observed and predicted values of data.
  *  for classification, we compute residual as "observed - probability($(classIndex))"
  *  for regression, we compute residual as "observed - prediction"
@@ -57,6 +59,8 @@ class ResidualTransformer(override val uid: String) extends Transformer
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     logTransform[DataFrame]({
+      println(s"$this - [ResidualTransformer] start transform at ${Calendar.getInstance().getTime()}")
+
       transformSchema(schema = dataset.schema, logging = true)
       // Make sure the observedCol is a DoubleType or IntegerType
       val observedColType = dataset.schema(getObservedCol).dataType
@@ -70,6 +74,9 @@ class ResidualTransformer(override val uid: String) extends Transformer
       } else dataset
 
       val predictedColDataType = convertedDataset.schema(getPredictedCol).dataType
+
+      println(s"$this - [ResidualTransformer] complete transform at ${Calendar.getInstance().getTime()}")
+
       predictedColDataType match {
         case SQLDataTypes.VectorType =>
           // For probability vector, compute the residual as "observed - probability($index)"

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/ResidualTransformer.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/ResidualTransformer.scala
@@ -57,8 +57,6 @@ class ResidualTransformer(override val uid: String) extends Transformer
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     logTransform[DataFrame]({
-      println(s"[${java.time.LocalDateTime.now}] $this - [ResidualTransformer] start transform")
-
       transformSchema(schema = dataset.schema, logging = true)
       // Make sure the observedCol is a DoubleType or IntegerType
       val observedColType = dataset.schema(getObservedCol).dataType
@@ -72,8 +70,6 @@ class ResidualTransformer(override val uid: String) extends Transformer
       } else dataset
 
       val predictedColDataType = convertedDataset.schema(getPredictedCol).dataType
-
-      println(s"[${java.time.LocalDateTime.now}] $this - [ResidualTransformer] complete transform")
 
       predictedColDataType match {
         case SQLDataTypes.VectorType =>

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/ResidualTransformer.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/ResidualTransformer.scala
@@ -15,8 +15,6 @@ import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.{BooleanType, DoubleType, IntegerType, LongType, NumericType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Dataset}
 
-import java.util.Calendar
-
 /** Compute the differences between observed and predicted values of data.
  *  for classification, we compute residual as "observed - probability($(classIndex))"
  *  for regression, we compute residual as "observed - prediction"
@@ -59,7 +57,7 @@ class ResidualTransformer(override val uid: String) extends Transformer
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     logTransform[DataFrame]({
-      println(s"$this - [ResidualTransformer] start transform at ${Calendar.getInstance().getTime()}")
+      println(s"[${java.time.LocalDateTime.now}] $this - [ResidualTransformer] start transform")
 
       transformSchema(schema = dataset.schema, logging = true)
       // Make sure the observedCol is a DoubleType or IntegerType
@@ -75,7 +73,7 @@ class ResidualTransformer(override val uid: String) extends Transformer
 
       val predictedColDataType = convertedDataset.schema(getPredictedCol).dataType
 
-      println(s"$this - [ResidualTransformer] complete transform at ${Calendar.getInstance().getTime()}")
+      println(s"[${java.time.LocalDateTime.now}] $this - [ResidualTransformer] complete transform")
 
       predictedColDataType match {
         case SQLDataTypes.VectorType =>

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/AutoTrainer.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/AutoTrainer.scala
@@ -4,7 +4,7 @@
 package com.microsoft.azure.synapse.ml.train
 
 import com.microsoft.azure.synapse.ml.codegen.Wrappable
-import com.microsoft.azure.synapse.ml.core.contracts.{HasFeaturesCol, HasInputCols, HasLabelCol, HasWeightCol}
+import com.microsoft.azure.synapse.ml.core.contracts.{HasFeaturesCol, HasInputCols, HasLabelCol}
 import com.microsoft.azure.synapse.ml.param.EstimatorParam
 import org.apache.spark.ml.param.{IntParam, Param}
 import org.apache.spark.ml.{ComplexParamsWritable, Estimator, Model}
@@ -12,7 +12,7 @@ import org.apache.spark.ml.{ComplexParamsWritable, Estimator, Model}
 /** Defines common inheritance and parameters across trainers.
  */
 trait AutoTrainer[TrainedModel <: Model[TrainedModel]] extends Estimator[TrainedModel]
-  with HasLabelCol with HasInputCols with ComplexParamsWritable with HasFeaturesCol with HasWeightCol with Wrappable {
+  with HasLabelCol with HasInputCols with ComplexParamsWritable with HasFeaturesCol with Wrappable {
 
   /** Doc for model to run.
    */

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/AutoTrainer.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/AutoTrainer.scala
@@ -4,7 +4,7 @@
 package com.microsoft.azure.synapse.ml.train
 
 import com.microsoft.azure.synapse.ml.codegen.Wrappable
-import com.microsoft.azure.synapse.ml.core.contracts.{HasFeaturesCol, HasInputCols, HasLabelCol}
+import com.microsoft.azure.synapse.ml.core.contracts.{HasFeaturesCol, HasInputCols, HasLabelCol, HasWeightCol}
 import com.microsoft.azure.synapse.ml.param.EstimatorParam
 import org.apache.spark.ml.param.{IntParam, Param}
 import org.apache.spark.ml.{ComplexParamsWritable, Estimator, Model}
@@ -12,7 +12,7 @@ import org.apache.spark.ml.{ComplexParamsWritable, Estimator, Model}
 /** Defines common inheritance and parameters across trainers.
  */
 trait AutoTrainer[TrainedModel <: Model[TrainedModel]] extends Estimator[TrainedModel]
-  with HasLabelCol with HasInputCols with ComplexParamsWritable with HasFeaturesCol with Wrappable {
+  with HasLabelCol with HasInputCols with ComplexParamsWritable with HasFeaturesCol with HasWeightCol with Wrappable {
 
   /** Doc for model to run.
    */

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/TrainClassifier.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/TrainClassifier.scala
@@ -322,8 +322,6 @@ class TrainedClassifierModel(val uid: String)
   //scalastyle:off
   override def transform(dataset: Dataset[_]): DataFrame = {
     logTransform[DataFrame]({
-      println(s"[${java.time.LocalDateTime.now}] $this - [trainClassifier] start transform on data ${dataset.count()}")
-
       val hasScoreCols = hasScoreColumns(getLastStage)
 
       // re-featurize and score the data
@@ -358,9 +356,6 @@ class TrainedClassifierModel(val uid: String)
         else CategoricalUtilities.setLevels(scoredDataWithUpdatedScoredLabels,
           SchemaConstants.SparkPredictionColumn,
           getLevels)
-
-      println(s"[${java.time.LocalDateTime.now}] $this - [trainClassifier] complete transform")
-
       // add metadata to the scored labels and true labels for the levels in label column
       if (get(levels).isEmpty || !labelColumnExists) scoredDataWithUpdatedScoredLevels
       else CategoricalUtilities.setLevels(scoredDataWithUpdatedScoredLevels,

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/TrainClassifier.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/TrainClassifier.scala
@@ -162,7 +162,6 @@ class TrainClassifier(override val uid: String) extends AutoTrainer[TrainedClass
         convertedLabelDataset.columns.filterNot(nonFeatureColumns.contains)
       }
 
-      println(s"[${java.time.LocalDateTime.now}] $this - [trainClassifier] start featurize")
       val featurizer = new Featurize()
         .setOutputCol(getFeaturesCol)
         .setInputCols(featureColumns)
@@ -170,16 +169,7 @@ class TrainClassifier(override val uid: String) extends AutoTrainer[TrainedClass
         .setNumFeatures(featuresToHashTo)
       val featurizedModel = featurizer.fit(convertedLabelDataset)
 
-// Error: java.util.NoSuchElementException: Failed to find a default value for weightCol
-//      val colstoSelect = if (isDefined(weightCol) || !$(weightCol).isEmpty)
-//        Array(getFeaturesCol, getLabelCol, getWeightCol)
-//      else Array(getFeaturesCol, getLabelCol)
-//
-//      val processedData = featurizedModel.transform(convertedLabelDataset).select(colstoSelect.map(col): _*)
-
-      val processedData = featurizedModel.transform(convertedLabelDataset).select(getFeaturesCol, getLabelCol)
-
-      println(s"[${java.time.LocalDateTime.now}] $this - [trainClassifier] complete featurize")
+      val processedData = featurizedModel.transform(convertedLabelDataset)
 
       if (!processedData.storageLevel.useMemory) {
         processedData.cache()
@@ -196,10 +186,8 @@ class TrainClassifier(override val uid: String) extends AutoTrainer[TrainedClass
         multilayerPerceptronClassifier.setLayers(multilayerPerceptronClassifier.getLayers)
       }
 
-      println(s"[${java.time.LocalDateTime.now}] $this - [trainClassifier] start fit")
       // Train the learner
       val fitModel = classifier.fit(processedData)
-      println(s"[${java.time.LocalDateTime.now}] $this - [trainClassifier] complete fit")
 
       if (processedData.storageLevel.useMemory) {
         processedData.unpersist()

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/TrainRegressor.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/TrainRegressor.scala
@@ -16,7 +16,7 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types._
 
-import java.util.{Calendar, UUID}
+import java.util.UUID
 
 /** Trains a regression model. */
 class TrainRegressor(override val uid: String) extends AutoTrainer[TrainedRegressorModel] with SynapseMLLogging {
@@ -157,8 +157,6 @@ class TrainedRegressorModel(val uid: String)
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     logTransform[DataFrame]({
-      println(s"$this - [trainRegressor] start transform at ${Calendar.getInstance().getTime()}")
-
       // re-featurize and score the data
       val scoredData = getModel.transform(dataset)
 
@@ -172,9 +170,6 @@ class TrainedRegressorModel(val uid: String)
         if (!labelColumnExists) cleanedScoredData
         else SparkSchema.setLabelColumnName(
           cleanedScoredData, moduleName, getLabelCol, SchemaConstants.RegressionKind)
-
-      println(s"$this - [trainRegressor] complete at ${Calendar.getInstance().getTime()}")
-
       SparkSchema.updateColumnMetadata(schematizedScoredDataWithLabel,
         moduleName, SchemaConstants.SparkPredictionColumn, SchemaConstants.RegressionKind)
     })

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/TrainRegressor.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/TrainRegressor.scala
@@ -108,22 +108,12 @@ class TrainRegressor(override val uid: String) extends AutoTrainer[TrainedRegres
 
       val featurizedModel = featurizer.fit(convertedLabelDataset)
 
-//      val colstoSelect = if (isDefined(weightCol) || !$(weightCol).isEmpty)
-//        Array(getFeaturesCol, getLabelCol, getWeightCol)
-//      else Array(getFeaturesCol, getLabelCol)
-//
-//      val processedData = featurizedModel.transform(convertedLabelDataset).select(colstoSelect.map(col): _*)
-
-      val processedData = featurizedModel.transform(convertedLabelDataset).select(getFeaturesCol, getLabelCol)
+      val processedData = featurizedModel.transform(convertedLabelDataset)
 
       processedData.cache()
 
       // Train the learner
-      println(s"$this - [trainRegressor] start fit at ${Calendar.getInstance().getTime()}")
-
       val fitModel = regressor.fit(processedData)
-
-      println(s"$this - [trainRegressor] complete fit at ${Calendar.getInstance().getTime()}")
 
       processedData.unpersist()
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
When applying DML on WExp project, the data has >1M records and >5 categorical features, DML run got timeout even with a large cluster.
We figured out that it's due to Synapse version of Spark optimizer won't be able to handle a complex query plan, split DML pipeline and cache each pipeline result, can fix the timeout issue.

## How is this patch tested?
with internal project data