### PR TITLE
fix: OpenAIChatCompletion class method shouldSkip method to skip row if no user message

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
@@ -48,14 +48,16 @@ class OpenAIChatCompletion(override val uid: String) extends OpenAIServicesBase(
 
   /**
    * Check if the row should be skipped. A row should be skipped if the messages column is empty or if any of the
-   * messages are empty or if there not exists a single message with "role" as "user" and "content" as non-empty.
+   * messages are empty or if there not exists a single message with "role" as "user" or "assistant" and
+   * "content" as non-empty.
    */
   override def shouldSkip(row: Row): Boolean ={
+    val acceptableRoles = Set("user", "assistant")
     super.shouldSkip(row) || {
       val messages = Option(row.getAs[Seq[Row]](getMessagesCol)).getOrElse(Seq.empty)
       messages.isEmpty || !messages
         // filter out messages system messages
-        .filter(m => Option(m.getAs[String]("role")).getOrElse("").equalsIgnoreCase("user"))
+        .filter(m => acceptableRoles.contains(Option(m.getAs[String]("role")).getOrElse("").toLowerCase))
         // check if there exists a user message with non-empty content
         .exists(m => Option(m.getAs[String]("content")).getOrElse("").nonEmpty)
     }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
@@ -53,11 +53,11 @@ class OpenAIChatCompletion(override val uid: String) extends OpenAIServicesBase(
   override def shouldSkip(row: Row): Boolean ={
     super.shouldSkip(row) || {
       val messages = Option(row.getAs[Seq[Row]](getMessagesCol)).getOrElse(Seq.empty)
-      messages.isEmpty || !messages.exists(m =>{
-        val content = Option(m.getAs[String]("content"))
-        val role = Option(m.getAs[String]("role"))
-        role.nonEmpty && role.get == "user" && content.nonEmpty && content.get.nonEmpty
-      })
+      messages.isEmpty || !messages
+        // filter out messages system messages
+        .filter(m => Option(m.getAs[String]("role")).getOrElse("").equalsIgnoreCase("user"))
+        // check if there exists a user message with non-empty content
+        .exists(m => Option(m.getAs[String]("content")).getOrElse("").nonEmpty)
     }
   }
 

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
@@ -217,6 +217,14 @@ class OpenAIChatCompletionSuite extends TransformerFuzzing[OpenAIChatCompletion]
       Seq(OpenAIMessage("user", "Whats your favorite color"))
     ).toDF("messages")
     shouldSkipRowHelper(dfWithEmptySystemMessage.collect(), expectedToBeSkipped = false)
+
+    val dfWithAssistantValidMessages = Seq(
+      Seq(
+        OpenAIMessage("system", "You are an AI chatbot with red as your favorite color"),
+        OpenAIMessage("assistant", "Whats your favorite color")
+      )
+    ).toDF("messages")
+    shouldSkipRowHelper(dfWithAssistantValidMessages.collect(), expectedToBeSkipped = false)
   }
 
   def shouldSkipRowHelper(rows: Seq[Row], expectedToBeSkipped: Boolean): Unit = {


### PR DESCRIPTION
`OpenAIChatCompletion` class method `shouldSkip` was not working as designed as there might OpenAIMessages with empty contents. These rows can be identified before sending requests to OpenAI service and getting errors. 

## What changes are proposed in this pull request?
In this PR, I am making changes to skip rows if there are no user messages in the message column.

## How is this patch tested?

- [X] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [X] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [X] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.
