### PR TITLE
feat: giving the gift of vision to OpenAIChatCompletions

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
@@ -138,19 +138,11 @@ class OpenAIChatCompletion(override val uid: String) extends OpenAIServicesBase(
 
   private[openai] def getStringEntity(messages: Seq[Row], optionalParams: Map[String, Any]): StringEntity = {
     val mappedMessages: Seq[Map[String, String]] = messages.map { m =>
-      /** if (m.getAs[String]("type").equals("image_url")) {
-      //  Seq("role", "content", "name").map(n =>
-          n -> Option(m.getAs[String](n))
-        ).toMap.filter(_._2.isDefined).mapValues(_.get)
-      }
-      else { **/
-        Seq("role", "content", "name").map(n =>
-          n -> Option(m.getAs[String](n))
-        ).toMap.filter(_._2.isDefined).mapValues(_.get)
-      //}
+      Seq("role", "content", "name").map(n =>
+        n -> Option(m.getAs[String](n))
+      ).toMap.filter(_._2.isDefined).mapValues(_.get)
     }
     val fullPayload = optionalParams.updated("messages", mappedMessages)
-    println(fullPayload.toJson.compactPrint)
     new StringEntity(fullPayload.toJson.compactPrint, ContentType.APPLICATION_JSON)
   }
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
@@ -140,14 +140,13 @@ class OpenAIChatCompletion(override val uid: String) extends OpenAIServicesBase(
                                        messages: Seq[Row],
                                        optionalParams: Map[String, Any]
                                      ): StringEntity = {
-    import spray.json._
     import OpenAIJsonProtocol._
 
     val mappedMessages = messages.map { row =>
       val role  = row.getAs[String]("role")
       val name  = row.getAs[String]("name")
 
-      val maybeContent = Option(row.getAs[String]("content")) // This is the old usage
+      val maybeContent = Option(row.getAs[String]("content"))
       val maybeItems   = Option(row.getAs[Seq[Row]]("contentList")).map { rows =>
         rows.map { r =>
           val ctype = r.getAs[String]("type")
@@ -169,11 +168,8 @@ class OpenAIChatCompletion(override val uid: String) extends OpenAIServicesBase(
     }
 
     val messagesJson: JsValue = mappedMessages.toJson
-    val paramsJson = optionalParams.toJson
-    val paramsObj = paramsJson.asJsObject
-    val fullObj = JsObject(paramsObj.fields + ("messages" -> messagesJson))
-    val jsonString = fullObj.compactPrint
-    println(jsonString)
+    val paramsObj = optionalParams.toJson.asJsObject
+    val jsonString = JsObject(paramsObj.fields + ("messages" -> messagesJson)).compactPrint
     new StringEntity(jsonString, ContentType.APPLICATION_JSON)
   }
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
@@ -138,11 +138,19 @@ class OpenAIChatCompletion(override val uid: String) extends OpenAIServicesBase(
 
   private[openai] def getStringEntity(messages: Seq[Row], optionalParams: Map[String, Any]): StringEntity = {
     val mappedMessages: Seq[Map[String, String]] = messages.map { m =>
-      Seq("role", "content", "name").map(n =>
-        n -> Option(m.getAs[String](n))
-      ).toMap.filter(_._2.isDefined).mapValues(_.get)
+      /** if (m.getAs[String]("type").equals("image_url")) {
+      //  Seq("role", "content", "name").map(n =>
+          n -> Option(m.getAs[String](n))
+        ).toMap.filter(_._2.isDefined).mapValues(_.get)
+      }
+      else { **/
+        Seq("role", "content", "name").map(n =>
+          n -> Option(m.getAs[String](n))
+        ).toMap.filter(_._2.isDefined).mapValues(_.get)
+      //}
     }
     val fullPayload = optionalParams.updated("messages", mappedMessages)
+    println(fullPayload.toJson.compactPrint)
     new StringEntity(fullPayload.toJson.compactPrint, ContentType.APPLICATION_JSON)
   }
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAISchemas.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAISchemas.scala
@@ -4,8 +4,6 @@
 package com.microsoft.azure.synapse.ml.services.openai
 
 import com.microsoft.azure.synapse.ml.core.schema.SparkBindings
-import com.microsoft.azure.synapse.ml.param.ArrayMapJsonProtocol.MapJsonFormat
-import org.apache.spark.sql.Row
 import spray.json._
 
 object CompletionResponse extends SparkBindings[CompletionResponse]
@@ -100,7 +98,6 @@ object OpenAIJsonProtocol extends DefaultJsonProtocol {
         "role" -> JsString(msg.role)
       ) ++ msg.name.map("name" -> JsString(_))
 
-      // Decide how to write 'content':
       val contentField: (String, JsValue) = (msg.content, msg.contentList) match {
         case (Some(text), None) =>
           "content" -> JsString(text)

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAISchemas.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAISchemas.scala
@@ -35,7 +35,8 @@ case class EmbeddingObject(`object`: String,
                            embedding: Array[Double],
                            index: Int)
 
-case class OpenAIMessage(role: String, content: String, name: Option[String] = None)
+case class OpenAIMessage(role: String, content: String, name: Option[String] = None) //, `type`: String = "text" )
+// Either type for content
 
 case class OpenAIChatChoice(message: OpenAIMessage,
                             index: Long,

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAISchemas.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAISchemas.scala
@@ -36,15 +36,15 @@ case class EmbeddingObject(`object`: String,
                            embedding: Array[Double],
                            index: Int)
 
-final case class OpenAIMessage(
+case class OpenAIMessage(
                                 role: String,
                                 content: Option[String] = None,
                                 contentList: Option[Seq[OpenAIContentItem]] = None,
                                 name: Option[String] = None
                               )
-final case class ImageUrl(url: String)
+case class ImageUrl(url: String)
 
-final case class OpenAIContentItem(`type`: String,
+case class OpenAIContentItem(`type`: String,
                              text: Option[String] = None,
                              image_url: Option[ImageUrl] = None)
 
@@ -109,10 +109,13 @@ object OpenAIJsonProtocol extends DefaultJsonProtocol {
           "content" -> JsArray(items.map(_.toJson).toVector)
 
         case (None, None) =>
-          serializationError("OpenAIMessage MUST have both content & contentItems")
+          // how can we put these errors in the Error col?
+          //serializationError("OpenAIMessage CANNOT have both content & contentItems")
+          "content" -> JsString("")
 
         case (Some(_), Some(_)) =>
-          serializationError("OpenAIMessage cannot have both content & contentItems")
+          "content" -> JsString("")
+          //serializationError("OpenAIMessage cannot have both content & contentItems")
       }
 
       JsObject(baseFields + contentField)

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
@@ -157,16 +157,19 @@ class OpenAIChatCompletionSuite extends TransformerFuzzing[OpenAIChatCompletion]
 
   test("Basic Usage") {
     testCompletion(completion, goodDf)
-    //testCompletion(completion, slowDf)
+    testCompletion(completion, slowDf)
   }
 
   test("Image usage") {
     val results = completion.transform(imageDf)
     results.show(false)
+    testCompletion(completion, imageDf)
   }
 
   test("Robustness to bad inputs") {
-    val results = completion.transform(badDf).collect()
+    val transformed = completion.transform(badDf)
+    transformed.show(false)
+    val results = transformed.collect()
     assert(Option(results.head.getAs[Row](completion.getErrorCol)).isDefined)
     assert(Option(results.apply(1).getAs[Row](completion.getErrorCol)).isDefined)
     assert(Option(results.apply(2).getAs[Row](completion.getErrorCol)).isEmpty)
@@ -187,7 +190,7 @@ class OpenAIChatCompletionSuite extends TransformerFuzzing[OpenAIChatCompletion]
 
     val messages: Seq[Row] = Seq(
       OpenAIMessage("user", "Whats your favorite color")
-    ).toDF("role", "content", "name").collect()
+    ).toDF("role", "content", "contentList", "name").collect()
 
     val optionalParams: Map[String, Any] = completion.getOptionalParams(messages.head)
     assert(!optionalParams.contains("response_format"))

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
@@ -141,7 +141,7 @@ class OpenAIChatCompletionSuite extends TransformerFuzzing[OpenAIChatCompletion]
 
   test("Basic Usage") {
     testCompletion(completion, goodDf)
-    testCompletion(completion, slowDf)
+    //testCompletion(completion, slowDf)
   }
 
   test("Robustness to bad inputs") {


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

Adding image support to OpenAIChatCompletion 

_Briefly describe the changes included in this Pull Request._

## How is this patch tested?

Added just one image test for now - I will add more, especially checking base64 encodings and null values, soon! 

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [X] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [X] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
