### PR TITLE
feat: Support OpenAI's Responses API

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAISchemas.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAISchemas.scala
@@ -41,18 +41,33 @@ case class OpenAIChatChoice(message: OpenAIMessage,
                             index: Long,
                             finish_reason: String)
 
-case class OpenAIUsage(completion_tokens: Long, prompt_tokens: Long, total_tokens: Long)
+case class ChatUsage(completion_tokens: Long, prompt_tokens: Long, total_tokens: Long)
 
-case class ChatCompletionResponse(id: String,
+case class ChatModelResponse(id: String,
                                   `object`: String,
                                   created: String,
                                   model: String,
                                   choices: Seq[OpenAIChatChoice],
                                   system_fingerprint: Option[String],
-                                  usage: Option[OpenAIUsage])
+                                  usage: Option[ChatUsage])
 
-object ChatCompletionResponse extends SparkBindings[ChatCompletionResponse]
+object ChatModelResponse extends SparkBindings[ChatModelResponse]
 
 object OpenAIJsonProtocol extends DefaultJsonProtocol {
   implicit val MessageEnc: RootJsonFormat[OpenAIMessage] = jsonFormat3(OpenAIMessage.apply)
 }
+
+case class ResponsesOutputContentComponent(`type`: String, text: String)
+case class OpenAIResponsesChoice(content: Seq[ResponsesOutputContentComponent], status: String)
+
+case class ResponsesUsage(output_tokens: Long, input_tokens: Long, total_tokens: Long)
+
+case class ResponsesModelResponse(id: String,
+                                  `object`: String,
+                                  created_at: String,
+                                  model: String,
+                                  output: Seq[OpenAIResponsesChoice],
+                                  system_fingerprint: Option[String],
+                                  usage: Option[ResponsesUsage])
+
+object ResponsesModelResponse extends SparkBindings[ResponsesModelResponse]

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/aifoundry/AIFoundryChatCompletionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/aifoundry/AIFoundryChatCompletionSuite.scala
@@ -133,7 +133,7 @@ class AIFoundryChatCompletionSuite extends TransformerFuzzing[AIFoundryChatCompl
     val optionalParams3: Map[String, Any] = completion.getOptionalParams(messages.head)
     validateResponseFormat(optionalParams3, "json_object")
 
-    completion.setResponseFormat(OpenAIResponseFormat.TEXT)
+    completion.setResponseFormat(OpenAIChatCompletionResponseFormat.TEXT)
     val optionalParams4: Map[String, Any] = completion.getOptionalParams(messages.head)
     validateResponseFormat(optionalParams4, "text")
   }
