### PR TITLE
[chore] Add .jvmopts to apply default jvm options

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,1 @@
+--add-exports=java.base/sun.nio.ch=ALL-UNNAMED


### PR DESCRIPTION
Removes the need to manually supply --add-exports java.base/sun.nio.ch=ALL-UNNAMED for sbt