### PR TITLE
[DRAFT - DO NOT MERGE] df.ai.gen - allow PySpark users to easily leverage OpenAI prompting

### DIFF
--- a/cognitive/src/main/python/synapse/ml/services/openai/DataFrameAIExtensions.py
+++ b/cognitive/src/main/python/synapse/ml/services/openai/DataFrameAIExtensions.py
@@ -17,7 +17,7 @@ class AIFunctions:
     def __init__(self, df):
         self.df = df
 
-    def prompt(self, template, **options):
+    def gen(self, template, **options):
         jvm = SparkContext.getOrCreate()._jvm
 
         secretJson = subprocess.check_output(
@@ -26,14 +26,14 @@ class AIFunctions:
         )
         openai_api_key = json.loads(secretJson)["value"]
 
-        prompt = jvm.com.microsoft.azure.synapse.ml.services.openai.OpenAIPrompt
-        prompt = prompt().setSubscriptionKey(openai_api_key)
+        prompt = jvm.com.microsoft.azure.synapse.ml.services.openai.OpenAIPrompt()
+        prompt = prompt.setSubscriptionKey(openai_api_key)
         prompt = prompt.setDeploymentName("gpt-35-turbo")
+        prompt = prompt.setCustomServiceName("synapseml-openai-2")
         prompt = prompt.setOutputCol("outParsed")
         prompt = prompt.setPromptTemplate(template)
         results = prompt.transform(self.df._jdf)
-        print(results)
-        return results
+        return DataFrame(results, self.df.sql_ctx)
 
 def get_AI_functions(df):
     return AIFunctions(df)

--- a/cognitive/src/main/python/synapse/ml/services/openai/DataFrameAIExtensions.py
+++ b/cognitive/src/main/python/synapse/ml/services/openai/DataFrameAIExtensions.py
@@ -1,0 +1,36 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+import sys
+import os, json, subprocess, unittest
+
+if sys.version >= "3":
+    basestring = str
+
+import pyspark
+from pyspark import SparkContext
+from pyspark import sql
+from pyspark.ml.param.shared import *
+from pyspark.sql import DataFrame
+
+
+def prompt(df, template, **options):
+    jvm = SparkContext.getOrCreate()._jvm
+
+    secretJson = subprocess.check_output(
+        "az keyvault secret show --vault-name mmlspark-build-keys --name openai-api-key-2",
+        shell=True,
+    )
+    openai_api_key = json.loads(secretJson)["value"]
+
+    prompt = jvm.com.microsoft.azure.synapse.ml.services.openai.OpenAIPrompt
+    prompt = prompt().setSubscriptionKey(openai_api_key)
+    prompt = prompt.setDeploymentName("gpt-35-turbo")
+    prompt = prompt.setOutputCol("outParsed")
+    prompt = prompt.setTemperature(0)
+    prompt = prompt.setPromptTemplate(template)
+    print(prompt.transform(df._jdf))
+    return prompt.transform(df._jdf)
+
+
+setattr(pyspark.sql.DataFrame, "prompt", prompt)

--- a/cognitive/src/main/python/synapse/ml/services/openai/DataFrameAIExtensions.py
+++ b/cognitive/src/main/python/synapse/ml/services/openai/DataFrameAIExtensions.py
@@ -13,24 +13,29 @@ from pyspark import sql
 from pyspark.ml.param.shared import *
 from pyspark.sql import DataFrame
 
+class AIFunctions:
+    def __init__(self, df):
+        self.df = df
 
-def prompt(df, template, **options):
-    jvm = SparkContext.getOrCreate()._jvm
+    def prompt(self, template, **options):
+        jvm = SparkContext.getOrCreate()._jvm
 
-    secretJson = subprocess.check_output(
-        "az keyvault secret show --vault-name mmlspark-build-keys --name openai-api-key-2",
-        shell=True,
-    )
-    openai_api_key = json.loads(secretJson)["value"]
+        secretJson = subprocess.check_output(
+            "az keyvault secret show --vault-name mmlspark-build-keys --name openai-api-key-2",
+            shell=True,
+        )
+        openai_api_key = json.loads(secretJson)["value"]
 
-    prompt = jvm.com.microsoft.azure.synapse.ml.services.openai.OpenAIPrompt
-    prompt = prompt().setSubscriptionKey(openai_api_key)
-    prompt = prompt.setDeploymentName("gpt-35-turbo")
-    prompt = prompt.setOutputCol("outParsed")
-    prompt = prompt.setTemperature(0)
-    prompt = prompt.setPromptTemplate(template)
-    print(prompt.transform(df._jdf))
-    return prompt.transform(df._jdf)
+        prompt = jvm.com.microsoft.azure.synapse.ml.services.openai.OpenAIPrompt
+        prompt = prompt().setSubscriptionKey(openai_api_key)
+        prompt = prompt.setDeploymentName("gpt-35-turbo")
+        prompt = prompt.setOutputCol("outParsed")
+        prompt = prompt.setPromptTemplate(template)
+        results = prompt.transform(self.df._jdf)
+        print(results)
+        return results
 
