### PR TITLE
fix: This fixes a bug in our RestHelpers that would result into empty string returned from reading a http response content. Which subsequently cause exception while parsing the json

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/RESTHelpers.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/RESTHelpers.scala
@@ -89,20 +89,18 @@ object RESTHelpers {
   }
 
   def parseResult(result: CloseableHttpResponse): String = {
-    try {
-      IOUtils.toString(result.getEntity.getContent, "utf-8")
-    }
-    catch{
-      case ex: Exception =>
-        "{}"
-    }
+    IOUtils.toString(result.getEntity.getContent, "utf-8")
   }
 
   def sendAndParseJson(request: HttpRequestBase, expectedCodes: Set[Int]=Set()): JsValue = {
     val response = safeSend(request, expectedCodes=expectedCodes, close=false)
-    val output = parseResult(response).parseJson
-    response.close()
-    output
+    if(response.getEntity.getContent.available() == 0){
+      JsObject()
+    }
+    else {
+      val output = parseResult(response).parseJson
+      response.close()
+      output
+    }
   }
-
 }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/RESTHelpers.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/RESTHelpers.scala
@@ -89,7 +89,13 @@ object RESTHelpers {
   }
 
   def parseResult(result: CloseableHttpResponse): String = {
-    IOUtils.toString(result.getEntity.getContent, "utf-8")
+    try {
+      IOUtils.toString(result.getEntity.getContent, "utf-8")
+    }
+    catch{
+      case ex: Exception =>
+        "{}"
+    }
   }
 
   def sendAndParseJson(request: HttpRequestBase, expectedCodes: Set[Int]=Set()): JsValue = {


### PR DESCRIPTION
This fixes a bug in our RestHelpers that would result into empty string returned from reading a http response content. Which subsequently cause exception while parsing the json.

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Issue: There is a bug in RestHelpers.parseResult in calling org.apache.commons.io.IOUtils.toString. There is two problem, first it misses on handling exceptions(NullPointerException, IOException, and UnsupportedCharactersetException) and second is the empty http response content. When this happens we are returning an empty string which does not confirm with json format.

The subsequent parsing throws the following exception. 
"spray.json.JsonParser$ParsingException: Unexpected end-of-input at input index 0 (line 1, position 1), expected JSON Value:


^"
Proposed mitigation: Return an empty json  "{}" in such situation. 


## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.
- [*] Manual tests.

## Does this PR change any dependencies?

- [*] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [*] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
