### PR TITLE
feat: Adding Custom Url Endpoints and Headers

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
@@ -189,17 +189,16 @@ trait HasCustomAuthHeader extends HasServiceParams {
 }
 
 trait HasCustomHeaders extends HasServiceParams {
-  // scalastyle:off field.name
-  val CustomHeaders = new ServiceParam[Map[String, String]](
-    this, "CustomHeader", "List of Custom Header Key-Value Tuples."
+
+  val customHeaders = new ServiceParam[Map[String, String]](
+    this, "customHeaders", "Map of Custom Header Key-Value Tuples."
   )
-  // scalastyle:on field.name
 
   def setCustomHeaders(v: Map[String, String]): this.type = {
-    setScalarParam(CustomHeaders, v)
+    setScalarParam(customHeaders, v)
   }
 
-  def getCustomHeader: Map[String, String] = getScalarParam(CustomHeaders)
+  def getCustomHeaders: Map[String, String] = getScalarParam(customHeaders)
 }
 
 trait HasCustomCogServiceDomain extends Wrappable with HasURL with HasUrlPath {

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
@@ -331,7 +331,7 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
   }
 
   protected def getCustomHeaders(row: Row): Option[Map[String, String]] = {
-    getValueOpt(row, CustomHeaders)
+    getValueOpt(row, customHeaders)
   }
 
   protected def addHeaders(req: HttpRequestBase,

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
@@ -188,18 +188,18 @@ trait HasCustomAuthHeader extends HasServiceParams {
   }
 }
 
-trait HasCustomHeader extends HasServiceParams {
+trait HasCustomHeaders extends HasServiceParams {
   // scalastyle:off field.name
-  val CustomHeader = new ServiceParam[Map[String, String]](
+  val CustomHeaders = new ServiceParam[Map[String, String]](
     this, "CustomHeader", "List of Custom Header Key-Value Tuples."
   )
   // scalastyle:on field.name
 
-  def setCustomHeader(v: Map[String, String]): this.type = {
-    setScalarParam(CustomHeader, v)
+  def setCustomHeaders(v: Map[String, String]): this.type = {
+    setScalarParam(CustomHeaders, v)
   }
 
-  def getCustomHeader: Map[String, String] = getScalarParam(CustomHeader)
+  def getCustomHeader: Map[String, String] = getScalarParam(CustomHeaders)
 }
 
 trait HasCustomCogServiceDomain extends Wrappable with HasURL with HasUrlPath {
@@ -270,7 +270,7 @@ object URLEncodingUtils {
 }
 
 trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAADToken with HasCustomAuthHeader
-  with HasCustomHeader with SynapseMLLogging {
+  with HasCustomHeaders with SynapseMLLogging {
 
   val customUrlRoot: Param[String] = new Param[String](
     this, "customUrlRoot", "The custom URL root for the service. " +
@@ -331,8 +331,8 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
     }
   }
 
-  protected def getCustomHeader(row: Row): Option[Map[String, String]] = {
-    getValueOpt(row, CustomHeader)
+  protected def getCustomHeaders(row: Row): Option[Map[String, String]] = {
+    getValueOpt(row, CustomHeaders)
   }
 
   protected def addHeaders(req: HttpRequestBase,
@@ -340,7 +340,7 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
                            aadToken: Option[String],
                            contentType: String = "",
                            customAuthHeader: Option[String] = None,
-                           customHeader: Option[Map[String, String]] = None): Unit = {
+                           customHeaders: Option[Map[String, String]] = None): Unit = {
 
     if (subscriptionKey.nonEmpty) {
       req.setHeader(subscriptionKeyHeaderName, subscriptionKey.get)
@@ -357,8 +357,8 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
         req.setHeader("x-ms-workload-resource-moniker", UUID.randomUUID().toString)
       })
     }
-    if (customHeader.nonEmpty) {
-      customHeader.foreach(m => {
+    if (customHeaders.nonEmpty) {
+      customHeaders.foreach(m => {
         m.foreach {
           case (headerName, headerValue) => req.setHeader(headerName, headerValue)
         }
@@ -381,7 +381,7 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
           getValueOpt(row, AADToken),
           contentType(row),
           getCustomAuthHeader(row),
-          getCustomHeader(row))
+          getCustomHeaders(row))
 
         req match {
           case er: HttpEntityEnclosingRequestBase =>

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -43,7 +43,7 @@ trait HasPromptInputs extends HasServiceParams {
 trait HasOpenAISharedParams extends HasServiceParams with HasAPIVersion {
 
   val deploymentName = new ServiceParam[String](
-    this, "deploymentName", "The name of the deployment", isRequired = true)
+    this, "deploymentName", "The name of the deployment", isRequired = false)
 
   def getDeploymentName: String = getScalarParam(deploymentName)
 

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
@@ -151,6 +151,30 @@ class OpenAIChatCompletionSuite extends TransformerFuzzing[OpenAIChatCompletion]
     assert(Option(results.apply(2).getAs[Row]("out")).isEmpty)
   }
 
+  test("Custom EndPoint") {
+    lazy val accessToken: String = sys.env.getOrElse("CUSTOM_ACCESS_TOKEN", "")
+    lazy val testEndPointUrl: String = s"https://${openAIServiceName}.openai.azure.com/" +
+      s"openai/deployments/${deploymentNameGpt4}/chat/completions"
+    lazy val customRootUrlValue: String = sys.env.getOrElse("CUSTOM_ROOT_URL", testEndPointUrl)
+
+    val customEndpointCompletion = new OpenAIChatCompletion()
+      .setCustomUrlRoot(customRootUrlValue)
+      .setOutputCol("out")
+      .setMessagesCol("messages")
+      .setTemperature(0)
+
+    if (accessToken.isEmpty) {
+      customEndpointCompletion.setSubscriptionKey(openAIAPIKey)
+    } else {
+      customEndpointCompletion.setAADToken(accessToken)
+        .setCustomHeader(Map("X-ModelType" -> "gpt-4-turbo-chat-completions",
+          "X-ScenarioGUID" -> "7687c733-45b0-425b-82b3-05eb4eb70247"))
+
+    }
+
+    testCompletion(customEndpointCompletion, goodDf)
+  }
+
   def testCompletion(completion: OpenAIChatCompletion, df: DataFrame, requiredLength: Int = 10): Unit = {
     val fromRow = ChatCompletionResponse.makeFromRowConverter
     completion.transform(df).collect().foreach(r =>

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
@@ -151,7 +151,7 @@ class OpenAIChatCompletionSuite extends TransformerFuzzing[OpenAIChatCompletion]
     assert(Option(results.apply(2).getAs[Row]("out")).isEmpty)
   }
 
-  test("Custom EndPoint") {
+  ignore("Custom EndPoint") {
     lazy val accessToken: String = sys.env.getOrElse("CUSTOM_ACCESS_TOKEN", "")
     lazy val customRootUrlValue: String = sys.env.getOrElse("CUSTOM_ROOT_URL", "")
 

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
@@ -167,7 +167,7 @@ class OpenAIChatCompletionSuite extends TransformerFuzzing[OpenAIChatCompletion]
         .setCustomServiceName(openAIServiceName)
     } else {
       customEndpointCompletion.setAADToken(accessToken)
-        .setCustomHeader(Map("X-ModelType" -> "gpt-4-turbo-chat-completions",
+        .setCustomHeaders(Map("X-ModelType" -> "gpt-4-turbo-chat-completions",
           "X-ScenarioGUID" -> "7687c733-45b0-425b-82b3-05eb4eb70247"))
     }
 

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
@@ -153,9 +153,7 @@ class OpenAIChatCompletionSuite extends TransformerFuzzing[OpenAIChatCompletion]
 
   test("Custom EndPoint") {
     lazy val accessToken: String = sys.env.getOrElse("CUSTOM_ACCESS_TOKEN", "")
-    lazy val testEndPointUrl: String = s"https://${openAIServiceName}.openai.azure.com/" +
-      s"openai/deployments/${deploymentNameGpt4}/chat/completions"
-    lazy val customRootUrlValue: String = sys.env.getOrElse("CUSTOM_ROOT_URL", testEndPointUrl)
+    lazy val customRootUrlValue: String = sys.env.getOrElse("CUSTOM_ROOT_URL", "")
 
     val customEndpointCompletion = new OpenAIChatCompletion()
       .setCustomUrlRoot(customRootUrlValue)
@@ -165,11 +163,12 @@ class OpenAIChatCompletionSuite extends TransformerFuzzing[OpenAIChatCompletion]
 
     if (accessToken.isEmpty) {
       customEndpointCompletion.setSubscriptionKey(openAIAPIKey)
+        .setDeploymentName(deploymentNameGpt4)
+        .setCustomServiceName(openAIServiceName)
     } else {
       customEndpointCompletion.setAADToken(accessToken)
         .setCustomHeader(Map("X-ModelType" -> "gpt-4-turbo-chat-completions",
           "X-ScenarioGUID" -> "7687c733-45b0-425b-82b3-05eb4eb70247"))
-
     }
 
     testCompletion(customEndpointCompletion, goodDf)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
Adding custom base url and headers to access additional OpenAI endpoint deployments

## What changes are proposed in this pull request?
- Adding trait HasCustomHeader that checks if a customHeader was assigned.
- Adding customHeader to the addHeaders function to iterate through the Map of headers provided and assign them to the request.
- Added customRootUrl - if provided will be used instead of the prepareUrlRoot() function

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [X] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [ ] No. You can skip this section.
- [X] Yes. Make sure the dependencies are resolved correctly, and list changes here.
   - deploymentName parameter was changed to not required

## Does this PR add a new feature? If so, have you added samples on website?

- [X] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
