### PR TITLE
fix: Using nltk version 3.8.1 Azure Databricks Notebook longchain.ipynb to fix failing test

### DIFF
--- a/docs/Explore Algorithms/OpenAI/Langchain.ipynb
+++ b/docs/Explore Algorithms/OpenAI/Langchain.ipynb
@@ -88,7 +88,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install openai==0.28.1 langchain==0.0.331 pdf2image pdfminer.six unstructured==0.10.24 pytesseract numpy==1.22.4"
+    "%pip install openai==0.28.1 langchain==0.0.331 pdf2image pdfminer.six unstructured==0.10.24 pytesseract numpy==1.22.4 nltk==3.8.1"
    ]
   },
   {


### PR DESCRIPTION
With release of new version of NLTK (3.9.1), the unit test started failing. 

## What changes are proposed in this pull request?
The version of NLTK is pinned to `3.8.1` in the notebook

## How is this patch tested?
I have manually ran the `Longchain.ipynb` and validated that it is not failing anymore.


## Does this PR change any dependencies?

- [X] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [X] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
