### PR TITLE
feat: factor accesstoken runtime-dependency wrapper out

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/fabric/TokenLibrary.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/fabric/TokenLibrary.scala
@@ -1,0 +1,27 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.fabric
+
+import scala.reflect.runtime.currentMirror
+import scala.reflect.runtime.universe._
+object TokenLibrary {
+  def getAccessToken: String = {
+    val objectName = "com.microsoft.azure.trident.tokenlibrary.TokenLibrary"
+    val mirror = currentMirror
+    val module = mirror.staticModule(objectName)
+    val obj = mirror.reflectModule(module).instance
+    val objType = mirror.reflect(obj).symbol.toType
+    val methodName = "getAccessToken"
+    val methodSymbols = objType.decl(TermName(methodName)).asTerm.alternatives
+    val argType = typeOf[String]
+    val selectedMethodSymbol = methodSymbols.find { m =>
+      m.asMethod.paramLists match {
+        case List(List(param)) => param.typeSignature =:= argType
+        case _ => false
+      }
+    }.getOrElse(throw new NoSuchMethodException(s"Method $methodName with argument type $argType not found"))
+    val methodMirror = mirror.reflect(obj).reflectMethod(selectedMethodSymbol.asMethod)
+    methodMirror("pbi").asInstanceOf[String]
+  }
+}


### PR DESCRIPTION


## What changes are proposed in this pull request?

Factor accesstoken wrapper into a separate class so it can be consumed by others as well.

## How is this patch tested?

Certified event tests

