### PR TITLE
chore: Add feature name to log_verb

### DIFF
--- a/core/src/main/python/synapse/ml/core/logging/SynapseMLLogger.py
+++ b/core/src/main/python/synapse/ml/core/logging/SynapseMLLogger.py
@@ -183,7 +183,7 @@ class SynapseMLLogger:
             json.dumps(self._get_payload(class_name, method_name, None, None, e))
         )
 
-    def log_verb(method_name: Optional[str] = None):
+    def log_verb(method_name: Optional[str] = None, feature_name: Optional[str] = None):
         def get_wrapper(func):
             @functools.wraps(func)
             def log_decorator_wrapper(self, *args, **kwargs):
@@ -198,7 +198,7 @@ class SynapseMLLogger:
                         method_name if method_name else func.__name__,
                         SynapseMLLogger.get_column_number(args, kwargs),
                         execution_time,
-                        None,
+                        feature_name,
                     )
                     return result
                 except Exception as e:

--- a/core/src/test/python/synapsemltest/core/test_logging.py
+++ b/core/src/test/python/synapsemltest/core/test_logging.py
@@ -30,7 +30,7 @@ class SampleTransformer(SynapseMLLogger):
     def test_throw(self):
         raise Exception("test exception")
 
-    @SynapseMLLogger.log_verb(feature_name = "test_logging")
+    @SynapseMLLogger.log_verb(feature_name="test_logging")
     def test_feature_name(self):
         return 0
 

--- a/core/src/test/python/synapsemltest/core/test_logging.py
+++ b/core/src/test/python/synapsemltest/core/test_logging.py
@@ -30,6 +30,10 @@ class SampleTransformer(SynapseMLLogger):
     def test_throw(self):
         raise Exception("test exception")
 
+    @SynapseMLLogger.log_verb(feature_name = "test_logging")
+    def test_feature_name(self):
+        return 0
+
 
 class LoggingTest(unittest.TestCase):
     def test_logging_smoke(self):
@@ -43,6 +47,7 @@ class LoggingTest(unittest.TestCase):
             t.test_throw()
         except Exception as e:
             assert f"{e}" == "test exception"
+        t.test_feature_name()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Adds feature name as a parameter to log_verb to allow us to use it when using the decorator to log.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
