### PR TITLE
docs: Fix installation instruction in the webpage for the `build.sbt` file

### DIFF
--- a/website/docs/getting_started/installation.md
+++ b/website/docs/getting_started/installation.md
@@ -60,8 +60,7 @@ your `build.sbt`:
 ```scala
 resolvers += "SynapseML" at "https://mmlspark.azureedge.net/maven"
 // Use 0.11.0 version for Spark3.2 and 0.9.5-13-d1b51517-SNAPSHOT version for Spark3.1
-libraryDependencies += "com.microsoft.azure" %% "synapseml_2.12" % "0.11.0"
-
+libraryDependencies += "com.microsoft.azure" % "synapseml_2.12" % "0.11.0"
 ```
 
 ## Spark package


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make installation instruction in the webpage consistent with the README file in the section related to `sbt`: <https://github.com/microsoft/SynapseML/blob/master/README.md#sbt>.

There may be other parts in the <https://github.com/microsoft/SynapseML/blob/master/README.md> that are not updated in <https://microsoft.github.io/SynapseML/docs/getting_started/installation/>, but I didn't check anything else.

## Does this PR change any dependencies?

- [x] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.