+def get_AI_functions(df):
+    return AIFunctions(df)
 
-setattr(pyspark.sql.DataFrame, "prompt", prompt)
+setattr(pyspark.sql.DataFrame, "ai", property(get_AI_functions))

--- a/cognitive/src/main/python/synapse/ml/services/openai/__init__.py
+++ b/cognitive/src/main/python/synapse/ml/services/openai/__init__.py
@@ -1,0 +1,1 @@
+from DataFrameAIExtensions import *

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
@@ -290,7 +290,7 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
     case _ => p.name
   }
 
-  override def getUrl: String = "https://synapseml-openai-2.openai.azure.com/openai/deployments/gpt-4/chat/completions"
+  override def getUrl: String = this.getOrDefault(url)
 
   protected def prepareUrlRoot: Row => String = {
     _ => getUrl

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
@@ -216,7 +216,7 @@ trait HasCustomCogServiceDomain extends Wrappable with HasURL with HasUrlPath {
     setUrl(v + urlPath.stripPrefix("/"))
   }
 
-  override def getUrl: String = this.getOrDefault(url)
+  override def getUrl: String = "https://synapseml-openai-2.openai.azure.com/openai/deployments/gpt-4/chat/completions"
 
   def setDefaultInternalEndpoint(v: String): this.type = setDefault(
     url, v + s"/cognitive/${this.internalServiceType}/" + urlPath.stripPrefix("/"))
@@ -290,7 +290,7 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
     case _ => p.name
   }
 
