### PR TITLE
chore: add support for dimensions parameter to OpenAIEmbedding

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -76,7 +76,7 @@ trait HasOpenAIEmbeddingParams extends HasOpenAISharedParams with HasAPIVersion 
     this, "dimensions", "Number of dimensions for output embeddings.", isRequired = false)
 
   def getDimensions: Int = getScalarParam(dimensions)
-  
+
   def setDimensions(value: Int): this.type = setScalarParam(dimensions, value)
 
   private[ml] def getOptionalParams(r: Row): Map[String, Any] = {

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -70,6 +70,24 @@ trait HasOpenAISharedParams extends HasServiceParams with HasAPIVersion {
 
 }
 
+trait HasOpenAIEmbeddingParams extends HasOpenAISharedParams with HasAPIVersion {
+
+  val dimensions: ServiceParam[Int] = new ServiceParam[Int](
+    this, "dimensions", "Number of dimensions for output embeddings.", isRequired = false)
+
+  def getDimensions: Int = getScalarParam(dimensions)
+  
+  def setDimensions(value: Int): this.type = setScalarParam(dimensions, value)
+
+  private[ml] def getOptionalParams(r: Row): Map[String, Any] = {
+    Seq(
+      dimensions
+    ).flatMap(param =>
+      getValueOpt(r, param).map(v => (GenerationUtils.camelToSnake(param.name), v))
+    ).toMap
+  }
+}
+
 trait HasOpenAITextParams extends HasOpenAISharedParams {
 
   val maxTokens: ServiceParam[Int] = new ServiceParam[Int](

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAICompletionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAICompletionSuite.scala
@@ -13,11 +13,11 @@ import org.scalactic.Equality
 
 trait OpenAIAPIKey {
   lazy val openAIAPIKey: String = sys.env.getOrElse("OPENAI_API_KEY", Secrets.OpenAIApiKey)
-  lazy val openAIServiceName: String = "synapseml-openai"
+  lazy val openAIServiceName: String = sys.env.getOrElse("OPENAI_SERVICE_NAME", "synapseml-openai")
   lazy val deploymentName: String = "gpt-35-turbo"
   lazy val modelName: String = "gpt-35-turbo"
   lazy val openAIAPIKeyGpt4: String = sys.env.getOrElse("OPENAI_API_KEY_2", Secrets.OpenAIApiKeyGpt4)
-  lazy val openAIServiceNameGpt4: String = "synapseml-openai-2"
+  lazy val openAIServiceNameGpt4: String = sys.env.getOrElse("OPENAI_SERVICE_NAME_2", "synapseml-openai-2")
   lazy val deploymentNameGpt4: String = "gpt-4"
   lazy val modelNameGpt4: String = "gpt-4"
 }

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIEmbeddingsSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIEmbeddingsSuite.scala
@@ -34,11 +34,12 @@ class OpenAIEmbeddingsSuite extends TransformerFuzzing[OpenAIEmbedding] with Ope
   }
 
   lazy val embeddingExtra: OpenAIEmbedding = new OpenAIEmbedding()
-    .setSubscriptionKey(openAIAPIKey)
+    .setSubscriptionKey(openAIAPIKeyGpt4)
     .setDeploymentName("text-embedding-3-small")
     .setApiVersion("2024-03-01-preview")
     .setDimensions(100)
-    .setCustomServiceName(openAIServiceName)
+    .setUser("testUser")
+    .setCustomServiceName(openAIServiceNameGpt4)
     .setTextCol("text")
     .setOutputCol("out")
 

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIEmbeddingsSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIEmbeddingsSuite.scala
@@ -33,6 +33,23 @@ class OpenAIEmbeddingsSuite extends TransformerFuzzing[OpenAIEmbedding] with Ope
     })
   }
 
+  lazy val embeddingExtra: OpenAIEmbedding = new OpenAIEmbedding()
+    .setSubscriptionKey(openAIAPIKey)
+    .setDeploymentName("text-embedding-3-small")
+    .setApiVersion("2024-03-01-preview")
+    .setDimensions(100)
+    .setCustomServiceName(openAIServiceName)
+    .setTextCol("text")
+    .setOutputCol("out")
+
+  test("Extra Params Usage") {
+    embeddingExtra.transform(df).collect().foreach(r => {
+      val v = r.getAs[Vector]("out")
+      assert(v.size == 100)
+    })
+  }
+
+
   override def testObjects(): Seq[TestObject[OpenAIEmbedding]] =
     Seq(new TestObject(embedding, df))
 

--- a/website/versioned_docs/version-1.0.4/Explore Algorithms/OpenAI/OpenAI.md
+++ b/website/versioned_docs/version-1.0.4/Explore Algorithms/OpenAI/OpenAI.md
@@ -38,6 +38,7 @@ from synapse.ml.core.platform import find_secret
 service_name = "synapseml-openai"
 deployment_name = "gpt-35-turbo"
 deployment_name_embeddings = "text-embedding-ada-002"
+deployment_name_embeddings_3 = "text-embedding-3-small"
 
 key = find_secret(
     secret_name="openai-api-key", keyvault="mmlspark-build-keys"
@@ -124,6 +125,29 @@ embedding = (
     .setSubscriptionKey(key)
     .setDeploymentName(deployment_name_embeddings)
     .setCustomServiceName(service_name)
+    .setTextCol("prompt")
+    .setErrorCol("error")
+    .setOutputCol("embeddings")
+)
+
+display(embedding.transform(df))
+```
+
+### Generating Text Embeddings with Reduced Dimensions
+
+Text-Embedding-3 models developed by OpenAI are trained using a Matryoshka Representation Learning technique
+which supports reducing the dimension of the embedding by trading-off some performance.
+
+```python
+from synapse.ml.services.openai import OpenAIEmbedding
+
+embedding = (
+    OpenAIEmbedding()
+    .setSubscriptionKey(key)
+    .setDeploymentName(deployment_name_embeddings_3)
+    .setCustomServiceName(service_name)
+    .setApiVersion("2024-03-01-preview")
+    .setDimensions(256)
     .setTextCol("prompt")
     .setErrorCol("error")
     .setOutputCol("embeddings")


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Closes #2177 

## What changes are proposed in this pull request?

Adding support for `dimensions` parameter when calling OpenAI Embeddings endpoint to reduce the size of the embedding vecor.

## How is this patch tested?

Added `Extra Param Usage` test to OpenAIEmbeddingSuite

- [X] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [X] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [X] Yes. Make sure you have added samples following below steps.

Added example to existing OpenAI.md

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
