### PR TITLE
fix: updated gpt-review to version 0.9.5 to fix break

### DIFF
--- a/.github/workflows/on-pull-request-target-review.yml
+++ b/.github/workflows/on-pull-request-target-review.yml
@@ -10,7 +10,7 @@ jobs:
     name: Azure OpenAI PR Comment
     steps:
       - id: review
-        uses: microsoft/gpt-review@v0.9.4
+        uses: microsoft/gpt-review@v0.9.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AZURE_OPENAI_API: ${{ secrets.AZURE_OPENAI_API }}


### PR DESCRIPTION
Verified that 0.9.4 has a dependency issues and reached out to owner who kindly cut a new release
