### PR TITLE
chore: null value passthrough for path columns in OpenAIPrompt

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPrompt.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPrompt.scala
@@ -469,12 +469,12 @@ class OpenAIPrompt(override val uid: String) extends Transformer
 
     // If there are path columns but all are null/empty, pass through null
     if (attachmentOrder.nonEmpty && orderedAttachments.isEmpty) {
-      return null //scalastyle:ignore null
+      null //scalastyle:ignore null
+    } else {
+      val contentParts = buildContentParts(userMessage, orderedAttachments)
+      val messages = getPromptsForMessage(Left(contentParts))
+      messages
     }
-
-    val contentParts = buildContentParts(userMessage, orderedAttachments)
-    val messages = getPromptsForMessage(Left(contentParts))
-    messages
   }
 
   private def buildContentParts(promptText: String, attachmentPaths: Seq[String]): Seq[Map[String, String]] = {

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPrompt.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPrompt.scala
@@ -462,8 +462,14 @@ class OpenAIPrompt(override val uid: String) extends Transformer
     attachmentMap: Map[String, String],
     attachmentOrder: Seq[String]
   ): Seq[OpenAICompositeMessage] = {
+    // Filter to get only non-null, non-empty path values
     val orderedAttachments = attachmentOrder.flatMap { columnName =>
-      attachmentMap.get(columnName).map(_.trim).filter(_.nonEmpty)
+      attachmentMap.get(columnName).flatMap(v => Option(v).map(_.trim).filter(_.nonEmpty))
+    }
+
+    // If there are path columns but all are null/empty, pass through null
+    if (attachmentOrder.nonEmpty && orderedAttachments.isEmpty) {
+      return null //scalastyle:ignore null
     }
 
     val contentParts = buildContentParts(userMessage, orderedAttachments)

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
@@ -360,7 +360,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
       ),
       (
         "What's in this image?",
-        null.asInstanceOf[String]
+        null // scalasty:ignore
       ),
       (
         "What's in this image?",

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
@@ -86,6 +86,27 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
     }
   }
 
+  test("createMessagesForRow returns null when all path columns are null") {
+    val prompt = new OpenAIPrompt()
+    val attachments = Map("filePath" -> null.asInstanceOf[String])
+    val messages = prompt.createMessagesForRow("Summarize the file", attachments, Seq("filePath"))
+    assert(messages == null)
+  }
+
+  test("createMessagesForRow returns messages when at least one path column has value") {
+    val prompt = new OpenAIPrompt()
+    val tempFile = Files.createTempFile("synapseml-openai", ".txt")
+    try {
+      Files.write(tempFile, "example content".getBytes(StandardCharsets.UTF_8))
+      val attachments = Map("filePath" -> null.asInstanceOf[String], "anotherPath" -> tempFile.toString)
+      val messages = prompt.createMessagesForRow("Summarize", attachments, Seq("filePath", "anotherPath"))
+      assert(messages != null)
+      assert(messages.nonEmpty)
+    } finally {
+      Files.deleteIfExists(tempFile)
+    }
+  }
+
   test("RAI Usage") {
     val result = prompt
       .setDeploymentName(deploymentName)
@@ -319,6 +340,45 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
     .foreach { case (row, keyword) =>
       assert(row.getString(0).toLowerCase.contains(keyword))
     }
+  }
+
+  test("null path columns return null output") {
+    val promptResponses = new OpenAIPrompt()
+      .setSubscriptionKey(openAIAPIKey)
+      .setDeploymentName(deploymentName)
+      .setCustomServiceName(openAIServiceName)
+      .setApiVersion("2025-04-01-preview")
+      .setApiType("responses")
+      .setColumnType("images", "path")
+      .setOutputCol("outParsed")
+      .setPromptTemplate("{questions}: {images}")
+
+    val urlDF = Seq(
+      (
+        "What's in this document?",
+        "https://mmlspark.blob.core.windows.net/datasets/OCR/paper.pdf"
+      ),
+      (
+        "What's in this image?",
+        null.asInstanceOf[String]
+      ),
+      (
+        "What's in this image?",
+        "https://mmlspark.blob.core.windows.net/datasets/OCR/test2.png"
+      )
+    ).toDF("questions", "images")
+
+    val results = promptResponses
+      .transform(urlDF)
+      .select("outParsed")
+      .collect()
+
+    // First row: valid path, should have output
+    assert(results(0).getString(0) != null)
+    // Second row: null path, should have null output
+    assert(results(1).get(0) == null)
+    // Third row: valid path, should have output
+    assert(results(2).getString(0) != null)
   }
 
   ignore("Custom EndPoint") {

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
@@ -86,9 +86,10 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
     }
   }
 
+  // scalastyle:off null
   test("createMessagesForRow returns null when all path columns are null") {
     val prompt = new OpenAIPrompt()
-    val attachments = Map("filePath" -> null.asInstanceOf[String])
+    val attachments = Map("filePath" -> null)
     val messages = prompt.createMessagesForRow("Summarize the file", attachments, Seq("filePath"))
     assert(messages == null)
   }
@@ -98,7 +99,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
     val tempFile = Files.createTempFile("synapseml-openai", ".txt")
     try {
       Files.write(tempFile, "example content".getBytes(StandardCharsets.UTF_8))
-      val attachments = Map("filePath" -> null.asInstanceOf[String], "anotherPath" -> tempFile.toString)
+      val attachments = Map("filePath" -> null, "anotherPath" -> tempFile.toString)
       val messages = prompt.createMessagesForRow("Summarize", attachments, Seq("filePath", "anotherPath"))
       assert(messages != null)
       assert(messages.nonEmpty)
@@ -106,6 +107,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
       Files.deleteIfExists(tempFile)
     }
   }
+  // scalastyle:on null
 
   test("RAI Usage") {
     val result = prompt
@@ -360,7 +362,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
       ),
       (
         "What's in this image?",
-        null // scalasty:ignore
+        null // scalastyle:ignore null
       ),
       (
         "What's in this image?",


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Adding a null passthrough mechanism for path columns in OpenAIPrompt. That if all of path columns are null, we passthrough null to underlying service which will also result in null.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [x] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
