### PR TITLE
Adding SubscriptionKey and Temperature to OpenAIDefaults

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
@@ -10,7 +10,8 @@ import com.microsoft.azure.synapse.ml.fabric.FabricClient
 import com.microsoft.azure.synapse.ml.io.http._
 import com.microsoft.azure.synapse.ml.logging.SynapseMLLogging
 import com.microsoft.azure.synapse.ml.logging.common.PlatformDetails
-import com.microsoft.azure.synapse.ml.param.{GlobalParams, HasGlobalParams, ServiceParam}
+import com.microsoft.azure.synapse.ml.param.{GlobalKey, GlobalParams, HasGlobalParams, ServiceParam}
+import com.microsoft.azure.synapse.ml.services.openai.OpenAIDeploymentNameKey
 import com.microsoft.azure.synapse.ml.stages.{DropColumns, Lambda}
 import org.apache.http.NameValuePair
 import org.apache.http.client.methods.{HttpEntityEnclosingRequestBase, HttpPost, HttpRequestBase}
@@ -128,9 +129,13 @@ trait HasServiceParams extends Params {
   }
 }
 
+case object OpenAISubscriptionKey extends GlobalKey[Either[String, String]]
+
 trait HasSubscriptionKey extends HasServiceParams {
   val subscriptionKey = new ServiceParam[String](
     this, "subscriptionKey", "the API key to use")
+
+  GlobalParams.registerParam(subscriptionKey, OpenAISubscriptionKey)
 
   def getSubscriptionKey: String = getScalarParam(subscriptionKey)
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -103,6 +103,8 @@ trait HasOpenAIEmbeddingParams extends HasOpenAISharedParams with HasAPIVersion 
   }
 }
 
+case object OpenAITemperatureKey extends GlobalKey[Either[Double, String]]
+
 trait HasOpenAITextParams extends HasOpenAISharedParams {
   val maxTokens: ServiceParam[Int] = new ServiceParam[Int](
     this, "maxTokens",
@@ -125,6 +127,8 @@ trait HasOpenAITextParams extends HasOpenAISharedParams {
       " Try 0.9 for more creative applications, and 0 (argmax sampling) for ones with a well-defined answer." +
       " We generally recommend using this or `top_p` but not both. Minimum of 0 and maximum of 2 allowed.",
     isRequired = false)
+
+  GlobalParams.registerParam(temperature, OpenAITemperatureKey)
 
   def getTemperature: Double = getScalarParam(temperature)
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaults.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaults.scala
@@ -4,9 +4,18 @@
 package com.microsoft.azure.synapse.ml.services.openai
 
 import com.microsoft.azure.synapse.ml.param.GlobalParams
+import com.microsoft.azure.synapse.ml.services.OpenAISubscriptionKey
 
 object OpenAIDefaults {
   def setDeploymentName(v: String): Unit = {
     GlobalParams.setGlobalParam(OpenAIDeploymentNameKey, Left(v))
+  }
+
+  def setSubscriptionKey(v: String): Unit = {
+    GlobalParams.setGlobalParam(OpenAISubscriptionKey, Left(v))
+  }
+
+  def setTemperature(v: Double): Unit = {
+    GlobalParams.setGlobalParam(OpenAITemperatureKey, Left(v))
   }
 }

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaultsSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaultsSuite.scala
@@ -11,12 +11,14 @@ class OpenAIDefaultsSuite extends Flaky with OpenAIAPIKey {
   import spark.implicits._
 
   OpenAIDefaults.setDeploymentName(deploymentName)
+  OpenAIDefaults.setSubscriptionKey(openAIAPIKey)
+  OpenAIDefaults.setTemperature(0.05)
+
 
   def promptCompletion: OpenAICompletion = new OpenAICompletion()
     .setCustomServiceName(openAIServiceName)
     .setMaxTokens(200)
     .setOutputCol("out")
-    .setSubscriptionKey(openAIAPIKey)
     .setPromptCol("prompt")
 
   lazy val promptDF: DataFrame = Seq(
@@ -33,10 +35,8 @@ class OpenAIDefaultsSuite extends Flaky with OpenAIAPIKey {
   }
 
   lazy val prompt: OpenAIPrompt = new OpenAIPrompt()
-    .setSubscriptionKey(openAIAPIKey)
     .setCustomServiceName(openAIServiceName)
     .setOutputCol("outParsed")
-    .setTemperature(0)
 
   lazy val df: DataFrame = Seq(
     ("apple", "fruits"),
@@ -55,5 +55,11 @@ class OpenAIDefaultsSuite extends Flaky with OpenAIAPIKey {
       .count(r => Option(r.getSeq[String](0)).isDefined)
 
     assert(nonNullCount == 3)
+  }
+
+  test("OpenAIPrompt Check Params") {
+    assert(prompt.getDeploymentName == deploymentName)
+    assert(prompt.getSubscriptionKey == openAIAPIKey)
+    assert(prompt.getTemperature == 0.05)
   }
 }


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Adding SubscriptionKey and Temperature to OpenAIDefaults. 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
