### PR TITLE
chore: Remove redundant text message for file input in OpenAIPrompt

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPrompt.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPrompt.scala
@@ -184,8 +184,6 @@ class OpenAIPrompt(override val uid: String) extends Transformer
     "promptTemplate", "outputCol", "postProcessing", "postProcessingOptions", "dropPrompt", "dropMessages",
     "systemPrompt", "apiType", "returnUsage")
 
-  private val multiModalTextPrompt = "The name of the file to analyze is %s.\nHere is the content:\n"
-
   private val textExtensions = Set("md", "csv", "tsv", "json", "xml")
   private val imageExtensions = Set("jpg", "jpeg", "png", "gif", "webp")
   private val audioExtensions = Set("mp3", "wav")
@@ -461,7 +459,6 @@ class OpenAIPrompt(override val uid: String) extends Transformer
 
   private def wrapFileToMessagesList(filePathStr: String): Seq[Map[String, String]] = {
     val (fileName, fileBytes, fileType, mimeType) = prepareFile(filePathStr)
-    val baseMessage = stringMessageWrapper(multiModalTextPrompt.format(fileName))
 
     val fileMessage = this.getApiType match {
       case "responses" =>
@@ -469,7 +466,7 @@ class OpenAIPrompt(override val uid: String) extends Transformer
       case "chat_completions" =>
         makeChatCompletionsFileMessage(fileName, fileBytes, fileType, mimeType)
     }
-    Seq(baseMessage, fileMessage)
+    Seq(fileMessage)
   }
 
   private def categorizeFileType(mimeType: String, extension: String): String = {


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

When using file input in `OpenAIPrompt` before, a text message will be sent along: `The name of the file to analyze is %s.\nHere is the content:\n`, this will cause info leak in file name, as long as extra token used. So it's for the best to remove this piece of message.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [x] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
