### PR TITLE
fix: cache df in synthetic diff in differences nb test

### DIFF
--- a/docs/Explore Algorithms/Causal Inference/Quickstart - Synthetic difference in differences.ipynb
+++ b/docs/Explore Algorithms/Causal Inference/Quickstart - Synthetic difference in differences.ipynb
@@ -81,6 +81,7 @@
         "    .option(\"inferSchema\", True)\n",
         "    .csv(\"wasbs://publicwasb@mmlspark.blob.core.windows.net/smoking.csv\")\n",
         "    .select(\"state\", \"year\", \"cigsale\", \"california\", \"after_treatment\")\n",
+        "    .cache()\n",
         ")\n",
         "display(df)"
       ]


### PR DESCRIPTION
cache the df in synthdiff to prevent flaky test failures