### PR TITLE
fix: improve docgen

### DIFF
--- a/tools/docgen/README.md
+++ b/tools/docgen/README.md
@@ -31,6 +31,15 @@ channels:
           ms.author: authors' Microsoft alias
 ```
 
+## Run the tool
+
+```bash
+cd tools/docgen
+pip install -e .
+
+python -m docgen --manifest docgen-manifest.yaml
+```
+
 ## Modify input file
 
 ### Image alt text

--- a/tools/docgen/docgen/__main__.py
+++ b/tools/docgen/docgen/__main__.py
@@ -8,7 +8,7 @@ def instantiate_channel(channel_yml):
     name = channel_yml["name"]
     module_name, class_name = name.rsplit(".", 1)
 
-    module_name = f"docgen.{module_name}"
+    module_name = f"{module_name}"
     print(f"Instantiating {class_name} from module {module_name}")
     clazz = getattr(importlib.import_module(module_name), class_name)
     channel_yml.pop("name")

--- a/tools/docgen/docgen/__main__.py
+++ b/tools/docgen/docgen/__main__.py
@@ -7,6 +7,8 @@ import importlib
 def instantiate_channel(channel_yml):
     name = channel_yml["name"]
     module_name, class_name = name.rsplit(".", 1)
+
+    module_name = f"docgen.{module_name}"
     print(f"Instantiating {class_name} from module {module_name}")
     clazz = getattr(importlib.import_module(module_name), class_name)
     channel_yml.pop("name")

--- a/tools/docgen/docgen/__main__.py
+++ b/tools/docgen/docgen/__main__.py
@@ -8,7 +8,6 @@ def instantiate_channel(channel_yml):
     name = channel_yml["name"]
     module_name, class_name = name.rsplit(".", 1)
 
-    module_name = f"{module_name}"
     print(f"Instantiating {class_name} from module {module_name}")
     clazz = getattr(importlib.import_module(module_name), class_name)
     channel_yml.pop("name")

--- a/tools/docgen/docgen/channels.py
+++ b/tools/docgen/docgen/channels.py
@@ -258,7 +258,7 @@ class FabricChannel(Channel):
                     "markdown.extensions.fenced_code",
                 ],
             )
-            parsed_html = BeautifulSoup(parsed_html)
+            parsed_html = BeautifulSoup(parsed_html, features="html.parser")
             parsed_html = self._download_and_replace_images(
                 parsed_html,
                 None,

--- a/tools/docgen/setup.py
+++ b/tools/docgen/setup.py
@@ -34,6 +34,7 @@ setup(
         "argparse",
         "pypandoc",
         "markdownify",
+        "markdown",
         "traitlets",
     ],
 )


### PR DESCRIPTION
add missing package dependency
fix channel resolution

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

_Briefly describe the changes included in this Pull Request._

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
