### PR TITLE
feat: Adding code for sending parameter "response_format" as request payload

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -271,7 +271,7 @@ trait HasOpenAITextParams extends HasOpenAISharedParams {
 
   // list of shared text parameters. In method getOptionalParams, we will iterate over these parameters
   // to compute the optional parameters. Since this list never changes, we can create it once and reuse it.
-  private val sharedTextParams = Seq(
+  private[openai] val sharedTextParams: Seq[ServiceParam[_]] = Seq(
     maxTokens,
     temperature,
     topP,

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
@@ -29,7 +29,7 @@ object OpenAIResponseFormat extends Enumeration {
 trait HasOpenAITextParamsExtended extends HasOpenAITextParams {
   val responseFormat: ServiceParam[Map[String, String]] = new ServiceParam[Map[String, String]](
       this,
-      "responseFromat",
+      "responseFormat",
       "Response format for the completion. Can be 'json_object' or 'text'.",
       isRequired = false) {
       override val payloadName: String = "response_format"

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
@@ -5,6 +5,7 @@ package com.microsoft.azure.synapse.ml.services.openai
 
 import com.microsoft.azure.synapse.ml.logging.{FeatureNames, SynapseMLLogging}
 import com.microsoft.azure.synapse.ml.param.AnyJsonFormat.anyFormat
+import com.microsoft.azure.synapse.ml.param.ServiceParam
 import com.microsoft.azure.synapse.ml.services.{HasCognitiveServiceInput, HasInternalJsonOutputParser}
 import org.apache.http.entity.{AbstractHttpEntity, ContentType, StringEntity}
 import org.apache.spark.ml.ComplexParamsReadable
@@ -18,8 +19,84 @@ import scala.language.existentials
 
 object OpenAIChatCompletion extends ComplexParamsReadable[OpenAIChatCompletion]
 
+object OpenAIResponseFormat extends Enumeration {
+  case class ResponseFormat(name: String, prompt: String) extends super.Val(name)
+  val TEXT: ResponseFormat = ResponseFormat("text", "Output must be in text format")
+  val JSON: ResponseFormat = ResponseFormat("json_object", "Output must be in JSON format")
+}
+
+
+trait HasOpenAITextParamsExtended extends HasOpenAITextParams {
+  val responseFormat: ServiceParam[Map[String, String]] = new ServiceParam[Map[String, String]](
+      this,
+      "responseFromat",
+      "Response format for the completion. Can be 'json_object' or 'text'.",
+      isRequired = false) {
+      override val payloadName: String = "response_format"
+    }
+
+  def getResponseFormat: Map[String, String] = getScalarParam(responseFormat)
+
+  def setResponseFormat(value: Map[String, String]): this.type = {
+    if (!OpenAIResponseFormat.values.map(_.asInstanceOf[OpenAIResponseFormat.ResponseFormat].name)
+      .contains(value("type"))) {
+      throw new IllegalArgumentException("Response format must be 'text' or 'json_object'")
+    }
+    setScalarParam(responseFormat, value)
+  }
+
+  def setResponseFormat(value: String): this.type = {
+    if (value.isEmpty) {
+      this
+    } else {
+      val normalizedValue = value.toLowerCase match {
+        case "json" => "json_object"
+        case other => other
+      }
+      // Validate the normalized value using the OpenAIResponseFormat enum
+      if (!OpenAIResponseFormat.values
+        .map(_.asInstanceOf[OpenAIResponseFormat.ResponseFormat].name)
+        .contains(normalizedValue)) {
+        throw new IllegalArgumentException("Response format must be valid for OpenAI API. " +
+          "Currently supported formats are " + OpenAIResponseFormat.values
+          .map(_.asInstanceOf[OpenAIResponseFormat.ResponseFormat].name)
+          .mkString(", "))
+      }
+
+      setScalarParam(responseFormat, Map("type" -> normalizedValue))
+    }
+  }
+
+  def setResponseFormat(value: OpenAIResponseFormat.ResponseFormat): this.type = {
+    // this method should throw an excption if the openAiCompletion is not a ChatCompletion
+    this.setResponseFormat(value.name)
+  }
+
+  def getResponseFormatCol: String = getVectorParam(responseFormat)
+
+  def setResponseFormatCol(value: String): this.type = setVectorParam(responseFormat, value)
+
+
+  // Recreating the sharedTextParams sequence to include additional parameter responseFormat
+  override private[openai] val sharedTextParams: Seq[ServiceParam[_]] = Seq(
+    maxTokens,
+    temperature,
+    topP,
+    user,
+    n,
+    echo,
+    stop,
+    cacheLevel,
+    presencePenalty,
+    frequencyPenalty,
+    bestOf,
+    logProbs,
+    responseFormat // Additional parameter
+  )
+}
+
 class OpenAIChatCompletion(override val uid: String) extends OpenAIServicesBase(uid)
-  with HasOpenAITextParams with HasMessagesInput with HasCognitiveServiceInput
+  with HasOpenAITextParamsExtended with HasMessagesInput with HasCognitiveServiceInput
   with HasInternalJsonOutputParser with SynapseMLLogging {
   logClass(FeatureNames.AiServices.OpenAI)
 
@@ -55,11 +132,20 @@ class OpenAIChatCompletion(override val uid: String) extends OpenAIServicesBase(
   override def responseDataType: DataType = ChatCompletionResponse.schema
 
   private[this] def getStringEntity(messages: Seq[Row], optionalParams: Map[String, Any]): StringEntity = {
-    val mappedMessages: Seq[Map[String, String]] = messages.map { m =>
+    var mappedMessages: Seq[Map[String, String]] = messages.map { m =>
       Seq("role", "content", "name").map(n =>
         n -> Option(m.getAs[String](n))
       ).toMap.filter(_._2.isDefined).mapValues(_.get)
     }
+
+    // if the optionalParams contains "response_format" key, and it's value contains "json_object",
+    // then we need to add a message to instruct openAI to return the response in JSON format
+    if (optionalParams.get("response_format")
+                      .exists(_.asInstanceOf[Map[String, String]]("type")
+                      .contentEquals("json_object"))) {
+      mappedMessages :+= Map("role" -> "system", "content" -> OpenAIResponseFormat.JSON.prompt)
+    }
+
     val fullPayload = optionalParams.updated("messages", mappedMessages)
     new StringEntity(fullPayload.toJson.compactPrint, ContentType.APPLICATION_JSON)
   }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPrompt.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPrompt.scala
@@ -129,7 +129,7 @@ class OpenAIPrompt(override val uid: String) extends Transformer
 
   private val localParamNames = Seq(
     "promptTemplate", "outputCol", "postProcessing", "postProcessingOptions", "dropPrompt", "dropMessages",
-    "systemPrompt", "responseFormat")
+    "systemPrompt")
 
   private def addRAIErrors(df: DataFrame, errorCol: String, outputCol: String): DataFrame = {
     val openAIResultFromRow = ChatCompletionResponse.makeFromRowConverter
@@ -225,7 +225,6 @@ class OpenAIPrompt(override val uid: String) extends Transformer
       }
     // apply all parameters
     extractParamMap().toSeq
-      .filter(p => completion.hasParam(p.param.name))
       .filter(p => !localParamNames.contains(p.param.name))
       .foreach(p => completion.set(completion.getParam(p.param.name), p.value))
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPrompt.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPrompt.scala
@@ -188,7 +188,6 @@ class OpenAIPrompt(override val uid: String) extends Transformer
 
     logTransform[DataFrame]({
       val df = dataset.toDF
-
       val completion = openAICompletion
       val promptCol = Functions.template(getPromptTemplate)
       val createMessagesUDF = udf((userMessage: String) => {
@@ -205,15 +204,13 @@ class OpenAIPrompt(override val uid: String) extends Transformer
           val messageColName = getMessagesCol
           val dfTemplated = df.withColumn(messageColName, createMessagesUDF(promptCol))
           val completionNamed = chatCompletion.setMessagesCol(messageColName)
-
           val transformed = addRAIErrors(
             completionNamed.transform(dfTemplated), chatCompletion.getErrorCol, chatCompletion.getOutputCol)
 
           val results = transformed
             .withColumn(getOutputCol,
               getParser.parse(F.element_at(F.col(completionNamed.getOutputCol).getField("choices"), 1)
-                .getField("message").getField("content")))
-            .drop(completionNamed.getOutputCol)
+                .getField("message").getField("content"))).drop(completionNamed.getOutputCol)
 
           if (getDropPrompt) {
             results.drop(messageColName)

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPrompt.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPrompt.scala
@@ -129,7 +129,7 @@ class OpenAIPrompt(override val uid: String) extends Transformer
 
   private val localParamNames = Seq(
     "promptTemplate", "outputCol", "postProcessing", "postProcessingOptions", "dropPrompt", "dropMessages",
-    "systemPrompt")
+    "systemPrompt", "responseFormat")
 
   private def addRAIErrors(df: DataFrame, errorCol: String, outputCol: String): DataFrame = {
     val openAIResultFromRow = ChatCompletionResponse.makeFromRowConverter

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
@@ -8,6 +8,8 @@ import com.microsoft.azure.synapse.ml.core.test.fuzzing.{TestObject, Transformer
 import org.apache.spark.ml.util.MLReadable
 import org.apache.spark.sql.{DataFrame, Row}
 import org.scalactic.Equality
+import org.scalatest.matchers.must.Matchers.{an, be}
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 class OpenAIChatCompletionSuite extends TransformerFuzzing[OpenAIChatCompletion] with OpenAIAPIKey with Flaky {
 
@@ -172,6 +174,45 @@ class OpenAIChatCompletionSuite extends TransformerFuzzing[OpenAIChatCompletion]
     }
 
     testCompletion(customEndpointCompletion, goodDf)
+  }
+
+  test("setResponseFormat should set the response format correctly") {
+    completion.setResponseFormat("text")
+    completion.getResponseFormat shouldEqual Map("type" -> "text")
+
+    completion.setResponseFormat("tExT")
+    completion.getResponseFormat shouldEqual Map("type" -> "text")
+
+    completion.setResponseFormat("json")
+    completion.getResponseFormat shouldEqual Map("type" -> "json_object")
+
+    completion.setResponseFormat("JSON")
+    completion.getResponseFormat shouldEqual Map("type" -> "json_object")
+
+    completion.setResponseFormat("json_object")
+    completion.getResponseFormat shouldEqual Map("type" -> "json_object")
+
+    completion.setResponseFormat("Json_ObjeCt")
+    completion.getResponseFormat shouldEqual Map("type" -> "json_object")
+  }
+
+  test("setResponseFormat should throw an exception for invalid response format") {
+    an[IllegalArgumentException] should be thrownBy {
+      completion.setResponseFormat("invalid_format")
+    }
+  }
+
+  test("setResponseFormat with ResponseFormat should set the response format correctly") {
+    completion.setResponseFormat(OpenAIResponseFormat.TEXT)
+    completion.getResponseFormat shouldEqual Map("type" -> "text")
+
+    completion.setResponseFormat(OpenAIResponseFormat.JSON)
+    completion.getResponseFormat shouldEqual Map("type" -> "json_object")
+  }
+
+  test("setResponseFormatCol should set the response format column correctly") {
+    completion.setResponseFormatCol("response_format_col")
+    completion.getResponseFormatCol shouldEqual "response_format_col"
   }
 
   def testCompletion(completion: OpenAIChatCompletion, df: DataFrame, requiredLength: Int = 10): Unit = {

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAICompletionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAICompletionSuite.scala
@@ -17,6 +17,7 @@ trait OpenAIAPIKey {
   lazy val deploymentName: String = "gpt-35-turbo"
   lazy val modelName: String = "gpt-35-turbo"
   lazy val deploymentNameGpt4: String = "gpt-4"
+  lazy val deploymentNameGpt4o: String = "gpt-4o"
   lazy val modelNameGpt4: String = "gpt-4"
 }
 

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAICompletionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAICompletionSuite.scala
@@ -17,6 +17,7 @@ trait OpenAIAPIKey {
   lazy val deploymentName: String = "gpt-35-turbo"
   lazy val modelName: String = "gpt-35-turbo"
   lazy val deploymentNameGpt4: String = "gpt-4"
+  lazy val deploymentNameDavinci3: String = "text-davinci-003"
   lazy val deploymentNameGpt4o: String = "gpt-4o"
   lazy val modelNameGpt4: String = "gpt-4"
 }

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
@@ -10,7 +10,7 @@ import org.apache.spark.ml.util.MLReadable
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions.col
 import org.scalactic.Equality
-import org.scalatest.matchers.must.Matchers.{be, include}
+import org.scalatest.matchers.must.Matchers.be
 import org.scalatest.matchers.should.Matchers.{an, convertToAnyShouldWrapper}
 
 class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIKey with Flaky {
@@ -23,12 +23,6 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
     super.beforeAll()
   }
 
-  lazy val prompt: OpenAIPrompt = new OpenAIPrompt()
-    .setSubscriptionKey(openAIAPIKey)
-    .setDeploymentName(deploymentName)
-    .setCustomServiceName(openAIServiceName)
-    .setOutputCol("outParsed")
-    .setTemperature(0)
 
   lazy val df: DataFrame = Seq(
     ("apple", "fruits"),
@@ -38,8 +32,8 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
   ).toDF("text", "category")
 
   test("RAI Usage") {
+    val prompt = createPromptInstance(deploymentNameGpt4)
     val result = prompt
-      .setDeploymentName(deploymentNameGpt4)
       .setPromptTemplate("Tell me about a graphically disgusting movie in detail")
       .transform(df)
       .select(prompt.getErrorCol)
@@ -48,6 +42,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
   }
 
   test("Basic Usage") {
+    val prompt: OpenAIPrompt = createPromptInstance(deploymentName)
     val nonNullCount = prompt
       .setPromptTemplate("here is a comma separated list of 5 {category}: {text}, ")
       .setPostProcessing("csv")
@@ -60,7 +55,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
   }
 
   test("Basic Usage with only post processing options") {
-    val nonNullCount = prompt
+    val nonNullCount = createPromptInstance(deploymentName)
       .setPromptTemplate("here is a comma separated list of 5 {category}: {text}, ")
       .setPostProcessingOptions(Map("delimiter" -> ","))
       .transform(df)
@@ -72,6 +67,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
   }
 
   test("Basic Usage JSON") {
+    val prompt = createPromptInstance(deploymentName)
     prompt.setPromptTemplate(
         """Split a word into prefix and postfix a respond in JSON
           |Cherry: {{"prefix": "Che", "suffix": "rry"}}
@@ -87,6 +83,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
   }
 
   test("Basic Usage JSON using text response format") {
+    val prompt = createPromptInstance(deploymentName)
     prompt.setPromptTemplate(
         """Split a word into prefix and postfix a respond in JSON
           |Cherry: {{"prefix": "Che", "suffix": "rry"}}
@@ -103,6 +100,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
   }
 
   test("Basic Usage JSON using only post processing oiptions") {
+    val prompt = createPromptInstance(deploymentName)
     prompt.setPromptTemplate(
         """Split a word into prefix and postfix a respond in JSON
           |Cherry: {{"prefix": "Che", "suffix": "rry"}}
@@ -116,16 +114,8 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
       .foreach(r => assert(r.getStruct(0).getString(0).nonEmpty))
   }
 
-
-
-  lazy val promptGpt4: OpenAIPrompt = new OpenAIPrompt()
-    .setSubscriptionKey(openAIAPIKey)
-    .setDeploymentName(deploymentNameGpt4)
-    .setCustomServiceName(openAIServiceName)
-    .setOutputCol("outParsed")
-    .setTemperature(0)
-
   test("Basic Usage - Gpt 4") {
+    val promptGpt4 = createPromptInstance(deploymentNameGpt4)
     val nonNullCount = promptGpt4
       .setPromptTemplate("here is a comma separated list of 5 {category}: {text}, ")
       .setPostProcessing("csv")
@@ -138,6 +128,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
   }
 
   test("Basic Usage JSON - Gpt 4") {
+    val promptGpt4 = createPromptInstance(deploymentNameGpt4)
     promptGpt4.setPromptTemplate(
         """Split a word into prefix and postfix a respond in JSON
           |Cherry: {{"prefix": "Che", "suffix": "rry"}}
@@ -153,6 +144,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
   }
 
   test("Basic Usage JSON - Gpt 4 using responseFormat TEXT") {
+    val promptGpt4 = createPromptInstance(deploymentNameGpt4)
     promptGpt4.setPromptTemplate(
         """Split a word into prefix and postfix a respond in JSON
           |Cherry: {{"prefix": "Che", "suffix": "rry"}}
@@ -168,14 +160,8 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
       .foreach(r => assert(r.getStruct(0).getString(0).nonEmpty))
   }
 
-  lazy val promptGpt4o: OpenAIPrompt = new OpenAIPrompt()
-    .setSubscriptionKey(openAIAPIKey)
-    .setDeploymentName(deploymentNameGpt4o)
-    .setCustomServiceName(openAIServiceName)
-    .setOutputCol("outParsed")
-    .setTemperature(0)
-
   test("Basic Usage JSON - Gpt 4o using responseFormat JSON") {
+    val promptGpt4o = createPromptInstance(deploymentNameGpt4o)
     promptGpt4o.setPromptTemplate(
         """Split a word into prefix and postfix
           |Cherry: {{"prefix": "Che", "suffix": "rry"}}
@@ -191,6 +177,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
   }
 
   test("Basic Usage - Gpt 4o with response format json") {
+    val promptGpt4o = createPromptInstance(deploymentNameGpt4o)
     val nonNullCount = promptGpt4o
       .setPromptTemplate("here is a comma separated list of 5 {category}: {text}, ")
       .setResponseFormat(OpenAIResponseFormat.JSON)
@@ -203,6 +190,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
   }
 
   test("Basic Usage - Gpt 4o with response format text") {
+    val promptGpt4o = createPromptInstance(deploymentNameGpt4o)
     val nonNullCount = promptGpt4o
       .setPromptTemplate("here is a comma separated list of 5 {category}: {text}, ")
       .setResponseFormat(OpenAIResponseFormat.TEXT)
@@ -215,6 +203,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
   }
 
   test("Setting and Keeping Messages Col - Gpt 4") {
+    val promptGpt4 = createPromptInstance(deploymentNameGpt4)
     promptGpt4.setMessagesCol("messages")
       .setDropPrompt(false)
       .setPromptTemplate(
@@ -229,6 +218,31 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
       .collect()
       .foreach(r => assert(r.get(0) != null))
   }
+
+  test("Basic Usage - Davinci 3 with no response format") {
+    val promptDavinci3 = createPromptInstance(deploymentNameDavinci3)
+    val rowCount = promptDavinci3
+      .setPromptTemplate("here is a comma separated list of 5 {category}: {text}, ")
+      .transform(df)
+      .select("outParsed")
+      .collect()
+      .length
+    assert(rowCount == 4)
+  }
+
+  test("Basic Usage - Davinci 3 with response format json") {
+    val promptDavinci3 = createPromptInstance(deploymentNameDavinci3)
+    intercept[IllegalArgumentException] {
+      promptDavinci3
+        .setPromptTemplate("here is a comma separated list of 5 {category}: {text}, ")
+        .setResponseFormat(OpenAIResponseFormat.JSON)
+        .transform(df)
+        .select("outParsed")
+        .collect()
+        .length
+    }
+  }
+
 
   ignore("Custom EndPoint") {
     lazy val accessToken: String = sys.env.getOrElse("CUSTOM_ACCESS_TOKEN", "")
@@ -257,23 +271,17 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
       .count(r => Option(r.getSeq[String](0)).isDefined)
   }
 
-  test("getResponseFormat should return the default response format") {
-    val prompt = new OpenAIPrompt()
-    prompt.getResponseFormat shouldEqual ""
-  }
-
   test("setResponseFormat should set the response format correctly with String") {
     val prompt = new OpenAIPrompt()
     prompt.setResponseFormat("json")
-    prompt.getResponseFormat shouldEqual "json_object"
+    prompt.getResponseFormat shouldEqual Map("type" -> "json_object")
 
     prompt.setResponseFormat("json_object")
-    prompt.getResponseFormat shouldEqual "json_object"
+    prompt.getResponseFormat shouldEqual Map("type" -> "json_object")
 
     prompt.setResponseFormat("text")
-    prompt.getResponseFormat shouldEqual "text"
+    prompt.getResponseFormat shouldEqual Map("type" -> "text")
   }
-
 
   test("setResponseFormat should throw an exception for invalid response format") {
     val prompt = new OpenAIPrompt()
@@ -281,35 +289,6 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
       prompt.setResponseFormat("invalid_format")
     }
   }
-
-  test("setResponseFormat should set the response format correctly with ResponseFormat") {
-    val prompt = new OpenAIPrompt()
-    prompt.setResponseFormat(OpenAIResponseFormat.JSON)
-    prompt.getResponseFormat shouldEqual "json_object"
-
-    prompt.setResponseFormat(OpenAIResponseFormat.TEXT)
-    prompt.getResponseFormat shouldEqual "text"
-  }
-
-
-  test("setResponseFormat should set the response format correctly for valid values") {
-    val prompt = new OpenAIPrompt()
-    prompt.setResponseFormat("text")
-    prompt.getResponseFormat should be ("text")
-
-    prompt.setResponseFormat("json")
-    prompt.getResponseFormat should be ("json_object")
-
-    prompt.setResponseFormat("json_object")
-    prompt.getResponseFormat should be ("json_object")
-
-    prompt.setResponseFormat("jSoN")
-    prompt.getResponseFormat should be ("json_object")
-
-    prompt.setResponseFormat("TEXT")
-    prompt.getResponseFormat should be ("text")
-  }
-
 
   test("setPostProcessingOptions should set postProcessing to 'csv' for delimiter option") {
     val prompt = new OpenAIPrompt()
@@ -356,6 +335,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
   }
 
   override def testObjects(): Seq[TestObject[OpenAIPrompt]] = {
+    val prompt = createPromptInstance(deploymentName)
     val testPrompt = prompt
       .setPromptTemplate("{text} rhymes with ")
 
@@ -364,4 +344,12 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
 
   override def reader: MLReadable[_] = OpenAIPrompt
 
+  private def createPromptInstance(deploymentName: String): OpenAIPrompt = {
+    new OpenAIPrompt()
+      .setSubscriptionKey(openAIAPIKey)
+      .setDeploymentName(deploymentName)
+      .setCustomServiceName(openAIServiceName)
+      .setOutputCol("outParsed")
+      .setTemperature(0)
+  }
 }

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
@@ -219,7 +219,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
       .foreach(r => assert(r.get(0) != null))
   }
 
-  test("Basic Usage - Davinci 3 with no response format") {
+  ignore("Basic Usage - Davinci 3 with no response format") {
     val promptDavinci3 = createPromptInstance(deploymentNameDavinci3)
     val rowCount = promptDavinci3
       .setPromptTemplate("here is a comma separated list of 5 {category}: {text}, ")
@@ -230,7 +230,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
     assert(rowCount == 4)
   }
 
-  test("Basic Usage - Davinci 3 with response format json") {
+  ignore("Basic Usage - Davinci 3 with response format json") {
     val promptDavinci3 = createPromptInstance(deploymentNameDavinci3)
     intercept[IllegalArgumentException] {
       promptDavinci3


### PR DESCRIPTION
## Related Issues/PRs
For newer models, openai accepts `response_format`, which can be `text` or `json_object`. This PR adds the parameter for this. Additionally, when developer set `postprocessingoptions`, in `OpenAIPrompt` class, post processing field is reduncdant and can be made optional. We cannot infer post processing from response format because json as response format is not supported by many models including GPT-4 and GPT-3.5-Turbo. All changes made in this PR as backward compatible and will not break any existing code.

## What changes are proposed in this pull request?

In this PR, we are adding:
1. Ability to add parameter for `response_format` in `OpenAIPrompt` class and `OpenAIChatCompletion` class.
2. Added unit tests to validate this
3. Added code to infer `postprocessing` from `postprocessingoptions` and hence making it optional.


## How is this patch tested?
Unit tests and integration tests are added to validate this change

## Does this PR change any dependencies?

- [X] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [X] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.
