### PR TITLE
chore: Updating AzureKeyVault task version

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -264,7 +264,7 @@ jobs:
         chmod +x git-chglog_linux_amd64
         ./git-chglog_linux_amd64 -o CHANGELOG.md $TAG
       condition: and(eq(variables.isMaster, true), startsWith(variables['tag'], 'v'))
-    - task: GitHubRelease@0
+    - task: GitHubRelease@1
       condition: and(eq(variables.isMaster, true), startsWith(variables['tag'], 'v'))
       inputs:
         gitHubConnection: 'MMLSpark Github'

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -294,7 +294,7 @@ jobs:
         conda env create --force -f environment.yml -v
       condition: and(eq(variables.isMaster, true), and(startsWith(variables['tag'], 'v'), eq(variables.CONDA_CACHE_RESTORED, 'false')))
       displayName: Create Anaconda environment
-    - task: AzureKeyVault@1
+    - task: AzureKeyVault@2
       condition: and(eq(variables.isMaster, true), startsWith(variables['tag'], 'v'))
       inputs:
         azureSubscription: 'SynapseML Build'

--- a/templates/kv.yml
+++ b/templates/kv.yml
@@ -1,5 +1,5 @@
 steps:
-  - task: AzureKeyVault@1
+  - task: AzureKeyVault@2
     retryCountOnTaskFailure: 3
     inputs:
       azureSubscription: 'SynapseML Build'


### PR DESCRIPTION
## Related Issues/PRs

`AzureKeyVault` task version has been deprecated and needs to be updated to the latest version. `GitRelease` task has also been deprecated. By updating these two tasks, we will get fewer warnings. It will reduce warnings from over 160 to about 60.

## What changes are proposed in this pull request?
Updating task version to 1 from 0 for `GitRelease` and `AzureKeyVault`

## How is this patch tested?
Pipeline change only.

- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [X] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [X] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

