### PR TITLE
chore: Wrap OpenAIDefaults for Python

### DIFF
--- a/cognitive/src/main/python/synapse/ml/services/openai/OpenAIDefaults.py
+++ b/cognitive/src/main/python/synapse/ml/services/openai/OpenAIDefaults.py
@@ -42,7 +42,7 @@ class OpenAIDefaults:
         self.defaults.resetSubscriptionKey()
 
     def set_temperature(self, temp):
-        self.defaults.setTemperature(temp)
+        self.defaults.setTemperature(float(temp))
 
     def get_temperature(self):
         return getOption(self.defaults.getTemperature())

--- a/cognitive/src/main/python/synapse/ml/services/openai/OpenAIDefaults.py
+++ b/cognitive/src/main/python/synapse/ml/services/openai/OpenAIDefaults.py
@@ -9,6 +9,12 @@ if sys.version >= "3":
 import pyspark
 from pyspark import SparkContext
 
+def getOption(opt):
+    if opt.isDefined():
+        return opt.get()
+    else:
+        return None
+
 class OpenAIDefaults:
     def __init__(self):
         self.defaults = SparkContext.getOrCreate()._jvm.com.microsoft.azure.synapse.ml.services.openai.OpenAIDefaults
@@ -17,7 +23,7 @@ class OpenAIDefaults:
         self.defaults.setDeploymentName(name)
 
     def get_deployment_name(self):
-        self.defaults.getDeploymentName()
+        return getOption(self.defaults.getDeploymentName())
 
     def reset_deployment_name(self):
         self.defaults.resetDeploymentName()
@@ -26,7 +32,7 @@ class OpenAIDefaults:
         self.defaults.setSubscriptionKey(key)
 
     def get_subscription_key(self):
-        self.defaults.getSubscriptionKey()
+        return getOption(self.defaults.getSubscriptionKey())
 
     def reset_subscription_key(self):
         self.defaults.resetSubscriptionKey()
@@ -35,7 +41,7 @@ class OpenAIDefaults:
         self.defaults.setTemperature(temp)
 
     def get_temperature(self):
-        self.defaults.getTemperature()
+        return getOption(self.defaults.getTemperature())
 
     def reset_temperature(self):
         self.defaults.resetTemperature()

--- a/cognitive/src/main/python/synapse/ml/services/openai/OpenAIDefaults.py
+++ b/cognitive/src/main/python/synapse/ml/services/openai/OpenAIDefaults.py
@@ -1,0 +1,32 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+import sys
+
+if sys.version >= "3":
+    basestring = str
+
+import pyspark
+from pyspark import SparkContext
+
+class OpenAIDefaults:
+    def __init__(self):
+        self.defaults = SparkContext.getOrCreate()._jvm.com.microsoft.azure.synapse.ml.services.openai.OpenAIDefaults
+
+    def set_deployment_name(self, name):
+        self.defaults.setDeploymentName(name)
+
+    def set_subscription_key(self, key):
+        self.defaults.setSubscriptionKey(key)
+
+    def set_temperature(self, temp):
+        self.defaults.setTemperature(temp)
+
+    def get_deployment_name(self):
+        self.defaults.getDeploymentName()
+
+    def get_subscription_key(self):
+        self.defaults.getSubscriptionKey()
+
+    def get_temperature(self):
+        self.defaults.getTemperature()

--- a/cognitive/src/main/python/synapse/ml/services/openai/OpenAIDefaults.py
+++ b/cognitive/src/main/python/synapse/ml/services/openai/OpenAIDefaults.py
@@ -9,15 +9,19 @@ if sys.version >= "3":
 import pyspark
 from pyspark import SparkContext
 
+
 def getOption(opt):
     if opt.isDefined():
         return opt.get()
     else:
         return None
 
+
 class OpenAIDefaults:
     def __init__(self):
-        self.defaults = SparkContext.getOrCreate()._jvm.com.microsoft.azure.synapse.ml.services.openai.OpenAIDefaults
+        self.defaults = (
+            SparkContext.getOrCreate()._jvm.com.microsoft.azure.synapse.ml.services.openai.OpenAIDefaults
+        )
 
     def set_deployment_name(self, name):
         self.defaults.setDeploymentName(name)

--- a/cognitive/src/main/python/synapse/ml/services/openai/OpenAIDefaults.py
+++ b/cognitive/src/main/python/synapse/ml/services/openai/OpenAIDefaults.py
@@ -16,17 +16,26 @@ class OpenAIDefaults:
     def set_deployment_name(self, name):
         self.defaults.setDeploymentName(name)
 
