### PR TITLE
docs: note discrete treatment data type

### DIFF
--- a/website/docs/features/causal_inference/about.md
+++ b/website/docs/features/causal_inference/about.md
@@ -47,7 +47,9 @@ dml = (DoubleMLEstimator()
       .setMaxIter(20))
 dmlModel = dml.fit(dataset)
 ```
-> Note: all columns except "Treatment" and "Outcome" in your dataset will be used as confounders.  
+> Note: all columns except "Treatment" and "Outcome" in your dataset will be used as confounders.
+
+> Note: For discrete treatment, the treatment column must be `int` or `bool`. `0` and `False` will be treated as the control group. 
 
 After fitting the model, you can get average treatment effect and confidence interval:
 ```python


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Update causal inference docs: discrete treatment column data type must be int or bool.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [x ] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [x ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
