### PR TITLE
chore: improve databricks test logging

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/env/PackageUtils.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/env/PackageUtils.scala
@@ -19,7 +19,7 @@ object PackageUtils {
   val PackageName = s"synapseml_$ScalaVersionSuffix"
   val PackageMavenCoordinate = s"$PackageGroup:$PackageName:${BuildInfo.version}"
   // Use a fixed version for local testing
-  // val PackageMavenCoordinate = s"$PackageGroup:$PackageName:1.0.9"
+  // val PackageMavenCoordinate = s"$PackageGroup:$PackageName:1.0.10"
 
   private val AvroCoordinate = "org.apache.spark:spark-avro_2.12:3.4.1"
   val PackageRepository: String = SparkMLRepository

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/DatabricksRapidsTests.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/DatabricksRapidsTests.scala
@@ -3,8 +3,6 @@
 
 package com.microsoft.azure.synapse.ml.nbtest
 
-import com.microsoft.azure.synapse.ml.nbtest.DatabricksUtilities._
-
 import com.microsoft.azure.synapse.ml.build.BuildInfo
 import com.microsoft.azure.synapse.ml.core.env.FileUtilities
 import com.microsoft.azure.synapse.ml.nbtest.DatabricksUtilities._


### PR DESCRIPTION
Databricks test logs are overly verbose due to exception-based retry logic, obscuring contents.
- Using new `retryUntil` utility function which will show progress less verbosely for scenarios where we query an endpoint more frequently while waiting for completion.
- fixed a bug in `tryWithRetries` where the final delay passed is ignored.
- Databricks cluster id and name are printed for easier debugging upon creation.
- databricks test run name now shows notebook name instead of `test1`