### PR TITLE
fix: Adding trailing / to URLs set

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaults.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaults.scala
@@ -45,7 +45,8 @@ object OpenAIDefaults {
   }
 
   def setURL(v: String): Unit = {
-    GlobalParams.setGlobalParam(URLKey, v)
+    val url = if (v.endsWith("/")) v else v + "/"
+    GlobalParams.setGlobalParam(URLKey, url)
   }
 
   def getURL: Option[String] = {

--- a/cognitive/src/test/python/synapsemltest/services/openai/test_OpenAIDefaults.py
+++ b/cognitive/src/test/python/synapsemltest/services/openai/test_OpenAIDefaults.py
@@ -21,12 +21,12 @@ class TestOpenAIDefaults(unittest.TestCase):
         defaults.set_deployment_name("Bing Bong")
         defaults.set_subscription_key("SubKey")
         defaults.set_temperature(0.05)
-        defaults.set_URL("Test URL")
+        defaults.set_URL("Test URL/")
 
         self.assertEqual(defaults.get_deployment_name(), "Bing Bong")
         self.assertEqual(defaults.get_subscription_key(), "SubKey")
         self.assertEqual(defaults.get_temperature(), 0.05)
-        self.assertEqual(defaults.get_URL(), "Test URL")
+        self.assertEqual(defaults.get_URL(), "Test URL/")
 
     def test_resetters(self):
         defaults = OpenAIDefaults()
@@ -39,7 +39,7 @@ class TestOpenAIDefaults(unittest.TestCase):
         self.assertEqual(defaults.get_deployment_name(), "Bing Bong")
         self.assertEqual(defaults.get_subscription_key(), "SubKey")
         self.assertEqual(defaults.get_temperature(), 0.05)
-        self.assertEqual(defaults.get_URL(), "Test URL")
+        self.assertEqual(defaults.get_URL(), "Test URL/")
 
         defaults.reset_deployment_name()
         defaults.reset_subscription_key()


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

User found a bug where URLs set without a trailing "/" don't work. Checking for the "/" and adding it now. 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
