### PR TITLE
fix: Fixing OpenAIPrompt class to be able to work with older models like text-davinci-003

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -8,6 +8,7 @@ import com.microsoft.azure.synapse.ml.fabric.{FabricClient, OpenAIFabricSetting}
 import com.microsoft.azure.synapse.ml.logging.common.PlatformDetails
 import com.microsoft.azure.synapse.ml.param.ServiceParam
 import com.microsoft.azure.synapse.ml.services._
+import org.apache.http.entity.AbstractHttpEntity
 import org.apache.spark.ml.PipelineModel
 import org.apache.spark.ml.param.{Param, Params}
 import org.apache.spark.sql.Row
@@ -294,7 +295,7 @@ trait HasOpenAITextParams extends HasOpenAISharedParams {
 }
 
 abstract class OpenAIServicesBase(override val uid: String) extends CognitiveServicesBase(uid: String)
-  with HasOpenAISharedParams with OpenAIFabricSetting {
+  with HasOpenAISharedParams with OpenAIFabricSetting with HasCognitiveServiceInput {
   setDefault(timeout -> 360.0)
 
   private def usingDefaultOpenAIEndpoint(): Boolean = {
@@ -307,4 +308,6 @@ abstract class OpenAIServicesBase(override val uid: String) extends CognitiveSer
     }
     super.getInternalTransformer(schema)
   }
+
+  private[openai] def prepareEntityAIService: Row => Option[AbstractHttpEntity] = this.prepareEntity
 }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPrompt.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPrompt.scala
@@ -99,7 +99,7 @@ class OpenAIPrompt(override val uid: String) extends Transformer
 
   private val localParamNames = Seq(
     "promptTemplate", "outputCol", "postProcessing", "postProcessingOptions", "dropPrompt", "dropMessages",
-    "systemPrompt", "messagesCol")
+    "systemPrompt")
 
   private def addRAIErrors(df: DataFrame, errorCol: String, outputCol: String): DataFrame = {
     val openAIResultFromRow = ChatCompletionResponse.makeFromRowConverter

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPrompt.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPrompt.scala
@@ -99,7 +99,7 @@ class OpenAIPrompt(override val uid: String) extends Transformer
 
   private val localParamNames = Seq(
     "promptTemplate", "outputCol", "postProcessing", "postProcessingOptions", "dropPrompt", "dropMessages",
-    "systemPrompt")
+    "systemPrompt", "messagesCol")
 
   private def addRAIErrors(df: DataFrame, errorCol: String, outputCol: String): DataFrame = {
     val openAIResultFromRow = ChatCompletionResponse.makeFromRowConverter
@@ -191,11 +191,10 @@ class OpenAIPrompt(override val uid: String) extends Transformer
         new OpenAICompletion()
       }
       else {
-        new OpenAIChatCompletion()
+        new OpenAIChatCompletion().setMessagesCol(getMessagesCol)
       }
     // apply all parameters
     extractParamMap().toSeq
-      .filter(p => completion.hasParam(p.param.name))
       .filter(p => !localParamNames.contains(p.param.name))
       .foreach(p => completion.set(completion.getParam(p.param.name), p.value))
 


### PR DESCRIPTION
## Issue
While working with `OpenAIPrompt` class, I discovered that this class does not work with older models. Upon investigation, I found that for models specified in the list `legacyModels`, OpenAIPrompt class suppose to use `OpenAICompletion` instance, for all other model deployment names, `OpenAIChatCompletion` class is to be used. When setting parameter for `OpenAICompletion`, it tries to set parameters that are not available in `OpenAICompletion`, which causes instance creation to fail. There are no current unit tests or integration tests that verified this. In this PR, I am fixing this problem and adding unit test to validate this. I am also cleaning unit test and OpenAIPrompt class.

## What changes are proposed in this pull request?
In this PR I am:
1. Ensuring that new prompt instances are created for each test. This will eliminate chance of one test interfering with another test.
2. Creating test to validate that for older model deployments, OpenAiCompletion instance is created in OpenAIPrompt class.
3. Fixing the bug that caused creation of OpenAICompletion object to fail.
4. Cleaning some code in OpenAIPrompt class.

## How is this patch tested?
- [X] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [X] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [X] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.
