### PR TITLE
chore: Updating codecov pipeline step

### DIFF
--- a/templates/codecov.yml
+++ b/templates/codecov.yml
@@ -4,7 +4,8 @@ steps:
       curl -Os https://cli.codecov.io/latest/linux/codecov
       chmod +x codecov
       echo "Starting Codecov Upload"
-      ./codecov --verbose upload-process  -t $(codecov-token)
+      ./codecov --verbose upload-process -t $(codecov-token) --dir .
+      echo "Codecov Upload Complete" # Ensure that uploading failure does not stop the pipeline
     retryCountOnTaskFailure: 1
     displayName: Upload Coverage Report To Codecov.io
     condition: succeededOrFailed()

--- a/templates/codecov.yml
+++ b/templates/codecov.yml
@@ -1,10 +1,10 @@
 steps:
   - bash: |
       set -e
-      curl -s https://codecov.io/bash > .codecov
-      chmod +x .codecov
+      curl -Os https://cli.codecov.io/latest/linux/codecov
+      chmod +x codecov
       echo "Starting Codecov Upload"
-      ./.codecov -t $(codecov-token)
+      ./codecov --verbose upload-process  -t $(codecov-token)
     retryCountOnTaskFailure: 1
     displayName: Upload Coverage Report To Codecov.io
     condition: succeededOrFailed()


### PR DESCRIPTION
## Why we need this change?

Codecov bash uploader has been deprecated and causing intermittent pipeline failures. As per Codecov recommendation we are moving to use the cli to upload.

## What changes are proposed in this pull request?

Updated pipeline step to run codecov cli.

## How is this patch tested?

Merge validation pipeline would run without error 

## Does this PR change any dependencies?

- [X] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [X] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.