-    def set_subscription_key(self, key):
-        self.defaults.setSubscriptionKey(key)
-
-    def set_temperature(self, temp):
-        self.defaults.setTemperature(temp)
-
     def get_deployment_name(self):
         self.defaults.getDeploymentName()
+
+    def reset_deployment_name(self):
+        self.defaults.resetDeploymentName()
+
+    def set_subscription_key(self, key):
+        self.defaults.setSubscriptionKey(key)
 
     def get_subscription_key(self):
         self.defaults.getSubscriptionKey()
 
+    def reset_subscription_key(self):
+        self.defaults.resetSubscriptionKey()
+
+    def set_temperature(self, temp):
+        self.defaults.setTemperature(temp)
+
     def get_temperature(self):
         self.defaults.getTemperature()
+
+    def reset_temperature(self):
+        self.defaults.resetTemperature()

--- a/cognitive/src/main/python/synapse/ml/services/openai/OpenAIDefaults.py
+++ b/cognitive/src/main/python/synapse/ml/services/openai/OpenAIDefaults.py
@@ -49,3 +49,12 @@ class OpenAIDefaults:
 
     def reset_temperature(self):
         self.defaults.resetTemperature()
+
+    def set_URL(self, URL):
+        self.defaults.setURL(URL)
+
+    def get_URL(self):
+        return getOption(self.defaults.getURL())
+
+    def reset_URL(self):
+        self.defaults.resetURL()

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaults.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaults.scala
@@ -5,6 +5,7 @@ package com.microsoft.azure.synapse.ml.services.openai
 
 import com.microsoft.azure.synapse.ml.param.GlobalParams
 import com.microsoft.azure.synapse.ml.services.OpenAISubscriptionKey
