### PR TITLE
fix: support scoring profiles in Azure Search index parsing

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchSchemas.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchSchemas.scala
@@ -17,12 +17,12 @@ case class IndexInfo(
                     name: Option[String],
                     fields: Seq[IndexField],
                     suggesters: Option[Seq[String]],
-                    scoringProfiles: Option[Seq[String]],
+                    scoringProfiles: Option[Seq[ScoringProfile]],
                     analyzers: Option[Seq[String]],
                     charFilters: Option[Seq[String]],
                     tokenizers: Option[Seq[String]],
                     tokenFilters: Option[Seq[String]],
-                    defaultScoringProfile: Option[Seq[String]],
+                    defaultScoringProfile: Option[String],
                     corsOptions: Option[Seq[String]],
                     vectorSearch: Option[VectorSearch]
                     )
@@ -59,6 +59,41 @@ case class VectorColParams(
                           dimension: Int
                           )
 
+case class ScoringFunction(
+                          `type`: String,
+                          boost: Option[Double],
+                          fieldName: String,
+                          interpolation: Option[String],
+                          freshness: Option[FreshnessFunction],
+                          magnitude: Option[MagnitudeFunction],
+                          distance: Option[DistanceFunction],
+                          tag: Option[TagFunction]
+                          )
+
+case class FreshnessFunction(boostingDuration: String)
+
+case class MagnitudeFunction(
+                            boostingRangeStart: Double,
+                            boostingRangeEnd: Double,
+                            constantBoostBeyondRange: Option[Boolean]
+                            )
+
+case class DistanceFunction(
+                           referencePointParameter: String,
+                           boostingDistance: Double
+                           )
+
+case class TagFunction(tagsParameter: String)
+
+case class ScoringProfile(
+                         name: String,
+                         text: Option[TextWeights],
+                         functions: Option[Seq[ScoringFunction]],
+                         functionAggregation: Option[String]
+                         )
+
+case class TextWeights(weights: Map[String, Double])
+
 case class IndexStats(documentCount: Int, storageSize: Int)
 
 case class IndexList(`@odata.context`: String, value: Seq[IndexName])
@@ -71,6 +106,13 @@ object AzureSearchProtocol extends DefaultJsonProtocol {
     "dimensions", "vectorSearchConfiguration"))
   implicit val AcEnc: RootJsonFormat[AlgorithmConfigs] = jsonFormat2(AlgorithmConfigs.apply)
   implicit val VsEnc: RootJsonFormat[VectorSearch] = jsonFormat1(VectorSearch.apply)
