### PR TITLE
chore: Creating a bigger pool for E2E tests

### DIFF
--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchWriterSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchWriterSuite.scala
@@ -183,12 +183,12 @@ class SearchWriterSuite extends TestBase with AzureSearchKey with IndexJsonGette
 
   private def retryWithBackoff[T](f: => T,
                                   timeouts: List[Long] =
-                                  List(5000, 10000, 50000, 100000, 200000, 200000)): T = {
+                                  List.fill(60)(5 * 1000)): T = { // 5 minutes
     try {
       f
     } catch {
       case _: Exception if timeouts.nonEmpty =>
-        println(s"Sleeping for ${timeouts.head}")
+        println(s"Sleeping for ${timeouts.head} ms with ${timeouts.tail.length} attempts remaining")
         blocking {
           Thread.sleep(timeouts.head)
         }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/DatabricksCPUTests.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/DatabricksCPUTests.scala
@@ -10,7 +10,7 @@ import scala.language.existentials
 
 class DatabricksCPUTests extends DatabricksTestHelper {
 
-  val clusterId: String = createClusterInPool(ClusterName, AdbRuntime, NumWorkers, PoolId, memory = Some("7g"))
+  val clusterId: String = createClusterInPool(ClusterName, AdbRuntime, NumWorkers, PoolId, memory = Some("8g"))
 
   databricksTestHelper(clusterId, Libraries, CPUNotebooks)
 

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/DatabricksCPUTests.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/DatabricksCPUTests.scala
@@ -10,7 +10,7 @@ import scala.language.existentials
 
 class DatabricksCPUTests extends DatabricksTestHelper {
 
-  val clusterId: String = createClusterInPool(ClusterName, AdbRuntime, NumWorkers, PoolId, memory = Some("8g"))
+  val clusterId: String = createClusterInPool(ClusterName, AdbRuntime, NumWorkers, PoolId, memory = Some("7g"))
 
   databricksTestHelper(clusterId, Libraries, CPUNotebooks)
 

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/DatabricksUtilities.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/DatabricksUtilities.scala
@@ -36,7 +36,7 @@ object DatabricksUtilities {
   val AdbRuntime = "13.3.x-scala2.12"
   // https://docs.databricks.com/en/release-notes/runtime/13.3lts-ml.html
   val AdbGpuRuntime = "13.3.x-gpu-ml-scala2.12"
-  val NumWorkers = 5
+  val NumWorkers = 7
   val AutoTerminationMinutes = 15
 
   lazy val Token: String = sys.env.getOrElse("MML_ADB_TOKEN", Secrets.AdbToken)

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/SynapseUtilities.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/SynapseUtilities.scala
@@ -196,8 +196,8 @@ object SynapseUtilities {
          | "driverMemory" : "28g",
          | "driverCores" : 4,
          | "executorMemory" : "28g",
-         | "executorCores" : 8,
-         | "numExecutors" : 4,
+         | "executorCores" : 4,
+         | "numExecutors" : 2,
          | "conf" :
          |     {
          |         "spark.jars.packages" : "$SparkMavenPackageList",

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/SynapseUtilities.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/SynapseUtilities.scala
@@ -240,13 +240,13 @@ object SynapseUtilities {
        |    },
        |    "autoScale": {
        |      "enabled": "true",
-       |      "maxNodeCount": "10",
+       |      "maxNodeCount": "12",
        |      "minNodeCount": "3"
        |    },
        |    "cacheSize": "20",
        |    "dynamicExecutorAllocation": {
        |      "enabled": "true",
-       |      "maxExecutors": "8",
+       |      "maxExecutors": "11",
        |      "minExecutors": "2"
        |    },
        |    "isComputeIsolationEnabled": "false",

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/SynapseUtilities.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/SynapseUtilities.scala
@@ -196,8 +196,8 @@ object SynapseUtilities {
          | "driverMemory" : "28g",
          | "driverCores" : 4,
          | "executorMemory" : "28g",
-         | "executorCores" : 4,
-         | "numExecutors" : 2,
+         | "executorCores" : 8,
+         | "numExecutors" : 4,
          | "conf" :
          |     {
          |         "spark.jars.packages" : "$SparkMavenPackageList",


### PR DESCRIPTION
Our E2E tests are failing intermittently so I am increasing poolsize to see if this helps

## What changes are proposed in this pull request?

_Briefly describe the changes included in this Pull Request._

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [x] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
