### PR TITLE
chore: Removing unnecessary logs

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPClients.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPClients.scala
@@ -152,10 +152,11 @@ object HandlingUtils extends SparkLogging {
         case r: HttpPost => Try(IOUtils.toString(r.getEntity.getContent, "UTF-8")).getOrElse("")
         case r => r.getURI
       }
-      SynapseMLLogging.logMessage(s"sending $message")
+      SynapseMLLogging.logDebug(s"sending $message")
       val start = System.currentTimeMillis()
       val resp = sendWithRetries(client, req, retryTimes.toArray)
-      SynapseMLLogging.logMessage(s"finished sending (${System.currentTimeMillis() - start}ms) $message")
+      SynapseMLLogging.logMessage(
+        s"finished sending to ${req.getURI} took (${System.currentTimeMillis() - start}ms)")
       val respData = convertAndClose(resp)
       req.releaseConnection()
       respData

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/logging/SynapseMLLogging.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/logging/SynapseMLLogging.scala
@@ -88,6 +88,7 @@ object SynapseMLLogging extends Logging {
     logInfo(SASScrubber.scrub(message))
   }
 
+  override def logDebug(msg: => String): Unit = super.logDebug(msg)
 }
 
 trait SynapseMLLogging extends Logging {

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/logging/SynapseMLLogging.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/logging/SynapseMLLogging.scala
@@ -88,7 +88,7 @@ object SynapseMLLogging extends Logging {
     logInfo(SASScrubber.scrub(message))
   }
 
-  override def logDebug(msg: => String): Unit = super.logDebug(msg)
+  override def logDebug(msg: => String): Unit = super.logDebug(SASScrubber.scrub(msg))
 }
 
 trait SynapseMLLogging extends Logging {


### PR DESCRIPTION
We are putting all request contents into logs, which just add unnecessary noise in the logs and we add the same message twice. I am ensuring that message is only added for debug.


## What changes are proposed in this pull request?

Reduce log by not logging entire messages twice

## How is this patch tested?
Just removing logs

## Does this PR change any dependencies?

- [X] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [X] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.