+import com.microsoft.azure.synapse.ml.io.http.URLKey
 
 object OpenAIDefaults {
   def setDeploymentName(v: String): Unit = {
@@ -41,6 +42,18 @@ object OpenAIDefaults {
 
   def resetTemperature(): Unit = {
     GlobalParams.resetGlobalParam(OpenAITemperatureKey)
+  }
+
+  def setURL(v: String): Unit = {
+    GlobalParams.setGlobalParam(URLKey, v)
+  }
+
+  def getURL: Option[String] = {
+    GlobalParams.getGlobalParam(URLKey)
+  }
+
+  def resetURL(): Unit = {
+    GlobalParams.resetGlobalParam(URLKey)
   }
 
   private def extractLeft[T](optEither: Option[Either[T, String]]): Option[T] = {

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaults.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaults.scala
@@ -11,12 +11,36 @@ object OpenAIDefaults {
     GlobalParams.setGlobalParam(OpenAIDeploymentNameKey, Left(v))
   }
 
+  def getDeploymentName: Option[String] = {
+    extractLeft(GlobalParams.getGlobalParam(OpenAIDeploymentNameKey))
+  }
+
+  def resetDeploymentName(): Unit = {
+    GlobalParams.resetGlobalParam(OpenAIDeploymentNameKey)
+  }
+
   def setSubscriptionKey(v: String): Unit = {
     GlobalParams.setGlobalParam(OpenAISubscriptionKey, Left(v))
   }
 
+  def getSubscriptionKey: Option[String] = {
+    extractLeft(GlobalParams.getGlobalParam(OpenAISubscriptionKey))
+  }
+
+  def resetSubscriptionKey(): Unit = {
+    GlobalParams.resetGlobalParam(OpenAISubscriptionKey)
+  }
+
   def setTemperature(v: Double): Unit = {
     GlobalParams.setGlobalParam(OpenAITemperatureKey, Left(v))
+  }
+
+  def getTemperature: Option[Double] = {
+    extractLeft(GlobalParams.getGlobalParam(OpenAITemperatureKey))
+  }
+
+  def resetTemperature(): Unit = {
+    GlobalParams.resetGlobalParam(OpenAITemperatureKey)
   }
 
   private def extractLeft[T](optEither: Option[Either[T, String]]): Option[T] = {
@@ -24,17 +48,5 @@ object OpenAIDefaults {
       case Some(Left(v)) => Some(v)
       case _ => None
     }
-  }
-
-  def getDeploymentName(): Option[String] = {
-    extractLeft(GlobalParams.getGlobalParam(OpenAIDeploymentNameKey))
-  }
-
-  def getSubscriptionKey(): Option[String] = {
-    extractLeft(GlobalParams.getGlobalParam(OpenAISubscriptionKey))
-  }
-
-  def getTemperature(): Option[Double] = {
-    extractLeft(GlobalParams.getGlobalParam(OpenAITemperatureKey))
   }
 }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaults.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaults.scala
@@ -18,4 +18,23 @@ object OpenAIDefaults {
   def setTemperature(v: Double): Unit = {
     GlobalParams.setGlobalParam(OpenAITemperatureKey, Left(v))
   }
+
+  private def extractLeft[T](optEither: Option[Either[T, String]]): Option[T] = {
+    optEither match {
+      case Some(Left(v)) => Some(v)
+      case _ => None
+    }
+  }
+
+  def getDeploymentName(): Option[String] = {
+    extractLeft(GlobalParams.getGlobalParam(OpenAIDeploymentNameKey))
+  }
+
+  def getSubscriptionKey(): Option[String] = {
+    extractLeft(GlobalParams.getGlobalParam(OpenAISubscriptionKey))
+  }
+
+  def getTemperature(): Option[Double] = {
+    extractLeft(GlobalParams.getGlobalParam(OpenAITemperatureKey))
+  }
 }

--- a/cognitive/src/test/python/synapsemltest/services/openai/test_OpenAIDefaults.py
+++ b/cognitive/src/test/python/synapsemltest/services/openai/test_OpenAIDefaults.py
@@ -21,10 +21,12 @@ class TestOpenAIDefaults(unittest.TestCase):
         defaults.set_deployment_name("Bing Bong")
         defaults.set_subscription_key("SubKey")
         defaults.set_temperature(0.05)
+        defaults.set_URL("Test URL")
 
         self.assertEqual(defaults.get_deployment_name(), "Bing Bong")
         self.assertEqual(defaults.get_subscription_key(), "SubKey")
         self.assertEqual(defaults.get_temperature(), 0.05)
+        self.assertEqual(defaults.get_URL(), "Test URL")
 
     def test_resetters(self):
         defaults = OpenAIDefaults()
@@ -32,18 +34,22 @@ class TestOpenAIDefaults(unittest.TestCase):
         defaults.set_deployment_name("Bing Bong")
         defaults.set_subscription_key("SubKey")
         defaults.set_temperature(0.05)
+        defaults.set_URL("Test URL")
 
         self.assertEqual(defaults.get_deployment_name(), "Bing Bong")
         self.assertEqual(defaults.get_subscription_key(), "SubKey")
         self.assertEqual(defaults.get_temperature(), 0.05)
+        self.assertEqual(defaults.get_URL(), "Test URL")
 
         defaults.reset_deployment_name()
         defaults.reset_subscription_key()
         defaults.reset_temperature()
+        defaults.reset_URL()
 
         self.assertEqual(defaults.get_deployment_name(), None)
         self.assertEqual(defaults.get_subscription_key(), None)
         self.assertEqual(defaults.get_temperature(), None)
+        self.assertEqual(defaults.get_URL(), None)
 
     def test_two_defaults(self):
         defaults = OpenAIDefaults()
@@ -78,10 +84,10 @@ class TestOpenAIDefaults(unittest.TestCase):
         defaults.set_deployment_name("gpt-35-turbo-0125")
         defaults.set_subscription_key(openai_api_key)
         defaults.set_temperature(0.05)
+        defaults.set_URL("https://synapseml-openai-2.openai.azure.com/")
 
         prompt = OpenAIPrompt()
         prompt = prompt.setOutputCol("outParsed")
-        prompt = prompt.setCustomServiceName("synapseml-openai-2")
         prompt = prompt.setPromptTemplate("Complete this comma separated list of 5 {category}: {text}, ")
         results = prompt.transform(df)
         results.select("outParsed").show(truncate = False)

--- a/cognitive/src/test/python/synapsemltest/services/openai/test_OpenAIDefaults.py
+++ b/cognitive/src/test/python/synapsemltest/services/openai/test_OpenAIDefaults.py
@@ -1,0 +1,27 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+from synapse.ml.services.openai.OpenAIDefaults import OpenAIDefaults
+from synapse.ml.services.openai.OpenAIPrompt import OpenAIPrompt
+import unittest
+from pyspark.sql import SQLContext
+
+from synapse.ml.core.init_spark import *
+
+spark = init_spark()
+sc = SQLContext(spark.sparkContext)
+
+class TestOpenAIDefaults(unittest.TestCase):
+    def test_OpenAIDefaults(self):
+        defaults = OpenAIDefaults()
+
+        defaults.set_deployment_name("Bing Bong")
+        defaults.set_subscription_key("SubKey")
+        defaults.set_temperature(0.05)
+
+        self.assertEqual(defaults.getDeploymentName(), "Bing Bong")
+        self.assertEqual(defaults.getSubscriptionKey, "SubKey")
+        self.assertEqual(defaults.getTemperature, 0.05)
+
+if __name__ == "__main__":
+    result = unittest.main()

--- a/cognitive/src/test/python/synapsemltest/services/openai/test_OpenAIDefaults.py
+++ b/cognitive/src/test/python/synapsemltest/services/openai/test_OpenAIDefaults.py
@@ -19,9 +19,9 @@ class TestOpenAIDefaults(unittest.TestCase):
         defaults.set_subscription_key("SubKey")
         defaults.set_temperature(0.05)
 
-        self.assertEqual(defaults.getDeploymentName(), "Bing Bong")
-        self.assertEqual(defaults.getSubscriptionKey, "SubKey")
-        self.assertEqual(defaults.getTemperature, 0.05)
+        self.assertEqual(defaults.get_deployment_name(), "Bing Bong")
+        self.assertEqual(defaults.get_subscription_key(), "SubKey")
+        self.assertEqual(defaults.get_temperature(), 0.05)
 
 if __name__ == "__main__":
     result = unittest.main()

--- a/cognitive/src/test/python/synapsemltest/services/openai/test_OpenAIDefaults.py
+++ b/cognitive/src/test/python/synapsemltest/services/openai/test_OpenAIDefaults.py
@@ -11,8 +11,9 @@ from synapse.ml.core.init_spark import *
 spark = init_spark()
 sc = SQLContext(spark.sparkContext)
 
+
 class TestOpenAIDefaults(unittest.TestCase):
-    def test_OpenAIDefaults(self):
+    def test_setters_and_getters(self):
         defaults = OpenAIDefaults()
 
         defaults.set_deployment_name("Bing Bong")
@@ -22,6 +23,41 @@ class TestOpenAIDefaults(unittest.TestCase):
         self.assertEqual(defaults.get_deployment_name(), "Bing Bong")
         self.assertEqual(defaults.get_subscription_key(), "SubKey")
         self.assertEqual(defaults.get_temperature(), 0.05)
+
+    def test_resetters(self):
+        defaults = OpenAIDefaults()
+
+        defaults.set_deployment_name("Bing Bong")
+        defaults.set_subscription_key("SubKey")
+        defaults.set_temperature(0.05)
+
+        self.assertEqual(defaults.get_deployment_name(), "Bing Bong")
+        self.assertEqual(defaults.get_subscription_key(), "SubKey")
+        self.assertEqual(defaults.get_temperature(), 0.05)
+
+        defaults.reset_deployment_name()
+        defaults.reset_subscription_key()
+        defaults.reset_temperature()
+
+        self.assertEqual(defaults.get_deployment_name(), None)
+        self.assertEqual(defaults.get_subscription_key(), None)
+        self.assertEqual(defaults.get_temperature(), None)
+
+    def test_two_defaults(self):
+        defaults = OpenAIDefaults()
+
+        defaults.set_deployment_name("Bing Bong")
+        self.assertEqual(defaults.get_deployment_name(), "Bing Bong")
+
+        defaults2 = OpenAIDefaults()
+        defaults.set_deployment_name("Bing Bong")
+        defaults2.set_deployment_name("Vamos")
+        self.assertEqual(defaults.get_deployment_name(), "Vamos")
+
+        defaults2.set_deployment_name("Test 2")
+        defaults.set_deployment_name("Test 1")
+        self.assertEqual(defaults.get_deployment_name(), "Test 1")
+
 
 if __name__ == "__main__":
     result = unittest.main()

--- a/cognitive/src/test/python/synapsemltest/services/openai/test_OpenAIDefaults.py
+++ b/cognitive/src/test/python/synapsemltest/services/openai/test_OpenAIDefaults.py
@@ -3,7 +3,7 @@
 
 from synapse.ml.services.openai.OpenAIDefaults import OpenAIDefaults
 from synapse.ml.services.openai.OpenAIPrompt import OpenAIPrompt
-import unittest,os, json, subprocess
+import unittest, os, json, subprocess
 from pyspark.sql import SQLContext
 from pyspark.sql.functions import col
 
@@ -74,11 +74,14 @@ class TestOpenAIDefaults(unittest.TestCase):
         )
         openai_api_key = json.loads(secretJson)["value"]
 
-        df = spark.createDataFrame([
-            ("apple", "fruits"),
-            ("mercedes", "cars"),
-            ("cake", "dishes"),
-        ], ["text", "category"])
+        df = spark.createDataFrame(
+            [
+                ("apple", "fruits"),
+                ("mercedes", "cars"),
+                ("cake", "dishes"),
+            ],
+            ["text", "category"],
+        )
 
         defaults = OpenAIDefaults()
         defaults.set_deployment_name("gpt-35-turbo-0125")
@@ -88,11 +91,13 @@ class TestOpenAIDefaults(unittest.TestCase):
 
         prompt = OpenAIPrompt()
         prompt = prompt.setOutputCol("outParsed")
-        prompt = prompt.setPromptTemplate("Complete this comma separated list of 5 {category}: {text}, ")
+        prompt = prompt.setPromptTemplate(
+            "Complete this comma separated list of 5 {category}: {text}, "
+        )
         results = prompt.transform(df)
-        results.select("outParsed").show(truncate = False)
+        results.select("outParsed").show(truncate=False)
         nonNullCount = results.filter(col("outParsed").isNotNull()).count()
-        assert (nonNullCount == 3)
+        assert nonNullCount == 3
 
 
 if __name__ == "__main__":

--- a/cognitive/src/test/python/synapsemltest/services/openai/test_OpenAIDefaults.py
+++ b/cognitive/src/test/python/synapsemltest/services/openai/test_OpenAIDefaults.py
@@ -3,8 +3,10 @@
 
 from synapse.ml.services.openai.OpenAIDefaults import OpenAIDefaults
 from synapse.ml.services.openai.OpenAIPrompt import OpenAIPrompt
-import unittest
+import unittest,os, json, subprocess
 from pyspark.sql import SQLContext
+from pyspark.sql.functions import col
+
 
 from synapse.ml.core.init_spark import *
 
@@ -57,6 +59,34 @@ class TestOpenAIDefaults(unittest.TestCase):
         defaults2.set_deployment_name("Test 2")
         defaults.set_deployment_name("Test 1")
         self.assertEqual(defaults.get_deployment_name(), "Test 1")
+
+    def test_prompt_w_defaults(self):
+
+        secretJson = subprocess.check_output(
+            "az keyvault secret show --vault-name mmlspark-build-keys --name openai-api-key-2",
+            shell=True,
+        )
+        openai_api_key = json.loads(secretJson)["value"]
+
+        df = spark.createDataFrame([
+            ("apple", "fruits"),
+            ("mercedes", "cars"),
+            ("cake", "dishes"),
+        ], ["text", "category"])
+
+        defaults = OpenAIDefaults()
+        defaults.set_deployment_name("gpt-35-turbo-0125")
+        defaults.set_subscription_key(openai_api_key)
+        defaults.set_temperature(0.05)
+
+        prompt = OpenAIPrompt()
+        prompt = prompt.setOutputCol("outParsed")
+        prompt = prompt.setCustomServiceName("synapseml-openai-2")
+        prompt = prompt.setPromptTemplate("Complete this comma separated list of 5 {category}: {text}, ")
+        results = prompt.transform(df)
+        results.select("outParsed").show(truncate = False)
+        nonNullCount = results.filter(col("outParsed").isNotNull()).count()
+        assert (nonNullCount == 3)
 
 
 if __name__ == "__main__":

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaultsSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaultsSuite.scala
@@ -11,7 +11,6 @@ class OpenAIDefaultsSuite extends Flaky with OpenAIAPIKey {
   import spark.implicits._
 
   def promptCompletion: OpenAICompletion = new OpenAICompletion()
-    .setCustomServiceName(openAIServiceName)
     .setMaxTokens(200)
     .setOutputCol("out")
     .setPromptCol("prompt")
@@ -26,6 +25,7 @@ class OpenAIDefaultsSuite extends Flaky with OpenAIAPIKey {
     OpenAIDefaults.setDeploymentName(deploymentName)
     OpenAIDefaults.setSubscriptionKey(openAIAPIKey)
     OpenAIDefaults.setTemperature(0.05)
+    OpenAIDefaults.setURL(s"https://$openAIServiceName.openai.azure.com/")
 
     val fromRow = CompletionResponse.makeFromRowConverter
     promptCompletion.transform(promptDF).collect().foreach(r =>
@@ -34,7 +34,6 @@ class OpenAIDefaultsSuite extends Flaky with OpenAIAPIKey {
   }
 
   lazy val prompt: OpenAIPrompt = new OpenAIPrompt()
-    .setCustomServiceName(openAIServiceName)
     .setOutputCol("outParsed")
 
   lazy val df: DataFrame = Seq(
@@ -48,6 +47,7 @@ class OpenAIDefaultsSuite extends Flaky with OpenAIAPIKey {
     OpenAIDefaults.setDeploymentName(deploymentName)
     OpenAIDefaults.setSubscriptionKey(openAIAPIKey)
     OpenAIDefaults.setTemperature(0.05)
+    OpenAIDefaults.setURL(s"https://$openAIServiceName.openai.azure.com/")
 
     val nonNullCount = prompt
       .setPromptTemplate("here is a comma separated list of 5 {category}: {text}, ")
@@ -65,22 +65,31 @@ class OpenAIDefaultsSuite extends Flaky with OpenAIAPIKey {
   }
 
   test("Test Getters") {
+    OpenAIDefaults.setDeploymentName(deploymentName)
+    OpenAIDefaults.setSubscriptionKey(openAIAPIKey)
+    OpenAIDefaults.setTemperature(0.05)
+    OpenAIDefaults.setURL(s"https://$openAIServiceName.openai.azure.com/")
+
     assert(OpenAIDefaults.getDeploymentName.contains(deploymentName))
     assert(OpenAIDefaults.getSubscriptionKey.contains(openAIAPIKey))
     assert(OpenAIDefaults.getTemperature.contains(0.05))
+    assert(OpenAIDefaults.getURL.contains(s"https://$openAIServiceName.openai.azure.com/"))
   }
 
   test("Test Resetters") {
     OpenAIDefaults.setDeploymentName(deploymentName)
     OpenAIDefaults.setSubscriptionKey(openAIAPIKey)
     OpenAIDefaults.setTemperature(0.05)
+    OpenAIDefaults.setURL(s"https://$openAIServiceName.openai.azure.com/")
 
     OpenAIDefaults.resetDeploymentName()
     OpenAIDefaults.resetSubscriptionKey()
     OpenAIDefaults.resetTemperature()
+    OpenAIDefaults.resetURL()
 
     assert(OpenAIDefaults.getDeploymentName.isEmpty)
     assert(OpenAIDefaults.getSubscriptionKey.isEmpty)
     assert(OpenAIDefaults.getTemperature.isEmpty)
+    assert(OpenAIDefaults.getURL.isEmpty)
   }
 }

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaultsSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaultsSuite.scala
@@ -55,9 +55,7 @@ class OpenAIDefaultsSuite extends Flaky with OpenAIAPIKey {
       .count(r => Option(r.getSeq[String](0)).isDefined)
 
     assert(nonNullCount == 3)
-  }
 
-  test("OpenAIPrompt Check Params") {
     assert(prompt.getDeploymentName == deploymentName)
     assert(prompt.getSubscriptionKey == openAIAPIKey)
     assert(prompt.getTemperature == 0.05)

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaultsSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaultsSuite.scala
@@ -10,11 +10,6 @@ class OpenAIDefaultsSuite extends Flaky with OpenAIAPIKey {
 
   import spark.implicits._
 
-  OpenAIDefaults.setDeploymentName(deploymentName)
-  OpenAIDefaults.setSubscriptionKey(openAIAPIKey)
-  OpenAIDefaults.setTemperature(0.05)
-
-
   def promptCompletion: OpenAICompletion = new OpenAICompletion()
     .setCustomServiceName(openAIServiceName)
     .setMaxTokens(200)
@@ -28,6 +23,10 @@ class OpenAIDefaultsSuite extends Flaky with OpenAIAPIKey {
   ).toDF("prompt")
 
   test("Completion w Globals") {
+    OpenAIDefaults.setDeploymentName(deploymentName)
+    OpenAIDefaults.setSubscriptionKey(openAIAPIKey)
+    OpenAIDefaults.setTemperature(0.05)
+
     val fromRow = CompletionResponse.makeFromRowConverter
     promptCompletion.transform(promptDF).collect().foreach(r =>
       fromRow(r.getAs[Row]("out")).choices.foreach(c =>
@@ -46,6 +45,10 @@ class OpenAIDefaultsSuite extends Flaky with OpenAIAPIKey {
   ).toDF("text", "category")
 
   test("OpenAIPrompt w Globals") {
+    OpenAIDefaults.setDeploymentName(deploymentName)
+    OpenAIDefaults.setSubscriptionKey(openAIAPIKey)
+    OpenAIDefaults.setTemperature(0.05)
+
     val nonNullCount = prompt
       .setPromptTemplate("here is a comma separated list of 5 {category}: {text}, ")
       .setPostProcessing("csv")
@@ -59,5 +62,25 @@ class OpenAIDefaultsSuite extends Flaky with OpenAIAPIKey {
     assert(prompt.getDeploymentName == deploymentName)
     assert(prompt.getSubscriptionKey == openAIAPIKey)
     assert(prompt.getTemperature == 0.05)
+  }
+
+  test("Test Getters") {
+    assert(OpenAIDefaults.getDeploymentName.contains(deploymentName))
+    assert(OpenAIDefaults.getSubscriptionKey.contains(openAIAPIKey))
+    assert(OpenAIDefaults.getTemperature.contains(0.05))
+  }
+
+  test("Test Resetters") {
+    OpenAIDefaults.setDeploymentName(deploymentName)
+    OpenAIDefaults.setSubscriptionKey(openAIAPIKey)
+    OpenAIDefaults.setTemperature(0.05)
+
+    OpenAIDefaults.resetDeploymentName()
+    OpenAIDefaults.resetSubscriptionKey()
+    OpenAIDefaults.resetTemperature()
+
+    assert(OpenAIDefaults.getDeploymentName.isEmpty)
+    assert(OpenAIDefaults.getSubscriptionKey.isEmpty)
+    assert(OpenAIDefaults.getTemperature.isEmpty)
   }
 }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPTransformer.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPTransformer.scala
@@ -7,7 +7,7 @@ import com.microsoft.azure.synapse.ml.codegen.Wrappable
 import com.microsoft.azure.synapse.ml.core.contracts.{HasInputCol, HasOutputCol}
 import com.microsoft.azure.synapse.ml.io.http.HandlingUtils.HandlerFunc
 import com.microsoft.azure.synapse.ml.logging.{FeatureNames, SynapseMLLogging}
-import com.microsoft.azure.synapse.ml.param.UDFParam
+import com.microsoft.azure.synapse.ml.param.{GlobalKey, GlobalParams, UDFParam}
 import org.apache.http.impl.client.CloseableHttpClient
 import org.apache.spark.injections.UDFUtils
 import org.apache.spark.ml.param._
@@ -76,9 +76,13 @@ trait ConcurrencyParams extends Wrappable {
   setDefault(concurrency -> 1, timeout -> 60.0)
 }
 
+case object URLKey extends GlobalKey[String]
+
 trait HasURL extends Params {
 
   val url: Param[String] = new Param[String](this, "url", "Url of the service")
+
+  GlobalParams.registerParam(url, URLKey)
 
   /** @group getParam */
   def getUrl: String = $(url)

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/param/GlobalParams.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/param/GlobalParams.scala
@@ -22,6 +22,10 @@ object GlobalParams {
     GlobalParams.get(key.asInstanceOf[GlobalKey[Any]]).map(_.asInstanceOf[T])
   }
 
+  def resetGlobalParam[T](key: GlobalKey[T]): Unit = {
+    GlobalParams -= key
+  }
+
   def getParam[T](p: Param[T]): Option[T] = {
     ParamToKeyMap.get(p).flatMap { key =>
       key match {

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/param/GlobalParams.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/param/GlobalParams.scala
@@ -18,7 +18,7 @@ object GlobalParams {
     GlobalParams(key) = value
   }
 
-  private def getGlobalParam[T](key: GlobalKey[T]): Option[T] = {
+  def getGlobalParam[T](key: GlobalKey[T]): Option[T] = {
     GlobalParams.get(key.asInstanceOf[GlobalKey[Any]]).map(_.asInstanceOf[T])
   }
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Wrap OpenAIDefaults to work for PySpark, and add URL as a OpenAIDefault. 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [X] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [X] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [X] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