-  override def getUrl: String = this.getOrDefault(url)
+  override def getUrl: String = "https://synapseml-openai-2.openai.azure.com/openai/deployments/gpt-4/chat/completions"
 
   protected def prepareUrlRoot: Row => String = {
     _ => getUrl

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
@@ -35,7 +35,7 @@ class OpenAIChatCompletion(override val uid: String) extends OpenAIServicesBase(
   }
 
   override protected def prepareUrlRoot: Row => String = { row =>
-    s"https://synapseml-openai-2.openai.azure.com/openai/deployments/gpt-4/chat/completions/openai/deployments/${getValue(row, deploymentName)}/chat/completions"
+    s"${getUrl}openai/deployments/${getValue(row, deploymentName)}/chat/completions"
   }
 
   override protected def prepareEntity: Row => Option[AbstractHttpEntity] = {

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
@@ -35,7 +35,7 @@ class OpenAIChatCompletion(override val uid: String) extends OpenAIServicesBase(
   }
 
   override protected def prepareUrlRoot: Row => String = { row =>
-    s"${getUrl}openai/deployments/${getValue(row, deploymentName)}/chat/completions"
+    s"https://synapseml-openai-2.openai.azure.com/openai/deployments/gpt-4/chat/completions/openai/deployments/${getValue(row, deploymentName)}/chat/completions"
   }
 
   override protected def prepareEntity: Row => Option[AbstractHttpEntity] = {

--- a/cognitive/src/test/python/synapsemltest/services/openai/test_DataFrameAIExtentions.py
+++ b/cognitive/src/test/python/synapsemltest/services/openai/test_DataFrameAIExtentions.py
@@ -15,7 +15,7 @@ spark = init_spark()
 sc = SQLContext(spark.sparkContext)
 
 class DataFrameAIExtentionsTest(unittest.TestCase):
-    def test_prompt(self):
+    def test_gen(self):
         schema = StructType([
             StructField("text", StringType(), True),
             StructField("category", StringType(), True)
@@ -29,10 +29,13 @@ class DataFrameAIExtentionsTest(unittest.TestCase):
 
         df = spark.createDataFrame(data, schema)
 
-        results = df.ai.prompt("here is a comma separated list of 5 {category}: {text}, ")
+        results = df.ai.gen("Complete this comma separated list of 5 {category}: {text}, ")
         results.show()
+        results.select("outParsed").show(truncate = False)
+        nonNullCount = results.filter(col("outParsed").isNotNull()).count()
+        assert (nonNullCount == 3)
 
-    def test_prompt_2(self):
+    def test_gen_2(self):
         schema = StructType([
             StructField("name", StringType(), True),
             StructField("address", StringType(), True)
@@ -45,9 +48,11 @@ class DataFrameAIExtentionsTest(unittest.TestCase):
 
         df = spark.createDataFrame(data, schema)
 
-        results = df.ai.prompt("Generate the likely country of {name}, given that they are from {address}. It is imperitive that your response contains the country only, no elaborations.")
+        results = df.ai.gen("Generate the likely country of {name}, given that they are from {address}. It is imperitive that your response contains the country only, no elaborations.")
         results.show()
-
+        results.select("outParsed").show(truncate = False)
+        nonNullCount = results.filter(col("outParsed").isNotNull()).count()
+        assert (nonNullCount == 2)
 
 if __name__ == "__main__":
     result = unittest.main()

--- a/cognitive/src/test/python/synapsemltest/services/openai/test_DataFrameAIExtentions.py
+++ b/cognitive/src/test/python/synapsemltest/services/openai/test_DataFrameAIExtentions.py
@@ -25,25 +25,37 @@ sc = SQLContext(spark.sparkContext)
 
 class DataFrameAIExtentionsTest(unittest.TestCase):
     def test_prompt(self):
-        # Define schema
         schema = StructType([
             StructField("text", StringType(), True),
             StructField("category", StringType(), True)
         ])
 
-        # Define data
         data = [
             ("apple", "fruits"),
             ("mercedes", "cars"),
             ("cake", "dishes"),
-            (None, "none")
         ]
 
-        # Create DataFrame
         df = spark.createDataFrame(data, schema)
 
-        results = df.prompt("here is a comma separated list of 5 {category}: {text}, ")
-        results.select("outParsed").show(truncate=False)
+        results = df.ai.prompt("here is a comma separated list of 5 {category}: {text}, ")
+        results.show()
+
+    def test_prompt_2(self):
+        schema = StructType([
+            StructField("name", StringType(), True),
+            StructField("address", StringType(), True)
+        ])
+
+        data = [
+            ("Anne F.", "123 First Street, 98053"),
+            ("George K.", "345 Washington Avenue, London"),
+        ]
+
+        df = spark.createDataFrame(data, schema)
+
+        results = df.ai.prompt("Generate the likely country of {name}, given that they are from {address}. It is imperitive that your response contains the country only, no elaborations.")
+        results.show()
 
 
 if __name__ == "__main__":

--- a/cognitive/src/test/python/synapsemltest/services/openai/test_DataFrameAIExtentions.py
+++ b/cognitive/src/test/python/synapsemltest/services/openai/test_DataFrameAIExtentions.py
@@ -1,0 +1,50 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+# Prepare training and test data.
+import unittest
+
+from synapse.ml.io.http import *
+from pyspark.sql.functions import struct
+from pyspark.sql.types import *
+from synapse.ml.services.openai import *
+
+from pyspark.sql import SparkSession, SQLContext
+from synapse.ml.core import __spark_package_version__
+spark = (SparkSession.builder
+         .master("local[*]")
+         .appName("PysparkTests")
+         .config("spark.jars.packages", "com.microsoft.azure:synapseml_2.12:" + __spark_package_version__ + ",org.apache.spark:spark-avro_2.12:3.4.1")
+         .config("spark.jars.repositories", "https://mmlspark.azureedge.net/maven")
+         .config("spark.executor.heartbeatInterval", "60s")
+         .config("spark.sql.shuffle.partitions", 10)
+         .config("spark.sql.crossJoin.enabled", "true")
+         .getOrCreate())
+
+sc = SQLContext(spark.sparkContext)
+
+class DataFrameAIExtentionsTest(unittest.TestCase):
+    def test_prompt(self):
+        # Define schema
+        schema = StructType([
+            StructField("text", StringType(), True),
+            StructField("category", StringType(), True)
+        ])
+
+        # Define data
+        data = [
+            ("apple", "fruits"),
+            ("mercedes", "cars"),
+            ("cake", "dishes"),
+            (None, "none")
+        ]
+
+        # Create DataFrame
+        df = spark.createDataFrame(data, schema)
+
+        results = df.prompt("here is a comma separated list of 5 {category}: {text}, ")
+        results.select("outParsed").show(truncate=False)
+
+
+if __name__ == "__main__":
+    result = unittest.main()

--- a/cognitive/src/test/python/synapsemltest/services/openai/test_DataFrameAIExtentions.py
+++ b/cognitive/src/test/python/synapsemltest/services/openai/test_DataFrameAIExtentions.py
@@ -5,22 +5,13 @@
 import unittest
 
 from synapse.ml.io.http import *
-from pyspark.sql.functions import struct
 from pyspark.sql.types import *
 from synapse.ml.services.openai import *
 
 from pyspark.sql import SparkSession, SQLContext
-from synapse.ml.core import __spark_package_version__
-spark = (SparkSession.builder
-         .master("local[*]")
-         .appName("PysparkTests")
-         .config("spark.jars.packages", "com.microsoft.azure:synapseml_2.12:" + __spark_package_version__ + ",org.apache.spark:spark-avro_2.12:3.4.1")
-         .config("spark.jars.repositories", "https://mmlspark.azureedge.net/maven")
-         .config("spark.executor.heartbeatInterval", "60s")
-         .config("spark.sql.shuffle.partitions", 10)
-         .config("spark.sql.crossJoin.enabled", "true")
-         .getOrCreate())
 
+from synapse.ml.core.init_spark import *
+spark = init_spark()
 sc = SQLContext(spark.sparkContext)
 
 class DataFrameAIExtentionsTest(unittest.TestCase):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

_Briefly describe the changes included in this Pull Request._

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