+  implicit val FfEnc: RootJsonFormat[FreshnessFunction] = jsonFormat1(FreshnessFunction.apply)
+  implicit val MfEnc: RootJsonFormat[MagnitudeFunction] = jsonFormat3(MagnitudeFunction.apply)
+  implicit val DfEnc: RootJsonFormat[DistanceFunction] = jsonFormat2(DistanceFunction.apply)
+  implicit val TfEnc: RootJsonFormat[TagFunction] = jsonFormat1(TagFunction.apply)
+  implicit val SfEnc: RootJsonFormat[ScoringFunction] = jsonFormat8(ScoringFunction.apply)
+  implicit val TwEnc: RootJsonFormat[TextWeights] = jsonFormat1(TextWeights.apply)
+  implicit val SpEnc: RootJsonFormat[ScoringProfile] = jsonFormat4(ScoringProfile.apply)
   implicit val IiEnc: RootJsonFormat[IndexInfo] = jsonFormat11(IndexInfo.apply)
   implicit val IsEnc: RootJsonFormat[IndexStats] = jsonFormat2(IndexStats.apply)
   implicit val InEnc: RootJsonFormat[IndexName] = jsonFormat1(IndexName.apply)

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchWriterSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchWriterSuite.scala
@@ -706,43 +706,15 @@ class SearchWriterSuite extends TestBase with AzureSearchKey with IndexJsonGette
   }
 
   test("Handle Azure Search index with scoring profiles") {
-    // Test parsing index JSON that includes scoring profiles
-    val indexJsonWithScoringProfile = """
-    {
-      "name": "test-index",
-      "fields": [
-        {
-          "name": "id",
-          "type": "Edm.String",
-          "key": true
-        },
-        {
-          "name": "date",
-          "type": "Edm.DateTimeOffset"
-        }
-      ],
-      "scoringProfiles": [
-        {
-          "name": "default_profiler",
-          "functionAggregation": "sum",
-          "functions": [
-            {
-              "type": "freshness",
-              "boost": 2.0,
-              "fieldName": "date",
-              "interpolation": "constant",
-              "freshness": {
-                "boostingDuration": "P1D"
-              }
-            }
-          ]
-        }
-      ]
-    }
-    """
-    // This should not throw a DeserializationException anymore
+    val indexJsonWithScoringProfile = """{"name": "test-index", "fields": [
+      {"name": "id", "type": "Edm.String", "key": true},
+      {"name": "date", "type": "Edm.DateTimeOffset"}
+    ], "scoringProfiles": [{
+      "name": "default_profiler", "functionAggregation": "sum",
+      "functions": [{"type": "freshness", "boost": 2.0, "fieldName": "date",
+        "interpolation": "constant", "freshness": {"boostingDuration": "P1D"}}]
+    }]}"""
     val parsedIndex = parseIndexJson(indexJsonWithScoringProfile)
-    // Verify the scoring profile was parsed correctly
     assert(parsedIndex.scoringProfiles.isDefined)
     assert(parsedIndex.scoringProfiles.get.length == 1)
     val scoringProfile = parsedIndex.scoringProfiles.get.head

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchWriterSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchWriterSuite.scala
@@ -740,10 +740,8 @@ class SearchWriterSuite extends TestBase with AzureSearchKey with IndexJsonGette
       ]
     }
     """
-    
     // This should not throw a DeserializationException anymore
     val parsedIndex = parseIndexJson(indexJsonWithScoringProfile)
-    
     // Verify the scoring profile was parsed correctly
     assert(parsedIndex.scoringProfiles.isDefined)
     assert(parsedIndex.scoringProfiles.get.length == 1)
@@ -752,7 +750,6 @@ class SearchWriterSuite extends TestBase with AzureSearchKey with IndexJsonGette
     assert(scoringProfile.functionAggregation.contains("sum"))
     assert(scoringProfile.functions.isDefined)
     assert(scoringProfile.functions.get.length == 1)
-    
     val function = scoringProfile.functions.get.head
     assert(function.`type` == "freshness")
     assert(function.boost.contains(2.0))

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchWriterSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchWriterSuite.scala
@@ -704,4 +704,60 @@ class SearchWriterSuite extends TestBase with AzureSearchKey with IndexJsonGette
     val indexJson = retryWithBackoff(getIndexJsonFromExistingIndex(azureSearchKey, testServiceName, in))
     assert(parseIndexJson(indexJson).fields.find(_.name == "vectorContent").get.vectorSearchConfiguration.nonEmpty)
   }
+
+  test("Handle Azure Search index with scoring profiles") {
+    // Test parsing index JSON that includes scoring profiles
+    val indexJsonWithScoringProfile = """
+    {
+      "name": "test-index",
+      "fields": [
+        {
+          "name": "id",
+          "type": "Edm.String",
+          "key": true
+        },
+        {
+          "name": "date",
+          "type": "Edm.DateTimeOffset"
+        }
+      ],
+      "scoringProfiles": [
+        {
+          "name": "default_profiler",
+          "functionAggregation": "sum",
+          "functions": [
+            {
+              "type": "freshness",
+              "boost": 2.0,
+              "fieldName": "date",
+              "interpolation": "constant",
+              "freshness": {
+                "boostingDuration": "P1D"
+              }
+            }
+          ]
+        }
+      ]
+    }
+    """
+    
+    // This should not throw a DeserializationException anymore
+    val parsedIndex = parseIndexJson(indexJsonWithScoringProfile)
+    
+    // Verify the scoring profile was parsed correctly
+    assert(parsedIndex.scoringProfiles.isDefined)
+    assert(parsedIndex.scoringProfiles.get.length == 1)
+    val scoringProfile = parsedIndex.scoringProfiles.get.head
+    assert(scoringProfile.name == "default_profiler")
+    assert(scoringProfile.functionAggregation.contains("sum"))
+    assert(scoringProfile.functions.isDefined)
+    assert(scoringProfile.functions.get.length == 1)
+    
+    val function = scoringProfile.functions.get.head
+    assert(function.`type` == "freshness")
+    assert(function.boost.contains(2.0))
+    assert(function.fieldName == "date")
+    assert(function.freshness.isDefined)
+    assert(function.freshness.get.boostingDuration == "P1D")
+  }
 }


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Fixes #2382

## What changes are proposed in this pull request?

Fixes `DeserializationException` when writing data to Azure Search indices that contain scoring profiles. The JSON parser was expecting scoring profiles to be simple strings but Azure Search returns complex JSON objects.

**Changes:**
- Add proper case classes for scoring profiles (`ScoringProfile`, `ScoringFunction`, etc.) in `AzureSearchSchemas.scala`
- Update `IndexInfo.scoringProfiles` type from `Option[Seq[String]]` to `Option[Seq[ScoringProfile]]`
- Add JSON formatters for all scoring profile-related case classes in `AzureSearchProtocol`
- Support all scoring function types: freshness, magnitude, distance, and tag functions
- Add comprehensive test to verify scoring profile parsing works correctly

This allows users to write data to Azure Search indices that have scoring profiles configured, which is common in production scenarios for relevance tuning.

## How is this patch tested?

- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

**Tests added:**
- `test("Handle Azure Search index with scoring profiles")` - Verifies parsing of index JSON containing scoring profiles
- Test covers complex scoring profile with freshness function, boost values, and aggregation
- Test validates all scoring profile fields are parsed correctly (name, functionAggregation, functions, etc.)
- Test ensures no `DeserializationException` is thrown when parsing scoring profiles

## Does this PR change any dependencies?

- [x] No. You can skip this section.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No. You can skip this section.
