### PR TITLE
fix: change the request uri version of AnomalyDetetion (v1.1-preview -> v1.1)

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/anomaly/AnomalyDetection.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/cognitive/anomaly/AnomalyDetection.scala
@@ -156,7 +156,7 @@ class DetectLastAnomaly(override val uid: String) extends AnomalyDetectorBase(ui
 
   def setSeriesCol(v: String): this.type = setVectorParam(series, v)
 
-  def urlPath: String = "/anomalydetector/v1.1-preview.1/timeseries/last/detect"
+  def urlPath: String = "/anomalydetector/v1.1/timeseries/last/detect"
 
   override def responseDataType: DataType = ADLastResponse.schema
 
@@ -173,7 +173,7 @@ class DetectAnomalies(override val uid: String) extends AnomalyDetectorBase(uid)
 
   def setSeriesCol(v: String): this.type = setVectorParam(series, v)
 
-  def urlPath: String = "/anomalydetector/v1.1-preview.1/timeseries/entire/detect"
+  def urlPath: String = "/anomalydetector/v1.1/timeseries/entire/detect"
 
   override def responseDataType: DataType = ADEntireResponse.schema
 
@@ -269,7 +269,7 @@ class SimpleDetectAnomalies(override val uid: String) extends AnomalyDetectorBas
 
   }
 
-  def urlPath: String = "/anomalydetector/v1.1-preview.1/timeseries/entire/detect"
+  def urlPath: String = "/anomalydetector/v1.1/timeseries/entire/detect"
 
   override def responseDataType: DataType = ADEntireResponse.schema
 


### PR DESCRIPTION
Hi, we want to use anomaly detection of SynapseML in Microsoft Fabric. But only "v1.1" in the request uri of anomaly detection is allowed in backend workload because of security. 

So I create this PR to try to fix the uri of anomaly detection from "v1.1-preview" to "v1.1"