### PR TITLE
Dev/manieh/use sparkversion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ import scala.xml.transform.{RewriteRule, RuleTransformer}
 import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}
 
 val condaEnvName = "synapseml"
-val sparkVersion = "3.2.3"
+val sparkVer = "3.2.3"
 name := "synapseml"
 ThisBuild / organization := "com.microsoft.azure"
 ThisBuild / scalaVersion := "2.12.15"
@@ -21,10 +21,10 @@ val excludes = Seq(
 )
 
 val coreDependencies = Seq(
-  "org.apache.spark" %% "spark-core" % sparkVersion % "compile",
-  "org.apache.spark" %% "spark-mllib" % sparkVersion % "compile",
-  "org.apache.spark" %% "spark-avro" % sparkVersion % "provided",
-  "org.apache.spark" %% "spark-tags" % sparkVersion % "test",
+  "org.apache.spark" %% "spark-core" % sparkVer % "compile",
+  "org.apache.spark" %% "spark-mllib" % sparkVer % "compile",
+  "org.apache.spark" %% "spark-avro" % sparkVer % "provided",
+  "org.apache.spark" %% "spark-tags" % sparkVer % "test",
   "com.globalmentor" % "hadoop-bare-naked-local-fs" % "0.1.0" % "test",
   "org.scalatest" %% "scalatest" % "3.2.14" % "test")
 val extraDependencies = Seq(
@@ -76,6 +76,8 @@ ThisBuild / datasetDir := {
   join((Compile / packageBin / artifactPath).value.getParentFile,
     "datasets", datasetName.split(".".toCharArray.head).head)
 }
+val sparkVersion = settingKey[String]("The spark version")
+ThisBuild / sparkVersion := { sparkVer }
 
 getDatasetsTask := {
   val d = datasetDir.value.getParentFile
@@ -415,7 +417,8 @@ lazy val core = (project in file("core"))
       version,
       scalaVersion,
       sbtVersion,
-      baseDirectory
+      baseDirectory,
+      sparkVersion
     ),
     name := "synapseml-core",
     buildInfoPackage := "com.microsoft.azure.synapse.ml.build"

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/SynapseExtension/SynapseExtensionUtilities.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/SynapseExtension/SynapseExtensionUtilities.scala
@@ -73,6 +73,11 @@ object SynapseExtensionUtilities {
   def updateSJDArtifact(path: String, artifactId: String, storeId: String): Artifact = {
     val eTag = getETagFromArtifact(artifactId)
     val store = Secrets.ArtifactStore.capitalize
+    val majorMinorRegex = "(\\d+\\.\\d+)".r
+    val sparkVersion = BuildInfo.version match {
+      case majorMinorRegex(major, minor) => s"$major.$minor"
+    }
+
     val excludes: String = "org.scala-lang:scala-reflect," +
       "org.apache.spark:spark-tags_2.12," +
       "org.scalactic:scalactic_2.12," +

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/SynapseExtension/SynapseExtensionUtilities.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/SynapseExtension/SynapseExtensionUtilities.scala
@@ -73,11 +73,8 @@ object SynapseExtensionUtilities {
   def updateSJDArtifact(path: String, artifactId: String, storeId: String): Artifact = {
     val eTag = getETagFromArtifact(artifactId)
     val store = Secrets.ArtifactStore.capitalize
-    val majorMinorRegex = "(\\d+\\.\\d+)".r
-    val sparkVersion = BuildInfo.version match {
-      case majorMinorRegex(major, minor) => s"$major.$minor"
-    }
-
+    val majorMinorPattern = "^(\\d+\\.\\d+)(.*)".r
+    val sparkVersion = majorMinorPattern.replaceAllIn(BuildInfo.sparkVersion, m => m.group(1))
     val excludes: String = "org.scala-lang:scala-reflect," +
       "org.apache.spark:spark-tags_2.12," +
       "org.scalactic:scalactic_2.12," +
@@ -89,7 +86,7 @@ object SynapseExtensionUtilities {
          |"{
          |  'Default${store}ArtifactId': '$storeId',
          |  'ExecutableFile': '$path',
-         |  'SparkVersion':'3.2',
+         |  'SparkVersion':'$sparkVersion',
          |  'SparkSettings': {
          |    'spark.jars.packages' : '$SparkMavenPackageList',
          |    'spark.jars.repositories' : '$SparkMavenRepositoryList',


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Record spark version in BuildInfo and then use that when creating SJD for E2E tests

## How is this patch tested?
partially tested locally; rest will be in PR build
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [x] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
