### PR TITLE
chore: Add sbt command for python stylechecking

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -508,3 +508,9 @@ testWebsiteDocs := {
     Seq("python", s"${join(baseDirectory.value, "website/doctest.py")}", version.value)
   )
 }
+
+val pythonStyle = TaskKey[Unit]("pythonStyle", "run python style check")
+pythonStyle := {
+  runCmd("black --diff --color .".split(" ").toSeq)
+  runCmd("black --check -q .".split(" ").toSeq)
+}

--- a/docs/Reference/Developer Setup.md
+++ b/docs/Reference/Developer Setup.md
@@ -106,6 +106,10 @@ Installs generated python wheel into existing env
 
 Generates and runs python tests
 
+### `pythonStyle`
+
+Checks style of python code
+
 ## Environment + Publishing Commands
 
 ### `getDatasets`

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -69,7 +69,7 @@ jobs:
     - bash: |
         set -e
         source activate synapseml
-        black --diff --color . && black --check -q .
+        sbt pythonStyle
       displayName: 'Python Style Check'
 
 - job: Publish


### PR DESCRIPTION
The build currently enforces python style but there is no convenient way to test locally without investigating the build pipeline.

This introduces an sbt command so that you can easily check python style locally