### PR TITLE
fix: bug #1987 ordering in FindBestModel

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/automl/FindBestModel.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/automl/FindBestModel.scala
@@ -99,7 +99,7 @@ class FindBestModel(override val uid: String) extends Estimator[BestModel]
 
       val bestIndex = simpleMetrics.zipWithIndex.foldLeft(Double.NaN, -1) {
         case (best, curr) =>
-          if (best._1.isNaN || operator.gt(best._1, curr._1))
+          if (best._1.isNaN || operator.lt(best._1, curr._1))
             curr
           else
             best


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

#1987

## What changes are proposed in this pull request?

Uses the correct ordering when selecting the best metric.

## How is this patch tested?

- [x] I have written *improved* tests 
