### PR TITLE
chore: Fixing logic for polling in LRO tasks

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
@@ -347,14 +347,15 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
   }
 
   protected def addHeaders(req: HttpRequestBase,
-                           row: Row): Unit = {
+                           row: Row,
+                           addContentType: Boolean = true): Unit = {
 
-    val headers = getHeaders(row)
+    val headers = getHeaders(row, addContentType)
     headers.foreach { case (headerName, headerValue) => req.addHeader(headerName, headerValue) }
   }
 
   // Returns a list of key-value pairs representing the headers
-  protected def getHeaders(row: Row): Map[String, String] = {
+  protected def getHeaders(row: Row, addContentType: Boolean = true): Map[String, String] = {
     val headers = mutable.Map.empty[String, String]
     val subscriptionKeyOpt = getValueOpt(row, subscriptionKey)
     val aadTokenOpt = getValueOpt(row, AADToken)
@@ -383,7 +384,7 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
       }
     }
 
-    if (!StringUtils.isEmpty(contentTypeValue)) {
+    if (addContentType && !StringUtils.isEmpty(contentTypeValue)) {
       headers += ("Content-Type" -> contentTypeValue)
     }
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
@@ -12,6 +12,7 @@ import com.microsoft.azure.synapse.ml.logging.SynapseMLLogging
 import com.microsoft.azure.synapse.ml.logging.common.PlatformDetails
 import com.microsoft.azure.synapse.ml.param.{ GlobalKey, GlobalParams, HasGlobalParams, ServiceParam }
 import com.microsoft.azure.synapse.ml.stages.{ DropColumns, Lambda }
+import org.apache.commons.lang.StringUtils
 import org.apache.http.NameValuePair
 import org.apache.http.client.methods.{ HttpEntityEnclosingRequestBase, HttpPost, HttpRequestBase }
 import org.apache.http.client.utils.URLEncodedUtils
@@ -348,12 +349,12 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
   protected def addHeaders(req: HttpRequestBase,
                            row: Row): Unit = {
 
-    val headers = geHeaders(row)
+    val headers = getHeaders(row)
     headers.foreach { case (headerName, headerValue) => req.addHeader(headerName, headerValue) }
   }
 
   // Returns a list of key-value pairs representing the headers
-  protected def geHeaders(row: Row): Map[String, String] = {
+  protected def getHeaders(row: Row): Map[String, String] = {
     val headers = mutable.Map.empty[String, String]
     val subscriptionKeyOpt = getValueOpt(row, subscriptionKey)
     val aadTokenOpt = getValueOpt(row, AADToken)
@@ -381,6 +382,11 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
         }
       }
     }
+
+    if (!StringUtils.isEmpty(contentTypeValue)) {
+      headers += ("Content-Type" -> contentTypeValue)
+    }
+
     new scala.collection.immutable.TreeMap[String, String]() ++ headers
   }
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
@@ -354,7 +354,7 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
 
   // Returns a list of key-value pairs representing the headers
   protected def geHeaders(row: Row): Map[String, String] = {
-    var headers = mutable.Map.empty[String, String]
+    val headers = mutable.Map.empty[String, String]
     val subscriptionKeyOpt = getValueOpt(row, subscriptionKey)
     val aadTokenOpt = getValueOpt(row, AADToken)
     val contentTypeValue = contentType(row)
@@ -381,7 +381,6 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
         }
       }
     }