@@ -159,16 +159,16 @@ class AIFoundryChatCompletionSuite extends TransformerFuzzing[AIFoundryChatCompl
     val goodDf: DataFrame = Seq(
       Seq(
         OpenAIMessage("system", "You are an AI chatbot with red as your favorite color"),
-        OpenAIMessage("system", OpenAIResponseFormat.JSON.prompt),
+        OpenAIMessage("system", OpenAIChatCompletionResponseFormat.JSON.prompt),
         OpenAIMessage("user", "Whats your favorite color")
       ),
       Seq(
         OpenAIMessage("system", "You are very excited"),
-        OpenAIMessage("system", OpenAIResponseFormat.JSON.prompt),
+        OpenAIMessage("system", OpenAIChatCompletionResponseFormat.JSON.prompt),
         OpenAIMessage("user", "How are you today")
       ),
       Seq(
-        OpenAIMessage("system", OpenAIResponseFormat.JSON.prompt),
+        OpenAIMessage("system", OpenAIChatCompletionResponseFormat.JSON.prompt),
         OpenAIMessage("system", "You are very excited"),
         OpenAIMessage("user", "How are you today"),
         OpenAIMessage("system", "Better than ever"),
@@ -191,7 +191,7 @@ class AIFoundryChatCompletionSuite extends TransformerFuzzing[AIFoundryChatCompl
   }
 
   def testCompletion(completion: AIFoundryChatCompletion, df: DataFrame, requiredLength: Int = 10): Unit = {
-    val fromRow = ChatCompletionResponse.makeFromRowConverter
+    val fromRow = ChatModelResponse.makeFromRowConverter
     completion.transform(df).collect().foreach(r =>
       fromRow(r.getAs[Row]("out")).choices.foreach(c =>
         assert(c.message.content.length > requiredLength)))

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletionSuite.scala
@@ -187,7 +187,7 @@ class OpenAIChatCompletionSuite extends TransformerFuzzing[OpenAIChatCompletion]
     val optionalParams3: Map[String, Any] = completion.getOptionalParams(messages.head)
     validateResponseFormat(optionalParams3, "json_object")
 
-    completion.setResponseFormat(OpenAIResponseFormat.TEXT)
+    completion.setResponseFormat(OpenAIChatCompletionResponseFormat.TEXT)
     val optionalParams4: Map[String, Any] = completion.getOptionalParams(messages.head)
     validateResponseFormat(optionalParams4, "text")
   }
@@ -213,16 +213,16 @@ class OpenAIChatCompletionSuite extends TransformerFuzzing[OpenAIChatCompletion]
     val goodDf: DataFrame = Seq(
       Seq(
         OpenAIMessage("system", "You are an AI chatbot with red as your favorite color"),
-        OpenAIMessage("system", OpenAIResponseFormat.JSON.prompt),
+        OpenAIMessage("system", OpenAIChatCompletionResponseFormat.JSON.prompt),
         OpenAIMessage("user", "Whats your favorite color")
         ),
       Seq(
         OpenAIMessage("system", "You are very excited"),
-        OpenAIMessage("system", OpenAIResponseFormat.JSON.prompt),
+        OpenAIMessage("system", OpenAIChatCompletionResponseFormat.JSON.prompt),
         OpenAIMessage("user", "How are you today")
         ),
       Seq(
-        OpenAIMessage("system", OpenAIResponseFormat.JSON.prompt),
+        OpenAIMessage("system", OpenAIChatCompletionResponseFormat.JSON.prompt),
         OpenAIMessage("system", "You are very excited"),
         OpenAIMessage("user", "How are you today"),
         OpenAIMessage("system", "Better than ever"),
@@ -283,7 +283,7 @@ class OpenAIChatCompletionSuite extends TransformerFuzzing[OpenAIChatCompletion]
   }
 
   def testCompletion(completion: OpenAIChatCompletion, df: DataFrame, requiredLength: Int = 10): Unit = {
-    val fromRow = ChatCompletionResponse.makeFromRowConverter
+    val fromRow = ChatModelResponse.makeFromRowConverter
     completion.transform(df).collect().foreach(r =>
       fromRow(r.getAs[Row]("out")).choices.foreach(c =>
         assert(c.message.content.length > requiredLength)))

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaultsSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIDefaultsSuite.scala
@@ -38,7 +38,7 @@ class OpenAIDefaultsSuite extends Flaky with OpenAIAPIKey {
     OpenAIDefaults.setTemperature(0.05)
     OpenAIDefaults.setURL(s"https://$openAIServiceName.openai.azure.com/")
 
-    val fromRow = ChatCompletionResponse.makeFromRowConverter
+    val fromRow = ChatModelResponse.makeFromRowConverter
     promptCompletion.transform(promptDF).collect().foreach(r =>
       fromRow(r.getAs[Row]("out")).choices.foreach(c =>
         assert(c.message.content.length > 10)))

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
@@ -80,6 +80,20 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
     assert(nonNullCount == 3)
   }
 
+    test("Basic Usage Responses API") {
+    val nonNullCount = prompt
+      .setPromptTemplate("give me a comma separated list of 5 {category}, starting with {text} ")
+      .setOpenAIAPIType("responses")
+      .setApiVersion("2025-04-01-preview")
+      .setDeploymentName("gpt-4.1-mini")
+      .setPostProcessing("csv")
+      .transform(df)
+      .select("outParsed")
+      .collect()
+      .count(r => Option(r.getSeq[String](0)).isDefined)
+    assert(nonNullCount == 3)
+  }
+
   test("Basic Usage JSON") {
     prompt.setPromptTemplate(
         """Split a word into prefix and postfix a respond in JSON.
@@ -187,7 +201,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
     prompt.setResponseFormat("json_object")
     val messages = prompt.getPromptsForMessage("test")
     assert(messages.nonEmpty)
-    messages.exists(p => p.role == "system" && p.content.contains(OpenAIResponseFormat.JSON.prompt))
+    messages.exists(p => p.role == "system" && p.content.contains(OpenAIChatCompletionResponseFormat.JSON.prompt))
   }
 
   ignore("Custom EndPoint") {

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIResponsesSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIResponsesSuite.scala
@@ -1,0 +1,122 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.services.openai
+
+import com.microsoft.azure.synapse.ml.core.test.base.Flaky
+import com.microsoft.azure.synapse.ml.core.test.fuzzing.{TestObject, TransformerFuzzing}
+import org.apache.spark.ml.util.MLReadable
+import org.apache.spark.sql.{DataFrame, Row}
+import org.scalactic.Equality
+
+class OpenAIResponsesSuite extends TransformerFuzzing[OpenAIResponses]
+  with OpenAIAPIKey with Flaky {
+
+  import spark.implicits._
+
+  lazy val responses: OpenAIResponses = new OpenAIResponses()
+    .setDeploymentName(deploymentNameGpt4)
+    .setCustomServiceName(openAIServiceName)
+    .setApiVersion("2025-04-01-preview")
+    .setMaxTokens(500)
+    .setOutputCol("out")
+    .setMessagesCol("messages")
+    .setTemperature(0)
+    .setSubscriptionKey(openAIAPIKey)
+
+  lazy val goodDf: DataFrame = Seq(
+    Seq(
+      OpenAIMessage("system", "You are an AI chatbot with red as your favorite color"),
+      OpenAIMessage("user", "Whats your favorite color")
+    ),
+    Seq(
+      OpenAIMessage("system", "You are very excited"),
+      OpenAIMessage("user", "How are you today")
+    )
+  ).toDF("messages")
+
+  lazy val badDf: DataFrame = Seq(
+    Seq(),
+    Seq(
+      OpenAIMessage("system", "You are very excited"),
+      OpenAIMessage("user", null) // scalastyle:ignore null
+    )
+  ).toDF("messages")
+
+  test("Basic Usage") {
+    testResponses(responses, goodDf)
+  }
+
+  test("Robustness to bad inputs") {
+    val results = responses.transform(badDf).collect()
+    assert(Option(results.head.getAs[Row](responses.getErrorCol)).isDefined)
+    assert(Option(results(1).getAs[Row](responses.getErrorCol)).isDefined)
+  }
+
+  test("getOptionalParam should include responseFormat") {
+    val transformer = new OpenAIResponses()
+      .setDeploymentName(deploymentNameGpt4)
+
+    def validate(params: Map[String, Any], expected: String): Unit = {
+      val payloadName = responses.responseFormat.payloadName
+      assert(params.contains(payloadName))
+      val value = params(payloadName).asInstanceOf[Map[String, String]]
+      assert(value.get("type").contains(expected))
+    }
+    val raw_messages = Seq(
+      OpenAIMessage("user", "Whats your favorite color")
+    )
+    val messages: Seq[Row] = raw_messages.toDF("role", "content", "name").collect()
+
+    val optionalParams = transformer.getOptionalParams(messages.head)
+    assert(!optionalParams.contains("response_format"))
+
+    transformer.setResponseFormat("json_object")
+    val paramsWithJson = transformer.getOptionalParams(messages.head)
+    validate(paramsWithJson, "json_object")
+
+    transformer.setResponseFormat(OpenAIResponseFormat.TEXT)
+    val paramsWithText = transformer.getOptionalParams(messages.head)
+    validate(paramsWithText, "text")
+  }
+
+  test("setResponseFormat should throw exception if invalid format") {
+    val transformer = new OpenAIResponses()
+      .setDeploymentName(deploymentNameGpt4)
+
+    assertThrows[IllegalArgumentException] {
+      transformer.setResponseFormat("invalid_format")
+    }
+
+    assertThrows[IllegalArgumentException] {
+      transformer.setResponseFormat(Map("type" -> "invalid_format"))
+    }
+
+    assertThrows[IllegalArgumentException] {
+      transformer.setResponseFormat(Map("invalid_key" -> "json_object"))
+    }
+  }
+
+  private def testResponses(model: OpenAIResponses,
+                            df: DataFrame,
+                            requiredLength: Int = 10): Unit = {
+    val fromRow = ResponsesModelResponse.makeFromRowConverter
+    model.transform(df).collect().foreach { row =>
+      val responseRow = row.getAs[Row]("out")
+      if (responseRow != null) {
+        fromRow(responseRow).output.foreach { choice =>
+          assert(choice.content.length > requiredLength)
+        }
+      }
+    }
+  }
+
+  override def assertDFEq(df1: DataFrame, df2: DataFrame)(implicit eq: Equality[DataFrame]): Unit = {
+    super.assertDFEq(df1.drop("out"), df2.drop("out"))(eq)
+  }
+
+  override def testObjects(): Seq[TestObject[OpenAIResponses]] =
+    Seq(new TestObject(responses, goodDf))
+
+  override def reader: MLReadable[_] = OpenAIResponses
+}


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Support OpenAI's Responses API as an alternate solution than Chat Completions, to support some unique feature like file input in the future.

## How is this patch tested?

- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [x] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [x] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
