### PR TITLE
fix: Fix geospatial test error caused by invalid auth

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/geospatial/AzureMapsTraits.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/geospatial/AzureMapsTraits.scala
@@ -91,8 +91,10 @@ trait HasAddressInput extends HasServiceParams {
 trait MapsAsyncReply extends HasAsyncReply {
 
   override protected def extractHeaderValuesForPolling(request: HTTPRequestData): Map[String, String] = {
-    // Extract query parameters instead of headers for Azure Maps authentication
-    // Azure Maps uses subscription-key as a URL query parameter, not an HTTP header.
+    // NOTE: Although the method name and return type refer to headers, this override extracts
+    // query parameters (specifically "subscription-key" and "api-version") from the request URI.
+    // This is necessary because Azure Maps uses these values as query parameters, not HTTP headers.
+    // The returned map is in the format expected by the base trait, which uses it to construct polling requests.
     Option(request.requestLine.uri).flatMap { uriString =>
       val uri = new URI(uriString)
       Option(uri.getQuery).map { queryParams =>

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/geospatial/AzureMapsTraitsSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/geospatial/AzureMapsTraitsSuite.scala
@@ -1,0 +1,165 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.services.geospatial
+
+import com.microsoft.azure.synapse.ml.io.http.{HTTPRequestData, HTTPResponseData, RequestLineData}
+import org.apache.http._
+import org.apache.http.client.methods.{CloseableHttpResponse, HttpRequestBase}
+import org.apache.http.conn.ClientConnectionManager
+import org.apache.http.entity.StringEntity
+import org.apache.http.impl.client.CloseableHttpClient
+import org.apache.http.message.{BasicHeader, BasicHeaderIterator, BasicStatusLine}
+import org.apache.http.params.HttpParams
+import org.apache.http.protocol.HttpContext
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.net.{URI, URISyntaxException}
+import java.util.Locale
+
+class AzureMapsTraitsSuite extends AnyFunSuite {
+
+  private class TestableMapsAsyncReply extends AddressGeocoder("test-maps-async") {
+
+    def extract(request: HTTPRequestData): Map[String, String] =
+      extractHeaderValuesForPolling(request)
+
+    def query(headers: Map[String, String],
+              client: CloseableHttpClient,
+              location: URI): Option[HTTPResponseData] =
+      queryForResult(headers, client, location)
+  }
+
+  private class RecordingHttpClient(responseFactory: () => CloseableHttpResponse)
+    extends CloseableHttpClient {
+    @volatile var lastRequestUri: Option[URI] = None
+
+    override def close(): Unit = {}
+
+    override def getConnectionManager: ClientConnectionManager = null
+
+    override def getParams: HttpParams = null
+
+    override protected def doExecute(target: HttpHost,
+                                     request: HttpRequest,
+                                     context: HttpContext): CloseableHttpResponse = {
+      request match {
+        case base: HttpRequestBase => lastRequestUri = Option(base.getURI)
+        case other =>
+          lastRequestUri = try {
+            Option(new URI(other.getRequestLine.getUri))
+          } catch {
+            case _: URISyntaxException => None
+          }
+      }
+      responseFactory()
+    }
+  }
+
+  private class StubCloseableHttpResponse(statusCode: Int,
+                                          headers: Seq[(String, String)] = Seq.empty,
+                                          entity: Option[HttpEntity] = None)
+    extends CloseableHttpResponse {
+
+    private val statusLine = new BasicStatusLine(HttpVersion.HTTP_1_1, statusCode, "OK")
+    private val headerObjects: Array[Header] = headers.map { case (n, v) => new BasicHeader(n, v) }.toArray
+
+    override def close(): Unit = {}
+
+    override def getStatusLine: StatusLine = statusLine
+
+    override def setStatusLine(statusline: StatusLine): Unit = {}
+
+    override def setStatusLine(ver: ProtocolVersion, code: Int): Unit = {}
+
+    override def setStatusLine(ver: ProtocolVersion, code: Int, reason: String): Unit = {}
+
+    override def setStatusCode(code: Int): Unit = {}
+
+    override def setReasonPhrase(reason: String): Unit = {}
+
+    override def getEntity: HttpEntity = entity.orNull
+
+    override def setEntity(entity: HttpEntity): Unit = {}
+
+    override def getLocale: Locale = Locale.US
+
+    override def setLocale(loc: Locale): Unit = {}
+
+    override def getProtocolVersion: ProtocolVersion = statusLine.getProtocolVersion
+
+    override def containsHeader(name: String): Boolean =
+      headerObjects.exists(_.getName.equalsIgnoreCase(name))
+
+    override def getHeaders(name: String): Array[Header] =
+      headerObjects.filter(_.getName.equalsIgnoreCase(name))
+
+    override def getAllHeaders: Array[Header] = headerObjects
+
+    override def addHeader(header: Header): Unit = {}
+
+    override def addHeader(name: String, value: String): Unit = {}
+
+    override def setHeader(header: Header): Unit = {}
+
+    override def setHeader(name: String, value: String): Unit = {}
+
+    override def setHeaders(headers: Array[Header]): Unit = {}
+
+    override def removeHeader(header: Header): Unit = {}
+
+    override def removeHeaders(name: String): Unit = {}
+
+    override def getFirstHeader(name: String): Header =
+      headerObjects.find(_.getName.equalsIgnoreCase(name)).orNull
+
+    override def getLastHeader(name: String): Header =
+      headerObjects.reverse.find(_.getName.equalsIgnoreCase(name)).orNull
+
+    override def headerIterator(): HeaderIterator =
+      new BasicHeaderIterator(headerObjects, null)
+
+    override def headerIterator(name: String): HeaderIterator =
+      new BasicHeaderIterator(headerObjects, name)
+
+    override def getParams: HttpParams = null
+
+    override def setParams(params: HttpParams): Unit = {}
+  }
+
+  test("extractHeaderValuesForPolling preserves encoded Azure Maps query params") {
+    val helper = new TestableMapsAsyncReply
+    val request = HTTPRequestData(
+      RequestLineData(
+        "GET",
+        "https://example.com/maps?foo=bar&subscription-key=abc%2B123%3D&api-version=2024-01-01",
+        None),
+      Array.empty,
+      None)
+
+    val params = helper.extract(request)
+    assert(params == Map("subscription-key" -> "abc%2B123%3D", "api-version" -> "2024-01-01"))
+  }
+
+  test("queryForResult appends auth params without double encoding or dropping fragments") {
+    val helper = new TestableMapsAsyncReply
+    val entity = new StringEntity("""{"status":"succeeded"}""", "UTF-8")
+    val client = new RecordingHttpClient(() => new StubCloseableHttpResponse(200, Seq.empty, Some(entity)))
+
+    val location = new URI("https://example.com/path?existing=1#frag")
+    val headers = Map("subscription-key" -> "abc%2B123%3D", "api-version" -> "2024-01-01")
+
+    val response = helper.query(headers, client, location)
+    assert(response.nonEmpty)
+    assert(response.get.statusLine.statusCode == 200)
+
+    val recordedUri = client.lastRequestUri.get
+    assert(recordedUri.getFragment == "frag")
+
+    val queryParts = recordedUri.getRawQuery.split("&").toSet
+    assert(queryParts.contains("existing=1"))
+    assert(queryParts.contains("subscription-key=abc%2B123%3D"))
+    assert(queryParts.contains("api-version=2024-01-01"))
+  }
+
+}

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/geospatial/AzureMapsTraitsSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/geospatial/AzureMapsTraitsSuite.scala
@@ -19,16 +19,7 @@ import java.util.Locale
 
 class AzureMapsTraitsSuite extends AnyFunSuite {
 
-  private class TestableMapsAsyncReply extends AddressGeocoder("test-maps-async") {
 
-    def extract(request: HTTPRequestData): Map[String, String] =
-      extractHeaderValuesForPolling(request)
-
-    def query(headers: Map[String, String],
-              client: CloseableHttpClient,
-              location: URI): Option[HTTPResponseData] =
-      queryForResult(headers, client, location)
-  }
 
   private class RecordingHttpClient(responseFactory: () => CloseableHttpResponse)
     extends CloseableHttpClient {
@@ -128,7 +119,7 @@ class AzureMapsTraitsSuite extends AnyFunSuite {
   }
 
   test("extractHeaderValuesForPolling preserves encoded Azure Maps query params") {
-    val helper = new TestableMapsAsyncReply
+    val helper = new AzureMapsTraitsSuite.TestableMapsAsyncReply
     val request = HTTPRequestData(
       RequestLineData(
         "GET",
@@ -142,7 +133,7 @@ class AzureMapsTraitsSuite extends AnyFunSuite {
   }
 
   test("queryForResult appends auth params without double encoding or dropping fragments") {
-    val helper = new TestableMapsAsyncReply
+    val helper = new AzureMapsTraitsSuite.TestableMapsAsyncReply
     val entity = new StringEntity("""{"status":"succeeded"}""", "UTF-8")
     val client = new RecordingHttpClient(() => new StubCloseableHttpResponse(HttpStatus.SC_OK, Seq.empty, Some(entity)))
 
@@ -162,4 +153,17 @@ class AzureMapsTraitsSuite extends AnyFunSuite {
     assert(queryParts.contains("api-version=2024-01-01"))
   }
 
+}
+
+object AzureMapsTraitsSuite {
+  private class TestableMapsAsyncReply extends AddressGeocoder("test-maps-async") {
+
+    def extract(request: HTTPRequestData): Map[String, String] =
+      extractHeaderValuesForPolling(request)
+
+    def query(headers: Map[String, String],
+              client: CloseableHttpClient,
+              location: URI): Option[HTTPResponseData] =
+      queryForResult(headers, client, location)
+  }
 }

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/geospatial/AzureMapsTraitsSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/geospatial/AzureMapsTraitsSuite.scala
@@ -36,9 +36,9 @@ class AzureMapsTraitsSuite extends AnyFunSuite {
 
     override def close(): Unit = {}
 
-    override def getConnectionManager: ClientConnectionManager = null
+    override def getConnectionManager: ClientConnectionManager = throw new UnsupportedOperationException
 
-    override def getParams: HttpParams = null
+    override def getParams: HttpParams = throw new UnsupportedOperationException
 
     override protected def doExecute(target: HttpHost,
                                      request: HttpRequest,
@@ -117,12 +117,12 @@ class AzureMapsTraitsSuite extends AnyFunSuite {
       headerObjects.reverse.find(_.getName.equalsIgnoreCase(name)).orNull
 
     override def headerIterator(): HeaderIterator =
-      new BasicHeaderIterator(headerObjects, null)
+      new BasicHeaderIterator(headerObjects, null) // scalastyle:ignore null
 
     override def headerIterator(name: String): HeaderIterator =
       new BasicHeaderIterator(headerObjects, name)
 
-    override def getParams: HttpParams = null
+    override def getParams: HttpParams = throw new UnsupportedOperationException
 
     override def setParams(params: HttpParams): Unit = {}
   }
@@ -144,14 +144,14 @@ class AzureMapsTraitsSuite extends AnyFunSuite {
   test("queryForResult appends auth params without double encoding or dropping fragments") {
     val helper = new TestableMapsAsyncReply
     val entity = new StringEntity("""{"status":"succeeded"}""", "UTF-8")
-    val client = new RecordingHttpClient(() => new StubCloseableHttpResponse(200, Seq.empty, Some(entity)))
+    val client = new RecordingHttpClient(() => new StubCloseableHttpResponse(HttpStatus.SC_OK, Seq.empty, Some(entity)))
 
     val location = new URI("https://example.com/path?existing=1#frag")
     val headers = Map("subscription-key" -> "abc%2B123%3D", "api-version" -> "2024-01-01")
 
     val response = helper.query(headers, client, location)
     assert(response.nonEmpty)
-    assert(response.get.statusLine.statusCode == 200)
+    assert(response.get.statusLine.statusCode == HttpStatus.SC_OK)
 
     val recordedUri = client.lastRequestUri.get
     assert(recordedUri.getFragment == "frag")

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/JarLoadingUtils.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/JarLoadingUtils.scala
@@ -33,7 +33,7 @@ object JarLoadingUtils {
     AllClasses
       .filter(classTag[T].runtimeClass.isAssignableFrom(_))
       .filter(c => jarName.forall({
-        val jarResource = c.getResource(c.getSimpleName + ".class")
+        val jarResource = c.getResource("/" + c.getName.replace('.', '/') + ".class")
         if (jarResource == null) {
           throw new IOException(s"Could not find resource for class ${c.getSimpleName}")
         }

--- a/src/test/scala/com/microsoft/azure/synapse/ml/core/test/fuzzing/FuzzingTest.scala
+++ b/src/test/scala/com/microsoft/azure/synapse/ml/core/test/fuzzing/FuzzingTest.scala
@@ -76,7 +76,8 @@ class FuzzingTest extends TestBase {
       "com.microsoft.azure.synapse.ml.services.form.GetCustomModel",
       "com.microsoft.azure.synapse.ml.services.form.AnalyzeCustomModel",
       "com.microsoft.azure.synapse.ml.services.anomaly.DetectLastMultivariateAnomaly",
-      "com.microsoft.azure.synapse.ml.services.anomaly.SimpleFitMultivariateAnomaly"
+      "com.microsoft.azure.synapse.ml.services.anomaly.SimpleFitMultivariateAnomaly",
+      "com.microsoft.azure.synapse.ml.services.geospatial.AzureMapsTraitsSuite$TestableMapsAsyncReply"
     )
     val applicableStages = pipelineStages.filter(t => !exemptions(t.getClass.getName))
     val applicableClasses = applicableStages.map(_.getClass.asInstanceOf[Class[_]]).toSet
@@ -137,7 +138,8 @@ class FuzzingTest extends TestBase {
       "com.microsoft.azure.synapse.ml.services.form.GetCustomModel",
       "com.microsoft.azure.synapse.ml.services.form.AnalyzeCustomModel",
       "com.microsoft.azure.synapse.ml.services.anomaly.DetectLastMultivariateAnomaly",
-      "com.microsoft.azure.synapse.ml.services.anomaly.SimpleFitMultivariateAnomaly"
+      "com.microsoft.azure.synapse.ml.services.anomaly.SimpleFitMultivariateAnomaly",
+      "com.microsoft.azure.synapse.ml.services.geospatial.AzureMapsTraitsSuite$TestableMapsAsyncReply"
     )
     val applicableStages = pipelineStages.filter(t => !exemptions(t.getClass.getName))
     val applicableClasses = applicableStages.map(_.getClass.asInstanceOf[Class[_]]).toSet
@@ -195,7 +197,8 @@ class FuzzingTest extends TestBase {
       "com.microsoft.azure.synapse.ml.services.form.GetCustomModel",
       "com.microsoft.azure.synapse.ml.services.form.AnalyzeCustomModel",
       "com.microsoft.azure.synapse.ml.services.anomaly.DetectLastMultivariateAnomaly",
-      "com.microsoft.azure.synapse.ml.services.anomaly.SimpleFitMultivariateAnomaly"
+      "com.microsoft.azure.synapse.ml.services.anomaly.SimpleFitMultivariateAnomaly",
+      "com.microsoft.azure.synapse.ml.services.geospatial.AzureMapsTraitsSuite$TestableMapsAsyncReply"
     )
     val applicableStages = pipelineStages.filter(t => !exemptions(t.getClass.getName))
     val applicableClasses = applicableStages.map(_.getClass.asInstanceOf[Class[_]]).toSet
@@ -255,7 +258,8 @@ class FuzzingTest extends TestBase {
       "com.microsoft.azure.synapse.ml.services.form.GetCustomModel",
       "com.microsoft.azure.synapse.ml.services.form.AnalyzeCustomModel",
       "com.microsoft.azure.synapse.ml.services.anomaly.DetectLastMultivariateAnomaly",
-      "com.microsoft.azure.synapse.ml.services.anomaly.SimpleFitMultivariateAnomaly"
+      "com.microsoft.azure.synapse.ml.services.anomaly.SimpleFitMultivariateAnomaly",
+      "com.microsoft.azure.synapse.ml.services.geospatial.AzureMapsTraitsSuite$TestableMapsAsyncReply"
     )
     val applicableStages = pipelineStages.filter(t => !exemptions(t.getClass.getName))
     val applicableClasses = applicableStages.map(_.getClass.asInstanceOf[Class[_]]).toSet


### PR DESCRIPTION
## Related Issues/PRs

Fixes failing Azure Maps tests due to authentication errors during async polling.

## What changes are proposed in this pull request?

This PR fixes an issue where the `subscription-key` and `api-version` were not being correctly passed during the polling phase of asynchronous Azure Maps operations (e.g., batch geocoding).

Changes:
- Modified `MapsAsyncReply` in [AzureMapsTraits.scala](cci:7://file:///Users/brendan/Work/SynapseML_base/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/geospatial/AzureMapsTraits.scala:0:0-0:0).
- Updated `extractHeaderValuesForPolling` to extract authentication parameters (`subscription-key`, `api-version`) from the original request's query string.
- Updated `queryForResult` to append these parameters to the polling URL, ensuring the polling requests are properly authenticated.

## How is this patch tested?

- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

Verified by running the following test suites locally:
- `com.microsoft.azure.synapse.ml.services.geospatial.AzMapsSearchAddressSuite`
- `com.microsoft.azure.synapse.ml.services.geospatial.AzMapsSearchReverseAddressSuite`
- `com.microsoft.azure.synapse.ml.services.geospatial.AzMapsPointInPolygonSuite`

All tests passed successfully.

## Does this PR change any dependencies?

- [x] No. You can skip this section.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No. You can skip this section.