-    if (contentTypeValue != "") headers += ("Content-Type" -> contentTypeValue)
     new scala.collection.immutable.TreeMap[String, String]() ++ headers
   }
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/geospatial/AzureMapsTraits.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/geospatial/AzureMapsTraits.scala
@@ -90,7 +90,7 @@ trait HasAddressInput extends HasServiceParams {
 
 trait MapsAsyncReply extends HasAsyncReply {
 
-  protected def queryForResult(key: Option[String], client: CloseableHttpClient,
+  protected def queryForResult(headers: Map[String, String], client: CloseableHttpClient,
                                location: URI): Option[HTTPResponseData] = {
     val statusRequest = new HttpGet()
     statusRequest.setURI(location)
@@ -116,7 +116,7 @@ trait MapsAsyncReply extends HasAsyncReply {
       val maxTries = getMaxPollingRetries
       val location = new URI(response.headers.filter(_.name.toLowerCase() == "location").head.value)
       val it = (0 to maxTries).toIterator.flatMap { _ =>
-        queryForResult(None, client, location).orElse({
+        queryForResult(Map.empty, client, location).orElse({
           blocking {
             Thread.sleep(getPollingDelay.toLong)
           }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/language/AnalyzeTextLROTraits.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/language/AnalyzeTextLROTraits.scala
@@ -540,10 +540,10 @@ trait ModifiableAsyncReply extends BasicAsyncReply {
   /**
    * Queries for the result of an asynchronous service call and applies the response modification logic.
    */
-  override final protected def queryForResult(key: Option[String],
+  override final protected def queryForResult(headers: Map[String, String],
                                               client: CloseableHttpClient,
                                               location: URI): Option[HTTPResponseData] = {
-    val originalResponse = super.queryForResult(key, client, location)
+    val originalResponse = super.queryForResult(headers, client, location)
     logDebug(s"Original response: $originalResponse")
     modifyResponse(originalResponse)
   }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/text/TextAnalytics.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/text/TextAnalytics.scala
@@ -168,14 +168,7 @@ private[ml] abstract class TextAnalyticsBaseNoBinding(uid: String)
       } else {
         import TAJSONFormat._
         val post = new HttpPost(prepareUrl(row))
-        addHeaders(
-          post,
-          getValueOpt(row, subscriptionKey),
-          getValueOpt(row, AADToken),
-          contentType(row),
-          getCustomAuthHeader(row),
-          getCustomHeaders(row)
-        )
+        addHeaders(post, row)
         val json = TARequest(makeDocuments(row)).toJson.compactPrint
         post.setEntity(new StringEntity(json, "UTF-8"))
         Some(post)
@@ -642,14 +635,7 @@ class TextAnalyze(override val uid: String) extends TextAnalyticsBaseNoBinding(u
         None
       } else {
         val post = new HttpPost(getUrl)
-        addHeaders(
-          post,
-          getValueOpt(row, subscriptionKey),
-          getValueOpt(row, AADToken),
-          contentType(row),
-          getCustomAuthHeader(row),
-          getCustomHeaders(row)
-        )
+        addHeaders(post, row)
         val tasks = TextAnalyzeTasks(
           entityRecognitionTasks = getTaskHelper(getIncludeEntityRecognition, getEntityRecognitionParams),
           entityLinkingTasks = getTaskHelper(getIncludeEntityLinking, getEntityLinkingParams),

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/translate/DocumentTranslator.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/translate/DocumentTranslator.scala
@@ -29,12 +29,12 @@ trait DocumentTranslatorAsyncReply extends BasicAsyncReply {
 
   import TranslatorJsonProtocol._
 
-  override protected def queryForResult(key: Option[String],
+  override protected def queryForResult(headers: Map[String, String],
                                         client: CloseableHttpClient,
                                         location: URI): Option[HTTPResponseData] = {
     val get = new HttpGet()
     get.setURI(location)
-    key.foreach(get.setHeader("Ocp-Apim-Subscription-Key", _))
+    headers.foreach { case (k, v) => get.setHeader(k, v) }
     get.setHeader("User-Agent", s"synapseml/${BuildInfo.version}${HeaderValues.PlatformInfo}")
     val resp = convertAndClose(sendWithRetries(client, get, getBackoffs))
     get.releaseConnection()

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/translate/TextTranslator.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/translate/TextTranslator.scala
@@ -110,14 +110,7 @@ trait TextAsOnlyEntity extends HasTextInput with HasCognitiveServiceInput with H
         }
 
         val post = new HttpPost(base + appended)
-        addHeaders(
-          post,
-          getValueOpt(row, subscriptionKey),
-          getValueOpt(row, AADToken),
-          contentType(row),
-          getCustomAuthHeader(row),
-          getCustomHeaders(row)
-        )
+        addHeaders(post, row)
         getValueOpt(row, subscriptionRegion).foreach(post.setHeader("Ocp-Apim-Subscription-Region", _))
 
         val json = texts.map(s => Map("Text" -> s)).toJson.compactPrint
@@ -255,14 +248,7 @@ class Translate(override val uid: String) extends TextTranslatorBase(uid)
         }
 
         val post = new HttpPost(base + appended)
-        addHeaders(
-          post,
-          getValueOpt(row, subscriptionKey),
-          getValueOpt(row, AADToken),
-          contentType(row),
-          getCustomAuthHeader(row),
-          getCustomHeaders(row)
-        )
+        addHeaders(post, row)
         getValueOpt(row, subscriptionRegion).foreach(post.setHeader("Ocp-Apim-Subscription-Region", _))
 
         val json = texts.map(s => Map("Text" -> s)).toJson.compactPrint
@@ -547,14 +533,7 @@ class DictionaryExamples(override val uid: String) extends TextTranslatorBase(ui
           }
 
           val post = new HttpPost(base + appended)
-          addHeaders(
-            post,
-            getValueOpt(row, subscriptionKey),
-            getValueOpt(row, AADToken),
-            contentType(row),
-            getCustomAuthHeader(row),
-            getCustomHeaders(row)
-          )
+          addHeaders(post, row)
           getValueOpt(row, subscriptionRegion).foreach(post.setHeader("Ocp-Apim-Subscription-Region", _))
 
           val json = textAndTranslations.head.getClass.getTypeName match {

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/vision/ComputerVision.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/vision/ComputerVision.scala
@@ -86,7 +86,7 @@ trait HasImageInput extends HasImageUrl
       } else {
         val req = prepareMethod()
         req.setURI(new URI(rowToUrl(row)))
-        addHeaders(req, row)
+        addHeaders(req, row, addContentType = false)
         req match {
           case er: HttpEntityEnclosingRequestBase =>
             rowToEntity(row).foreach(er.setEntity)

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/vision/ComputerVision.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/vision/ComputerVision.scala
@@ -358,10 +358,8 @@ trait HasAsyncReply extends Params {
     suppressMaxRetriesException -> false)
   //scalastyle:on magic.number
 
-  protected def headerNamesForPolling: Set[String] = Set("Ocp-Apim-Subscription-Key", "Authorization")
-
   protected def extractHeaderValuesForPolling(request: HTTPRequestData): Map[String, String] = {
-    request.headers.filter(h => headerNamesForPolling.contains(h.name)).map(h => h.name -> h.value).toMap
+    request.headers.map(h => h.name -> h.value).toMap
   }
 
   protected def queryForResult(headers: Map[String, String],

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/vision/ComputerVision.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/vision/ComputerVision.scala
@@ -86,13 +86,7 @@ trait HasImageInput extends HasImageUrl
       } else {
         val req = prepareMethod()
         req.setURI(new URI(rowToUrl(row)))
-        addHeaders(req,
-          getValueOpt(row, subscriptionKey),
-          getValueOpt(row, AADToken),
-          "",
-          getCustomAuthHeader(row),
-          getCustomHeaders(row)
-        )
+        addHeaders(req, row)
         req match {
           case er: HttpEntityEnclosingRequestBase =>
             rowToEntity(row).foreach(er.setEntity)
@@ -223,12 +217,14 @@ object RecognizeText extends ComplexParamsReadable[RecognizeText] {
 
 trait BasicAsyncReply extends HasAsyncReply {
 
-  override protected def queryForResult(key: Option[String],
+  override protected def queryForResult(headers: Map[String, String],
                                         client: CloseableHttpClient,
                                         location: URI): Option[HTTPResponseData] = {
     val get = new HttpGet()
     get.setURI(location)
-    key.foreach(get.setHeader("Ocp-Apim-Subscription-Key", _))
+    headers.foreach { case (name, value) =>
+      get.setHeader(name, value)
+    }
     get.setHeader("User-Agent", s"synapseml/${BuildInfo.version}${HeaderValues.PlatformInfo}")
     val resp = convertAndClose(sendWithRetries(client, get, getBackoffs))
     get.releaseConnection()
@@ -271,12 +267,12 @@ trait BasicAsyncReply extends HasAsyncReply {
       val originalLocation = new URI(response.headers.filter(_.name.toLowerCase() == "operation-location").head.value)
       val location = modifyPollingURI(originalLocation)
       val maxTries = getMaxPollingRetries
-      val key = request.headers.find(_.name == "Ocp-Apim-Subscription-Key").map(_.value)
+      val headers = extractHeaderValuesForPolling(request)
       blocking {
         Thread.sleep(getInitialPollingDelay.toLong)
       }
       val it = (0 to maxTries).toIterator.flatMap { i =>
-        queryForResult(key, client, location).orElse({
+        queryForResult(headers, client, location).orElse({
           blocking {
             Thread.sleep(getPollingDelay.toLong)
           }
@@ -362,7 +358,13 @@ trait HasAsyncReply extends Params {
     suppressMaxRetriesException -> false)
   //scalastyle:on magic.number
 
-  protected def queryForResult(key: Option[String],
+  protected def headerNamesForPolling: Set[String] = Set("Ocp-Apim-Subscription-Key", "Authorization")
+
+  protected def extractHeaderValuesForPolling(request: HTTPRequestData): Map[String, String] = {
+    request.headers.filter(h => headerNamesForPolling.contains(h.name)).map(h => h.name -> h.value).toMap
+  }
+
+  protected def queryForResult(headers: Map[String, String],
                                client: CloseableHttpClient,
                                location: URI): Option[HTTPResponseData]
 

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/language/AnalyzeTextLROSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/language/AnalyzeTextLROSuite.scala
@@ -6,7 +6,6 @@ package com.microsoft.azure.synapse.ml.services.language
 import com.microsoft.azure.synapse.ml.core.test.fuzzing.{ TestObject, TransformerFuzzing }
 import com.microsoft.azure.synapse.ml.services.text.{ SentimentAssessment, TextEndpoint }
 import com.microsoft.azure.synapse.ml.Secrets
-import com.microsoft.azure.synapse.ml.Secrets.getAccessToken
 import org.apache.spark.ml.util.MLReadable
 import org.apache.spark.sql.{ DataFrame, Row }
 import org.apache.spark.sql.functions.{ col, flatten, map }
@@ -94,6 +93,7 @@ class ExtractiveSummarizationSuite extends TransformerFuzzing[AnalyzeTextLongRun
       assert(sentence.getAs[Int]("length") > 0)
     }
   }
+
 
   test("show-stats and sentence-count") {
     val sentenceCount = 10

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/language/AnalyzeTextLROSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/language/AnalyzeTextLROSuite.scala
@@ -95,39 +95,6 @@ class ExtractiveSummarizationSuite extends TransformerFuzzing[AnalyzeTextLongRun
     }
   }
 
-
-  test("Basic usage with AAD Token") {
-    val model: AnalyzeTextLongRunningOperations = new AnalyzeTextLongRunningOperations()
-      .setAADToken(getAccessToken("https://cognitiveservices.azure.com/"))
-      .setLocation(textApiLocation)
-      .setTextCol("text")
-      .setLanguage("en")
-      .setKind(AnalysisTaskKind.ExtractiveSummarization)
-      .setOutputCol("response")
-      .setErrorCol("error")
-    val responses = model.transform(df)
-                         .withColumn("documents", col("response.documents"))
-                         .withColumn("modelVersion", col("response.modelVersion"))
-                         .withColumn("errors", col("response.errors"))
-                         .withColumn("statistics", col("response.statistics"))
-                         .collect()
-    assert(responses.length == 1)
-    val response = responses.head
-    val documents = response.getAs[Seq[Row]]("documents")
-    val errors = response.getAs[Seq[Row]]("errors")
-    assert(documents.length == errors.length)
-    assert(documents.length == 3)
-    val sentences = documents.head.getAs[Seq[Row]]("sentences")
-    assert(sentences.nonEmpty)
-    sentences.foreach { sentence =>
-      assert(sentence.getAs[String]("text").nonEmpty)
-      assert(sentence.getAs[Double]("rankScore") > 0.0)
-      assert(sentence.getAs[Int]("offset") >= 0)
-      assert(sentence.getAs[Int]("length") > 0)
-    }
-  }
-
-
   test("show-stats and sentence-count") {
     val sentenceCount = 10
     val model: AnalyzeTextLongRunningOperations = new AnalyzeTextLongRunningOperations()


### PR DESCRIPTION
## Related Issues/PRs

We have found that for Analytics LRO service, auth headers were not correctly passed as a result for polling the service was failing. We have now refactored the code and we are now passing in all headers. for polling


## Does this PR change any dependencies?

- [X] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [X] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
