### PR TITLE
ci: set pull-requests read permission

### DIFF
--- a/.github/workflows/check-semantic-prs.yaml
+++ b/.github/workflows/check-semantic-prs.yaml
@@ -6,7 +6,8 @@ on:
       - opened
       - edited
       - synchronize
-
+permissions:
+  pull-requests: read
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

n/a

## What changes are proposed in this pull request?

Checking the PR title in the workflow is done with the specific github action `amannn/action-semantic-pull-request@v5.4.0`.

It's recommended to set the permission to `permissions: pull-request: read` based on the actions docs [here](https://github.com/amannn/action-semantic-pull-request?tab=readme-ov-file#installation).

## How is this patch tested?

n/a

## Does this PR change any dependencies?

- [X] No. You can skip this section.

## Does this PR add a new feature? If so, have you added samples on website?

- [X] No. You can skip this section.
