### PR TITLE
chore: Adding responseFormat parameter in OpenAI Chat Completion Request

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -279,7 +279,7 @@ trait HasOpenAITextParams extends HasOpenAISharedParams {
 
   // list of shared text parameters. In method getOptionalParams, we will iterate over these parameters
   // to compute the optional parameters. Since this list never changes, we can create it once and reuse it.
-  private val sharedTextParams = Seq(
+  private[openai] val sharedTextParams: Seq[ServiceParam[_]] = Seq(
     maxTokens,
     temperature,
     topP,

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
@@ -5,6 +5,7 @@ package com.microsoft.azure.synapse.ml.services.openai
 
 import com.microsoft.azure.synapse.ml.logging.{FeatureNames, SynapseMLLogging}
 import com.microsoft.azure.synapse.ml.param.AnyJsonFormat.anyFormat
+import com.microsoft.azure.synapse.ml.param.ServiceParam
 import com.microsoft.azure.synapse.ml.services.{HasCognitiveServiceInput, HasInternalJsonOutputParser}
 import org.apache.http.entity.{AbstractHttpEntity, ContentType, StringEntity}
 import org.apache.spark.ml.ComplexParamsReadable
@@ -16,10 +17,79 @@ import spray.json._
 
 import scala.language.existentials
 
+object OpenAIResponseFormat extends Enumeration {
+  case class ResponseFormat(paylodName: String, prompt: String) extends super.Val(paylodName)
+
+  val TEXT: ResponseFormat = ResponseFormat("text", "Output must be in text format")
+  val JSON: ResponseFormat = ResponseFormat("json_object", "Output must be in JSON format")
+
+  def asStringSet: Set[String] =
+    OpenAIResponseFormat.values.map(_.asInstanceOf[OpenAIResponseFormat.ResponseFormat].paylodName)
+}
+
+trait HasOpenAITextParamsExtended extends HasOpenAITextParams {
+  val responseFormat: ServiceParam[Map[String, String]] = new ServiceParam[Map[String, String]](
+    this,
+    "responseFormat",
+    "Response format for the completion. Can be 'json_object' or 'text'.",
+    isRequired = false) {
+    override val payloadName: String = "response_format"
+  }
+
+  def getResponseFormat: Map[String, String] = getScalarParam(responseFormat)
+
+  def setResponseFormat(value: Map[String, String]): this.type = {
+    val allowedFormat = OpenAIResponseFormat.asStringSet
+
+    // This test is to validate that value is properly formatted Map('type' -> '<format>')
+    if (value == null || value.size !=1  || !value.contains("type") || value("type").isEmpty) {
+      throw new IllegalArgumentException("Response format map must of the form Map('type' -> '<format>')"
+                                           + " where <format> is one of " + allowedFormat.mkString(", "))
+    }
+
+    // This test is to validate that the format is one of the allowed formats
+    if (!allowedFormat.contains(value("type").toLowerCase)) {
+      throw new IllegalArgumentException("Response format must be valid for OpenAI API. " +
+                                           "Currently supported formats are " +
+                                           allowedFormat.mkString(", "))
+    }
+    setScalarParam(responseFormat, value)
+  }
+
+  def setResponseFormat(value: String): this.type = {
+    if (value == null || value.isEmpty) {
+      this
+    } else {
+      setResponseFormat(Map("type" -> value.toLowerCase))
+    }
+  }
+
+  def setResponseFormat(value: OpenAIResponseFormat.ResponseFormat): this.type = {
+    setScalarParam(responseFormat, Map("type" -> value.paylodName))
+  }
+
+  // override this field to include the new parameter
+  override private[openai] val sharedTextParams: Seq[ServiceParam[_]] = Seq(
+    maxTokens,
+    temperature,
+    topP,
+    user,
+    n,
+    echo,
+    stop,
+    cacheLevel,
+    presencePenalty,
+    frequencyPenalty,
+    bestOf,
+    logProbs,
+    responseFormat
+    )
+}
+
 object OpenAIChatCompletion extends ComplexParamsReadable[OpenAIChatCompletion]
 
 class OpenAIChatCompletion(override val uid: String) extends OpenAIServicesBase(uid)
-  with HasOpenAITextParams with HasMessagesInput with HasCognitiveServiceInput
+  with HasOpenAITextParamsExtended with HasMessagesInput with HasCognitiveServiceInput
   with HasInternalJsonOutputParser with SynapseMLLogging {
   logClass(FeatureNames.AiServices.OpenAI)
 
@@ -54,13 +124,27 @@ class OpenAIChatCompletion(override val uid: String) extends OpenAIServicesBase(
 
   override def responseDataType: DataType = ChatCompletionResponse.schema
 
-  private[this] def getStringEntity(messages: Seq[Row], optionalParams: Map[String, Any]): StringEntity = {
+  // This method is used to convert the messages into a format that the OpenAI API can understand. The
+  // StringEntity returned by this method is in JSON format.
+  // It is marked as package private so that it can be tested.
+  private[openai] def getStringEntity(messages: Seq[Row], optionalParams: Map[String, Any]): StringEntity = {
     val mappedMessages: Seq[Map[String, String]] = messages.map { m =>
       Seq("role", "content", "name").map(n =>
         n -> Option(m.getAs[String](n))
       ).toMap.filter(_._2.isDefined).mapValues(_.get)
     }
-    val fullPayload = optionalParams.updated("messages", mappedMessages)
+
+    val mappedMessagesWithAdditionalMessages = {
+      // if response format is JSON, then openAI expects the prompt to contain instruction to return JSON
+      // for this reason, we add an additional message to the system prompt to ensure that the response is in JSON
+      if (isSet(responseFormat) && getResponseFormat("type") == OpenAIResponseFormat.JSON.paylodName) {
+        mappedMessages :+ Map("role" -> "system",
+                              "content" -> OpenAIResponseFormat.JSON.prompt)
+      } else {
+        mappedMessages
+      }
+    }
+    val fullPayload = optionalParams.updated("messages", mappedMessagesWithAdditionalMessages)
     new StringEntity(fullPayload.toJson.compactPrint, ContentType.APPLICATION_JSON)
   }
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPrompt.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPrompt.scala
@@ -150,7 +150,6 @@ class OpenAIPrompt(override val uid: String) extends Transformer
     transferGlobalParamsToParamMap()
     logTransform[DataFrame]({
       val df = dataset.toDF
-
       val completion = openAICompletion
       val promptCol = Functions.template(getPromptTemplate)
       val createMessagesUDF = udf((userMessage: String) => {
@@ -170,7 +169,6 @@ class OpenAIPrompt(override val uid: String) extends Transformer
 
           val transformed = addRAIErrors(
             completionNamed.transform(dfTemplated), chatCompletion.getErrorCol, chatCompletion.getOutputCol)
-
           val results = transformed
             .withColumn(getOutputCol,
               getParser.parse(F.element_at(F.col(completionNamed.getOutputCol).getField("choices"), 1)
@@ -190,7 +188,6 @@ class OpenAIPrompt(override val uid: String) extends Transformer
           val promptColName = df.withDerivativeCol("prompt")
           val dfTemplated = df.withColumn(promptColName, promptCol)
           val completionNamed = completion.setPromptCol(promptColName)
-
           // run completion
           val results = completionNamed
             .transform(dfTemplated)

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
@@ -254,7 +254,7 @@ class OpenAIChatCompletionSuite extends TransformerFuzzing[OpenAIChatCompletion]
       .setDeploymentName(deploymentNameGpt4o)
       .setCustomServiceName(openAIServiceName)
       .setApiVersion("2023-05-15")
-      .setMaxTokens(5000)
+      .setMaxTokens(500)
       .setOutputCol("out")
       .setMessagesCol("messages")
       .setTemperature(0)

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
@@ -210,6 +210,26 @@ class OpenAIChatCompletionSuite extends TransformerFuzzing[OpenAIChatCompletion]
   }
 
   test("validate that gpt4o accepts json_object response format") {
+    val goodDf: DataFrame = Seq(
+      Seq(
+        OpenAIMessage("system", "You are an AI chatbot with red as your favorite color"),
+        OpenAIMessage("system", OpenAIResponseFormat.JSON.prompt),
+        OpenAIMessage("user", "Whats your favorite color")
+        ),
+      Seq(
+        OpenAIMessage("system", "You are very excited"),
+        OpenAIMessage("system", OpenAIResponseFormat.JSON.prompt),
+        OpenAIMessage("user", "How are you today")
+        ),
+      Seq(
+        OpenAIMessage("system", OpenAIResponseFormat.JSON.prompt),
+        OpenAIMessage("system", "You are very excited"),
+        OpenAIMessage("user", "How are you today"),
+        OpenAIMessage("system", "Better than ever"),
+        OpenAIMessage("user", "Why?")
+        )
+      ).toDF("messages")
+
     val completion = new OpenAIChatCompletion()
       .setDeploymentName(deploymentNameGpt4o)
       .setCustomServiceName(openAIServiceName)

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
@@ -209,46 +209,6 @@ class OpenAIChatCompletionSuite extends TransformerFuzzing[OpenAIChatCompletion]
     }
   }
 
-  test("getStringEntity should add system message if response format is json_object") {
-    val completion = new OpenAIChatCompletion()
-      .setDeploymentName(deploymentNameGpt4)
-      .setMessagesCol("messages")
-      .setResponseFormat("json_object")
-      .setTemperature(0.7)
-
-    val messages: Seq[Row] = Seq(
-      OpenAIMessage("user", "Whats your favorite color")
-      ).toDF("role", "content", "name").collect()
-
-    val optionalParams: Map[String, Any] = completion.getOptionalParams(messages.head)
-
-    val expectedStringExcerpt = """{"role":"system","content":""" +"\"" + OpenAIResponseFormat.JSON.prompt + "\"}"
-    val actualStringEntity = completion.getStringEntity(messages, optionalParams)
-    val actualJsonString = IOUtils.toString(actualStringEntity.getContent, "UTF-8")
-    assert(actualJsonString.contains(expectedStringExcerpt))
-  }
-
-  test("getStringEntity should not add system message if response format is not json_object") {
-    val completion = new OpenAIChatCompletion()
-      .setDeploymentName(deploymentNameGpt4)
-      .setMessagesCol("messages")
-      .setResponseFormat("text")
-      .setTemperature(0.7)
-
-    val messages: Seq[Row] = Seq(
-      OpenAIMessage("user", "Whats your favorite color")
-      ).toDF("role", "content", "name").collect()
-
-    val optionalParams: Map[String, Any] = completion.getOptionalParams(messages.head)
-
-    val textFormatStringExcerpt = """{"role":"system","content":""" +"\"" + OpenAIResponseFormat.TEXT.prompt + "\"}"
-    val jsonFormatStringExcerpt = """{"role":"system","content":""" +"\"" + OpenAIResponseFormat.JSON.prompt + "\"}"
-    val actualStringEntity = completion.getStringEntity(messages, optionalParams)
-    val actualJsonString = IOUtils.toString(actualStringEntity.getContent, "UTF-8")
-    assert(!actualJsonString.contains(textFormatStringExcerpt))
-    assert(!actualJsonString.contains(jsonFormatStringExcerpt))
-  }
-
   test("validate that gpt4o accepts json_object response format") {
     val completion = new OpenAIChatCompletion()
       .setDeploymentName(deploymentNameGpt4o)

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
@@ -5,6 +5,7 @@ package com.microsoft.azure.synapse.ml.services.openai
 
 import com.microsoft.azure.synapse.ml.core.test.base.Flaky
 import com.microsoft.azure.synapse.ml.core.test.fuzzing.{TestObject, TransformerFuzzing}
+import org.apache.commons.io.IOUtils
 import org.apache.spark.ml.util.MLReadable
 import org.apache.spark.sql.{DataFrame, Row}
 import org.scalactic.Equality
@@ -149,6 +150,133 @@ class OpenAIChatCompletionSuite extends TransformerFuzzing[OpenAIChatCompletion]
     assert(Option(results.apply(1).getAs[Row](completion.getErrorCol)).isDefined)
     assert(Option(results.apply(2).getAs[Row](completion.getErrorCol)).isEmpty)
     assert(Option(results.apply(2).getAs[Row]("out")).isEmpty)
+  }
+
+  test("getOptionalParam should include responseFormat"){
+    val completion = new OpenAIChatCompletion()
+      .setDeploymentName(deploymentNameGpt4)
+
+    def validateResponseFormat(params: Map[String, Any], responseFormat: String): Unit = {
+      val responseFormatPayloadName = this.completion.responseFormat.payloadName
+      assert(params.contains(responseFormatPayloadName))
+      val responseFormatMap = params(responseFormatPayloadName).asInstanceOf[Map[String, String]]
+      assert(responseFormatMap.contains("type"))
+      assert(responseFormatMap("type") == responseFormat)
+    }
+
+    val messages: Seq[Row] = Seq(
+      OpenAIMessage("user", "Whats your favorite color")
+    ).toDF("role", "content", "name").collect()
+
+    val optionalParams: Map[String, Any] = completion.getOptionalParams(messages.head)
+    assert(!optionalParams.contains("response_format"))
+
+    completion.setResponseFormat("")
+    val optionalParams0: Map[String, Any] = completion.getOptionalParams(messages.head)
+    assert(!optionalParams0.contains("response_format"))
+
+    completion.setResponseFormat("json_object")
+    val optionalParams1: Map[String, Any] = completion.getOptionalParams(messages.head)
+    validateResponseFormat(optionalParams1, "json_object")
+
+    completion.setResponseFormat("text")
+    val optionalParams2: Map[String, Any] = completion.getOptionalParams(messages.head)
+    validateResponseFormat(optionalParams2, "text")
+
+    completion.setResponseFormat(Map("type" -> "json_object"))
+    val optionalParams3: Map[String, Any] = completion.getOptionalParams(messages.head)
+    validateResponseFormat(optionalParams3, "json_object")
+
+    completion.setResponseFormat(OpenAIResponseFormat.TEXT)
+    val optionalParams4: Map[String, Any] = completion.getOptionalParams(messages.head)
+    validateResponseFormat(optionalParams4, "text")
+  }
+
+  test("setResponseFormat should throw exception if invalid format"){
+    val completion = new OpenAIChatCompletion()
+      .setDeploymentName(deploymentNameGpt4)
+
+    assertThrows[IllegalArgumentException] {
+      completion.setResponseFormat("invalid_format")
+    }
+
+    assertThrows[IllegalArgumentException] {
+      completion.setResponseFormat(Map("type" -> "invalid_format"))
+    }
+
+    assertThrows[IllegalArgumentException] {
+      completion.setResponseFormat(Map("invalid_key" -> "json_object"))
+    }
+  }
+
+  test("getStringEntity should add system message if response format is json_object") {
+    val completion = new OpenAIChatCompletion()
+      .setDeploymentName(deploymentNameGpt4)
+      .setMessagesCol("messages")
+      .setResponseFormat("json_object")
+      .setTemperature(0.7)
+
+    val messages: Seq[Row] = Seq(
+      OpenAIMessage("user", "Whats your favorite color")
+      ).toDF("role", "content", "name").collect()
+
+    val optionalParams: Map[String, Any] = completion.getOptionalParams(messages.head)
+
+    val expectedStringExcerpt = """{"role":"system","content":""" +"\"" + OpenAIResponseFormat.JSON.prompt + "\"}"
+    val actualStringEntity = completion.getStringEntity(messages, optionalParams)
+    val actualJsonString = IOUtils.toString(actualStringEntity.getContent, "UTF-8")
+    assert(actualJsonString.contains(expectedStringExcerpt))
+  }
+
+  test("getStringEntity should not add system message if response format is not json_object") {
+    val completion = new OpenAIChatCompletion()
+      .setDeploymentName(deploymentNameGpt4)
+      .setMessagesCol("messages")
+      .setResponseFormat("text")
+      .setTemperature(0.7)
+
+    val messages: Seq[Row] = Seq(
+      OpenAIMessage("user", "Whats your favorite color")
+      ).toDF("role", "content", "name").collect()
+
+    val optionalParams: Map[String, Any] = completion.getOptionalParams(messages.head)
+
+    val textFormatStringExcerpt = """{"role":"system","content":""" +"\"" + OpenAIResponseFormat.TEXT.prompt + "\"}"
+    val jsonFormatStringExcerpt = """{"role":"system","content":""" +"\"" + OpenAIResponseFormat.JSON.prompt + "\"}"
+    val actualStringEntity = completion.getStringEntity(messages, optionalParams)
+    val actualJsonString = IOUtils.toString(actualStringEntity.getContent, "UTF-8")
+    assert(!actualJsonString.contains(textFormatStringExcerpt))
+    assert(!actualJsonString.contains(jsonFormatStringExcerpt))
+  }
+
+  test("validate that gpt4o accepts json_object response format") {
+    val completion = new OpenAIChatCompletion()
+      .setDeploymentName(deploymentNameGpt4o)
+      .setCustomServiceName(openAIServiceName)
+      .setApiVersion("2023-05-15")
+      .setMaxTokens(5000)
+      .setOutputCol("out")
+      .setMessagesCol("messages")
+      .setTemperature(0)
+      .setSubscriptionKey(openAIAPIKey)
+      .setResponseFormat("json_object")
+
+    testCompletion(completion, goodDf)
+  }
+
+  test("validate that gpt4 accepts text response format") {
+    val completion = new OpenAIChatCompletion()
+      .setDeploymentName(deploymentNameGpt4)
+      .setCustomServiceName(openAIServiceName)
+      .setApiVersion("2023-05-15")
+      .setMaxTokens(5000)
+      .setOutputCol("out")
+      .setMessagesCol("messages")
+      .setTemperature(0)
+      .setSubscriptionKey(openAIAPIKey)
+      .setResponseFormat("text")
+
+    testCompletion(completion, goodDf)
   }
 
   ignore("Custom EndPoint") {

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAICompletionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAICompletionSuite.scala
@@ -17,6 +17,7 @@ trait OpenAIAPIKey {
   lazy val deploymentName: String = "gpt-35-turbo"
   lazy val modelName: String = "gpt-35-turbo"
   lazy val deploymentNameGpt4: String = "gpt-4"
+  lazy val deploymentNameGpt4o: String = "gpt-4o"
   lazy val modelNameGpt4: String = "gpt-4"
 }
 

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
@@ -143,21 +143,20 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
       .setCustomServiceName(openAIServiceName)
       .setOutputCol("outParsed")
       .setTemperature(0)
-      .setResponseFormat(OpenAIResponseFormat.JSON)
+      .setPromptTemplate(
+        """Split a word into prefix and postfix
+          |Cherry: {{"prefix": "Che", "suffix": "rry"}}
+          |{text}:
+          |""".stripMargin)
+      .setResponseFormat("json_object")
+      .setPostProcessingOptions(Map("jsonSchema" -> "prefix STRING, suffix STRING"))
 
-    promptGpt4o.setPromptTemplate(
-                """Split a word into prefix and postfix
-                  |Cherry: {{"prefix": "Che", "suffix": "rry"}}
-                  |{text}:
-                  |""".stripMargin)
-              .setPostProcessing("json")
-              .setResponseFormat("json_object")
-              .setPostProcessingOptions(Map("jsonSchema" -> "prefix STRING, suffix STRING"))
-              .transform(df)
-              .select("outParsed")
-              .where(col("outParsed").isNotNull)
-              .collect()
-              .foreach(r => assert(r.getStruct(0).getString(0).nonEmpty))
+
+    promptGpt4o.transform(df)
+               .select("outParsed")
+               .where(col("outParsed").isNotNull)
+               .collect()
+               .foreach(r => assert(r.getStruct(0).getString(0).nonEmpty))
   }
 
   test("if responseFormat is set then appropriate system prompt should be present") {

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
@@ -136,6 +136,30 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
       .foreach(r => assert(r.get(0) != null))
   }
 
+  test("Basic Usage JSON - Gpt 4o with responseFormat") {
+    val promptGpt4o: OpenAIPrompt = new OpenAIPrompt()
+      .setSubscriptionKey(openAIAPIKey)
+      .setDeploymentName(deploymentNameGpt4o)
+      .setCustomServiceName(openAIServiceName)
+      .setOutputCol("outParsed")
+      .setTemperature(0)
+      .setResponseFormat(OpenAIResponseFormat.JSON)
+
+    promptGpt4o.setPromptTemplate(
+                """Split a word into prefix and postfix
+                  |Cherry: {{"prefix": "Che", "suffix": "rry"}}
+                  |{text}:
+                  |""".stripMargin)
+              .setPostProcessing("json")
+              .setResponseFormat("json_object")
+              .setPostProcessingOptions(Map("jsonSchema" -> "prefix STRING, suffix STRING"))
+              .transform(df)
+              .select("outParsed")
+              .where(col("outParsed").isNotNull)
+              .collect()
+              .foreach(r => assert(r.getStruct(0).getString(0).nonEmpty))
+  }
+
   ignore("Custom EndPoint") {
     lazy val accessToken: String = sys.env.getOrElse("CUSTOM_ACCESS_TOKEN", "")
     lazy val customRootUrlValue: String = sys.env.getOrElse("CUSTOM_ROOT_URL", "")

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
@@ -160,6 +160,14 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
               .foreach(r => assert(r.getStruct(0).getString(0).nonEmpty))
   }
 
+  test("if responseFormat is set then appropriate system prompt should be present") {
+    val prompt = new OpenAIPrompt()
+    prompt.setResponseFormat("json_object")
+    val messages = prompt.getPromptsForMessage("test")
+    assert(messages.nonEmpty)
+    messages.exists(p => p.role == "system" && p.content.contains(OpenAIResponseFormat.JSON.prompt))
+  }
+
   ignore("Custom EndPoint") {
     lazy val accessToken: String = sys.env.getOrElse("CUSTOM_ACCESS_TOKEN", "")
     lazy val customRootUrlValue: String = sys.env.getOrElse("CUSTOM_ROOT_URL", "")


### PR DESCRIPTION
OpenAI chat completion accepts `response_format` as request parameter. Setting this parameter as `json_object`guarantees that response from OpenAi service will be in JSON format. It does also require that one of the prompt must also have the word JSON in it. In this PR, we are adding a new field in request, which can be `json_object` or `text` as prescribed by OpenAI. In case it is set as `json_object`, then we also add a system prompt instructing openAI to respond in JSON format.

Unit tests have been added to validate this functionality

## What changes are proposed in this pull request?

We have added new field ChatCompletion class that takes responseFormat as parameter.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [X] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [X] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
