### PR TITLE
fix ComputeModelStatistics.scala

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.scala
@@ -260,7 +260,7 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
                                 labelColumnName: String): DataFrame = {
     // TODO: We call cache in order to avoid a bug with catalyst where CMS seems to get stuck in a loop
     // For future spark upgrade past 2.2.0, we should try to see if the cache() call can be removed
-    dataset.select(col(predictionColumnName), col(labelColumnName).cast(DoubleType))
+    dataset.select(col(predictionColumnName).cast(DoubleType), col(labelColumnName).cast(DoubleType))
       .cache()
       .na
       .drop(Array(predictionColumnName, labelColumnName))
@@ -284,7 +284,7 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
     // Calculate confusion matrix and output it as DataFrame
     // TODO: We call cache in order to avoid a bug with catalyst where CMS seems to get stuck in a loop
     // For future spark upgrade past 2.2.0, we should try to see if the cache() call can be removed
-    dataset.select(col(scoredLabelsColumnName).cast(DoubleType), col(labelColumnName))
+    dataset.select(col(scoredLabelsColumnName).cast(DoubleType), col(labelColumnName).cast(DoubleType))
       .cache()
       .na
       .drop(Array(scoredLabelsColumnName, labelColumnName))
@@ -314,7 +314,7 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
                          levelsToIndexMap: Map[Any, Double]): RDD[(Double, Double)] = {
     // TODO: We call cache in order to avoid a bug with catalyst where CMS seems to get stuck in a loop
     // For future spark upgrade past 2.2.0, we should try to see if the cache() call can be removed
-    dataset.select(col(scoresColumnName), col(labelColumnName))
+    dataset.select(col(scoresColumnName).cast(DoubleType), col(labelColumnName).cast(DoubleType))
       .cache()
       .na
       .drop(Array(scoresColumnName, labelColumnName))


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?
I propose converting the label and prediction columns to double type when they are both present in the dataframe.

_Briefly describe the changes included in this Pull Request._
When the `label` or `prediction` are not both of double type, it throws the "error prediction and label columns invalid or missing". 

To users, this error is not informative as one can spend hours trying to figure out the cause of the error despite the 'label' and 'prediction' variables being present in the data frame.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
