### PR TITLE
fix: Fix problem with empty partition assigned to validation data

### DIFF
--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/BasePartitionTask.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/BasePartitionTask.scala
@@ -324,6 +324,9 @@ abstract class BasePartitionTask extends Serializable with Logging {
         s" shouldExecuteTraining: $shouldExecuteTraining, isEmptyPartition: $isEmptyPartition")
 
     val shouldCalcValidationDataset = trainingCtx.sharedState.validationDatasetWorker.getOrElse(-1) == taskId
+    if (trainingCtx.hasValidationData)
+      log.info(s"Validation data found. Task: $taskId, PartId: $partitionId. Main task: $mainExecutorWorkerId" +
+        s" shouldCalcValidationDataset: $shouldCalcValidationDataset, isEmptyPartition: $isEmptyPartition")
 
     PartitionTaskContext(trainingCtx,
                          partitionId,

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/StreamingPartitionTask.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/StreamingPartitionTask.scala
@@ -106,7 +106,7 @@ class StreamingPartitionTask extends BasePartitionTask {
     if (!shouldExecuteTraining && !isEmptyPartition) ctx.sharedState().incrementDataPrepDoneSignal(log)
 
     // First dataset to reach here calculates the validation Dataset if needed
-    if (ctx.hasValidationData) {
+    if (ctx.hasValidationData && !isEmptyPartition) {
       ctx.sharedState().linkValidationDatasetWorker()
     }
   }


### PR DESCRIPTION
If a zero-count partition gets assigned to create the validation Dataset, it fails. The fix is simply to not let this scenario happen.