### PR TITLE
ci: bootstrap branch-specific prebuilt CI images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,10 @@
-target
-.idea
-.git
-tools/docker/Dockerfile.dev
-pipeline.yaml
-.dockerignore
+# Allowlist: only send files referenced by COPY instructions in Dockerfiles.
+# CI Dockerfile:  environment.yml, project/, build.sbt, sonatype.sbt
+# Demo Dockerfile: tools/docker/demo/init_notebook.py, docs/
+*
+!environment.yml
+!project/
+!build.sbt
+!sonatype.sbt
+!tools/docker/demo/init_notebook.py
+!docs/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,7 @@
 # Allowlist: only send files referenced by COPY instructions in Dockerfiles.
-# CI Dockerfile:  environment.yml, project/, build.sbt, sonatype.sbt
+# CI Dockerfile: environment.yml
 # Demo Dockerfile: tools/docker/demo/init_notebook.py, docs/
 *
 !environment.yml
-!project/
-!build.sbt
-!sonatype.sbt
 !tools/docker/demo/init_notebook.py
 !docs/

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ condaenv.*.requirements.txt
 # Dev-loop artifacts
 .dev-loop/
 .dev-loop-artifacts/
+pipeline.yaml.bak

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ condaenv.*.requirements.txt
 # Dev-loop artifacts
 .dev-loop/
 .dev-loop-artifacts/
+pipeline.yaml.bak

--- a/.gitignore
+++ b/.gitignore
@@ -96,4 +96,3 @@ condaenv.*.requirements.txt
 # Dev-loop artifacts
 .dev-loop/
 .dev-loop-artifacts/
-pipeline.yaml.bak

--- a/build.sbt
+++ b/build.sbt
@@ -104,7 +104,12 @@ getDatasetsTask := {
   val f = new File(d, datasetName)
   if (!d.exists()) d.mkdirs()
   if (!f.exists()) {
-    FileUtils.copyURLToFile(datasetUrl, f)
+    val cached = new File(sys.env.getOrElse("DATASET_CACHE", "/opt/datasets"), datasetName)
+    if (cached.exists()) {
+      java.nio.file.Files.copy(cached.toPath, f.toPath)
+    } else {
+      FileUtils.copyURLToFile(datasetUrl, f)
+    }
     UnzipUtils.unzip(f, d)
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -283,8 +283,9 @@ uploadNotebooks := {
 }
 
 val settings = Seq(
-  // javac otherwise emits bytecode for the build JDK, while published artifacts still support Java 8 Spark runtimes.
-  Compile / javacOptions ++= Seq("--release", "8"),
+  // Resolve both Java and Scala sources against Java 8 APIs so published artifacts remain compatible.
+  Compile / compile / javacOptions ++= Seq("--release", "8"),
+  Compile / compile / scalacOptions ++= Seq("-release:8"),
   Test / scalastyleConfig := (ThisBuild / baseDirectory).value / "scalastyle-test-config.xml",
   Test / logBuffered := false,
   Test / parallelExecution := false,

--- a/build.sbt
+++ b/build.sbt
@@ -103,7 +103,8 @@ getDatasetsTask := {
   val d = datasetDir.value.getParentFile
   val f = new File(d, datasetName)
   if (!d.exists()) d.mkdirs()
-  if (!f.exists()) {
+  if (!datasetDir.value.exists()) {
+    if (f.exists()) f.delete() // Remove partial downloads
     val cached = new File(sys.env.getOrElse("DATASET_CACHE", "/opt/datasets"), datasetName)
     if (cached.exists()) {
       java.nio.file.Files.copy(cached.toPath, f.toPath)

--- a/build.sbt
+++ b/build.sbt
@@ -283,6 +283,8 @@ uploadNotebooks := {
 }
 
 val settings = Seq(
+  // javac otherwise emits bytecode for the build JDK, while published artifacts still support Java 8 Spark runtimes.
+  Compile / javacOptions ++= Seq("--release", "8"),
   Test / scalastyleConfig := (ThisBuild / baseDirectory).value / "scalastyle-test-config.xml",
   Test / logBuffered := false,
   Test / parallelExecution := false,

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/codegen/RTestGen.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/codegen/RTestGen.scala
@@ -101,7 +101,7 @@ object RTestGen {
          |  "spark.sql.shuffle.partitions=10",
          |  "spark.sql.crossJoin.enabled=true")
          |
-         |sc <- spark_connect(master = "local", version = "3.5.0", config = conf)
+         |sc <- spark_connect(master = "local", spark_home = Sys.getenv("SPARK_HOME"), config = conf)
          |
          |""".stripMargin, StandardOpenOption.CREATE)
 

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/codegen/VerifyRCodegen.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/codegen/VerifyRCodegen.scala
@@ -12,7 +12,7 @@ import java.nio.file.Files
 
 class VerifyRCodegen extends TestBase {
 
-  test("generated R extension uses the supported Maven repository") {
+  private def withTempConfig(test: CodegenConfig => Unit): Unit = {
     val tempDir = Files.createTempDirectory("synapseml-r-codegen").toFile
     val targetDir = new java.io.File(tempDir, "target")
     val conf = CodegenConfig(
@@ -27,14 +27,29 @@ class VerifyRCodegen extends TestBase {
     )
 
     try {
+      test(conf)
+    } finally {
+      ApacheFileUtils.deleteDirectory(tempDir)
+    }
+  }
+
+  test("generated R extension uses the supported Maven repository") {
+    withTempConfig { conf =>
       RCodegen.generateRPackageData(conf)
       val registration = readFile(new java.io.File(conf.rSrcDir, "package_register.R"))
 
       assert(PackageUtils.PackageRepository === "https://mmlspark.blob.core.windows.net/maven")
       assert(registration.contains(s"""repositories = c("${PackageUtils.PackageRepository}")"""))
       assert(!registration.contains("azureedge.net"))
-    } finally {
-      ApacheFileUtils.deleteDirectory(tempDir)
+    }
+  }
+
+  test("generated R tests use the configured Spark home") {
+    withTempConfig { conf =>
+      RTestGen.generateRPackageData(conf)
+      val setup = readFile(new java.io.File(conf.rTestThatDir, "setup.R"))
+
+      assert(setup.contains("""spark_home = Sys.getenv("SPARK_HOME")"""))
     }
   }
 }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/core/env/VerifyNativeLoader.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/core/env/VerifyNativeLoader.scala
@@ -1,0 +1,32 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.core.env
+
+import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+
+import java.io.DataInputStream
+
+class VerifyNativeLoader extends TestBase {
+
+  private val classFileMagic = 0xcafebabe
+  private val java8MajorVersion = 52
+
+  test("NativeLoader bytecode remains Java 8 compatible") {
+    val stream = Option(classOf[NativeLoader].getResourceAsStream("NativeLoader.class"))
+      .getOrElse(fail("NativeLoader.class was not found"))
+    val input = new DataInputStream(stream)
+
+    try {
+      assert(input.readInt() == classFileMagic)
+      input.readUnsignedShort()
+      val majorVersion = input.readUnsignedShort()
+      assert(
+        majorVersion <= java8MajorVersion,
+        s"NativeLoader class file version $majorVersion requires a newer runtime than Java 8"
+      )
+    } finally {
+      input.close()
+    }
+  }
+}

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/core/test/base/TestBase.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/core/test/base/TestBase.scala
@@ -17,7 +17,7 @@ import org.scalactic.Equality
 import org.scalactic.source.Position
 import org.scalatest._
 import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.concurrent.TimeLimits
+import org.scalatest.concurrent.{Signaler, ThreadSignaler, TimeLimits}
 import org.scalatest.time.{Seconds, Span}
 
 import java.io.File
@@ -151,6 +151,11 @@ abstract class TestBase extends AnyFunSuite with BeforeAndAfterEachTestData with
 
   // Global per-test timeout (10 minutes). Override in subclass if needed.
   val testTimeoutInSeconds: Int = 10 * 60
+
+  // ScalaTest's default signaler is DoNotSignal, which only reports a timeout *after* the body
+  // returns - so a genuinely hung test would still block forever. ThreadSignaler interrupts the
+  // running test thread when the deadline passes, which is what makes the timeout able to break hangs.
+  implicit protected val testSignaler: Signaler = ThreadSignaler
 
   override def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit pos: Position): Unit = {
     super.test(testName, testTags: _*) {

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/DatabricksUtilities.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/DatabricksUtilities.scala
@@ -683,6 +683,9 @@ object DatabricksState {
 
 abstract class DatabricksTestHelper extends TestBase {
 
+  // Notebook monitoring can run for 32 minutes; let its own timeout report the failure first.
+  override val testTimeoutInSeconds: Int = 35 * 60
+
   import DatabricksUtilities._
 
   def databricksTestHelper(clusterId: String,

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricNotebookTests.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricNotebookTests.scala
@@ -29,6 +29,8 @@ trait HasFabricNotebookTestConnection extends HasFabricOperationsConnection {
 }
 
 class FabricTestCleanup extends TestBase with HasFabricNotebookTestConnection {
+  override val testTimeoutInSeconds: Int = 65 * 60
+
   test("Clean up old artifacts") {
     val cutoff = LocalDateTime.now().minusDays(3)
     fabric.listArtifacts()
@@ -45,6 +47,8 @@ class FabricTestCleanup extends TestBase with HasFabricNotebookTestConnection {
 }
 
 class FabricSmokeTests extends TestBase with HasFabricNotebookTestConnection {
+
+  override val testTimeoutInSeconds: Int = 65 * 60
 
   val trivialScript: String =
     """
@@ -104,6 +108,8 @@ class FabricSmokeTests extends TestBase with HasFabricNotebookTestConnection {
 }
 
 class FabricNotebookTests extends TestBase with HasFabricNotebookTestConnection {
+  override val testTimeoutInSeconds: Int = 65 * 60
+
   SharedNotebookE2ETestUtilities.generateNotebooks()
 
   val selectedPythonFiles: Array[File] = FileUtilities

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricNotebookTests.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricNotebookTests.scala
@@ -27,6 +27,8 @@ trait HasFabricNotebookTestConnection extends HasFabricOperationsConnection {
 }
 
 class FabricTestCleanup extends TestBase with HasFabricNotebookTestConnection {
+  override val testTimeoutInSeconds: Int = 65 * 60
+
   test("Clean up old artifacts") {
     val cutoff = LocalDateTime.now().minusDays(3)
     fabric.listArtifacts()
@@ -43,6 +45,8 @@ class FabricTestCleanup extends TestBase with HasFabricNotebookTestConnection {
 }
 
 class FabricSmokeTests extends TestBase with HasFabricNotebookTestConnection {
+
+  override val testTimeoutInSeconds: Int = 65 * 60
 
   val trivialScript: String =
     """
@@ -102,6 +106,8 @@ class FabricSmokeTests extends TestBase with HasFabricNotebookTestConnection {
 }
 
 class FabricNotebookTests extends TestBase with HasFabricNotebookTestConnection {
+  override val testTimeoutInSeconds: Int = 65 * 60
+
   SharedNotebookE2ETestUtilities.generateNotebooks()
 
   val selectedPythonFiles: Array[File] = FileUtilities

--- a/deep-learning/src/test/scala/com/microsoft/azure/synapse/ml/onnx/ONNXRuntimeDependencySuite.scala
+++ b/deep-learning/src/test/scala/com/microsoft/azure/synapse/ml/onnx/ONNXRuntimeDependencySuite.scala
@@ -5,7 +5,10 @@ package com.microsoft.azure.synapse.ml.onnx
 
 import com.microsoft.azure.synapse.ml.build.BuildInfo
 import com.microsoft.azure.synapse.ml.core.env.FileUtilities
+import org.objectweb.asm.{ClassReader, ClassVisitor, MethodVisitor, Opcodes}
 import org.scalatest.funsuite.AnyFunSuite
+
+import scala.collection.mutable.ArrayBuffer
 
 /**
   * GH2417: verifies the published dependency strategy for ONNX Runtime, independent of whatever version
@@ -42,6 +45,41 @@ class ONNXRuntimeDependencySuite extends AnyFunSuite {
       "build.sbt must declare com.microsoft.onnxruntime:onnxruntime (CPU-only, cross-platform, " +
         "including macOS) as the default deep-learning dependency so ONNXModel works out of the box " +
         "on macOS/Linux/Windows.")
+  }
+
+  test("compiled ONNX buffer rewinds use Java 8 method signatures") {
+    val input = Option(getClass.getResourceAsStream("ONNXUtils$.class"))
+      .getOrElse(fail("ONNXUtils$.class was not found"))
+    val rewindCalls = ArrayBuffer.empty[String]
+
+    try {
+      new ClassReader(input).accept(new ClassVisitor(Opcodes.ASM9) {
+        override def visitMethod(access: Int,
+                                 name: String,
+                                 descriptor: String,
+                                 signature: String,
+                                 exceptions: Array[String]): MethodVisitor = {
+          new MethodVisitor(Opcodes.ASM9) {
+            override def visitMethodInsn(opcode: Int,
+                                         owner: String,
+                                         name: String,
+                                         descriptor: String,
+                                         isInterface: Boolean): Unit = {
+              if (owner.startsWith("java/nio/") && name == "rewind") {
+                rewindCalls += s"$owner.$name$descriptor"
+              }
+            }
+          }
+        }
+      }, ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES)
+    } finally {
+      input.close()
+    }
+
+    assert(rewindCalls.nonEmpty, "Expected ONNXUtils to invoke java.nio buffer rewind methods")
+    val incompatibleCalls = rewindCalls.filterNot(_.endsWith("()Ljava/nio/Buffer;"))
+    assert(incompatibleCalls.isEmpty,
+      s"Found buffer calls that require post-Java-8 covariant signatures: ${incompatibleCalls.mkString(", ")}")
   }
 
   test("deep-learning does not force the GPU-only onnxruntime_gpu artifact on every user by default") {

--- a/opencv/src/test/scala/com/microsoft/azure/synapse/ml/opencv/ImageTransformerSuite.scala
+++ b/opencv/src/test/scala/com/microsoft/azure/synapse/ml/opencv/ImageTransformerSuite.scala
@@ -11,6 +11,7 @@ import com.microsoft.azure.synapse.ml.io.IOImplicits._
 import com.microsoft.azure.synapse.ml.param.DataFrameEquality
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkException
+import org.apache.spark.ml.image.ImageSchema
 import org.apache.spark.ml.linalg.DenseVector
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types._
@@ -22,6 +23,7 @@ import org.scalactic.Equality
 
 import java.awt.GridLayout
 import java.io.File
+import java.util.Collections
 import javax.swing._
 
 trait OpenCVTestUtils {
@@ -171,9 +173,19 @@ class ImageTransformerSuite extends TransformerFuzzing[ImageTransformer] with Op
   lazy val images: DataFrame = spark.read.image.option("dropInvalid", value = true)
     .load(FileUtilities.join(fileLocation, "**").toString)
 
-  lazy val badImages: DataFrame =
-    spark.read.image.load(
-      ".//opencv//src//test//scala//com//microsoft//azure//synapse//ml//opencv//cmyk_image.jpg")
+  lazy val badImages: DataFrame = {
+    // Unlike a valid but unusual image encoding, invalid dimensions fail consistently across decoders.
+    val invalidImage = Row(
+      "invalid",
+      -1,
+      -1,
+      -1,
+      ImageSchema.ocvTypes(ImageSchema.undefinedImageType),
+      Array.empty[Byte])
+    spark.createDataFrame(
+      Collections.singletonList(Row(invalidImage)),
+      ImageSchema.imageSchema)
+  }
 
   test("general workflow") {
     //assert(images.count() == 30) //TODO this does not work on build machine for some reason

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1,5 +1,11 @@
 resources:
-- repo: self
+  containers:
+    - container: ci
+      image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-latest
+      endpoint: 'SynapseML MCR'
+  repositories:
+    - repository: self
+      type: self
 
 trigger:
   branches:
@@ -95,12 +101,83 @@ variables:
   runCoverage: $[or(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))]
 
 jobs:
-- job: Style
+- job: BuildCIImage
+  displayName: 'Ensure CI Image'
   cancelTimeoutInMinutes: 0
-  condition: and(eq(variables.runTests, 'True'), eq('${{ parameters.testStyle }}', true))
+  timeoutInMinutes: 60
   pool:
     vmImage: $(UBUNTU_VERSION)
   steps:
+    - bash: |
+        set -e
+        echo "=== Disk space BEFORE cleanup ==="
+        df -h / | grep -E 'Filesystem|/$'
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /usr/lib/google-cloud-sdk || true
+        sudo rm -rf /usr/share/dotnet || true
+        sudo rm -rf /opt/ghc || true
+        sudo rm -rf /opt/hostedtoolcache || true
+        sudo rm -rf /usr/local/share/boost || true
+        sudo rm -rf /usr/share/swift || true
+        sudo rm -rf /usr/local/.ghcup || true
+        sudo rm -rf /usr/share/miniconda || true
+        sudo rm -rf /usr/local/share/chromium || true
+        sudo docker image prune -af || true
+        echo "=== Disk space AFTER cleanup ==="
+        df -h / | grep -E 'Filesystem|/$'
+      displayName: 'Free disk space'
+    - task: Docker@2
+      displayName: 'Login to ACR'
+      inputs:
+        command: login
+        containerRegistry: 'SynapseML MCR'
+    - bash: |
+        set -e
+        # Hash each dependency file individually (with filename) to avoid boundary-shift collisions
+        HASH=$(sha256sum environment.yml project/plugins.sbt project/build.properties build.sbt sonatype.sbt tools/docker/ci/Dockerfile | sha256sum | cut -c1-12)
+        TAG="ci-${HASH}"
+        LATEST_TAG="ci-latest"
+        REGISTRY="mmlsparkmcr.azurecr.io"
+        REPO="synapseml/ci"
+        echo "Content hash: $TAG"
+
+        # Retry manifest inspect to tolerate transient ACR failures
+        IMAGE_EXISTS=false
+        for i in 1 2 3; do
+          if docker manifest inspect "${REGISTRY}/${REPO}:${TAG}" > /dev/null 2>&1; then
+            IMAGE_EXISTS=true
+            break
+          fi
+          [ $i -lt 3 ] && echo "Manifest inspect attempt $i failed, retrying..." && sleep 5
+        done
+
+        if [ "$IMAGE_EXISTS" = "true" ]; then
+          echo "Image ${TAG} exists. Re-tagging server-side as ${LATEST_TAG}."
+          docker buildx imagetools create \
+            --tag "${REGISTRY}/${REPO}:${LATEST_TAG}" \
+            "${REGISTRY}/${REPO}:${TAG}"
+        else
+          echo "Image ${TAG} not found. Building..."
+          docker pull "${REGISTRY}/${REPO}:${LATEST_TAG}" || true
+          docker build \
+            --cache-from "${REGISTRY}/${REPO}:${LATEST_TAG}" \
+            -t "${REGISTRY}/${REPO}:${TAG}" \
+            -t "${REGISTRY}/${REPO}:${LATEST_TAG}" \
+            -f tools/docker/ci/Dockerfile .
+          docker push "${REGISTRY}/${REPO}:${TAG}"
+          docker push "${REGISTRY}/${REPO}:${LATEST_TAG}"
+        fi
+      displayName: 'Check/Build CI Image'
+
+- job: Style
+  dependsOn: BuildCIImage
+  cancelTimeoutInMinutes: 0
+  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testStyle }}', true))
+  pool:
+    vmImage: $(UBUNTU_VERSION)
+  container: ci
+  steps:
+    - template: templates/free_disk.yml
     - task: AzureCLI@2
       displayName: 'Scala Style Check'
       inputs:
@@ -108,7 +185,6 @@ jobs:
         scriptLocation: inlineScript
         scriptType: bash
         inlineScript: 'sbt scalastyle test:scalastyle'
-    - template: templates/conda.yml
     - bash: |
         set -e
         source activate synapseml
@@ -116,14 +192,14 @@ jobs:
       displayName: 'Python Style Check'
 - ${{ if eq(parameters.publishArtifacts, true) }}:
   - job: Publish
-    condition: eq('${{ parameters.publishArtifacts }}', true)
+    dependsOn: BuildCIImage
+    condition: and(succeeded(), eq('${{ parameters.publishArtifacts }}', true))
     cancelTimeoutInMinutes: 0
     pool:
       vmImage: $(UBUNTU_VERSION)
+    container: ci
     steps:
-      #- template: templates/ivy_cache.yml
-      - template: templates/update_cli.yml
-      - template: templates/conda.yml
+      - template: templates/free_disk.yml
       - template: templates/kv.yml
       - task: MavenAuthenticate@0
         name: mavenAuthPublicPackages
@@ -139,7 +215,6 @@ jobs:
           scriptType: bash
           inlineScript: |
             set -e
-            sudo apt-get install graphviz doxygen -y
             source activate synapseml
             sbt packagePython uploadNotebooks
             sbt -DskipCodegen=true publishBlob publishDocs publishR publishPython
@@ -167,11 +242,13 @@ jobs:
 
 - job: DatabricksE2E
   displayName: 'Databricks E2E'
-  condition: eq('${{ parameters.testDatabricksE2E }}', true)
+  dependsOn: BuildCIImage
+  condition: and(succeeded(), eq('${{ parameters.testDatabricksE2E }}', true))
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 0
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   strategy:
     matrix:
       databricks-cpu-1:
@@ -195,9 +272,7 @@ jobs:
 #      databricks-rapids:
 #        TEST-CLASS: "com.microsoft.azure.synapse.ml.nbtest.DatabricksRapidsTests"
   steps:
-    #- template: templates/ivy_cache.yml
-    - template: templates/update_cli.yml
-    - template: templates/conda.yml
+    - template: templates/free_disk.yml
     - template: templates/kv.yml
     - template: templates/publish.yml
     - task: AzureCLI@2
@@ -218,17 +293,19 @@ jobs:
         failTaskOnFailedTests: true
       condition: and(eq(variables.runTests, 'True'), succeededOrFailed())
 
+# FabricE2E runs in the CI container. The Fabric tests are Scala/JVM tests
+# that call Fabric REST APIs — no special Python packages beyond the base env.
 - job: FabricE2E
   displayName: 'Fabric E2E'
-  condition: eq('${{ parameters.testFabricE2E }}', true)
+  dependsOn: BuildCIImage
+  condition: and(succeeded(), eq('${{ parameters.testFabricE2E }}', true))
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 0
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   steps:
-    #- template: templates/ivy_cache.yml
-    - template: templates/update_cli.yml
-    - template: templates/conda.yml
+    - template: templates/free_disk.yml
     - template: templates/kv.yml
     - template: templates/fabric_kv.yml
     - template: templates/publish.yml
@@ -426,11 +503,13 @@ jobs:
         condition: and(eq(variables.isMaster, true), startsWith(variables['tag'], 'v'))
 
 - job: PythonTests
+  dependsOn: BuildCIImage
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 0
-  condition: and(eq(variables.runTests, 'True'), eq('${{ parameters.testPython }}', true))
+  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testPython }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   strategy:
     matrix:
       core:
@@ -452,9 +531,7 @@ jobs:
       cognitive:
         PACKAGE: "cognitive"
   steps:
-    #- template: templates/ivy_cache.yml
-    - template: templates/update_cli.yml
-    - template: templates/conda.yml
+    - template: templates/free_disk.yml
     - template: templates/kv.yml
     - task: AzureCLI@2
       displayName: 'Install and package deps'
@@ -466,11 +543,9 @@ jobs:
         inlineScript: |
           source activate synapseml
           if [ "$(runCoverage)" = "True" ]; then COV_CMD="coverage"; else COV_CMD=""; fi
-          sbt $COV_CMD getDatasets installPipPackage
-          sbt publishM2
+          sbt $COV_CMD getDatasets "project core" installPipPackage publishM2 "project $(PACKAGE)" installPipPackage publishM2
     - task: AzureCLI@2
       displayName: 'Test Python Code'
-      retryCountOnTaskFailure: 1
       timeoutInMinutes: 40
       inputs:
         azureSubscription: 'SynapseML Build'
@@ -479,7 +554,7 @@ jobs:
         inlineScript: |
           set -e
           source activate synapseml
-          export SBT_OPTS="-Xms2G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
+          export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
           echo "##vso[task.setvariable variable=SBT_OPTS]$SBT_OPTS"
           echo "SBT_OPTS=$SBT_OPTS"
           IGNORE_TEST_PATH_FLAG=""
@@ -494,7 +569,6 @@ jobs:
           echo "TEST_SUB_PATH=$TEST_SUB_PATH"
           echo "IGNORE_TEST_PATH_FLAG=$IGNORE_TEST_PATH_FLAG"
           echo "TEST_SUB_PATH_FLAG=$TEST_SUB_PATH_FLAG"
-          (sbt $IGNORE_TEST_PATH_FLAG $TEST_SUB_PATH_FLAG "project $(PACKAGE)" coverage testPython) || \
           (sbt $IGNORE_TEST_PATH_FLAG $TEST_SUB_PATH_FLAG "project $(PACKAGE)" coverage testPython) || \
           (sbt $IGNORE_TEST_PATH_FLAG $TEST_SUB_PATH_FLAG "project $(PACKAGE)" coverage testPython)
     - task: PublishTestResults@2
@@ -515,11 +589,13 @@ jobs:
     - ${{ if or(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/tags/')) }}:
       - template: templates/codecov.yml
 - job: RTests
+  dependsOn: BuildCIImage
   timeoutInMinutes: 60
   cancelTimeoutInMinutes: 0
-  condition: and(eq(variables.runTests, 'True'), eq('${{ parameters.testR }}', true))
+  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testR }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   strategy:
     matrix:
       core:
@@ -535,9 +611,8 @@ jobs:
       cognitive:
         PACKAGE: "cognitive"
   steps:
+    - template: templates/free_disk.yml
     #- template: templates/ivy_cache_2.yml
-    - template: templates/update_cli.yml
-    - template: templates/conda.yml
     - template: templates/kv.yml
     - task: AzureCLI@2
       displayName: 'Prepare for tests'
@@ -549,18 +624,15 @@ jobs:
         scriptType: bash
         inlineScript: |
           set -e
-          export SBT_OPTS="-Xms2G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
+          export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
           source activate synapseml
-          (timeout 5m sbt setup) || (echo "retrying" && timeout 5m sbt setup) || (echo "retrying" && timeout 5m sbt setup)
-          sbt codegen
-          sbt publishM2
+          timeout 30m sbt setup codegen publishM2
           SPARK_VERSION=3.5.0
           HADOOP_VERSION=3
-          # wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
-          wget https://mmlspark.blob.core.windows.net/installers/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
+          wget -q https://mmlspark.blob.core.windows.net/installers/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
     - task: AzureCLI@2
       displayName: 'Test R Code'
-      retryCountOnTaskFailure: 3
+      retryCountOnTaskFailure: 1
       timeoutInMinutes: 20
       inputs:
         azureSubscription: 'SynapseML Build'
@@ -568,7 +640,7 @@ jobs:
         scriptType: bash
         inlineScript: |
           set -e
-          export SBT_OPTS="-Xms2G -Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xss5M  -Duser.timezone=GMT"
+          export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
           source activate synapseml
           timeout 20m sbt -DskipCodegen=true "project $(PACKAGE)" coverage testR
     - task: PublishTestResults@2
@@ -589,23 +661,16 @@ jobs:
     - ${{ if or(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/tags/')) }}:
       - template: templates/codecov.yml
 
-- job: BuildAndCacheCondaEnv
-  cancelTimeoutInMinutes: 0
-  condition: eq(variables.runTests, 'True')
-  pool:
-    vmImage: $(UBUNTU_VERSION)
-  steps:
-    - template: templates/conda.yml
-
 - job: WebsiteSamplesTests
+  dependsOn: BuildCIImage
   cancelTimeoutInMinutes: 0
-  condition: and(eq(variables.runTests, 'True'), eq('${{ parameters.testWebsiteSamples }}', true))
+  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testWebsiteSamples }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   steps:
+    - template: templates/free_disk.yml
     #- template: templates/ivy_cache.yml
-    - template: templates/update_cli.yml
-    - template: templates/conda.yml
     - template: templates/kv.yml
     - template: templates/publish.yml
     - task: AzureCLI@2
@@ -616,9 +681,10 @@ jobs:
         scriptLocation: inlineScript
         scriptType: bash
         inlineScript: |
-          (timeout 5m sbt setup) || (echo "retrying" && timeout 5m sbt setup) || (echo "retrying" && timeout 5m sbt setup)
+          export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M -Duser.timezone=GMT"
           if [ "$(runCoverage)" = "True" ]; then COV_CMD="coverage"; else COV_CMD=""; fi
-          (sbt $COV_CMD testWebsiteDocs)
+          (timeout 30m sbt setup) || (echo "retrying" && timeout 30m sbt setup)
+          sbt $COV_CMD testWebsiteDocs
     - task: PublishTestResults@2
       displayName: 'Publish Test Results'
       inputs:
@@ -638,124 +704,166 @@ jobs:
       - template: templates/codecov.yml
 
 - job: UnitTests
+  dependsOn: BuildCIImage
   cancelTimeoutInMinutes: 1
-  timeoutInMinutes: 80
-  condition: and(eq(variables.runTests, 'True'), eq('${{ parameters.testUnit }}', true))
+  timeoutInMinutes: 50
+  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testUnit }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   strategy:
     matrix:
       automl:
         PACKAGE: "automl"
+        PROJECT: "core"
       causal:
         PACKAGE: "causal"
+        PROJECT: "core"
       onnx:
         PACKAGE: "onnx"
+        PROJECT: "deepLearning"
       geospatial:
         PACKAGE: "services.geospatial"
+        PROJECT: "cognitive"
       anomaly:
         PACKAGE: "services.anomaly"
+        PROJECT: "cognitive"
         FLAKY: "true"
       face:
         PACKAGE: "services.face"
+        PROJECT: "cognitive"
         FLAKY: "true"
       form:
         PACKAGE: "services.form"
+        PROJECT: "cognitive"
         FLAKY: "true"
       language:
         PACKAGE: "services.language"
+        PROJECT: "cognitive"
         FLAKY: "true"
       openai:
         PACKAGE: "services.openai"
+        PROJECT: "cognitive"
         FLAKY: "true"
       aifoundry:
         PACKAGE: "services.aifoundry"
+        PROJECT: "cognitive"
         FLAKY: "true"
       search1:
         PACKAGE: "services.search.split1"
+        PROJECT: "cognitive"
         FFMPEG: "true"
         FLAKY: "true"
       search2:
         PACKAGE: "services.search.split2"
+        PROJECT: "cognitive"
         FFMPEG: "true"
         FLAKY: "true"
       speech1:
         PACKAGE: "services.speech"
         TEST_CLASSES: "com.microsoft.azure.synapse.ml.services.speech.SpeechToTextSDKSuite"
+        PROJECT: "cognitive"
         FFMPEG: "true"
         FLAKY: "true"
       speech2:
         PACKAGE: "services.speech"
         TEST_CLASSES: "com.microsoft.azure.synapse.ml.services.speech.ConversationTranscriptionSuite com.microsoft.azure.synapse.ml.services.speech.SpeechToTextSuite com.microsoft.azure.synapse.ml.services.speech.TextToSpeechSuite com.microsoft.azure.synapse.ml.services.speech.SpeakerEmotionInferenceSuite"
+        PROJECT: "cognitive"
         FFMPEG: "true"
         FLAKY: "true"
       text:
         PACKAGE: "services.text"
+        PROJECT: "cognitive"
         FLAKY: "true"
       translate:
         PACKAGE: "services.translate"
+        PROJECT: "cognitive"
         FLAKY: "true"
       vision:
         PACKAGE: "services.vision"
+        PROJECT: "cognitive"
         FLAKY: "true"
       core:
         PACKAGE: "core"
+        PROJECT: "core"
       explainers1:
         PACKAGE: "explainers.split1"
+        PROJECT: "core"
       explainers2:
         PACKAGE: "explainers.split2"
+        PROJECT: "deepLearning"
       explainers3:
         PACKAGE: "explainers.split3"
+        PROJECT: "deepLearning"
       exploratory:
         PACKAGE: "exploratory"
+        PROJECT: "core"
       featurize:
         PACKAGE: "featurize"
+        PROJECT: "core"
       image:
         PACKAGE: "image"
+        PROJECT: "core"
       io1:
         PACKAGE: "io.split1"
+        PROJECT: "core"
         FLAKY: "true"
       io2:
         PACKAGE: "io.split2"
+        PROJECT: "core"
         FLAKY: "true"
       isolationforest:
         PACKAGE: "isolationforest"
+        PROJECT: "core"
       flaky:
         PACKAGE: "flaky"           #TODO fix flaky test so isolation is not needed
+        PROJECT: "core"
         FLAKY: "true"
       lightgbm1:
         PACKAGE: "lightgbm.split1" #TODO speed up LGBM Tests and remove split
+        PROJECT: "lightgbm"
         FLAKY: "true"
       lightgbm2:
         PACKAGE: "lightgbm.split2"
+        PROJECT: "lightgbm"
         FLAKY: "true"
       lightgbm3:
         PACKAGE: "lightgbm.split3"
+        PROJECT: "lightgbm"
         FLAKY: "true"
       lightgbm4:
         PACKAGE: "lightgbm.split4"
+        PROJECT: "lightgbm"
         FLAKY: "true"
       lightgbm5:
         PACKAGE: "lightgbm.split5"
+        PROJECT: "lightgbm"
         FLAKY: "true"
       lightgbm6:
         PACKAGE: "lightgbm.split6"
+        PROJECT: "lightgbm"
         FLAKY: "true"
       opencv:
         PACKAGE: "opencv"
+        PROJECT: "opencv"
       recommendation:
         PACKAGE: "recommendation"
+        PROJECT: "core"
       stages:
         PACKAGE: "stages"
+        PROJECT: "core"
       nn:
         PACKAGE: "nn"
+        PROJECT: "core"
       train:
         PACKAGE: "train"
+        PROJECT: "core"
       vw:
         PACKAGE: "vw"
+        PROJECT: "vw"
   steps:
+    - template: templates/free_disk.yml
     #- template: templates/ivy_cache.yml
-    - template: templates/update_cli.yml
     - task: AzureCLI@2
       displayName: 'Setup repo'
       retryCountOnTaskFailure: 1
@@ -764,14 +872,10 @@ jobs:
         scriptLocation: inlineScript
         scriptType: bash
         inlineScript: |
-          (timeout 30s pip install requests) || (echo "retrying" && timeout 30s pip install requests)
-          (${FFMPEG:-false} && sudo apt-get update && \
-          sudo apt-get install ffmpeg libgstreamer1.0-0 \
-          gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly -y)
-          (timeout 5m sbt setup) || (echo "retrying" && timeout 5m sbt setup) || (echo "retrying" && timeout 5m sbt setup)
+          export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M -Duser.timezone=GMT"
+          sbt getDatasets "project $(PROJECT)" Test/compile
     - task: AzureCLI@2
       displayName: 'Unit Test'
-      retryCountOnTaskFailure: 1
       timeoutInMinutes: 90
       inputs:
         azureSubscription: 'SynapseML Build'
@@ -779,12 +883,13 @@ jobs:
         scriptType: bash
         inlineScript: |
           ulimit -c unlimited
-          export SBT_OPTS="-XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M  -Duser.timezone=GMT"
+          echo "Available CPUs: $(nproc)"
+          export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M -Duser.timezone=GMT -Dscala.concurrent.context.numThreads=8 -Dscala.concurrent.context.maxThreads=8"
           # Only run coverage on PRs, master, or tag builds
           if [ "$(runCoverage)" = "True" ]; then COV_CMD="coverage"; else COV_CMD=""; fi
           TEST_SPEC="${TEST_CLASSES:-com.microsoft.azure.synapse.ml.$(PACKAGE).**}"
-          (timeout 30m sbt $COV_CMD "testOnly $TEST_SPEC") ||
-          (${FLAKY:-false} && timeout 30m sbt $COV_CMD "testOnly $TEST_SPEC")
+          (timeout 30m sbt $COV_CMD "project $(PROJECT)" "testOnly $TEST_SPEC") ||
+          (${FLAKY:-false} && timeout 30m sbt $COV_CMD "project $(PROJECT)" "testOnly $TEST_SPEC")
     - task: PublishTestResults@2
       displayName: 'Publish Test Results'
       inputs:

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -120,14 +120,8 @@ jobs:
       fetchDepth: 1
     - bash: |
         set -euo pipefail
-        hash_files=(
-          environment.yml
-          build.sbt
-          sonatype.sbt
-          tools/docker/ci/Dockerfile
-        )
         HASH=$({
-          sha256sum "${hash_files[@]}"
+          sha256sum environment.yml build.sbt sonatype.sbt tools/docker/ci/Dockerfile
           find project -type f -print0 | sort -z | xargs -0 sha256sum
         } | sha256sum | cut -c1-12)
         EXPECTED_TAG="ci-${HASH}"
@@ -262,14 +256,8 @@ jobs:
         containerRegistry: 'SynapseML MCR'
     - bash: |
         set -euo pipefail
-        hash_files=(
-          environment.yml
-          build.sbt
-          sonatype.sbt
-          tools/docker/ci/Dockerfile
-        )
         HASH=$({
-          sha256sum "${hash_files[@]}"
+          sha256sum environment.yml build.sbt sonatype.sbt tools/docker/ci/Dockerfile
           find project -type f -print0 | sort -z | xargs -0 sha256sum
         } | sha256sum | cut -c1-12)
         TAG="ci-${HASH}"
@@ -329,7 +317,6 @@ jobs:
     - bash: |
         set -e
         source activate synapseml
-        pip install 'black[jupyter]==22.3.0'
         black --diff --color . && black --check -q .
       displayName: 'Python Style Check'
 - ${{ if eq(parameters.publishArtifacts, true) }}:
@@ -345,7 +332,6 @@ jobs:
     steps:
       - template: templates/free_disk.yml
       - template: templates/sbt_cache.yml
-      - template: templates/conda.yml
       - template: templates/kv.yml
       - bash: |
           set -euo pipefail

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1,14 +1,9 @@
 resources:
   containers:
-  # Use the existing ARM service connection for both ACR resource access and
-  # publishing. BuildCIImage creates a missing immutable tag before consumers run.
+  # BuildCIImage publishes immutable ci-* tags through the existing public MCR
+  # mapping. Consumers, including fork PRs, never need private registry credentials.
   - container: ci
-    image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-112db6614927
-    type: acr
-    azureSubscription: 'SynapseML Build'
-    resourceGroup: marhamil-mmlspark
-    registry: mmlsparkmcr
-    repository: synapseml/ci
+    image: mcr.microsoft.com/mmlspark/build-demo:ci-112db6614927
   repositories:
   - repository: SynapseML-Internal
     type: git
@@ -214,41 +209,89 @@ jobs:
             exit 1
           fi
           registry="mmlsparkmcr.azurecr.io"
-          repository="synapseml/ci"
+          repository="public/mmlspark/build-demo"
           image="${registry}/${repository}:${tag}"
+          public_image="mcr.microsoft.com/mmlspark/build-demo:${tag}"
+          manifest_url="https://mcr.microsoft.com/v2/mmlspark/build-demo/manifests/${tag}"
           java_version="$(python3 tools/ci/ci_image.py java-version)"
           spark_version="$(python3 tools/ci/ci_image.py spark-version)"
           spark_sha512="$(python3 tools/ci/ci_image.py spark-sha512)"
           torch_version="$(python3 tools/ci/ci_image.py dependency-version torch)"
           torchvision_version="$(python3 tools/ci/ci_image.py dependency-version torchvision)"
 
-          az acr login --name mmlsparkmcr
-          if docker manifest inspect "$image" >/dev/null 2>&1; then
-            echo "Immutable CI image already exists: $image"
+          get_public_digest() {
+            curl --fail --silent --head \
+              --header 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
+              "$manifest_url" 2>/dev/null \
+              | tr -d '\r' \
+              | awk -F': ' 'tolower($1) == "docker-content-digest" {print $2}' \
+              || true
+          }
+
+          public_digest="$(get_public_digest)"
+          if [ -n "$public_digest" ]; then
+            echo "Public immutable CI image already exists: $public_image ($public_digest)"
             exit 0
           fi
 
-          echo "Building $image with Java $java_version and Spark $spark_version"
-          sudo rm -rf /usr/local/lib/android \
-            /usr/lib/google-cloud-sdk \
-            /usr/share/dotnet \
-            /opt/ghc \
-            /opt/hostedtoolcache \
-            /usr/local/share/boost \
-            /usr/share/swift \
-            /usr/local/.ghcup \
-            /usr/share/miniconda \
-            /usr/local/share/chromium
-          docker image prune -af
-          docker build \
-            --build-arg JAVA_VERSION="$java_version" \
-            --build-arg SPARK_VERSION="$spark_version" \
-            --build-arg SPARK_SHA512="$spark_sha512" \
-            --build-arg TORCH_VERSION="$torch_version" \
-            --build-arg TORCHVISION_VERSION="$torchvision_version" \
-            --tag "$image" \
-            --file tools/docker/ci/Dockerfile .
-          docker push "$image"
+          az acr login --name mmlsparkmcr
+          acr_digest="$(
+            az acr repository show \
+              --name mmlsparkmcr \
+              --image "${repository}:${tag}" \
+              --query digest \
+              --output tsv 2>/dev/null || true
+          )"
+          if [ -n "$acr_digest" ]; then
+            echo "Immutable CI image already exists: $image"
+          else
+            echo "Building $image with Java $java_version and Spark $spark_version"
+            sudo rm -rf /usr/local/lib/android \
+              /usr/lib/google-cloud-sdk \
+              /usr/share/dotnet \
+              /opt/ghc \
+              /opt/hostedtoolcache \
+              /usr/local/share/boost \
+              /usr/share/swift \
+              /usr/local/.ghcup \
+              /usr/share/miniconda \
+              /usr/local/share/chromium
+            docker image prune -af
+            docker build \
+              --build-arg JAVA_VERSION="$java_version" \
+              --build-arg SPARK_VERSION="$spark_version" \
+              --build-arg SPARK_SHA512="$spark_sha512" \
+              --build-arg TORCH_VERSION="$torch_version" \
+              --build-arg TORCHVISION_VERSION="$torchvision_version" \
+              --tag "$image" \
+              --file tools/docker/ci/Dockerfile .
+            docker push "$image"
+            acr_digest="$(
+              az acr repository show \
+                --name mmlsparkmcr \
+                --image "${repository}:${tag}" \
+                --query digest \
+                --output tsv
+            )"
+          fi
+
+          for attempt in $(seq 1 30); do
+            public_digest="$(get_public_digest)"
+            if [ "$public_digest" = "$acr_digest" ]; then
+              echo "Public CI image is ready: $public_image ($public_digest)"
+              exit 0
+            fi
+            if [ -n "$public_digest" ]; then
+              echo "##vso[task.logissue type=error]MCR digest $public_digest does not match ACR digest $acr_digest."
+              exit 1
+            fi
+            if [ "$attempt" -eq 30 ]; then
+              echo "##vso[task.logissue type=error]Timed out waiting for $public_image to become available from MCR."
+              exit 1
+            fi
+            echo "Waiting for MCR to publish $public_image (attempt $attempt/30)"
+            sleep 20
+          done
 
 - job: ValidateCIImageForFork
   displayName: 'Validate fork CI image inputs'
@@ -271,6 +314,22 @@ jobs:
           git diff --name-only "$target_ref...HEAD" -- "${image_inputs[@]}"
           exit 1
         fi
+
+        tag="$(python3 tools/ci/ci_image.py tag)"
+        manifest_url="https://mcr.microsoft.com/v2/mmlspark/build-demo/manifests/${tag}"
+        public_digest="$(
+          curl --fail --silent --head \
+            --header 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
+            "$manifest_url" \
+            | tr -d '\r' \
+            | awk -F': ' 'tolower($1) == "docker-content-digest" {print $2}' \
+            || true
+        )"
+        if [ -z "$public_digest" ]; then
+          echo "##vso[task.logissue type=error]The public CI image for $tag is unavailable. Ask a maintainer to publish it from a trusted branch."
+          exit 1
+        fi
+        echo "Public CI image is ready for this fork: $public_digest"
       displayName: 'Reject unpublished fork image changes'
 
 - job: Style

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -11,7 +11,7 @@ resources:
   #      BuildCIImage job on master. A change to any of those inputs therefore
   #      needs its image published from master before this pipeline can pull it.
   - container: ci
-    image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-060baf1aac44
+    image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-2b4cdb1f2a8d
     endpoint: 'SynapseML MCR'
   repositories:
   - repository: SynapseML-Internal
@@ -111,7 +111,7 @@ variables:
   CONDA_CACHE_DIR: /usr/share/miniconda/envs
   UBUNTU_VERSION: ubuntu-22.04
   ComponentDetection.Timeout: 900
-  CI_IMAGE_TAG: ci-060baf1aac44
+  CI_IMAGE_TAG: ci-2b4cdb1f2a8d
   isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isTag: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]
@@ -132,7 +132,7 @@ jobs:
         set -euo pipefail
         HASH=$({
           sha256sum environment.yml build.sbt sonatype.sbt tools/docker/ci/Dockerfile
-          find project -type f -print0 | sort -z | xargs -0 sha256sum
+          git ls-files -z -- project | sort -z | xargs -0 sha256sum
         } | sha256sum | cut -c1-12)
         EXPECTED_TAG="ci-${HASH}"
         VARIABLE_TAG="$(CI_IMAGE_TAG)"
@@ -268,7 +268,7 @@ jobs:
         set -euo pipefail
         HASH=$({
           sha256sum environment.yml build.sbt sonatype.sbt tools/docker/ci/Dockerfile
-          find project -type f -print0 | sort -z | xargs -0 sha256sum
+          git ls-files -z -- project | sort -z | xargs -0 sha256sum
         } | sha256sum | cut -c1-12)
         TAG="ci-${HASH}"
         EXPECTED_TAG="$(CI_IMAGE_TAG)"
@@ -792,7 +792,11 @@ jobs:
     - bash: |
         source activate synapseml
         if [ "$(runCoverage)" = "True" ]; then COV_CMD="coverage"; else COV_CMD=""; fi
-        sbt $COV_CMD getDatasets "project core" installPipPackage publishM2 "project $(PACKAGE)" installPipPackage publishM2
+        SBT_TASKS=(getDatasets "project core" installPipPackage publishM2)
+        if [ "$(PACKAGE)" != "core" ]; then
+          SBT_TASKS+=("project $(PACKAGE)" installPipPackage publishM2)
+        fi
+        sbt $COV_CMD "${SBT_TASKS[@]}"
       displayName: 'Install and package deps'
       timeoutInMinutes: 40
     - task: AzureCLI@2

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -11,7 +11,7 @@ resources:
     #      BuildCIImage job on master. A change to any of those inputs therefore
     #      needs its image published from master before this pipeline can pull it.
     - container: ci
-      image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-d68ec548140c
+      image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-048168ac6295
       endpoint: 'SynapseML MCR'
 
 trigger:
@@ -101,7 +101,7 @@ variables:
   CONDA_CACHE_DIR: /usr/share/miniconda/envs
   UBUNTU_VERSION: ubuntu-22.04
   ComponentDetection.Timeout: 900
-  CI_IMAGE_TAG: ci-d68ec548140c
+  CI_IMAGE_TAG: ci-048168ac6295
   isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isTag: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -4,7 +4,7 @@ resources:
   # publishing. BuildCIImage creates a missing immutable tag before consumers run.
   - container: ci
     image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-112db6614927
-    type: ACR
+    type: acr
     azureSubscription: 'SynapseML Build'
     resourceGroup: marhamil-mmlspark
     registry: mmlsparkmcr

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -11,7 +11,7 @@ resources:
     #      BuildCIImage job on master. A change to any of those inputs therefore
     #      needs its image published from master before this pipeline can pull it.
     - container: ci
-      image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-060baf1aac44
+      image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-2b4cdb1f2a8d
       endpoint: 'SynapseML MCR'
 
 trigger:
@@ -101,7 +101,7 @@ variables:
   CONDA_CACHE_DIR: /usr/share/miniconda/envs
   UBUNTU_VERSION: ubuntu-22.04
   ComponentDetection.Timeout: 900
-  CI_IMAGE_TAG: ci-060baf1aac44
+  CI_IMAGE_TAG: ci-2b4cdb1f2a8d
   isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isTag: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]
@@ -122,7 +122,7 @@ jobs:
         set -euo pipefail
         HASH=$({
           sha256sum environment.yml build.sbt sonatype.sbt tools/docker/ci/Dockerfile
-          find project -type f -print0 | sort -z | xargs -0 sha256sum
+          git ls-files -z -- project | sort -z | xargs -0 sha256sum
         } | sha256sum | cut -c1-12)
         EXPECTED_TAG="ci-${HASH}"
         VARIABLE_TAG="$(CI_IMAGE_TAG)"
@@ -258,7 +258,7 @@ jobs:
         set -euo pipefail
         HASH=$({
           sha256sum environment.yml build.sbt sonatype.sbt tools/docker/ci/Dockerfile
-          find project -type f -print0 | sort -z | xargs -0 sha256sum
+          git ls-files -z -- project | sort -z | xargs -0 sha256sum
         } | sha256sum | cut -c1-12)
         TAG="ci-${HASH}"
         EXPECTED_TAG="$(CI_IMAGE_TAG)"
@@ -712,7 +712,11 @@ jobs:
     - bash: |
         source activate synapseml
         if [ "$(runCoverage)" = "True" ]; then COV_CMD="coverage"; else COV_CMD=""; fi
-        sbt $COV_CMD getDatasets "project core" installPipPackage publishM2 "project $(PACKAGE)" installPipPackage publishM2
+        SBT_TASKS=(getDatasets "project core" installPipPackage publishM2)
+        if [ "$(PACKAGE)" != "core" ]; then
+          SBT_TASKS+=("project $(PACKAGE)" installPipPackage publishM2)
+        fi
+        sbt $COV_CMD "${SBT_TASKS[@]}"
       displayName: 'Install and package deps'
       timeoutInMinutes: 40
     - task: AzureCLI@2

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1,18 +1,14 @@
 resources:
   containers:
-  # Prerequisites, both of which fail the build at resource-validation time —
-  # before any job starts — so neither surfaces as a normal job failure:
-  #   1. A Docker Registry service connection named exactly 'SynapseML MCR',
-  #      pointing at mmlsparkmcr.azurecr.io, must exist in the ADO project and
-  #      be authorized for this pipeline.
-  #   2. The tag below must already be present in the registry. It is content
-  #      addressed from .dockerignore + environment.yml + build.sbt + sonatype.sbt +
-  #      project/ + tools/docker/ci/Dockerfile, and is built and pushed only by the
-  #      BuildCIImage job on master. A change to any of those inputs therefore
-  #      needs its image published from master before this pipeline can pull it.
+  # Use the existing ARM service connection for both ACR resource access and
+  # publishing. BuildCIImage creates a missing immutable tag before consumers run.
   - container: ci
-    image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-048168ac6295
-    endpoint: 'SynapseML MCR'
+    image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-112db6614927
+    type: ACR
+    azureSubscription: 'SynapseML Build'
+    resourceGroup: marhamil-mmlspark
+    registry: mmlsparkmcr
+    repository: synapseml/ci
   repositories:
   - repository: SynapseML-Internal
     type: git
@@ -111,7 +107,7 @@ variables:
   CONDA_CACHE_DIR: /usr/share/miniconda/envs
   UBUNTU_VERSION: ubuntu-22.04
   ComponentDetection.Timeout: 900
-  CI_IMAGE_TAG: ci-048168ac6295
+  CI_IMAGE_TAG: ci-112db6614927
   isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isTag: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]
@@ -130,45 +126,7 @@ jobs:
       fetchDepth: 1
     - bash: |
         set -euo pipefail
-        HASH=$({
-          sha256sum .dockerignore environment.yml build.sbt sonatype.sbt tools/docker/ci/Dockerfile
-          git ls-files -z -- project | sort -z | xargs -0 sha256sum
-        } | sha256sum | cut -c1-12)
-        EXPECTED_TAG="ci-${HASH}"
-        VARIABLE_TAG="$(CI_IMAGE_TAG)"
-        RESOURCE_TAG="$(
-          python3 - <<'PY'
-        from pathlib import Path
-
-        lines = Path("pipeline.yaml").read_text(encoding="utf-8").splitlines()
-        in_ci = False
-        for line in lines:
-            stripped = line.strip()
-            if stripped == "- container: ci":
-                in_ci = True
-                continue
-            if in_ci and stripped.startswith("image:"):
-                image = stripped.split(":", 1)[1].strip().strip("'\"")
-                print(image.rsplit(":", 1)[1])
-                break
-        else:
-            raise SystemExit("Could not find resources.containers ci image tag")
-        PY
-        )"
-
-        echo "CI image content hash tag: $EXPECTED_TAG"
-        echo "CI_IMAGE_TAG variable: $VARIABLE_TAG"
-        echo "resources.containers[ci] image tag: $RESOURCE_TAG"
-
-        if [ "$VARIABLE_TAG" != "$EXPECTED_TAG" ]; then
-          echo "##vso[task.logissue type=error]CI_IMAGE_TAG ($VARIABLE_TAG) does not match dependency hash ($EXPECTED_TAG). Update the CI image tag with the Dockerfile/dependency change."
-          exit 1
-        fi
-
-        if [ "$RESOURCE_TAG" != "$EXPECTED_TAG" ]; then
-          echo "##vso[task.logissue type=error]resources.containers[ci] image tag ($RESOURCE_TAG) does not match dependency hash ($EXPECTED_TAG). Update resources.containers[ci].image with the same tag."
-          exit 1
-        fi
+        python3 tools/ci/ci_image.py check
       displayName: 'Validate CI image tag'
     - bash: |
         set -uo pipefail
@@ -231,91 +189,97 @@ jobs:
 
 
 - job: BuildCIImage
-  displayName: 'Build trusted CI image'
+  displayName: 'Publish missing trusted CI image'
   cancelTimeoutInMinutes: 0
-  timeoutInMinutes: 60
+  timeoutInMinutes: 90
+  condition: or(ne(variables.isPR, true), ne(variables['System.PullRequest.IsFork'], 'True'))
   pool:
     vmImage: $(UBUNTU_VERSION)
   steps:
     - checkout: self
       fetchDepth: 1
-    - bash: |
-        set -euo pipefail
-        echo "=== Disk space BEFORE cleanup ==="
-        df -h / | grep -E 'Filesystem|/$'
-        sudo rm -rf /usr/local/lib/android || true
-        sudo rm -rf /usr/lib/google-cloud-sdk || true
-        sudo rm -rf /usr/share/dotnet || true
-        sudo rm -rf /opt/ghc || true
-        sudo rm -rf /opt/hostedtoolcache || true
-        sudo rm -rf /usr/local/share/boost || true
-        sudo rm -rf /usr/share/swift || true
-        sudo rm -rf /usr/local/.ghcup || true
-        sudo rm -rf /usr/share/miniconda || true
-        sudo rm -rf /usr/local/share/chromium || true
-        sudo docker image prune -af || true
-        echo "=== Disk space AFTER cleanup ==="
-        df -h / | grep -E 'Filesystem|/$'
-      displayName: 'Free disk space'
-      condition: and(succeeded(), eq(variables.isMaster, true), ne(variables.isPR, true))
-    - task: Docker@2
-      displayName: 'Login to ACR'
-      condition: and(succeeded(), eq(variables.isMaster, true), ne(variables.isPR, true))
+    - task: AzureCLI@2
+      displayName: 'Build or reuse CI image'
       inputs:
-        command: login
-        containerRegistry: 'SynapseML MCR'
+        azureSubscription: 'SynapseML Build'
+        scriptLocation: inlineScript
+        scriptType: bash
+        inlineScript: |
+          set -euo pipefail
+          python3 tools/ci/ci_image.py check
+
+          tag="$(python3 tools/ci/ci_image.py tag)"
+          if [ "$tag" != "$(CI_IMAGE_TAG)" ]; then
+            echo "##vso[task.logissue type=error]Computed CI image tag $tag does not match $(CI_IMAGE_TAG)."
+            exit 1
+          fi
+          registry="mmlsparkmcr.azurecr.io"
+          repository="synapseml/ci"
+          image="${registry}/${repository}:${tag}"
+          java_version="$(python3 tools/ci/ci_image.py java-version)"
+          spark_version="$(python3 tools/ci/ci_image.py spark-version)"
+          spark_sha512="$(python3 tools/ci/ci_image.py spark-sha512)"
+          torch_version="$(python3 tools/ci/ci_image.py dependency-version torch)"
+          torchvision_version="$(python3 tools/ci/ci_image.py dependency-version torchvision)"
+
+          az acr login --name mmlsparkmcr
+          if docker manifest inspect "$image" >/dev/null 2>&1; then
+            echo "Immutable CI image already exists: $image"
+            exit 0
+          fi
+
+          echo "Building $image with Java $java_version and Spark $spark_version"
+          sudo rm -rf /usr/local/lib/android \
+            /usr/lib/google-cloud-sdk \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /opt/hostedtoolcache \
+            /usr/local/share/boost \
+            /usr/share/swift \
+            /usr/local/.ghcup \
+            /usr/share/miniconda \
+            /usr/local/share/chromium
+          docker image prune -af
+          docker build \
+            --build-arg JAVA_VERSION="$java_version" \
+            --build-arg SPARK_VERSION="$spark_version" \
+            --build-arg SPARK_SHA512="$spark_sha512" \
+            --build-arg TORCH_VERSION="$torch_version" \
+            --build-arg TORCHVISION_VERSION="$torchvision_version" \
+            --tag "$image" \
+            --file tools/docker/ci/Dockerfile .
+          docker push "$image"
+
+- job: ValidateCIImageForFork
+  displayName: 'Validate fork CI image inputs'
+  cancelTimeoutInMinutes: 0
+  condition: and(not(failed()), not(canceled()), eq(variables['System.PullRequest.IsFork'], 'True'))
+  pool:
+    vmImage: $(UBUNTU_VERSION)
+  steps:
+    - checkout: self
+      fetchDepth: 0
     - bash: |
         set -euo pipefail
-        HASH=$({
-          sha256sum .dockerignore environment.yml build.sbt sonatype.sbt tools/docker/ci/Dockerfile
-          git ls-files -z -- project | sort -z | xargs -0 sha256sum
-        } | sha256sum | cut -c1-12)
-        TAG="ci-${HASH}"
-        EXPECTED_TAG="$(CI_IMAGE_TAG)"
-        LATEST_TAG="ci-latest"
-        REGISTRY="mmlsparkmcr.azurecr.io"
-        REPO="synapseml/ci"
-        echo "Content hash: $TAG"
-
-        if [ "$TAG" != "$EXPECTED_TAG" ]; then
-          echo "##vso[task.logissue type=error]CI_IMAGE_TAG ($EXPECTED_TAG) does not match dependency hash ($TAG). Update the pipeline image tag with the Dockerfile/dependency change."
+        target_branch="${SYSTEM_PULLREQUEST_TARGETBRANCH#refs/heads/}"
+        target_ref="refs/remotes/origin/${target_branch}"
+        git fetch --no-tags --depth=1 origin \
+          "+refs/heads/${target_branch}:${target_ref}"
+        mapfile -t image_inputs < <(python3 tools/ci/ci_image.py inputs)
+        if ! git diff --quiet "$target_ref...HEAD" -- "${image_inputs[@]}"; then
+          echo "##vso[task.logissue type=error]Fork pull requests cannot change tools/docker/ci/** or other CI image inputs because registry credentials are not exposed to forks. Ask a maintainer to publish the new immutable image from a trusted branch."
+          git diff --name-only "$target_ref...HEAD" -- "${image_inputs[@]}"
           exit 1
         fi
-
-        IMAGE_EXISTS=false
-        for i in 1 2 3; do
-          if docker manifest inspect "${REGISTRY}/${REPO}:${TAG}" > /dev/null 2>&1; then
-            IMAGE_EXISTS=true
-            break
-          fi
-          [ $i -lt 3 ] && echo "Manifest inspect attempt $i failed, retrying..." && sleep 5
-        done
-
-        if [ "$IMAGE_EXISTS" = "true" ]; then
-          echo "Image $TAG exists. Re-tagging server-side as $LATEST_TAG."
-          docker buildx imagetools create \
-            --tag "${REGISTRY}/${REPO}:${LATEST_TAG}" \
-            "${REGISTRY}/${REPO}:${TAG}"
-        else
-          echo "Image $TAG not found. Building from trusted master."
-          docker pull "${REGISTRY}/${REPO}:${LATEST_TAG}" || true
-          docker build \
-            --cache-from "${REGISTRY}/${REPO}:${LATEST_TAG}" \
-            -t "${REGISTRY}/${REPO}:${TAG}" \
-            -t "${REGISTRY}/${REPO}:${LATEST_TAG}" \
-            -f tools/docker/ci/Dockerfile .
-          docker push "${REGISTRY}/${REPO}:${TAG}"
-          docker push "${REGISTRY}/${REPO}:${LATEST_TAG}"
-        fi
-      displayName: 'Check/Build CI Image'
-      condition: and(succeeded(), eq(variables.isMaster, true), ne(variables.isPR, true))
+      displayName: 'Reject unpublished fork image changes'
 
 - job: Style
   dependsOn:
     - BuildAndCacheSbt
     - BuildCIImage
+    - ValidateCIImageForFork
   cancelTimeoutInMinutes: 0
-  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testStyle }}', true))
+  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testStyle }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   container: ci
@@ -334,7 +298,8 @@ jobs:
     dependsOn:
       - BuildAndCacheSbt
       - BuildCIImage
-    condition: and(succeeded(), eq('${{ parameters.publishArtifacts }}', true))
+      - ValidateCIImageForFork
+    condition: and(not(failed()), not(canceled()), eq('${{ parameters.publishArtifacts }}', true))
     cancelTimeoutInMinutes: 0
     pool:
       vmImage: $(UBUNTU_VERSION)
@@ -394,10 +359,12 @@ jobs:
   dependsOn:
     - BuildAndCacheSbt
     - BuildCIImage
+    - ValidateCIImageForFork
   displayName: 'Databricks CPU E2E'
   condition: >-
     and(
-      succeeded(),
+      not(failed()),
+      not(canceled()),
       eq(variables.runTests, 'True'),
       eq('${{ parameters.testDatabricksE2E }}', true),
       eq(dependencies.BuildAndCacheSbt.outputs['detectDatabricksImpact.runDatabricksCpuE2E'], 'true')
@@ -430,10 +397,12 @@ jobs:
   dependsOn:
     - BuildAndCacheSbt
     - BuildCIImage
+    - ValidateCIImageForFork
   displayName: 'Databricks GPU E2E'
   condition: >-
     and(
-      succeeded(),
+      not(failed()),
+      not(canceled()),
       eq(variables.runTests, 'True'),
       eq('${{ parameters.testDatabricksE2E }}', true),
       eq(dependencies.BuildAndCacheSbt.outputs['detectDatabricksImpact.runDatabricksGpuE2E'], 'true')
@@ -456,6 +425,7 @@ jobs:
   dependsOn:
     - BuildAndCacheSbt
     - BuildCIImage
+    - ValidateCIImageForFork
   displayName: 'Fabric E2E'
   condition: >-
     and(
@@ -758,9 +728,10 @@ jobs:
   dependsOn:
     - BuildAndCacheSbt
     - BuildCIImage
+    - ValidateCIImageForFork
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 0
-  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testPython }}', true))
+  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testPython }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   container: ci
@@ -844,9 +815,10 @@ jobs:
   dependsOn:
     - BuildAndCacheSbt
     - BuildCIImage
+    - ValidateCIImageForFork
   timeoutInMinutes: 60
   cancelTimeoutInMinutes: 0
-  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testR }}', true))
+  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testR }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   container: ci
@@ -907,8 +879,9 @@ jobs:
   dependsOn:
     - BuildAndCacheSbt
     - BuildCIImage
+    - ValidateCIImageForFork
   cancelTimeoutInMinutes: 0
-  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testWebsiteSamples }}', true))
+  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testWebsiteSamples }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   container: ci
@@ -951,9 +924,10 @@ jobs:
   dependsOn:
     - BuildAndCacheSbt
     - BuildCIImage
+    - ValidateCIImageForFork
   cancelTimeoutInMinutes: 1
   timeoutInMinutes: 100
-  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testUnit }}', true))
+  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testUnit }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   container: ci

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -110,14 +110,8 @@ jobs:
       fetchDepth: 1
     - bash: |
         set -euo pipefail
-        hash_files=(
-          environment.yml
-          build.sbt
-          sonatype.sbt
-          tools/docker/ci/Dockerfile
-        )
         HASH=$({
-          sha256sum "${hash_files[@]}"
+          sha256sum environment.yml build.sbt sonatype.sbt tools/docker/ci/Dockerfile
           find project -type f -print0 | sort -z | xargs -0 sha256sum
         } | sha256sum | cut -c1-12)
         EXPECTED_TAG="ci-${HASH}"
@@ -252,14 +246,8 @@ jobs:
         containerRegistry: 'SynapseML MCR'
     - bash: |
         set -euo pipefail
-        hash_files=(
-          environment.yml
-          build.sbt
-          sonatype.sbt
-          tools/docker/ci/Dockerfile
-        )
         HASH=$({
-          sha256sum "${hash_files[@]}"
+          sha256sum environment.yml build.sbt sonatype.sbt tools/docker/ci/Dockerfile
           find project -type f -print0 | sort -z | xargs -0 sha256sum
         } | sha256sum | cut -c1-12)
         TAG="ci-${HASH}"
@@ -319,7 +307,6 @@ jobs:
     - bash: |
         set -e
         source activate synapseml
-        pip install 'black[jupyter]==22.3.0'
         black --diff --color . && black --check -q .
       displayName: 'Python Style Check'
 - ${{ if eq(parameters.publishArtifacts, true) }}:
@@ -335,7 +322,6 @@ jobs:
     steps:
       - template: templates/free_disk.yml
       - template: templates/sbt_cache.yml
-      - template: templates/conda.yml
       - template: templates/kv.yml
       - bash: |
           set -euo pipefail

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -11,7 +11,7 @@ resources:
   #      BuildCIImage job on master. A change to any of those inputs therefore
   #      needs its image published from master before this pipeline can pull it.
   - container: ci
-    image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-d68ec548140c
+    image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-048168ac6295
     endpoint: 'SynapseML MCR'
   repositories:
   - repository: SynapseML-Internal
@@ -111,7 +111,7 @@ variables:
   CONDA_CACHE_DIR: /usr/share/miniconda/envs
   UBUNTU_VERSION: ubuntu-22.04
   ComponentDetection.Timeout: 900
-  CI_IMAGE_TAG: ci-d68ec548140c
+  CI_IMAGE_TAG: ci-048168ac6295
   isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isTag: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -11,7 +11,7 @@ resources:
     #      BuildCIImage job on master. A change to any of those inputs therefore
     #      needs its image published from master before this pipeline can pull it.
     - container: ci
-      image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-9d15e6d9bfde
+      image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-060baf1aac44
       endpoint: 'SynapseML MCR'
 
 trigger:
@@ -101,7 +101,7 @@ variables:
   CONDA_CACHE_DIR: /usr/share/miniconda/envs
   UBUNTU_VERSION: ubuntu-22.04
   ComponentDetection.Timeout: 900
-  CI_IMAGE_TAG: ci-9d15e6d9bfde
+  CI_IMAGE_TAG: ci-060baf1aac44
   isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isTag: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -11,7 +11,7 @@ resources:
   #      BuildCIImage job on master. A change to any of those inputs therefore
   #      needs its image published from master before this pipeline can pull it.
   - container: ci
-    image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-3e4e3ef8e44d
+    image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-d68ec548140c
     endpoint: 'SynapseML MCR'
   repositories:
   - repository: SynapseML-Internal
@@ -111,7 +111,7 @@ variables:
   CONDA_CACHE_DIR: /usr/share/miniconda/envs
   UBUNTU_VERSION: ubuntu-22.04
   ComponentDetection.Timeout: 900
-  CI_IMAGE_TAG: ci-3e4e3ef8e44d
+  CI_IMAGE_TAG: ci-d68ec548140c
   isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isTag: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -3,9 +3,6 @@ resources:
     - container: ci
       image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-cc980b65de98
       endpoint: 'SynapseML MCR'
-  repositories:
-    - repository: self
-      type: self
 
 trigger:
   branches:

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1784,6 +1784,10 @@ jobs:
         echo "=== SynapseML-Internal now at $INTERNAL_BRANCH ==="
         git log --oneline -1
       displayName: 'Select matching SynapseML-Internal branch'
+      # Azure Repos occasionally returns a transient 503 while this private
+      # checkout is fetched. The step is idempotent, so retry it instead of
+      # discarding an otherwise healthy compatibility lane.
+      retryCountOnTaskFailure: 3
     - template: templates/sbt_cache.yml
     - task: AzureCLI@2
       displayName: 'Publish OSS to local Maven'

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1,4 +1,8 @@
 resources:
+  containers:
+  - container: ci
+    image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-cc980b65de98
+    endpoint: 'SynapseML MCR'
   repositories:
   - repository: SynapseML-Internal
     type: git
@@ -97,6 +101,7 @@ variables:
   CONDA_CACHE_DIR: /usr/share/miniconda/envs
   UBUNTU_VERSION: ubuntu-22.04
   ComponentDetection.Timeout: 900
+  CI_IMAGE_TAG: ci-cc980b65de98
   isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isTag: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]
@@ -172,37 +177,112 @@ jobs:
         maxAttempts: 7
         maxBackoffSeconds: 180
 
-- job: Style
-  dependsOn: BuildAndCacheSbt
+
+- job: BuildCIImage
+  displayName: 'Build trusted CI image'
   cancelTimeoutInMinutes: 0
-  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testStyle }}', true))
+  timeoutInMinutes: 60
+  condition: and(succeeded(), eq(variables.isMaster, true), ne(variables.isPR, true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   steps:
-    - template: templates/sbt_cache.yml
+    - checkout: self
+      fetchDepth: 1
+    - bash: |
+        set -euo pipefail
+        echo "=== Disk space BEFORE cleanup ==="
+        df -h / | grep -E 'Filesystem|/$'
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /usr/lib/google-cloud-sdk || true
+        sudo rm -rf /usr/share/dotnet || true
+        sudo rm -rf /opt/ghc || true
+        sudo rm -rf /opt/hostedtoolcache || true
+        sudo rm -rf /usr/local/share/boost || true
+        sudo rm -rf /usr/share/swift || true
+        sudo rm -rf /usr/local/.ghcup || true
+        sudo rm -rf /usr/share/miniconda || true
+        sudo rm -rf /usr/local/share/chromium || true
+        sudo docker image prune -af || true
+        echo "=== Disk space AFTER cleanup ==="
+        df -h / | grep -E 'Filesystem|/$'
+      displayName: 'Free disk space'
+    - task: Docker@2
+      displayName: 'Login to ACR'
+      inputs:
+        command: login
+        containerRegistry: 'SynapseML MCR'
+    - bash: |
+        set -euo pipefail
+        HASH=$(sha256sum environment.yml project/plugins.sbt project/build.properties build.sbt sonatype.sbt tools/docker/ci/Dockerfile | sha256sum | cut -c1-12)
+        TAG="ci-${HASH}"
+        EXPECTED_TAG="$(CI_IMAGE_TAG)"
+        LATEST_TAG="ci-latest"
+        REGISTRY="mmlsparkmcr.azurecr.io"
+        REPO="synapseml/ci"
+        echo "Content hash: $TAG"
+
+        if [ "$TAG" != "$EXPECTED_TAG" ]; then
+          echo "##vso[task.logissue type=error]CI_IMAGE_TAG ($EXPECTED_TAG) does not match dependency hash ($TAG). Update the pipeline image tag with the Dockerfile/dependency change."
+          exit 1
+        fi
+
+        IMAGE_EXISTS=false
+        for i in 1 2 3; do
+          if docker manifest inspect "${REGISTRY}/${REPO}:${TAG}" > /dev/null 2>&1; then
+            IMAGE_EXISTS=true
+            break
+          fi
+          [ $i -lt 3 ] && echo "Manifest inspect attempt $i failed, retrying..." && sleep 5
+        done
+
+        if [ "$IMAGE_EXISTS" = "true" ]; then
+          echo "Image $TAG exists. Re-tagging server-side as $LATEST_TAG."
+          docker buildx imagetools create \
+            --tag "${REGISTRY}/${REPO}:${LATEST_TAG}" \
+            "${REGISTRY}/${REPO}:${TAG}"
+        else
+          echo "Image $TAG not found. Building from trusted master."
+          docker pull "${REGISTRY}/${REPO}:${LATEST_TAG}" || true
+          docker build \
+            --cache-from "${REGISTRY}/${REPO}:${LATEST_TAG}" \
+            -t "${REGISTRY}/${REPO}:${TAG}" \
+            -t "${REGISTRY}/${REPO}:${LATEST_TAG}" \
+            -f tools/docker/ci/Dockerfile .
+          docker push "${REGISTRY}/${REPO}:${TAG}"
+          docker push "${REGISTRY}/${REPO}:${LATEST_TAG}"
+        fi
+      displayName: 'Check/Build CI Image'
+
+- job: Style
+  dependsOn:
+    - BuildAndCacheSbt
+    - BuildCIImage
+  cancelTimeoutInMinutes: 0
+  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testStyle }}', true))
+  pool:
+    vmImage: $(UBUNTU_VERSION)
+  container: ci
+  steps:
+    - template: templates/free_disk.yml
     - bash: sbt scalastyle test:scalastyle
       displayName: 'Scala Style Check'
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.11'
-        architecture: 'x64'
-        disableDownloadFromRegistry: true
     - bash: |
         set -e
-        python -m pip install -q 'black[jupyter]==22.3.0'
+        source activate synapseml
         black --diff --color . && black --check -q .
       displayName: 'Python Style Check'
 - ${{ if eq(parameters.publishArtifacts, true) }}:
   - job: Publish
-    dependsOn: BuildAndCacheSbt
-    condition: and(succeeded(), eq('${{ parameters.publishArtifacts }}', true))
+    dependsOn:
+      - BuildAndCacheSbt
+      - BuildCIImage
+    condition: and(not(failed()), not(canceled()), eq('${{ parameters.publishArtifacts }}', true))
     cancelTimeoutInMinutes: 0
     pool:
       vmImage: $(UBUNTU_VERSION)
+    container: ci
     steps:
-      - template: templates/sbt_cache.yml
-      - template: templates/update_cli.yml
-      - template: templates/conda.yml
+      - template: templates/free_disk.yml
       - template: templates/kv.yml
       - bash: |
           set -euo pipefail
@@ -249,15 +329,18 @@ jobs:
           inlineScript: |
             set -e
             sbt publishBadges
-        condition: and(succeeded(), eq(variables.isMaster, true))
+        condition: and(not(failed()), not(canceled()), eq(variables.isMaster, true))
         displayName: Publish Badges
 
 - job: DatabricksCPUE2E
-  dependsOn: BuildAndCacheSbt
+  dependsOn:
+    - BuildAndCacheSbt
+    - BuildCIImage
   displayName: 'Databricks CPU E2E'
   condition: >-
     and(
-      succeeded(),
+      not(failed()),
+      not(canceled()),
       eq(variables.runTests, 'True'),
       eq('${{ parameters.testDatabricksE2E }}', true),
       eq(dependencies.BuildAndCacheSbt.outputs['detectDatabricksImpact.runDatabricksCpuE2E'], 'true')
@@ -266,6 +349,7 @@ jobs:
   cancelTimeoutInMinutes: 0
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   variables:
     MML_ADB_AUTH_TYPE: "aad"
     MML_ADB_WORKSPACE_HOST: "adb-1885762835647850.10.azuredatabricks.net"
@@ -286,11 +370,14 @@ jobs:
     - template: templates/databricks_e2e_steps.yml
 
 - job: DatabricksGPUE2E
-  dependsOn: BuildAndCacheSbt
+  dependsOn:
+    - BuildAndCacheSbt
+    - BuildCIImage
   displayName: 'Databricks GPU E2E'
   condition: >-
     and(
-      succeeded(),
+      not(failed()),
+      not(canceled()),
       eq(variables.runTests, 'True'),
       eq('${{ parameters.testDatabricksE2E }}', true),
       eq(dependencies.BuildAndCacheSbt.outputs['detectDatabricksImpact.runDatabricksGpuE2E'], 'true')
@@ -299,6 +386,7 @@ jobs:
   cancelTimeoutInMinutes: 0
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   variables:
     TEST-CLASS: "com.microsoft.azure.synapse.ml.nbtest.DatabricksGPUTests"
     MML_ADB_AUTH_TYPE: "aad"
@@ -309,11 +397,14 @@ jobs:
     - template: templates/databricks_e2e_steps.yml
 
 - job: FabricE2E
-  dependsOn: BuildAndCacheSbt
+  dependsOn:
+    - BuildAndCacheSbt
+    - BuildCIImage
   displayName: 'Fabric E2E'
   condition: >-
     and(
-      succeeded(),
+      not(failed()),
+      not(canceled()),
       eq(variables.runTests, 'True'),
       eq('${{ parameters.testFabricE2E }}', true),
       ne(variables['System.PullRequest.IsFork'], 'True')
@@ -322,10 +413,9 @@ jobs:
   cancelTimeoutInMinutes: 5
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   steps:
-    - template: templates/sbt_cache.yml
-    - template: templates/update_cli.yml
-    - template: templates/conda.yml
+    - template: templates/free_disk.yml
     - template: templates/kv.yml
       parameters:
         secretsFilter: >
@@ -372,6 +462,7 @@ jobs:
         INTEGRATION_ACCOUNT: $(sempy-integration-account)
         INTEGRATION_CERTIFICATE: $(sempy-integration-certificate)
         INTEGRATION_WORKSPACE_PREFIX: $(sempy-integration-workspace-prefix)
+      condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'))
     - bash: |
         set -euo pipefail
         artifact_root='$(Build.ArtifactStagingDirectory)/fabric-e2e'
@@ -607,12 +698,15 @@ jobs:
         condition: and(eq(variables.isMaster, true), startsWith(variables['tag'], 'v'))
 
 - job: PythonTests
-  dependsOn: BuildAndCacheSbt
+  dependsOn:
+    - BuildAndCacheSbt
+    - BuildCIImage
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 0
-  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testPython }}', true))
+  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testPython }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   strategy:
     matrix:
       core:
@@ -634,15 +728,12 @@ jobs:
       cognitive:
         PACKAGE: "cognitive"
   steps:
-    - template: templates/sbt_cache.yml
-    - template: templates/update_cli.yml
-    - template: templates/conda.yml
+    - template: templates/free_disk.yml
     - template: templates/kv.yml
     - bash: |
         source activate synapseml
         if [ "$(runCoverage)" = "True" ]; then COV_CMD="coverage"; else COV_CMD=""; fi
-        sbt $COV_CMD getDatasets installPipPackage
-        sbt publishM2
+        sbt $COV_CMD getDatasets "project core" installPipPackage publishM2 "project $(PACKAGE)" installPipPackage publishM2
       displayName: 'Install and package deps'
       timeoutInMinutes: 40
     - task: AzureCLI@2
@@ -656,7 +747,7 @@ jobs:
         inlineScript: |
           set -e
           source activate synapseml
-          export SBT_OPTS="-Xms2G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
+          export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
           echo "##vso[task.setvariable variable=SBT_OPTS]$SBT_OPTS"
           echo "SBT_OPTS=$SBT_OPTS"
           IGNORE_TEST_PATH_FLAG=""
@@ -671,7 +762,6 @@ jobs:
           echo "TEST_SUB_PATH=$TEST_SUB_PATH"
           echo "IGNORE_TEST_PATH_FLAG=$IGNORE_TEST_PATH_FLAG"
           echo "TEST_SUB_PATH_FLAG=$TEST_SUB_PATH_FLAG"
-          (sbt $IGNORE_TEST_PATH_FLAG $TEST_SUB_PATH_FLAG "project $(PACKAGE)" coverage testPython) || \
           (sbt $IGNORE_TEST_PATH_FLAG $TEST_SUB_PATH_FLAG "project $(PACKAGE)" coverage testPython) || \
           (sbt $IGNORE_TEST_PATH_FLAG $TEST_SUB_PATH_FLAG "project $(PACKAGE)" coverage testPython)
     - task: PublishTestResults@2
@@ -688,12 +778,15 @@ jobs:
       - template: templates/codecov.yml
     - template: templates/publish_coverage_ado.yml
 - job: RTests
-  dependsOn: BuildAndCacheSbt
+  dependsOn:
+    - BuildAndCacheSbt
+    - BuildCIImage
   timeoutInMinutes: 60
   cancelTimeoutInMinutes: 0
-  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testR }}', true))
+  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testR }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   strategy:
     matrix:
       core:
@@ -709,21 +802,16 @@ jobs:
       cognitive:
         PACKAGE: "cognitive"
   steps:
-    - template: templates/sbt_cache.yml
-    - template: templates/update_cli.yml
-    - template: templates/conda.yml
+    - template: templates/free_disk.yml
     - template: templates/kv.yml
     - bash: |
         set -e
-        export SBT_OPTS="-Xms2G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
+        export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
         source activate synapseml
-        bash tools/ci/sbt_retry.sh setup
-        sbt codegen
-        sbt publishM2
+        timeout 30m sbt setup codegen publishM2
         SPARK_VERSION=3.5.0
         HADOOP_VERSION=3
-        # wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
-        wget https://mmlspark.blob.core.windows.net/installers/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
+        wget -q https://mmlspark.blob.core.windows.net/installers/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
       displayName: 'Prepare for tests'
       retryCountOnTaskFailure: 1
       timeoutInMinutes: 60
@@ -737,7 +825,7 @@ jobs:
         scriptType: bash
         inlineScript: |
           set -e
-          export SBT_OPTS="-Xms2G -Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xss5M  -Duser.timezone=GMT"
+          export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
           source activate synapseml
           timeout 20m sbt -DskipCodegen=true "project $(PACKAGE)" coverage testR
     - task: PublishTestResults@2
@@ -755,15 +843,16 @@ jobs:
     - template: templates/publish_coverage_ado.yml
 
 - job: WebsiteSamplesTests
-  dependsOn: BuildAndCacheSbt
+  dependsOn:
+    - BuildAndCacheSbt
+    - BuildCIImage
   cancelTimeoutInMinutes: 0
-  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testWebsiteSamples }}', true))
+  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testWebsiteSamples }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   steps:
-    - template: templates/sbt_cache.yml
-    - template: templates/update_cli.yml
-    - template: templates/conda.yml
+    - template: templates/free_disk.yml
     - template: templates/kv.yml
     - template: templates/publish.yml
     - task: AzureCLI@2
@@ -774,9 +863,10 @@ jobs:
         scriptLocation: inlineScript
         scriptType: bash
         inlineScript: |
-          bash tools/ci/sbt_retry.sh setup
+          export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M -Duser.timezone=GMT"
           if [ "$(runCoverage)" = "True" ]; then COV_CMD="coverage"; else COV_CMD=""; fi
-          (sbt $COV_CMD testWebsiteDocs)
+          (timeout 30m sbt setup) || (echo "retrying" && timeout 30m sbt setup)
+          sbt $COV_CMD testWebsiteDocs
     - task: PublishTestResults@2
       displayName: 'Publish Test Results'
       inputs:
@@ -796,66 +886,86 @@ jobs:
         failIfCoverageEmpty: false
 
 - job: UnitTests
-  dependsOn: BuildAndCacheSbt
+  dependsOn:
+    - BuildAndCacheSbt
+    - BuildCIImage
   cancelTimeoutInMinutes: 1
-  timeoutInMinutes: 80
-  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testUnit }}', true))
+  timeoutInMinutes: 100
+  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testUnit }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   strategy:
     matrix:
       automl:
         PACKAGE: "automl"
+        PROJECT: "core"
       causal:
         PACKAGE: "causal"
+        PROJECT: "core"
       onnx:
         PACKAGE: "onnx"
+        PROJECT: "deepLearning"
       geospatial:
         PACKAGE: "services.geospatial"
+        PROJECT: "cognitive"
       face:
         PACKAGE: "services.face"
+        PROJECT: "cognitive"
         FLAKY: "true"
       form:
         PACKAGE: "services.form"
+        PROJECT: "cognitive"
         FLAKY: "true"
       language:
         PACKAGE: "services.language"
+        PROJECT: "cognitive"
         FLAKY: "true"
       openai:
         PACKAGE: "services.openai"
+        PROJECT: "cognitive"
         FLAKY: "true"
       aifoundry:
         PACKAGE: "services.aifoundry"
+        PROJECT: "cognitive"
         FLAKY: "true"
       search1:
         PACKAGE: "services.search.split1"
+        PROJECT: "cognitive"
         FFMPEG: "true"
         FLAKY: "true"
       search2:
         PACKAGE: "services.search.split2"
+        PROJECT: "cognitive"
         FFMPEG: "true"
         FLAKY: "true"
       speech1:
         PACKAGE: "services.speech"
+        PROJECT: "cognitive"
         TEST_CLASSES: "com.microsoft.azure.synapse.ml.services.speech.SpeechToTextSDKSuite"
         FFMPEG: "true"
         FLAKY: "true"
       speech2:
         PACKAGE: "services.speech"
+        PROJECT: "cognitive"
         TEST_CLASSES: "com.microsoft.azure.synapse.ml.services.speech.ConversationTranscriptionSuite com.microsoft.azure.synapse.ml.services.speech.SpeechToTextSuite com.microsoft.azure.synapse.ml.services.speech.TextToSpeechSuite com.microsoft.azure.synapse.ml.services.speech.SpeakerEmotionInferenceSuite"
         FFMPEG: "true"
         FLAKY: "true"
       text:
         PACKAGE: "services.text"
+        PROJECT: "cognitive"
         FLAKY: "true"
       translate:
         PACKAGE: "services.translate"
+        PROJECT: "cognitive"
         FLAKY: "true"
       vision:
         PACKAGE: "services.vision"
+        PROJECT: "cognitive"
         FLAKY: "true"
       core:
         PACKAGE: "core"
+        PROJECT: "core"
         TEST_CLASSES: >-
           com.microsoft.azure.synapse.ml.core.**
           com.microsoft.azure.synapse.ml.codegen.**
@@ -863,61 +973,84 @@ jobs:
           com.microsoft.azure.synapse.ml.nbtest.DatabricksUtilitiesSuite
       explainers1:
         PACKAGE: "explainers.split1"
+        PROJECT: "core"
       explainers2:
         PACKAGE: "explainers.split2"
+        PROJECT: "deepLearning"
       explainers3:
         PACKAGE: "explainers.split3"
+        PROJECT: "deepLearning"
       exploratory:
         PACKAGE: "exploratory"
+        PROJECT: "core"
       featurize:
         PACKAGE: "featurize"
+        PROJECT: "core"
       image:
         PACKAGE: "image"
+        PROJECT: "core"
       io1:
         PACKAGE: "io.split1"
+        PROJECT: "core"
         FLAKY: "true"
       io2:
         PACKAGE: "io.split2"
+        PROJECT: "core"
         FLAKY: "true"
       isolationforest:
         PACKAGE: "isolationforest"
+        PROJECT: "core"
       flaky:
         PACKAGE: "flaky"           #TODO fix flaky test so isolation is not needed
+        PROJECT: "core"
         FLAKY: "true"
       lightgbm1:
         PACKAGE: "lightgbm.split1" #TODO speed up LGBM Tests and remove split
+        PROJECT: "lightgbm"
         FLAKY: "true"
       lightgbm2:
         PACKAGE: "lightgbm.split2"
+        PROJECT: "lightgbm"
         FLAKY: "true"
       lightgbm3:
         PACKAGE: "lightgbm.split3"
+        PROJECT: "lightgbm"
         FLAKY: "true"
       lightgbm4:
         PACKAGE: "lightgbm.split4"
+        PROJECT: "lightgbm"
         FLAKY: "true"
       lightgbm5:
         PACKAGE: "lightgbm.split5"
+        PROJECT: "lightgbm"
         FLAKY: "true"
       lightgbm6:
         PACKAGE: "lightgbm.split6"
+        PROJECT: "lightgbm"
         FLAKY: "true"
       opencv:
         PACKAGE: "opencv"
+        PROJECT: "opencv"
       recommendation:
         PACKAGE: "recommendation"
+        PROJECT: "core"
       stages:
         PACKAGE: "stages"
+        PROJECT: "core"
       nn:
         PACKAGE: "nn"
+        PROJECT: "core"
       train:
         PACKAGE: "train"
+        PROJECT: "core"
       vw:
         PACKAGE: "vw"
+        PROJECT: "vw"
       # Suites whose packages no other leg claims. PipelineTestCoverageSuite fails the build when
       # a new suite lands in a package this matrix never names.
       misc:
         PACKAGE: "misc"
+        PROJECT: "core"
         TEST_CLASSES: >-
           com.microsoft.azure.synapse.ml.param.**
           com.microsoft.azure.synapse.ml.logging.**
@@ -942,14 +1075,10 @@ jobs:
           com.microsoft.azure.synapse.ml.services.search.SearchIndexRetentionSuite
           com.microsoft.azure.synapse.ml.services.speech.SpeechToTextSDKSecuritySuite
   steps:
-    - template: templates/sbt_cache.yml
-    - template: templates/update_cli.yml
+    - template: templates/free_disk.yml
     - bash: |
-        (timeout 30s pip install requests) || (echo "retrying" && timeout 30s pip install requests)
-        (${FFMPEG:-false} && sudo apt-get update && \
-        sudo apt-get install ffmpeg libgstreamer1.0-0 \
-        gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly -y)
-        bash tools/ci/sbt_retry.sh setup
+        export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M -Duser.timezone=GMT"
+        sbt getDatasets "project $(PROJECT)" Test/compile
       displayName: 'Setup repo'
       retryCountOnTaskFailure: 1
     - task: AzureCLI@2
@@ -962,12 +1091,13 @@ jobs:
         scriptType: bash
         inlineScript: |
           ulimit -c unlimited
-          export SBT_OPTS="-XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M  -Duser.timezone=GMT"
+          echo "Available CPUs: $(nproc)"
+          export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M -Duser.timezone=GMT -Dscala.concurrent.context.numThreads=8 -Dscala.concurrent.context.maxThreads=8"
           # Only run coverage on PRs, master, or tag builds
           if [ "$(runCoverage)" = "True" ]; then COV_CMD="coverage"; else COV_CMD=""; fi
           TEST_SPEC="${TEST_CLASSES:-com.microsoft.azure.synapse.ml.$(PACKAGE).**}"
-          (timeout 30m sbt $COV_CMD "testOnly $TEST_SPEC") ||
-          (${FLAKY:-false} && timeout 30m sbt $COV_CMD "testOnly $TEST_SPEC")
+          (timeout 30m sbt $COV_CMD "project $(PROJECT)" "testOnly $TEST_SPEC") ||
+          (${FLAKY:-false} && timeout 30m sbt $COV_CMD "project $(PROJECT)" "testOnly $TEST_SPEC")
     - task: PublishTestResults@2
       displayName: 'Publish Test Results'
       inputs:

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -11,7 +11,7 @@ resources:
   #      BuildCIImage job on master. A change to any of those inputs therefore
   #      needs its image published from master before this pipeline can pull it.
   - container: ci
-    image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-9d15e6d9bfde
+    image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-060baf1aac44
     endpoint: 'SynapseML MCR'
   repositories:
   - repository: SynapseML-Internal
@@ -111,7 +111,7 @@ variables:
   CONDA_CACHE_DIR: /usr/share/miniconda/envs
   UBUNTU_VERSION: ubuntu-22.04
   ComponentDetection.Timeout: 900
-  CI_IMAGE_TAG: ci-9d15e6d9bfde
+  CI_IMAGE_TAG: ci-060baf1aac44
   isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isTag: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -3,7 +3,7 @@ resources:
   # BuildCIImage publishes immutable ci-* tags through the existing public MCR
   # mapping. Consumers, including fork PRs, never need private registry credentials.
   - container: ci
-    image: mcr.microsoft.com/mmlspark/build-demo:ci-112db6614927
+    image: mcr.microsoft.com/mmlspark/build-demo:ci-2a90442c0282
   repositories:
   - repository: SynapseML-Internal
     type: git
@@ -102,7 +102,7 @@ variables:
   CONDA_CACHE_DIR: /usr/share/miniconda/envs
   UBUNTU_VERSION: ubuntu-22.04
   ComponentDetection.Timeout: 900
-  CI_IMAGE_TAG: ci-112db6614927
+  CI_IMAGE_TAG: ci-2a90442c0282
   isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isTag: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -11,7 +11,7 @@ resources:
     #      BuildCIImage job on master. A change to any of those inputs therefore
     #      needs its image published from master before this pipeline can pull it.
     - container: ci
-      image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-3e4e3ef8e44d
+      image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-d68ec548140c
       endpoint: 'SynapseML MCR'
 
 trigger:
@@ -101,7 +101,7 @@ variables:
   CONDA_CACHE_DIR: /usr/share/miniconda/envs
   UBUNTU_VERSION: ubuntu-22.04
   ComponentDetection.Timeout: 900
-  CI_IMAGE_TAG: ci-3e4e3ef8e44d
+  CI_IMAGE_TAG: ci-d68ec548140c
   isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isTag: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -306,7 +306,9 @@ jobs:
         set -euo pipefail
         target_branch="${SYSTEM_PULLREQUEST_TARGETBRANCH#refs/heads/}"
         target_ref="refs/remotes/origin/${target_branch}"
-        git fetch --no-tags --depth=1 origin \
+        # Preserve target history so the triple-dot diff can always find a
+        # merge base, including when a fork branch trails the target tip.
+        git fetch --no-tags origin \
           "+refs/heads/${target_branch}:${target_ref}"
         mapfile -t image_inputs < <(python3 tools/ci/ci_image.py inputs)
         if ! git diff --quiet "$target_ref...HEAD" -- "${image_inputs[@]}"; then

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1,5 +1,15 @@
 resources:
   containers:
+  # Prerequisites, both of which fail the build at resource-validation time —
+  # before any job starts — so neither surfaces as a normal job failure:
+  #   1. A Docker Registry service connection named exactly 'SynapseML MCR',
+  #      pointing at mmlsparkmcr.azurecr.io, must exist in the ADO project and
+  #      be authorized for this pipeline.
+  #   2. The tag below must already be present in the registry. It is content
+  #      addressed from environment.yml + build.sbt + sonatype.sbt + project/ +
+  #      tools/docker/ci/Dockerfile, and is built and pushed only by the
+  #      BuildCIImage job on master. A change to any of those inputs therefore
+  #      needs its image published from master before this pipeline can pull it.
   - container: ci
     image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-9d15e6d9bfde
     endpoint: 'SynapseML MCR'

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -6,12 +6,12 @@ resources:
   #      pointing at mmlsparkmcr.azurecr.io, must exist in the ADO project and
   #      be authorized for this pipeline.
   #   2. The tag below must already be present in the registry. It is content
-  #      addressed from environment.yml + build.sbt + sonatype.sbt + project/ +
-  #      tools/docker/ci/Dockerfile, and is built and pushed only by the
+  #      addressed from .dockerignore + environment.yml + build.sbt + sonatype.sbt +
+  #      project/ + tools/docker/ci/Dockerfile, and is built and pushed only by the
   #      BuildCIImage job on master. A change to any of those inputs therefore
   #      needs its image published from master before this pipeline can pull it.
   - container: ci
-    image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-2b4cdb1f2a8d
+    image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-3e4e3ef8e44d
     endpoint: 'SynapseML MCR'
   repositories:
   - repository: SynapseML-Internal
@@ -111,7 +111,7 @@ variables:
   CONDA_CACHE_DIR: /usr/share/miniconda/envs
   UBUNTU_VERSION: ubuntu-22.04
   ComponentDetection.Timeout: 900
-  CI_IMAGE_TAG: ci-2b4cdb1f2a8d
+  CI_IMAGE_TAG: ci-3e4e3ef8e44d
   isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isTag: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]
@@ -131,7 +131,7 @@ jobs:
     - bash: |
         set -euo pipefail
         HASH=$({
-          sha256sum environment.yml build.sbt sonatype.sbt tools/docker/ci/Dockerfile
+          sha256sum .dockerignore environment.yml build.sbt sonatype.sbt tools/docker/ci/Dockerfile
           git ls-files -z -- project | sort -z | xargs -0 sha256sum
         } | sha256sum | cut -c1-12)
         EXPECTED_TAG="ci-${HASH}"
@@ -267,7 +267,7 @@ jobs:
     - bash: |
         set -euo pipefail
         HASH=$({
-          sha256sum environment.yml build.sbt sonatype.sbt tools/docker/ci/Dockerfile
+          sha256sum .dockerignore environment.yml build.sbt sonatype.sbt tools/docker/ci/Dockerfile
           git ls-files -z -- project | sort -z | xargs -0 sha256sum
         } | sha256sum | cut -c1-12)
         TAG="ci-${HASH}"

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -6,8 +6,8 @@ resources:
     #      pointing at mmlsparkmcr.azurecr.io, must exist in the ADO project and
     #      be authorized for this pipeline.
     #   2. The tag below must already be present in the registry. It is content
-    #      addressed from environment.yml + build.sbt + sonatype.sbt + project/ +
-    #      tools/docker/ci/Dockerfile, and is built and pushed only by the
+    #      addressed from .dockerignore + environment.yml + build.sbt + sonatype.sbt +
+    #      project/ + tools/docker/ci/Dockerfile, and is built and pushed only by the
     #      BuildCIImage job on master. A change to any of those inputs therefore
     #      needs its image published from master before this pipeline can pull it.
     - container: ci
@@ -355,7 +355,6 @@ jobs:
             set -e
             test -n "$(packageVersion)"
             echo "Publishing SynapseML package version $(packageVersion)"
-            sudo apt-get install graphviz doxygen -y
             source activate synapseml
             sbt packagePython uploadNotebooks
             sbt -DskipCodegen=true publishBlob publishDocs publishR publishPython

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -365,7 +365,6 @@ jobs:
             set -e
             test -n "$(packageVersion)"
             echo "Publishing SynapseML package version $(packageVersion)"
-            sudo apt-get install graphviz doxygen -y
             source activate synapseml
             sbt packagePython uploadNotebooks
             sbt -DskipCodegen=true publishBlob publishDocs publishR publishPython

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1,5 +1,15 @@
 resources:
   containers:
+    # Prerequisites, both of which fail the build at resource-validation time —
+    # before any job starts — so neither surfaces as a normal job failure:
+    #   1. A Docker Registry service connection named exactly 'SynapseML MCR',
+    #      pointing at mmlsparkmcr.azurecr.io, must exist in the ADO project and
+    #      be authorized for this pipeline.
+    #   2. The tag below must already be present in the registry. It is content
+    #      addressed from environment.yml + build.sbt + sonatype.sbt + project/ +
+    #      tools/docker/ci/Dockerfile, and is built and pushed only by the
+    #      BuildCIImage job on master. A change to any of those inputs therefore
+    #      needs its image published from master before this pipeline can pull it.
     - container: ci
       image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-9d15e6d9bfde
       endpoint: 'SynapseML MCR'

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1,7 +1,7 @@
 resources:
   containers:
     - container: ci
-      image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-cc980b65de98
+      image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-9d15e6d9bfde
       endpoint: 'SynapseML MCR'
 
 trigger:
@@ -91,7 +91,7 @@ variables:
   CONDA_CACHE_DIR: /usr/share/miniconda/envs
   UBUNTU_VERSION: ubuntu-22.04
   ComponentDetection.Timeout: 900
-  CI_IMAGE_TAG: ci-cc980b65de98
+  CI_IMAGE_TAG: ci-9d15e6d9bfde
   isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isTag: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]
@@ -108,6 +108,54 @@ jobs:
   steps:
     - checkout: self
       fetchDepth: 1
+    - bash: |
+        set -euo pipefail
+        hash_files=(
+          environment.yml
+          build.sbt
+          sonatype.sbt
+          tools/docker/ci/Dockerfile
+        )
+        HASH=$({
+          sha256sum "${hash_files[@]}"
+          find project -type f -print0 | sort -z | xargs -0 sha256sum
+        } | sha256sum | cut -c1-12)
+        EXPECTED_TAG="ci-${HASH}"
+        VARIABLE_TAG="$(CI_IMAGE_TAG)"
+        RESOURCE_TAG="$(
+          python3 - <<'PY'
+        from pathlib import Path
+
+        lines = Path("pipeline.yaml").read_text(encoding="utf-8").splitlines()
+        in_ci = False
+        for line in lines:
+            stripped = line.strip()
+            if stripped == "- container: ci":
+                in_ci = True
+                continue
+            if in_ci and stripped.startswith("image:"):
+                image = stripped.split(":", 1)[1].strip().strip("'\"")
+                print(image.rsplit(":", 1)[1])
+                break
+        else:
+            raise SystemExit("Could not find resources.containers ci image tag")
+        PY
+        )"
+
+        echo "CI image content hash tag: $EXPECTED_TAG"
+        echo "CI_IMAGE_TAG variable: $VARIABLE_TAG"
+        echo "resources.containers[ci] image tag: $RESOURCE_TAG"
+
+        if [ "$VARIABLE_TAG" != "$EXPECTED_TAG" ]; then
+          echo "##vso[task.logissue type=error]CI_IMAGE_TAG ($VARIABLE_TAG) does not match dependency hash ($EXPECTED_TAG). Update the CI image tag with the Dockerfile/dependency change."
+          exit 1
+        fi
+
+        if [ "$RESOURCE_TAG" != "$EXPECTED_TAG" ]; then
+          echo "##vso[task.logissue type=error]resources.containers[ci] image tag ($RESOURCE_TAG) does not match dependency hash ($EXPECTED_TAG). Update resources.containers[ci].image with the same tag."
+          exit 1
+        fi
+      displayName: 'Validate CI image tag'
     - bash: |
         set -uo pipefail
         run_databricks_cpu=true
@@ -172,7 +220,6 @@ jobs:
   displayName: 'Build trusted CI image'
   cancelTimeoutInMinutes: 0
   timeoutInMinutes: 60
-  condition: and(succeeded(), eq(variables.isMaster, true), ne(variables.isPR, true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   steps:
@@ -196,14 +243,25 @@ jobs:
         echo "=== Disk space AFTER cleanup ==="
         df -h / | grep -E 'Filesystem|/$'
       displayName: 'Free disk space'
+      condition: and(succeeded(), eq(variables.isMaster, true), ne(variables.isPR, true))
     - task: Docker@2
       displayName: 'Login to ACR'
+      condition: and(succeeded(), eq(variables.isMaster, true), ne(variables.isPR, true))
       inputs:
         command: login
         containerRegistry: 'SynapseML MCR'
     - bash: |
         set -euo pipefail
-        HASH=$(sha256sum environment.yml project/plugins.sbt project/build.properties build.sbt sonatype.sbt tools/docker/ci/Dockerfile | sha256sum | cut -c1-12)
+        hash_files=(
+          environment.yml
+          build.sbt
+          sonatype.sbt
+          tools/docker/ci/Dockerfile
+        )
+        HASH=$({
+          sha256sum "${hash_files[@]}"
+          find project -type f -print0 | sort -z | xargs -0 sha256sum
+        } | sha256sum | cut -c1-12)
         TAG="ci-${HASH}"
         EXPECTED_TAG="$(CI_IMAGE_TAG)"
         LATEST_TAG="ci-latest"
@@ -242,23 +300,26 @@ jobs:
           docker push "${REGISTRY}/${REPO}:${LATEST_TAG}"
         fi
       displayName: 'Check/Build CI Image'
+      condition: and(succeeded(), eq(variables.isMaster, true), ne(variables.isPR, true))
 
 - job: Style
   dependsOn:
     - BuildAndCacheSbt
     - BuildCIImage
   cancelTimeoutInMinutes: 0
-  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testStyle }}', true))
+  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testStyle }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   container: ci
   steps:
     - template: templates/free_disk.yml
+    - template: templates/sbt_cache.yml
     - bash: sbt scalastyle test:scalastyle
       displayName: 'Scala Style Check'
     - bash: |
         set -e
         source activate synapseml
+        pip install 'black[jupyter]==22.3.0'
         black --diff --color . && black --check -q .
       displayName: 'Python Style Check'
 - ${{ if eq(parameters.publishArtifacts, true) }}:
@@ -266,13 +327,15 @@ jobs:
     dependsOn:
       - BuildAndCacheSbt
       - BuildCIImage
-    condition: and(not(failed()), not(canceled()), eq('${{ parameters.publishArtifacts }}', true))
+    condition: and(succeeded(), eq('${{ parameters.publishArtifacts }}', true))
     cancelTimeoutInMinutes: 0
     pool:
       vmImage: $(UBUNTU_VERSION)
     container: ci
     steps:
       - template: templates/free_disk.yml
+      - template: templates/sbt_cache.yml
+      - template: templates/conda.yml
       - template: templates/kv.yml
       - bash: |
           set -euo pipefail
@@ -329,8 +392,7 @@ jobs:
   displayName: 'Databricks CPU E2E'
   condition: >-
     and(
-      not(failed()),
-      not(canceled()),
+      succeeded(),
       eq(variables.runTests, 'True'),
       eq('${{ parameters.testDatabricksE2E }}', true),
       eq(dependencies.BuildAndCacheSbt.outputs['detectDatabricksImpact.runDatabricksCpuE2E'], 'true')
@@ -366,8 +428,7 @@ jobs:
   displayName: 'Databricks GPU E2E'
   condition: >-
     and(
-      not(failed()),
-      not(canceled()),
+      succeeded(),
       eq(variables.runTests, 'True'),
       eq('${{ parameters.testDatabricksE2E }}', true),
       eq(dependencies.BuildAndCacheSbt.outputs['detectDatabricksImpact.runDatabricksGpuE2E'], 'true')
@@ -391,7 +452,7 @@ jobs:
     - BuildAndCacheSbt
     - BuildCIImage
   displayName: 'Fabric E2E'
-  condition: and(not(failed()), not(canceled()), eq('${{ parameters.testFabricE2E }}', true))
+  condition: and(succeeded(), eq('${{ parameters.testFabricE2E }}', true))
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 0
   pool:
@@ -399,6 +460,7 @@ jobs:
   container: ci
   steps:
     - template: templates/free_disk.yml
+    - template: templates/sbt_cache.yml
     - template: templates/kv.yml
     - template: templates/fabric_kv.yml
     - template: templates/publish.yml
@@ -623,7 +685,7 @@ jobs:
     - BuildCIImage
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 0
-  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testPython }}', true))
+  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testPython }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   container: ci
@@ -649,6 +711,7 @@ jobs:
         PACKAGE: "cognitive"
   steps:
     - template: templates/free_disk.yml
+    - template: templates/sbt_cache.yml
     - template: templates/kv.yml
     - bash: |
         source activate synapseml
@@ -683,6 +746,7 @@ jobs:
           echo "IGNORE_TEST_PATH_FLAG=$IGNORE_TEST_PATH_FLAG"
           echo "TEST_SUB_PATH_FLAG=$TEST_SUB_PATH_FLAG"
           (sbt $IGNORE_TEST_PATH_FLAG $TEST_SUB_PATH_FLAG "project $(PACKAGE)" coverage testPython) || \
+          (sbt $IGNORE_TEST_PATH_FLAG $TEST_SUB_PATH_FLAG "project $(PACKAGE)" coverage testPython) || \
           (sbt $IGNORE_TEST_PATH_FLAG $TEST_SUB_PATH_FLAG "project $(PACKAGE)" coverage testPython)
     - task: PublishTestResults@2
       displayName: 'Publish Test Results'
@@ -703,7 +767,7 @@ jobs:
     - BuildCIImage
   timeoutInMinutes: 60
   cancelTimeoutInMinutes: 0
-  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testR }}', true))
+  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testR }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   container: ci
@@ -723,15 +787,13 @@ jobs:
         PACKAGE: "cognitive"
   steps:
     - template: templates/free_disk.yml
+    - template: templates/sbt_cache.yml
     - template: templates/kv.yml
     - bash: |
         set -e
         export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
         source activate synapseml
         timeout 30m sbt setup codegen publishM2
-        SPARK_VERSION=3.5.0
-        HADOOP_VERSION=3
-        wget -q https://mmlspark.blob.core.windows.net/installers/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
       displayName: 'Prepare for tests'
       retryCountOnTaskFailure: 1
       timeoutInMinutes: 60
@@ -767,12 +829,13 @@ jobs:
     - BuildAndCacheSbt
     - BuildCIImage
   cancelTimeoutInMinutes: 0
-  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testWebsiteSamples }}', true))
+  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testWebsiteSamples }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   container: ci
   steps:
     - template: templates/free_disk.yml
+    - template: templates/sbt_cache.yml
     - template: templates/kv.yml
     - template: templates/publish.yml
     - task: AzureCLI@2
@@ -811,7 +874,7 @@ jobs:
     - BuildCIImage
   cancelTimeoutInMinutes: 1
   timeoutInMinutes: 100
-  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testUnit }}', true))
+  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testUnit }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   container: ci
@@ -995,6 +1058,7 @@ jobs:
           com.microsoft.azure.synapse.ml.services.speech.SpeechToTextSDKSecuritySuite
   steps:
     - template: templates/free_disk.yml
+    - template: templates/sbt_cache.yml
     - bash: |
         export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M -Duser.timezone=GMT"
         sbt getDatasets "project $(PROJECT)" Test/compile

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1,5 +1,11 @@
 resources:
-- repo: self
+  containers:
+    - container: ci
+      image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-cc980b65de98
+      endpoint: 'SynapseML MCR'
+  repositories:
+    - repository: self
+      type: self
 
 trigger:
   branches:
@@ -88,6 +94,7 @@ variables:
   CONDA_CACHE_DIR: /usr/share/miniconda/envs
   UBUNTU_VERSION: ubuntu-22.04
   ComponentDetection.Timeout: 900
+  CI_IMAGE_TAG: ci-cc980b65de98
   isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isTag: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]
@@ -163,37 +170,112 @@ jobs:
         maxAttempts: 7
         maxBackoffSeconds: 180
 
-- job: Style
-  dependsOn: BuildAndCacheSbt
+
+- job: BuildCIImage
+  displayName: 'Build trusted CI image'
   cancelTimeoutInMinutes: 0
-  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testStyle }}', true))
+  timeoutInMinutes: 60
+  condition: and(succeeded(), eq(variables.isMaster, true), ne(variables.isPR, true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   steps:
-    - template: templates/sbt_cache.yml
+    - checkout: self
+      fetchDepth: 1
+    - bash: |
+        set -euo pipefail
+        echo "=== Disk space BEFORE cleanup ==="
+        df -h / | grep -E 'Filesystem|/$'
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /usr/lib/google-cloud-sdk || true
+        sudo rm -rf /usr/share/dotnet || true
+        sudo rm -rf /opt/ghc || true
+        sudo rm -rf /opt/hostedtoolcache || true
+        sudo rm -rf /usr/local/share/boost || true
+        sudo rm -rf /usr/share/swift || true
+        sudo rm -rf /usr/local/.ghcup || true
+        sudo rm -rf /usr/share/miniconda || true
+        sudo rm -rf /usr/local/share/chromium || true
+        sudo docker image prune -af || true
+        echo "=== Disk space AFTER cleanup ==="
+        df -h / | grep -E 'Filesystem|/$'
+      displayName: 'Free disk space'
+    - task: Docker@2
+      displayName: 'Login to ACR'
+      inputs:
+        command: login
+        containerRegistry: 'SynapseML MCR'
+    - bash: |
+        set -euo pipefail
+        HASH=$(sha256sum environment.yml project/plugins.sbt project/build.properties build.sbt sonatype.sbt tools/docker/ci/Dockerfile | sha256sum | cut -c1-12)
+        TAG="ci-${HASH}"
+        EXPECTED_TAG="$(CI_IMAGE_TAG)"
+        LATEST_TAG="ci-latest"
+        REGISTRY="mmlsparkmcr.azurecr.io"
+        REPO="synapseml/ci"
+        echo "Content hash: $TAG"
+
+        if [ "$TAG" != "$EXPECTED_TAG" ]; then
+          echo "##vso[task.logissue type=error]CI_IMAGE_TAG ($EXPECTED_TAG) does not match dependency hash ($TAG). Update the pipeline image tag with the Dockerfile/dependency change."
+          exit 1
+        fi
+
+        IMAGE_EXISTS=false
+        for i in 1 2 3; do
+          if docker manifest inspect "${REGISTRY}/${REPO}:${TAG}" > /dev/null 2>&1; then
+            IMAGE_EXISTS=true
+            break
+          fi
+          [ $i -lt 3 ] && echo "Manifest inspect attempt $i failed, retrying..." && sleep 5
+        done
+
+        if [ "$IMAGE_EXISTS" = "true" ]; then
+          echo "Image $TAG exists. Re-tagging server-side as $LATEST_TAG."
+          docker buildx imagetools create \
+            --tag "${REGISTRY}/${REPO}:${LATEST_TAG}" \
+            "${REGISTRY}/${REPO}:${TAG}"
+        else
+          echo "Image $TAG not found. Building from trusted master."
+          docker pull "${REGISTRY}/${REPO}:${LATEST_TAG}" || true
+          docker build \
+            --cache-from "${REGISTRY}/${REPO}:${LATEST_TAG}" \
+            -t "${REGISTRY}/${REPO}:${TAG}" \
+            -t "${REGISTRY}/${REPO}:${LATEST_TAG}" \
+            -f tools/docker/ci/Dockerfile .
+          docker push "${REGISTRY}/${REPO}:${TAG}"
+          docker push "${REGISTRY}/${REPO}:${LATEST_TAG}"
+        fi
+      displayName: 'Check/Build CI Image'
+
+- job: Style
+  dependsOn:
+    - BuildAndCacheSbt
+    - BuildCIImage
+  cancelTimeoutInMinutes: 0
+  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testStyle }}', true))
+  pool:
+    vmImage: $(UBUNTU_VERSION)
+  container: ci
+  steps:
+    - template: templates/free_disk.yml
     - bash: sbt scalastyle test:scalastyle
       displayName: 'Scala Style Check'
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.11'
-        architecture: 'x64'
-        disableDownloadFromRegistry: true
     - bash: |
         set -e
-        python -m pip install -q 'black[jupyter]==22.3.0'
+        source activate synapseml
         black --diff --color . && black --check -q .
       displayName: 'Python Style Check'
 - ${{ if eq(parameters.publishArtifacts, true) }}:
   - job: Publish
-    dependsOn: BuildAndCacheSbt
-    condition: and(succeeded(), eq('${{ parameters.publishArtifacts }}', true))
+    dependsOn:
+      - BuildAndCacheSbt
+      - BuildCIImage
+    condition: and(not(failed()), not(canceled()), eq('${{ parameters.publishArtifacts }}', true))
     cancelTimeoutInMinutes: 0
     pool:
       vmImage: $(UBUNTU_VERSION)
+    container: ci
     steps:
-      - template: templates/sbt_cache.yml
-      - template: templates/update_cli.yml
-      - template: templates/conda.yml
+      - template: templates/free_disk.yml
       - template: templates/kv.yml
       - bash: |
           set -euo pipefail
@@ -240,15 +322,18 @@ jobs:
           inlineScript: |
             set -e
             sbt publishBadges
-        condition: and(succeeded(), eq(variables.isMaster, true))
+        condition: and(not(failed()), not(canceled()), eq(variables.isMaster, true))
         displayName: Publish Badges
 
 - job: DatabricksCPUE2E
-  dependsOn: BuildAndCacheSbt
+  dependsOn:
+    - BuildAndCacheSbt
+    - BuildCIImage
   displayName: 'Databricks CPU E2E'
   condition: >-
     and(
-      succeeded(),
+      not(failed()),
+      not(canceled()),
       eq(variables.runTests, 'True'),
       eq('${{ parameters.testDatabricksE2E }}', true),
       eq(dependencies.BuildAndCacheSbt.outputs['detectDatabricksImpact.runDatabricksCpuE2E'], 'true')
@@ -257,6 +342,7 @@ jobs:
   cancelTimeoutInMinutes: 0
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   variables:
     MML_ADB_AUTH_TYPE: "aad"
     MML_ADB_WORKSPACE_HOST: "adb-1885762835647850.10.azuredatabricks.net"
@@ -277,11 +363,14 @@ jobs:
     - template: templates/databricks_e2e_steps.yml
 
 - job: DatabricksGPUE2E
-  dependsOn: BuildAndCacheSbt
+  dependsOn:
+    - BuildAndCacheSbt
+    - BuildCIImage
   displayName: 'Databricks GPU E2E'
   condition: >-
     and(
-      succeeded(),
+      not(failed()),
+      not(canceled()),
       eq(variables.runTests, 'True'),
       eq('${{ parameters.testDatabricksE2E }}', true),
       eq(dependencies.BuildAndCacheSbt.outputs['detectDatabricksImpact.runDatabricksGpuE2E'], 'true')
@@ -290,6 +379,7 @@ jobs:
   cancelTimeoutInMinutes: 0
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   variables:
     TEST-CLASS: "com.microsoft.azure.synapse.ml.nbtest.DatabricksGPUTests"
     MML_ADB_AUTH_TYPE: "aad"
@@ -300,17 +390,18 @@ jobs:
     - template: templates/databricks_e2e_steps.yml
 
 - job: FabricE2E
-  dependsOn: BuildAndCacheSbt
+  dependsOn:
+    - BuildAndCacheSbt
+    - BuildCIImage
   displayName: 'Fabric E2E'
-  condition: and(succeeded(), eq('${{ parameters.testFabricE2E }}', true))
+  condition: and(not(failed()), not(canceled()), eq('${{ parameters.testFabricE2E }}', true))
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 0
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   steps:
-    - template: templates/sbt_cache.yml
-    - template: templates/update_cli.yml
-    - template: templates/conda.yml
+    - template: templates/free_disk.yml
     - template: templates/kv.yml
     - template: templates/fabric_kv.yml
     - template: templates/publish.yml
@@ -331,7 +422,7 @@ jobs:
         INTEGRATION_ACCOUNT: $(sempy-integration-account)
         INTEGRATION_CERTIFICATE: $(sempy-integration-certificate)
         INTEGRATION_WORKSPACE_PREFIX: $(sempy-integration-workspace-prefix)
-      condition: and(succeeded(), eq(variables.runTests, 'True'))
+      condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'))
     - task: PublishTestResults@2
       displayName: 'Publish Test Results'
       inputs:
@@ -530,12 +621,15 @@ jobs:
         condition: and(eq(variables.isMaster, true), startsWith(variables['tag'], 'v'))
 
 - job: PythonTests
-  dependsOn: BuildAndCacheSbt
+  dependsOn:
+    - BuildAndCacheSbt
+    - BuildCIImage
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 0
-  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testPython }}', true))
+  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testPython }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   strategy:
     matrix:
       core:
@@ -557,15 +651,12 @@ jobs:
       cognitive:
         PACKAGE: "cognitive"
   steps:
-    - template: templates/sbt_cache.yml
-    - template: templates/update_cli.yml
-    - template: templates/conda.yml
+    - template: templates/free_disk.yml
     - template: templates/kv.yml
     - bash: |
         source activate synapseml
         if [ "$(runCoverage)" = "True" ]; then COV_CMD="coverage"; else COV_CMD=""; fi
-        sbt $COV_CMD getDatasets installPipPackage
-        sbt publishM2
+        sbt $COV_CMD getDatasets "project core" installPipPackage publishM2 "project $(PACKAGE)" installPipPackage publishM2
       displayName: 'Install and package deps'
       timeoutInMinutes: 40
     - task: AzureCLI@2
@@ -579,7 +670,7 @@ jobs:
         inlineScript: |
           set -e
           source activate synapseml
-          export SBT_OPTS="-Xms2G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
+          export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
           echo "##vso[task.setvariable variable=SBT_OPTS]$SBT_OPTS"
           echo "SBT_OPTS=$SBT_OPTS"
           IGNORE_TEST_PATH_FLAG=""
@@ -594,7 +685,6 @@ jobs:
           echo "TEST_SUB_PATH=$TEST_SUB_PATH"
           echo "IGNORE_TEST_PATH_FLAG=$IGNORE_TEST_PATH_FLAG"
           echo "TEST_SUB_PATH_FLAG=$TEST_SUB_PATH_FLAG"
-          (sbt $IGNORE_TEST_PATH_FLAG $TEST_SUB_PATH_FLAG "project $(PACKAGE)" coverage testPython) || \
           (sbt $IGNORE_TEST_PATH_FLAG $TEST_SUB_PATH_FLAG "project $(PACKAGE)" coverage testPython) || \
           (sbt $IGNORE_TEST_PATH_FLAG $TEST_SUB_PATH_FLAG "project $(PACKAGE)" coverage testPython)
     - task: PublishTestResults@2
@@ -611,12 +701,15 @@ jobs:
       - template: templates/codecov.yml
     - template: templates/publish_coverage_ado.yml
 - job: RTests
-  dependsOn: BuildAndCacheSbt
+  dependsOn:
+    - BuildAndCacheSbt
+    - BuildCIImage
   timeoutInMinutes: 60
   cancelTimeoutInMinutes: 0
-  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testR }}', true))
+  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testR }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   strategy:
     matrix:
       core:
@@ -632,21 +725,16 @@ jobs:
       cognitive:
         PACKAGE: "cognitive"
   steps:
-    - template: templates/sbt_cache.yml
-    - template: templates/update_cli.yml
-    - template: templates/conda.yml
+    - template: templates/free_disk.yml
     - template: templates/kv.yml
     - bash: |
         set -e
-        export SBT_OPTS="-Xms2G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
+        export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
         source activate synapseml
-        bash tools/ci/sbt_retry.sh setup
-        sbt codegen
-        sbt publishM2
+        timeout 30m sbt setup codegen publishM2
         SPARK_VERSION=3.5.0
         HADOOP_VERSION=3
-        # wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
-        wget https://mmlspark.blob.core.windows.net/installers/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
+        wget -q https://mmlspark.blob.core.windows.net/installers/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
       displayName: 'Prepare for tests'
       retryCountOnTaskFailure: 1
       timeoutInMinutes: 60
@@ -660,7 +748,7 @@ jobs:
         scriptType: bash
         inlineScript: |
           set -e
-          export SBT_OPTS="-Xms2G -Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=4G -Xss5M  -Duser.timezone=GMT"
+          export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
           source activate synapseml
           timeout 20m sbt -DskipCodegen=true "project $(PACKAGE)" coverage testR
     - task: PublishTestResults@2
@@ -678,15 +766,16 @@ jobs:
     - template: templates/publish_coverage_ado.yml
 
 - job: WebsiteSamplesTests
-  dependsOn: BuildAndCacheSbt
+  dependsOn:
+    - BuildAndCacheSbt
+    - BuildCIImage
   cancelTimeoutInMinutes: 0
-  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testWebsiteSamples }}', true))
+  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testWebsiteSamples }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   steps:
-    - template: templates/sbt_cache.yml
-    - template: templates/update_cli.yml
-    - template: templates/conda.yml
+    - template: templates/free_disk.yml
     - template: templates/kv.yml
     - template: templates/publish.yml
     - task: AzureCLI@2
@@ -697,9 +786,10 @@ jobs:
         scriptLocation: inlineScript
         scriptType: bash
         inlineScript: |
-          bash tools/ci/sbt_retry.sh setup
+          export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M -Duser.timezone=GMT"
           if [ "$(runCoverage)" = "True" ]; then COV_CMD="coverage"; else COV_CMD=""; fi
-          (sbt $COV_CMD testWebsiteDocs)
+          (timeout 30m sbt setup) || (echo "retrying" && timeout 30m sbt setup)
+          sbt $COV_CMD testWebsiteDocs
     - task: PublishTestResults@2
       displayName: 'Publish Test Results'
       inputs:
@@ -719,66 +809,86 @@ jobs:
         failIfCoverageEmpty: false
 
 - job: UnitTests
-  dependsOn: BuildAndCacheSbt
+  dependsOn:
+    - BuildAndCacheSbt
+    - BuildCIImage
   cancelTimeoutInMinutes: 1
-  timeoutInMinutes: 80
-  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testUnit }}', true))
+  timeoutInMinutes: 100
+  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testUnit }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
+  container: ci
   strategy:
     matrix:
       automl:
         PACKAGE: "automl"
+        PROJECT: "core"
       causal:
         PACKAGE: "causal"
+        PROJECT: "core"
       onnx:
         PACKAGE: "onnx"
+        PROJECT: "deepLearning"
       geospatial:
         PACKAGE: "services.geospatial"
+        PROJECT: "cognitive"
       face:
         PACKAGE: "services.face"
+        PROJECT: "cognitive"
         FLAKY: "true"
       form:
         PACKAGE: "services.form"
+        PROJECT: "cognitive"
         FLAKY: "true"
       language:
         PACKAGE: "services.language"
+        PROJECT: "cognitive"
         FLAKY: "true"
       openai:
         PACKAGE: "services.openai"
+        PROJECT: "cognitive"
         FLAKY: "true"
       aifoundry:
         PACKAGE: "services.aifoundry"
+        PROJECT: "cognitive"
         FLAKY: "true"
       search1:
         PACKAGE: "services.search.split1"
+        PROJECT: "cognitive"
         FFMPEG: "true"
         FLAKY: "true"
       search2:
         PACKAGE: "services.search.split2"
+        PROJECT: "cognitive"
         FFMPEG: "true"
         FLAKY: "true"
       speech1:
         PACKAGE: "services.speech"
+        PROJECT: "cognitive"
         TEST_CLASSES: "com.microsoft.azure.synapse.ml.services.speech.SpeechToTextSDKSuite"
         FFMPEG: "true"
         FLAKY: "true"
       speech2:
         PACKAGE: "services.speech"
+        PROJECT: "cognitive"
         TEST_CLASSES: "com.microsoft.azure.synapse.ml.services.speech.ConversationTranscriptionSuite com.microsoft.azure.synapse.ml.services.speech.SpeechToTextSuite com.microsoft.azure.synapse.ml.services.speech.TextToSpeechSuite com.microsoft.azure.synapse.ml.services.speech.SpeakerEmotionInferenceSuite"
         FFMPEG: "true"
         FLAKY: "true"
       text:
         PACKAGE: "services.text"
+        PROJECT: "cognitive"
         FLAKY: "true"
       translate:
         PACKAGE: "services.translate"
+        PROJECT: "cognitive"
         FLAKY: "true"
       vision:
         PACKAGE: "services.vision"
+        PROJECT: "cognitive"
         FLAKY: "true"
       core:
         PACKAGE: "core"
+        PROJECT: "core"
         TEST_CLASSES: >-
           com.microsoft.azure.synapse.ml.core.**
           com.microsoft.azure.synapse.ml.codegen.**
@@ -786,61 +896,84 @@ jobs:
           com.microsoft.azure.synapse.ml.nbtest.DatabricksUtilitiesSuite
       explainers1:
         PACKAGE: "explainers.split1"
+        PROJECT: "core"
       explainers2:
         PACKAGE: "explainers.split2"
+        PROJECT: "deepLearning"
       explainers3:
         PACKAGE: "explainers.split3"
+        PROJECT: "deepLearning"
       exploratory:
         PACKAGE: "exploratory"
+        PROJECT: "core"
       featurize:
         PACKAGE: "featurize"
+        PROJECT: "core"
       image:
         PACKAGE: "image"
+        PROJECT: "core"
       io1:
         PACKAGE: "io.split1"
+        PROJECT: "core"
         FLAKY: "true"
       io2:
         PACKAGE: "io.split2"
+        PROJECT: "core"
         FLAKY: "true"
       isolationforest:
         PACKAGE: "isolationforest"
+        PROJECT: "core"
       flaky:
         PACKAGE: "flaky"           #TODO fix flaky test so isolation is not needed
+        PROJECT: "core"
         FLAKY: "true"
       lightgbm1:
         PACKAGE: "lightgbm.split1" #TODO speed up LGBM Tests and remove split
+        PROJECT: "lightgbm"
         FLAKY: "true"
       lightgbm2:
         PACKAGE: "lightgbm.split2"
+        PROJECT: "lightgbm"
         FLAKY: "true"
       lightgbm3:
         PACKAGE: "lightgbm.split3"
+        PROJECT: "lightgbm"
         FLAKY: "true"
       lightgbm4:
         PACKAGE: "lightgbm.split4"
+        PROJECT: "lightgbm"
         FLAKY: "true"
       lightgbm5:
         PACKAGE: "lightgbm.split5"
+        PROJECT: "lightgbm"
         FLAKY: "true"
       lightgbm6:
         PACKAGE: "lightgbm.split6"
+        PROJECT: "lightgbm"
         FLAKY: "true"
       opencv:
         PACKAGE: "opencv"
+        PROJECT: "opencv"
       recommendation:
         PACKAGE: "recommendation"
+        PROJECT: "core"
       stages:
         PACKAGE: "stages"
+        PROJECT: "core"
       nn:
         PACKAGE: "nn"
+        PROJECT: "core"
       train:
         PACKAGE: "train"
+        PROJECT: "core"
       vw:
         PACKAGE: "vw"
+        PROJECT: "vw"
       # Suites whose packages no other leg claims. PipelineTestCoverageSuite fails the build when
       # a new suite lands in a package this matrix never names.
       misc:
         PACKAGE: "misc"
+        PROJECT: "core"
         TEST_CLASSES: >-
           com.microsoft.azure.synapse.ml.param.**
           com.microsoft.azure.synapse.ml.logging.**
@@ -864,14 +997,10 @@ jobs:
           com.microsoft.azure.synapse.ml.services.search.IndexSchemaParsingSuite
           com.microsoft.azure.synapse.ml.services.speech.SpeechToTextSDKSecuritySuite
   steps:
-    - template: templates/sbt_cache.yml
-    - template: templates/update_cli.yml
+    - template: templates/free_disk.yml
     - bash: |
-        (timeout 30s pip install requests) || (echo "retrying" && timeout 30s pip install requests)
-        (${FFMPEG:-false} && sudo apt-get update && \
-        sudo apt-get install ffmpeg libgstreamer1.0-0 \
-        gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly -y)
-        bash tools/ci/sbt_retry.sh setup
+        export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M -Duser.timezone=GMT"
+        sbt getDatasets "project $(PROJECT)" Test/compile
       displayName: 'Setup repo'
       retryCountOnTaskFailure: 1
     - task: AzureCLI@2
@@ -884,12 +1013,13 @@ jobs:
         scriptType: bash
         inlineScript: |
           ulimit -c unlimited
-          export SBT_OPTS="-XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M  -Duser.timezone=GMT"
+          echo "Available CPUs: $(nproc)"
+          export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M -Duser.timezone=GMT -Dscala.concurrent.context.numThreads=8 -Dscala.concurrent.context.maxThreads=8"
           # Only run coverage on PRs, master, or tag builds
           if [ "$(runCoverage)" = "True" ]; then COV_CMD="coverage"; else COV_CMD=""; fi
           TEST_SPEC="${TEST_CLASSES:-com.microsoft.azure.synapse.ml.$(PACKAGE).**}"
-          (timeout 30m sbt $COV_CMD "testOnly $TEST_SPEC") ||
-          (${FLAKY:-false} && timeout 30m sbt $COV_CMD "testOnly $TEST_SPEC")
+          (timeout 30m sbt $COV_CMD "project $(PROJECT)" "testOnly $TEST_SPEC") ||
+          (${FLAKY:-false} && timeout 30m sbt $COV_CMD "project $(PROJECT)" "testOnly $TEST_SPEC")
     - task: PublishTestResults@2
       displayName: 'Publish Test Results'
       inputs:

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -851,7 +851,7 @@ jobs:
         inlineScript: |
           set -e
           source activate synapseml
-          export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
+          export SBT_OPTS="-Xmx4G -Xss5M -Duser.timezone=GMT"
           echo "##vso[task.setvariable variable=SBT_OPTS]$SBT_OPTS"
           echo "SBT_OPTS=$SBT_OPTS"
           IGNORE_TEST_PATH_FLAG=""
@@ -913,7 +913,7 @@ jobs:
     - template: templates/kv.yml
     - bash: |
         set -e
-        export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
+        export SBT_OPTS="-Xmx4G -Xss5M -Duser.timezone=GMT"
         source activate synapseml
         timeout 30m sbt setup codegen publishM2
       displayName: 'Prepare for tests'
@@ -929,7 +929,7 @@ jobs:
         scriptType: bash
         inlineScript: |
           set -e
-          export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
+          export SBT_OPTS="-Xmx4G -Xss5M -Duser.timezone=GMT"
           source activate synapseml
           timeout 20m sbt -DskipCodegen=true "project $(PACKAGE)" coverage testR
     - task: PublishTestResults@2
@@ -969,7 +969,7 @@ jobs:
         scriptLocation: inlineScript
         scriptType: bash
         inlineScript: |
-          export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M -Duser.timezone=GMT"
+          export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
           if [ "$(runCoverage)" = "True" ]; then COV_CMD="coverage"; else COV_CMD=""; fi
           (timeout 30m sbt setup) || (echo "retrying" && timeout 30m sbt setup)
           sbt $COV_CMD testWebsiteDocs
@@ -1185,7 +1185,7 @@ jobs:
     - template: templates/free_disk.yml
     - template: templates/sbt_cache.yml
     - bash: |
-        export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M -Duser.timezone=GMT"
+        export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
         sbt getDatasets "project $(PROJECT)" Test/compile
       displayName: 'Setup repo'
       retryCountOnTaskFailure: 1
@@ -1200,7 +1200,7 @@ jobs:
         inlineScript: |
           ulimit -c unlimited
           echo "Available CPUs: $(nproc)"
-          export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M -Duser.timezone=GMT -Dscala.concurrent.context.numThreads=8 -Dscala.concurrent.context.maxThreads=8"
+          export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT -Dscala.concurrent.context.numThreads=8 -Dscala.concurrent.context.maxThreads=8"
           # Only run coverage on PRs, master, or tag builds
           if [ "$(runCoverage)" = "True" ]; then COV_CMD="coverage"; else COV_CMD=""; fi
           TEST_SPEC="${TEST_CLASSES:-com.microsoft.azure.synapse.ml.$(PACKAGE).**}"

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -317,14 +317,26 @@ jobs:
 
         tag="$(python3 tools/ci/ci_image.py tag)"
         manifest_url="https://mcr.microsoft.com/v2/mmlspark/build-demo/manifests/${tag}"
-        public_digest="$(
+        get_public_digest() {
           curl --fail --silent --head \
-            --header 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
-            "$manifest_url" \
+              --header 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
+              "$manifest_url" 2>/dev/null \
             | tr -d '\r' \
             | awk -F': ' 'tolower($1) == "docker-content-digest" {print $2}' \
             || true
-        )"
+        }
+
+        public_digest=""
+        for attempt in $(seq 1 5); do
+          public_digest="$(get_public_digest)"
+          if [ -n "$public_digest" ]; then
+            break
+          fi
+          if [ "$attempt" -lt 5 ]; then
+            echo "Public CI image lookup failed (attempt $attempt/5); retrying"
+            sleep 5
+          fi
+        done
         if [ -z "$public_digest" ]; then
           echo "##vso[task.logissue type=error]The public CI image for $tag is unavailable. Ask a maintainer to publish it from a trusted branch."
           exit 1

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -11,7 +11,7 @@ resources:
     #      BuildCIImage job on master. A change to any of those inputs therefore
     #      needs its image published from master before this pipeline can pull it.
     - container: ci
-      image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-2b4cdb1f2a8d
+      image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-3e4e3ef8e44d
       endpoint: 'SynapseML MCR'
 
 trigger:
@@ -101,7 +101,7 @@ variables:
   CONDA_CACHE_DIR: /usr/share/miniconda/envs
   UBUNTU_VERSION: ubuntu-22.04
   ComponentDetection.Timeout: 900
-  CI_IMAGE_TAG: ci-2b4cdb1f2a8d
+  CI_IMAGE_TAG: ci-3e4e3ef8e44d
   isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isTag: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]
@@ -121,7 +121,7 @@ jobs:
     - bash: |
         set -euo pipefail
         HASH=$({
-          sha256sum environment.yml build.sbt sonatype.sbt tools/docker/ci/Dockerfile
+          sha256sum .dockerignore environment.yml build.sbt sonatype.sbt tools/docker/ci/Dockerfile
           git ls-files -z -- project | sort -z | xargs -0 sha256sum
         } | sha256sum | cut -c1-12)
         EXPECTED_TAG="ci-${HASH}"
@@ -257,7 +257,7 @@ jobs:
     - bash: |
         set -euo pipefail
         HASH=$({
-          sha256sum environment.yml build.sbt sonatype.sbt tools/docker/ci/Dockerfile
+          sha256sum .dockerignore environment.yml build.sbt sonatype.sbt tools/docker/ci/Dockerfile
           git ls-files -z -- project | sort -z | xargs -0 sha256sum
         } | sha256sum | cut -c1-12)
         TAG="ci-${HASH}"

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1,7 +1,7 @@
 resources:
   containers:
   - container: ci
-    image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-cc980b65de98
+    image: mmlsparkmcr.azurecr.io/synapseml/ci:ci-9d15e6d9bfde
     endpoint: 'SynapseML MCR'
   repositories:
   - repository: SynapseML-Internal
@@ -101,7 +101,7 @@ variables:
   CONDA_CACHE_DIR: /usr/share/miniconda/envs
   UBUNTU_VERSION: ubuntu-22.04
   ComponentDetection.Timeout: 900
-  CI_IMAGE_TAG: ci-cc980b65de98
+  CI_IMAGE_TAG: ci-9d15e6d9bfde
   isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isTag: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]
@@ -118,6 +118,54 @@ jobs:
   steps:
     - checkout: self
       fetchDepth: 1
+    - bash: |
+        set -euo pipefail
+        hash_files=(
+          environment.yml
+          build.sbt
+          sonatype.sbt
+          tools/docker/ci/Dockerfile
+        )
+        HASH=$({
+          sha256sum "${hash_files[@]}"
+          find project -type f -print0 | sort -z | xargs -0 sha256sum
+        } | sha256sum | cut -c1-12)
+        EXPECTED_TAG="ci-${HASH}"
+        VARIABLE_TAG="$(CI_IMAGE_TAG)"
+        RESOURCE_TAG="$(
+          python3 - <<'PY'
+        from pathlib import Path
+
+        lines = Path("pipeline.yaml").read_text(encoding="utf-8").splitlines()
+        in_ci = False
+        for line in lines:
+            stripped = line.strip()
+            if stripped == "- container: ci":
+                in_ci = True
+                continue
+            if in_ci and stripped.startswith("image:"):
+                image = stripped.split(":", 1)[1].strip().strip("'\"")
+                print(image.rsplit(":", 1)[1])
+                break
+        else:
+            raise SystemExit("Could not find resources.containers ci image tag")
+        PY
+        )"
+
+        echo "CI image content hash tag: $EXPECTED_TAG"
+        echo "CI_IMAGE_TAG variable: $VARIABLE_TAG"
+        echo "resources.containers[ci] image tag: $RESOURCE_TAG"
+
+        if [ "$VARIABLE_TAG" != "$EXPECTED_TAG" ]; then
+          echo "##vso[task.logissue type=error]CI_IMAGE_TAG ($VARIABLE_TAG) does not match dependency hash ($EXPECTED_TAG). Update the CI image tag with the Dockerfile/dependency change."
+          exit 1
+        fi
+
+        if [ "$RESOURCE_TAG" != "$EXPECTED_TAG" ]; then
+          echo "##vso[task.logissue type=error]resources.containers[ci] image tag ($RESOURCE_TAG) does not match dependency hash ($EXPECTED_TAG). Update resources.containers[ci].image with the same tag."
+          exit 1
+        fi
+      displayName: 'Validate CI image tag'
     - bash: |
         set -uo pipefail
         run_databricks_cpu=true
@@ -182,7 +230,6 @@ jobs:
   displayName: 'Build trusted CI image'
   cancelTimeoutInMinutes: 0
   timeoutInMinutes: 60
-  condition: and(succeeded(), eq(variables.isMaster, true), ne(variables.isPR, true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   steps:
@@ -206,14 +253,25 @@ jobs:
         echo "=== Disk space AFTER cleanup ==="
         df -h / | grep -E 'Filesystem|/$'
       displayName: 'Free disk space'
+      condition: and(succeeded(), eq(variables.isMaster, true), ne(variables.isPR, true))
     - task: Docker@2
       displayName: 'Login to ACR'
+      condition: and(succeeded(), eq(variables.isMaster, true), ne(variables.isPR, true))
       inputs:
         command: login
         containerRegistry: 'SynapseML MCR'
     - bash: |
         set -euo pipefail
-        HASH=$(sha256sum environment.yml project/plugins.sbt project/build.properties build.sbt sonatype.sbt tools/docker/ci/Dockerfile | sha256sum | cut -c1-12)
+        hash_files=(
+          environment.yml
+          build.sbt
+          sonatype.sbt
+          tools/docker/ci/Dockerfile
+        )
+        HASH=$({
+          sha256sum "${hash_files[@]}"
+          find project -type f -print0 | sort -z | xargs -0 sha256sum
+        } | sha256sum | cut -c1-12)
         TAG="ci-${HASH}"
         EXPECTED_TAG="$(CI_IMAGE_TAG)"
         LATEST_TAG="ci-latest"
@@ -252,23 +310,26 @@ jobs:
           docker push "${REGISTRY}/${REPO}:${LATEST_TAG}"
         fi
       displayName: 'Check/Build CI Image'
+      condition: and(succeeded(), eq(variables.isMaster, true), ne(variables.isPR, true))
 
 - job: Style
   dependsOn:
     - BuildAndCacheSbt
     - BuildCIImage
   cancelTimeoutInMinutes: 0
-  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testStyle }}', true))
+  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testStyle }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   container: ci
   steps:
     - template: templates/free_disk.yml
+    - template: templates/sbt_cache.yml
     - bash: sbt scalastyle test:scalastyle
       displayName: 'Scala Style Check'
     - bash: |
         set -e
         source activate synapseml
+        pip install 'black[jupyter]==22.3.0'
         black --diff --color . && black --check -q .
       displayName: 'Python Style Check'
 - ${{ if eq(parameters.publishArtifacts, true) }}:
@@ -276,13 +337,15 @@ jobs:
     dependsOn:
       - BuildAndCacheSbt
       - BuildCIImage
-    condition: and(not(failed()), not(canceled()), eq('${{ parameters.publishArtifacts }}', true))
+    condition: and(succeeded(), eq('${{ parameters.publishArtifacts }}', true))
     cancelTimeoutInMinutes: 0
     pool:
       vmImage: $(UBUNTU_VERSION)
     container: ci
     steps:
       - template: templates/free_disk.yml
+      - template: templates/sbt_cache.yml
+      - template: templates/conda.yml
       - template: templates/kv.yml
       - bash: |
           set -euo pipefail
@@ -339,8 +402,7 @@ jobs:
   displayName: 'Databricks CPU E2E'
   condition: >-
     and(
-      not(failed()),
-      not(canceled()),
+      succeeded(),
       eq(variables.runTests, 'True'),
       eq('${{ parameters.testDatabricksE2E }}', true),
       eq(dependencies.BuildAndCacheSbt.outputs['detectDatabricksImpact.runDatabricksCpuE2E'], 'true')
@@ -376,8 +438,7 @@ jobs:
   displayName: 'Databricks GPU E2E'
   condition: >-
     and(
-      not(failed()),
-      not(canceled()),
+      succeeded(),
       eq(variables.runTests, 'True'),
       eq('${{ parameters.testDatabricksE2E }}', true),
       eq(dependencies.BuildAndCacheSbt.outputs['detectDatabricksImpact.runDatabricksGpuE2E'], 'true')
@@ -416,6 +477,7 @@ jobs:
   container: ci
   steps:
     - template: templates/free_disk.yml
+    - template: templates/sbt_cache.yml
     - template: templates/kv.yml
       parameters:
         secretsFilter: >
@@ -703,7 +765,7 @@ jobs:
     - BuildCIImage
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 0
-  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testPython }}', true))
+  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testPython }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   container: ci
@@ -729,6 +791,7 @@ jobs:
         PACKAGE: "cognitive"
   steps:
     - template: templates/free_disk.yml
+    - template: templates/sbt_cache.yml
     - template: templates/kv.yml
     - bash: |
         source activate synapseml
@@ -763,6 +826,7 @@ jobs:
           echo "IGNORE_TEST_PATH_FLAG=$IGNORE_TEST_PATH_FLAG"
           echo "TEST_SUB_PATH_FLAG=$TEST_SUB_PATH_FLAG"
           (sbt $IGNORE_TEST_PATH_FLAG $TEST_SUB_PATH_FLAG "project $(PACKAGE)" coverage testPython) || \
+          (sbt $IGNORE_TEST_PATH_FLAG $TEST_SUB_PATH_FLAG "project $(PACKAGE)" coverage testPython) || \
           (sbt $IGNORE_TEST_PATH_FLAG $TEST_SUB_PATH_FLAG "project $(PACKAGE)" coverage testPython)
     - task: PublishTestResults@2
       displayName: 'Publish Test Results'
@@ -783,7 +847,7 @@ jobs:
     - BuildCIImage
   timeoutInMinutes: 60
   cancelTimeoutInMinutes: 0
-  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testR }}', true))
+  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testR }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   container: ci
@@ -803,15 +867,13 @@ jobs:
         PACKAGE: "cognitive"
   steps:
     - template: templates/free_disk.yml
+    - template: templates/sbt_cache.yml
     - template: templates/kv.yml
     - bash: |
         set -e
         export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
         source activate synapseml
         timeout 30m sbt setup codegen publishM2
-        SPARK_VERSION=3.5.0
-        HADOOP_VERSION=3
-        wget -q https://mmlspark.blob.core.windows.net/installers/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
       displayName: 'Prepare for tests'
       retryCountOnTaskFailure: 1
       timeoutInMinutes: 60
@@ -847,12 +909,13 @@ jobs:
     - BuildAndCacheSbt
     - BuildCIImage
   cancelTimeoutInMinutes: 0
-  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testWebsiteSamples }}', true))
+  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testWebsiteSamples }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   container: ci
   steps:
     - template: templates/free_disk.yml
+    - template: templates/sbt_cache.yml
     - template: templates/kv.yml
     - template: templates/publish.yml
     - task: AzureCLI@2
@@ -891,7 +954,7 @@ jobs:
     - BuildCIImage
   cancelTimeoutInMinutes: 1
   timeoutInMinutes: 100
-  condition: and(not(failed()), not(canceled()), eq(variables.runTests, 'True'), eq('${{ parameters.testUnit }}', true))
+  condition: and(succeeded(), eq(variables.runTests, 'True'), eq('${{ parameters.testUnit }}', true))
   pool:
     vmImage: $(UBUNTU_VERSION)
   container: ci
@@ -1076,6 +1139,7 @@ jobs:
           com.microsoft.azure.synapse.ml.services.speech.SpeechToTextSDKSecuritySuite
   steps:
     - template: templates/free_disk.yml
+    - template: templates/sbt_cache.yml
     - bash: |
         export SBT_OPTS="-Xmx4G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M -Duser.timezone=GMT"
         sbt getDatasets "project $(PROJECT)" Test/compile

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -3,7 +3,7 @@ resources:
   # BuildCIImage publishes immutable ci-* tags through the existing public MCR
   # mapping. Consumers, including fork PRs, never need private registry credentials.
   - container: ci
-    image: mcr.microsoft.com/mmlspark/build-demo:ci-2a90442c0282
+    image: mcr.microsoft.com/mmlspark/build-demo:ci-3d044ca3829c
   repositories:
   - repository: SynapseML-Internal
     type: git
@@ -102,7 +102,7 @@ variables:
   CONDA_CACHE_DIR: /usr/share/miniconda/envs
   UBUNTU_VERSION: ubuntu-22.04
   ComponentDetection.Timeout: 900
-  CI_IMAGE_TAG: ci-2a90442c0282
+  CI_IMAGE_TAG: ci-3d044ca3829c
   isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isTag: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]

--- a/project/CodegenPlugin.scala
+++ b/project/CodegenPlugin.scala
@@ -268,7 +268,6 @@ object CodegenPlugin extends AutoPlugin {
     installPipPackage := {
       val packagePythonResult: Unit = packagePython.value
       val publishLocalResult: Unit = (publishLocal dependsOn packagePython).value
-      val rootPublishLocalResult: Unit = (LocalRootProject / Compile / publishLocal).value
       val packageDir = join(codegenDir.value, "package", "python")
       val wheel = findBuiltPythonWheel(packageDir, name.value)
       runCmd(

--- a/project/CodegenPlugin.scala
+++ b/project/CodegenPlugin.scala
@@ -270,7 +270,6 @@ object CodegenPlugin extends AutoPlugin {
     installPipPackage := {
       val packagePythonResult: Unit = packagePython.value
       val publishLocalResult: Unit = (publishLocal dependsOn packagePython).value
-      val rootPublishLocalResult: Unit = (LocalRootProject / Compile / publishLocal).value
       val packageDir = join(codegenDir.value, "package", "python")
       val wheel = findBuiltPythonWheel(packageDir, name.value)
       runCmd(

--- a/templates/databricks_e2e_steps.yml
+++ b/templates/databricks_e2e_steps.yml
@@ -1,5 +1,6 @@
 steps:
   - template: free_disk.yml
+  - template: sbt_cache.yml
   - template: kv.yml
   - template: publish.yml
   - task: AzureCLI@2

--- a/templates/databricks_e2e_steps.yml
+++ b/templates/databricks_e2e_steps.yml
@@ -1,7 +1,5 @@
 steps:
-  - template: sbt_cache.yml
-  - template: update_cli.yml
-  - template: conda.yml
+  - template: free_disk.yml
   - template: kv.yml
   - template: publish.yml
   - task: AzureCLI@2

--- a/templates/free_disk.yml
+++ b/templates/free_disk.yml
@@ -1,0 +1,6 @@
+steps:
+  - script: |
+      sudo rm -rf /usr/local/lib/android /usr/lib/google-cloud-sdk /usr/share/dotnet /opt/ghc || true
+      df -h /
+    displayName: 'Free disk space'
+    target: host

--- a/tools/ci/ci_image.py
+++ b/tools/ci/ci_image.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+"""Manage the immutable content tag and runtime inputs for the CI image."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[2]
+PIPELINE_PATH = Path("pipeline.yaml")
+IMAGE_INPUTS = (
+    Path(".dockerignore"),
+    Path("environment.yml"),
+    Path("build.sbt"),
+    Path("templates/java_setup.yml"),
+    Path("tools/ci/ci_image.py"),
+    Path("tools/docker/ci/Dockerfile"),
+)
+
+TAG_PATTERN = re.compile(r"ci-[0-9a-f]{12}")
+SPARK_VERSION_PATTERN = re.compile(
+    r'^\s*val\s+sparkVersion\s*=\s*"(?P<version>[^"]+)"\s*$',
+    re.MULTILINE,
+)
+JAVA_VERSION_PATTERN = re.compile(
+    r"^\s*versionSpec:\s*['\"](?P<version>[^'\"]+)['\"]\s*$",
+    re.MULTILINE,
+)
+PIP_DEPENDENCY_PATTERNS = (
+    r"^\s*-\s*['\"]?{name}==(?P<version>[0-9][0-9A-Za-z.]*)"
+    r"(?:\+cpu)?['\"]?(?:\s+#.*)?$",
+    r"^\s*-\s*['\"]?https?://[^'\"\s]*/{name}-"
+    r"(?P<version>[0-9][0-9A-Za-z.]*)"
+    r"(?:%2B|\+)cpu-[^'\"\s]+['\"]?\s*$",
+)
+
+SPARK_SHA512 = {
+    "3.5.0": (
+        "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7c"
+        "b92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319"
+    ),
+    "4.0.1": (
+        "9198602c6b931b46686f32a25793b3bb58b522cd98a5b6a94d2484bae32e3e7b"
+        "520d60f4bffe72ba29ff5c9ecd862443841ee47dde0f2f9e1bf52539f7baef41"
+    ),
+    "4.1.1": (
+        "9f39e588e7d4c70ec0126109679f386eb9bfa26979dc42669fe4f3e3446a082dc"
+        "a8ffbf5e8dbe8ad411cf2ce5bf803ce670341620bf52d968067acf86626106e"
+    ),
+}
+
+
+class CIImageConfigError(ValueError):
+    """Raised when CI image metadata is missing, stale, or ambiguous."""
+
+
+def _read(root: Path, relative_path: Path) -> str:
+    return (root / relative_path).read_text(encoding="utf-8")
+
+
+def _matched_version(
+    root: Path, relative_path: Path, pattern: re.Pattern[str], description: str
+) -> str:
+    match = pattern.search(_read(root, relative_path))
+    if not match:
+        raise CIImageConfigError(f"Could not find {description} in {relative_path}")
+    return match.group("version")
+
+
+def calculate_tag(root: Path = ROOT) -> str:
+    digest = hashlib.sha256()
+    for relative_path in IMAGE_INPUTS:
+        path = root / relative_path
+        if not path.is_file():
+            raise CIImageConfigError(f"CI image input does not exist: {relative_path}")
+        digest.update(relative_path.as_posix().encode("utf-8"))
+        digest.update(b"\0")
+        contents = path.read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+        digest.update(contents)
+        digest.update(b"\0")
+    return f"ci-{digest.hexdigest()[:12]}"
+
+
+content_tag = calculate_tag
+
+
+def spark_version(root: Path = ROOT) -> str:
+    return _matched_version(
+        root, Path("build.sbt"), SPARK_VERSION_PATTERN, "Spark version"
+    )
+
+
+def java_version(root: Path = ROOT) -> str:
+    return _matched_version(
+        root,
+        Path("templates/java_setup.yml"),
+        JAVA_VERSION_PATTERN,
+        "Java version",
+    )
+
+
+def spark_sha512(root: Path = ROOT) -> str:
+    version = spark_version(root)
+    try:
+        return SPARK_SHA512[version]
+    except KeyError as exc:
+        supported = ", ".join(sorted(SPARK_SHA512))
+        raise CIImageConfigError(
+            f"Unsupported Spark version {version!r}; add its official SHA-512 "
+            f"to tools/ci/ci_image.py. Supported versions: {supported}"
+        ) from exc
+
+
+def pip_dependency_version(name: str, root: Path = ROOT) -> str:
+    environment = _read(root, Path("environment.yml"))
+    for raw_pattern in PIP_DEPENDENCY_PATTERNS:
+        pattern = re.compile(
+            raw_pattern.format(name=re.escape(name)),
+            re.MULTILINE | re.IGNORECASE,
+        )
+        match = pattern.search(environment)
+        if match:
+            return match.group("version")
+    raise CIImageConfigError(f"Could not find an exact {name} pin in environment.yml")
+
+
+def current_pipeline_tags(root: Path = ROOT) -> list[str]:
+    return TAG_PATTERN.findall(_read(root, PIPELINE_PATH))
+
+
+def _validate_tag_locations(tags: Sequence[str]) -> None:
+    if len(tags) != 2:
+        raise CIImageConfigError(
+            "pipeline.yaml must contain exactly one resource tag and exactly "
+            f"one publisher tag (two total); found {len(tags)}"
+        )
+
+
+def check_pipeline(root: Path = ROOT) -> str:
+    expected = calculate_tag(root)
+    tags = current_pipeline_tags(root)
+    _validate_tag_locations(tags)
+    if any(tag != expected for tag in tags):
+        raise CIImageConfigError(
+            "CI image tag is stale or inconsistent: "
+            f"expected both locations to use {expected}, found {tags}. "
+            "Run `python tools/ci/ci_image.py update`."
+        )
+    return expected
+
+
+def update_pipeline(root: Path = ROOT) -> str:
+    pipeline_path = root / PIPELINE_PATH
+    pipeline = pipeline_path.read_text(encoding="utf-8")
+    tags = TAG_PATTERN.findall(pipeline)
+    _validate_tag_locations(tags)
+    expected = calculate_tag(root)
+    with pipeline_path.open("w", encoding="utf-8", newline="\n") as stream:
+        stream.write(TAG_PATTERN.sub(expected, pipeline))
+    return expected
+
+
+check_pipeline_tags = check_pipeline
+update_pipeline_tags = update_pipeline
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in ("tag", "check", "update", "java-version", "spark-version"):
+        subparsers.add_parser(command)
+    subparsers.add_parser("spark-sha512")
+    dependency = subparsers.add_parser("dependency-version")
+    dependency.add_argument("name")
+    subparsers.add_parser("inputs")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "tag":
+            print(calculate_tag())
+        elif args.command == "check":
+            check_pipeline()
+        elif args.command == "update":
+            print(update_pipeline())
+        elif args.command == "java-version":
+            print(java_version())
+        elif args.command == "spark-version":
+            print(spark_version())
+        elif args.command == "spark-sha512":
+            print(spark_sha512())
+        elif args.command == "dependency-version":
+            print(pip_dependency_version(args.name))
+        elif args.command == "inputs":
+            print("\n".join(path.as_posix() for path in IMAGE_INPUTS))
+    except (OSError, CIImageConfigError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/tests/test_ci_image.py
+++ b/tools/ci/tests/test_ci_image.py
@@ -1,0 +1,156 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+from pathlib import Path
+
+import pytest
+
+from tools.ci import ci_image
+
+
+def _write_image_inputs(root: Path) -> None:
+    contents = {
+        ".dockerignore": "*\n!environment.yml\n",
+        "environment.yml": (
+            "dependencies:\n"
+            "  - python=3.11.8\n"
+            "  - pip:\n"
+            "    - torch==2.1.2\n"
+            "    - torchvision==0.16.2\n"
+        ),
+        "build.sbt": 'val sparkVersion = "3.5.0"\n',
+        "templates/java_setup.yml": "inputs:\n  versionSpec: '11'\n",
+        "tools/ci/ci_image.py": "# tag implementation\n",
+        "tools/docker/ci/Dockerfile": "FROM ubuntu:22.04\n",
+    }
+    for relative, content in contents.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+
+def _pipeline(tag: str) -> str:
+    return f"""resources:
+  containers:
+  - container: ci
+    image: mmlsparkmcr.azurecr.io/synapseml/ci:{tag}
+variables:
+  CI_IMAGE_TAG: {tag}
+"""
+
+
+def test_tag_changes_when_any_image_input_changes(tmp_path):
+    _write_image_inputs(tmp_path)
+    original = ci_image.calculate_tag(tmp_path)
+
+    for relative in ci_image.IMAGE_INPUTS:
+        path = tmp_path / relative
+        before = path.read_bytes()
+        path.write_bytes(before + b"# changed\n")
+        assert ci_image.calculate_tag(tmp_path) != original
+        path.write_bytes(before)
+
+
+def test_tag_is_stable_across_platform_line_endings(tmp_path):
+    _write_image_inputs(tmp_path)
+    for relative in ci_image.IMAGE_INPUTS:
+        path = tmp_path / relative
+        path.write_bytes(path.read_bytes().replace(b"\r\n", b"\n"))
+    original = ci_image.calculate_tag(tmp_path)
+
+    for relative in ci_image.IMAGE_INPUTS:
+        path = tmp_path / relative
+        path.write_bytes(path.read_bytes().replace(b"\n", b"\r\n"))
+
+    assert ci_image.calculate_tag(tmp_path) == original
+
+
+def test_runtime_values_are_derived_from_branch_files(tmp_path):
+    _write_image_inputs(tmp_path)
+
+    assert ci_image.spark_version(tmp_path) == "3.5.0"
+    assert ci_image.java_version(tmp_path) == "11"
+    assert ci_image.pip_dependency_version("torch", tmp_path) == "2.1.2"
+    assert ci_image.pip_dependency_version("torchvision", tmp_path) == "0.16.2"
+    assert ci_image.spark_sha512(tmp_path) == (
+        "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7"
+        "cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319"
+    )
+
+
+def test_cpu_wheel_urls_are_supported_for_spark_release_branches(tmp_path):
+    _write_image_inputs(tmp_path)
+    (tmp_path / "environment.yml").write_text(
+        """dependencies:
+  - python=3.12.11
+  - pip:
+    - "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl#sha256=abc"
+    - "https://download.pytorch.org/whl/cpu/torchvision-0.24.1%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl#sha256=def"
+""",
+        encoding="utf-8",
+    )
+
+    assert ci_image.pip_dependency_version("torch", tmp_path) == "2.9.1"
+    assert ci_image.pip_dependency_version("torchvision", tmp_path) == "0.24.1"
+
+
+@pytest.mark.parametrize(
+    ("version", "checksum"),
+    [
+        (
+            "4.0.1",
+            "9198602c6b931b46686f32a25793b3bb58b522cd98a5b6a94d2484bae32e3e7b"
+            "520d60f4bffe72ba29ff5c9ecd862443841ee47dde0f2f9e1bf52539f7baef41",
+        ),
+        (
+            "4.1.1",
+            "9f39e588e7d4c70ec0126109679f386eb9bfa26979dc42669fe4f3e3446a082dc"
+            "a8ffbf5e8dbe8ad411cf2ce5bf803ce670341620bf52d968067acf86626106e",
+        ),
+    ],
+)
+def test_spark_release_branch_checksums(tmp_path, version, checksum):
+    _write_image_inputs(tmp_path)
+    (tmp_path / "build.sbt").write_text(
+        f'val sparkVersion = "{version}"\n', encoding="utf-8"
+    )
+
+    assert ci_image.spark_sha512(tmp_path) == checksum
+
+
+def test_unknown_spark_version_fails_with_an_actionable_error(tmp_path):
+    _write_image_inputs(tmp_path)
+    (tmp_path / "build.sbt").write_text(
+        'val sparkVersion = "9.9.9"\n', encoding="utf-8"
+    )
+
+    with pytest.raises(ci_image.CIImageConfigError, match="9.9.9"):
+        ci_image.spark_sha512(tmp_path)
+
+
+def test_update_and_check_keep_both_pipeline_tags_in_sync(tmp_path):
+    _write_image_inputs(tmp_path)
+    pipeline = tmp_path / "pipeline.yaml"
+    pipeline.write_text(_pipeline("ci-000000000000"), encoding="utf-8")
+
+    expected = ci_image.update_pipeline(tmp_path)
+
+    assert expected == ci_image.calculate_tag(tmp_path)
+    assert pipeline.read_text(encoding="utf-8").count(expected) == 2
+    assert ci_image.check_pipeline(tmp_path) == expected
+
+
+def test_check_rejects_a_stale_or_ambiguous_pipeline_tag(tmp_path):
+    _write_image_inputs(tmp_path)
+    pipeline = tmp_path / "pipeline.yaml"
+    pipeline.write_text(_pipeline("ci-000000000000"), encoding="utf-8")
+
+    with pytest.raises(ci_image.CIImageConfigError, match="Run .* update"):
+        ci_image.check_pipeline(tmp_path)
+
+    pipeline.write_text(
+        _pipeline("ci-000000000000") + "  CI_IMAGE_TAG: ci-111111111111\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ci_image.CIImageConfigError, match="exactly one"):
+        ci_image.update_pipeline(tmp_path)

--- a/tools/ci/tests/test_ci_image.py
+++ b/tools/ci/tests/test_ci_image.py
@@ -33,7 +33,7 @@ def _pipeline(tag: str) -> str:
     return f"""resources:
   containers:
   - container: ci
-    image: mmlsparkmcr.azurecr.io/synapseml/ci:{tag}
+    image: mcr.microsoft.com/mmlspark/build-demo:{tag}
 variables:
   CI_IMAGE_TAG: {tag}
 """

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -218,12 +218,10 @@ def test_ci_image_tag_matches_dependency_hash():
     expected_tag = ci_image.calculate_tag(REPO_ROOT)
     assert data["variables"]["CI_IMAGE_TAG"] == expected_tag
     assert ci_container["image"].rsplit(":", 1)[1] == expected_tag
-    assert ci_container["type"] == "acr"
-    assert ci_container["azureSubscription"] == "SynapseML Build"
-    assert ci_container["resourceGroup"] == "marhamil-mmlspark"
-    assert ci_container["registry"] == "mmlsparkmcr"
-    assert ci_container["repository"] == "synapseml/ci"
-    assert "endpoint" not in ci_container
+    assert ci_container == {
+        "container": "ci",
+        "image": f"mcr.microsoft.com/mmlspark/build-demo:{expected_tag}",
+    }
 
 
 def test_ci_image_bootstraps_with_the_existing_arm_connection():
@@ -254,6 +252,13 @@ def test_ci_image_bootstraps_with_the_existing_arm_connection():
     assert "--build-arg JAVA_VERSION=" in script
     assert "--build-arg SPARK_VERSION=" in script
     assert "--build-arg SPARK_SHA512=" in script
+    assert 'repository="public/mmlspark/build-demo"' in script
+    assert 'public_image="mcr.microsoft.com/mmlspark/build-demo:${tag}"' in script
+    assert "docker-content-digest" in script
+    assert 'public_digest="$(get_public_digest)"' in script
+    assert "Public immutable CI image already exists" in script
+    assert 'if [ "$public_digest" = "$acr_digest" ]' in script
+    assert "Timed out waiting for $public_image to become available from MCR" in script
     assert not any(step.get("task") == "Docker@2" for step in build_image["steps"])
 
 
@@ -274,6 +279,9 @@ def test_fork_image_guard_rejects_unpublishable_input_changes():
     assert "tools/ci/ci_image.py inputs" in script
     assert '"$target_ref...HEAD"' in script
     assert "tools/docker/ci/**" in script
+    assert "mcr.microsoft.com/v2/mmlspark/build-demo/manifests/${tag}" in script
+    assert "docker-content-digest" in script
+    assert "The public CI image for $tag is unavailable" in script
 
 
 def test_containerized_jobs_can_reuse_the_target_image_for_forks():

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -355,6 +355,13 @@ def test_containerized_jobs_can_reuse_the_target_image_for_forks():
         assert "not(canceled())" in condition
 
 
+def test_sbt_options_are_compatible_with_branch_jdks():
+    pipeline = _pipeline_text()
+
+    assert "-XX:+UseConcMarkSweepGC" not in pipeline
+    assert "-XX:+CMSClassUnloadingEnabled" not in pipeline
+
+
 def test_ci_dockerfile_uses_branch_runtime_and_writable_shared_cache():
     dockerfile = CI_DOCKERFILE.read_text()
 

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -228,6 +228,25 @@ def test_ci_image_tag_matches_dependency_hash():
     assert ci_container["image"].rsplit(":", 1)[1] == expected_tag
 
 
+def test_containerized_jobs_do_not_apt_install():
+    """The CI image already ships system packages and drops its apt lists.
+
+    A containerized job that still runs `apt-get install` fails at runtime with
+    "Unable to locate package", so install into the image instead.
+    """
+    data = yaml.safe_load(_pipeline_text())
+    offenders = [
+        job.get("job")
+        for job in _jobs(data["jobs"])
+        if job.get("container")
+        and "apt-get install" in yaml.safe_dump(job.get("steps", []))
+    ]
+    assert not offenders, (
+        "tools/docker/ci/Dockerfile removes /var/lib/apt/lists, so apt-get install "
+        f"cannot resolve packages inside the container: {offenders}"
+    )
+
+
 def test_sbt_cache_template_exists_and_parses():
     assert SBT_CACHE_TPL.exists()
     data = yaml.safe_load(SBT_CACHE_TPL.read_text())

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -35,6 +35,11 @@ RELEASE_COMPAT_PREREQUISITES = (
 )
 ASCII_WHITESPACE = " \t\r\n\v\f"
 
+# Matches a real `sbt <args>` invocation while ignoring filenames that merely end
+# in ".sbt" (e.g. `sha256sum build.sbt sonatype.sbt ...`), which would otherwise
+# make any job that hashes the build files look like it runs sbt.
+_INVOKES_SBT = re.compile(r"(?<![\w./-])sbt\s")
+
 
 def _pipeline_text():
     return PIPELINE.read_text()
@@ -1612,7 +1617,14 @@ def test_publish_jobs_resolve_and_preserve_package_versions():
     publish = jobs["Publish"]
     publish_steps = publish["steps"]
     assert any(step.get("task") == "MavenAuthenticate@0" for step in publish_steps)
-    assert any(step.get("template") == "templates/conda.yml" for step in publish_steps)
+    # When Publish runs in the prebuilt CI container the synapseml conda env is
+    # baked into the image, so restoring it via templates/conda.yml would be a
+    # no-op at best. At worst it is destructive: conda.yml resolves
+    # $(CONDA_CACHE_DIR) to the hosted-agent path and runs `conda env remove`
+    # + `conda env create`, which would delete the prebaked env. Only require
+    # the template for a non-containerized job.
+    if not publish.get("container"):
+        assert any(step.get("template") == "templates/conda.yml" for step in publish_steps)
     assert any(step.get("template") == "templates/kv.yml" for step in publish_steps)
     version_step = next(
         step
@@ -1675,7 +1687,15 @@ def test_style_does_not_restore_the_full_conda_environment():
         for step in style["steps"]
         if step.get("displayName") == "Python Style Check"
     )
-    assert "black[jupyter]==22.3.0" in python_style["bash"]
+    # The formatter version must be pinned exactly. A containerized Style job
+    # inherits the pin from environment.yml, which the CI image bakes in, so
+    # re-installing it at step time would only add network flakiness. A
+    # non-containerized job has to pin it inline.
+    if style.get("container"):
+        env_text = (REPO_ROOT / "environment.yml").read_text(encoding="utf-8")
+        assert "black[jupyter]==22.3.0" in env_text
+    else:
+        assert "black[jupyter]==22.3.0" in python_style["bash"]
 
 
 def test_every_sbt_running_job_waits_for_the_prewarm_cache():
@@ -1701,7 +1721,7 @@ def test_every_sbt_running_job_waits_for_the_prewarm_cache():
         steps = job.get("steps", [])
         texts = flatten(steps)
         runs_sbt = any(
-            "sbt " in t or t.strip().startswith("sbt") or "sbt_retry.sh" in t
+            _INVOKES_SBT.search(t) or t.strip().startswith("sbt") or "sbt_retry.sh" in t
             for t in texts
         )
         templates = [

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -530,7 +530,9 @@ def test_publish_jobs_resolve_and_preserve_package_versions():
     # + `conda env create`, which would delete the prebaked env. Only require
     # the template for a non-containerized job.
     if not publish.get("container"):
-        assert any(step.get("template") == "templates/conda.yml" for step in publish_steps)
+        assert any(
+            step.get("template") == "templates/conda.yml" for step in publish_steps
+        )
     assert any(step.get("template") == "templates/kv.yml" for step in publish_steps)
     version_step = next(
         step

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -42,6 +42,9 @@ def _pipeline_text():
 
 def _ci_image_dependency_tag():
     inputs = [
+        # .dockerignore selects the build context, so it can change the built
+        # image without changing any file listed below.
+        REPO_ROOT / ".dockerignore",
         REPO_ROOT / "environment.yml",
         REPO_ROOT / "build.sbt",
         REPO_ROOT / "sonatype.sbt",

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -1878,6 +1878,11 @@ def test_r_tests_use_the_preinstalled_spark_distribution():
     generator = R_TEST_GEN.read_text()
 
     assert 'if (!nzchar(Sys.getenv("SPARK_HOME", "")))' in runner
+    assert "spark_install_tar(" in runner
+    assert "tools::file_path_sans_ext(basename(" in runner
+    assert "if (!dir.exists(installed_spark_home))" in runner
+    assert "spark_home_set(installed_spark_home)" in runner
+    assert runner.index("spark_install_tar(") < runner.index("spark_home_set(")
     assert 'spark_home = Sys.getenv("SPARK_HOME")' in generator
 
 

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -281,7 +281,14 @@ def test_fork_image_guard_rejects_unpublishable_input_changes():
     assert "tools/docker/ci/**" in script
     assert "mcr.microsoft.com/v2/mmlspark/build-demo/manifests/${tag}" in script
     assert "docker-content-digest" in script
+    assert "for attempt in $(seq 1 5); do" in script
+    assert 'public_digest="$(get_public_digest)"' in script
+    assert 'if [ "$attempt" -lt 5 ]; then' in script
+    assert "sleep 5" in script
     assert "The public CI image for $tag is unavailable" in script
+    assert script.index("for attempt in $(seq 1 5); do") < script.index(
+        "The public CI image for $tag is unavailable"
+    )
 
 
 def test_containerized_jobs_can_reuse_the_target_image_for_forks():

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -6,6 +6,7 @@ bootstrap inputs, and the duplicated inline retry blocks were replaced by the
 shared helper. Run with: ``python -m pytest tools/ci/tests/test_pipeline_yaml.py``.
 """
 
+import hashlib
 import os
 import re
 import shutil
@@ -18,6 +19,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PIPELINE = REPO_ROOT / "pipeline.yaml"
+CI_DOCKERFILE = REPO_ROOT / "tools" / "docker" / "ci" / "Dockerfile"
 SBT_CACHE_TPL = REPO_ROOT / "templates" / "sbt_cache.yml"
 SBT_RETRY = REPO_ROOT / "tools" / "ci" / "sbt_retry.sh"
 SBT_VERSION = REPO_ROOT / "tools" / "ci" / "get_sbt_version.sh"
@@ -36,6 +38,27 @@ _INVOKES_SBT = re.compile(r"(?<![\w./-])sbt\s")
 
 def _pipeline_text():
     return PIPELINE.read_text()
+
+
+def _ci_image_dependency_tag():
+    inputs = [
+        REPO_ROOT / "environment.yml",
+        REPO_ROOT / "build.sbt",
+        REPO_ROOT / "sonatype.sbt",
+        CI_DOCKERFILE,
+    ]
+    project_inputs = subprocess.check_output(
+        ["git", "-C", str(REPO_ROOT), "ls-files", "--", "project"], text=True
+    ).splitlines()
+    inputs.extend(REPO_ROOT / path for path in sorted(project_inputs))
+    manifest = b"".join(
+        (
+            f"{hashlib.sha256(path.read_bytes()).hexdigest()}  "
+            f"{path.relative_to(REPO_ROOT).as_posix()}\n"
+        ).encode()
+        for path in inputs
+    )
+    return "ci-" + hashlib.sha256(manifest).hexdigest()[:12]
 
 
 def _jobs(node):
@@ -80,6 +103,18 @@ def test_pipeline_and_templates_parse():
     assert yaml.safe_load(CLEAN_ACR_PIPELINE.read_text()) is not None
     for tpl in (REPO_ROOT / "templates").glob("*.yml"):
         assert yaml.safe_load(tpl.read_text()) is not None, f"{tpl} failed to parse"
+
+
+def test_ci_image_tag_matches_dependency_hash():
+    data = yaml.safe_load(_pipeline_text())
+    ci_container = next(
+        container
+        for container in data["resources"]["containers"]
+        if container["container"] == "ci"
+    )
+    expected_tag = _ci_image_dependency_tag()
+    assert data["variables"]["CI_IMAGE_TAG"] == expected_tag
+    assert ci_container["image"].rsplit(":", 1)[1] == expected_tag
 
 
 def test_sbt_cache_template_exists_and_parses():

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -1624,7 +1624,9 @@ def test_publish_jobs_resolve_and_preserve_package_versions():
     # + `conda env create`, which would delete the prebaked env. Only require
     # the template for a non-containerized job.
     if not publish.get("container"):
-        assert any(step.get("template") == "templates/conda.yml" for step in publish_steps)
+        assert any(
+            step.get("template") == "templates/conda.yml" for step in publish_steps
+        )
     assert any(step.get("template") == "templates/kv.yml" for step in publish_steps)
     version_step = next(
         step

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -52,6 +52,14 @@ RELEASE_COMPAT_PREREQUISITES = (
     REPO_ROOT / ".pipelines" / "release-compat-prerequisites.txt"
 )
 ASCII_WHITESPACE = " \t\r\n\v\f"
+GIT_REPOSITORY_ENV = (
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_WORK_TREE",
+)
 
 # Matches a real `sbt <args>` invocation while ignoring filenames that merely end
 # in ".sbt" (e.g. `sha256sum build.sbt sonatype.sbt ...`), which would otherwise
@@ -136,12 +144,20 @@ def _release_compat_script():
     )
 
 
+def _scratch_git_env():
+    env = os.environ.copy()
+    for name in GIT_REPOSITORY_ENV:
+        env.pop(name, None)
+    return env
+
+
 def _git(repo, *args):
     result = subprocess.run(
         ["git", "-C", str(repo), *args],
         check=False,
         capture_output=True,
         text=True,
+        env=_scratch_git_env(),
     )
     assert result.returncode == 0, (
         f"git {' '.join(args)} failed\nstdout:\n{result.stdout}\nstderr:\n"
@@ -156,6 +172,7 @@ def _init_release_compat_scratch_repo(repo):
         check=True,
         capture_output=True,
         text=True,
+        env=_scratch_git_env(),
     )
     for key, value in (
         ("user.name", "Release Compat Test"),
@@ -167,6 +184,33 @@ def _init_release_compat_scratch_repo(repo):
         ("rebase.autostash", "false"),
     ):
         _git(repo, "config", key, value)
+
+
+def test_release_compat_scratch_repo_ignores_outer_git_environment(
+    tmp_path, monkeypatch
+):
+    outer = tmp_path / "outer"
+    scratch = tmp_path / "scratch"
+    subprocess.run(
+        ["git", "init", "--initial-branch=master", str(outer)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_scratch_git_env(),
+    )
+    _git(outer, "config", "user.name", "Outer Identity")
+    _git(outer, "config", "user.email", "outer@example.test")
+
+    monkeypatch.setenv("GIT_DIR", str(outer / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(outer))
+    _init_release_compat_scratch_repo(scratch)
+
+    assert _git(scratch, "config", "user.name").stdout.strip() == "Release Compat Test"
+    assert _git(scratch, "config", "user.email").stdout.strip() == (
+        "release-compat@example.test"
+    )
+    assert _git(outer, "config", "user.name").stdout.strip() == "Outer Identity"
+    assert _git(outer, "config", "user.email").stdout.strip() == "outer@example.test"
 
 
 def _assert_git_clean(repo, context):

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -321,6 +321,8 @@ def test_fork_image_guard_rejects_unpublishable_input_changes():
     script = guard_step["bash"]
     assert "SYSTEM_PULLREQUEST_TARGETBRANCH" in script
     assert "tools/ci/ci_image.py inputs" in script
+    assert "git fetch --no-tags origin" in script
+    assert "--depth" not in script
     assert '"$target_ref...HEAD"' in script
     assert "tools/docker/ci/**" in script
     assert "mcr.microsoft.com/v2/mmlspark/build-demo/manifests/${tag}" in script

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -49,6 +49,9 @@ def _pipeline_text():
 
 def _ci_image_dependency_tag():
     inputs = [
+        # .dockerignore selects the build context, so it can change the built
+        # image without changing any file listed below.
+        REPO_ROOT / ".dockerignore",
         REPO_ROOT / "environment.yml",
         REPO_ROOT / "build.sbt",
         REPO_ROOT / "sonatype.sbt",

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -1881,8 +1881,8 @@ def test_r_tests_use_the_preinstalled_spark_distribution():
     assert "spark_install_tar(" in runner
     assert "tools::file_path_sans_ext(basename(" in runner
     assert "if (!dir.exists(installed_spark_home))" in runner
-    assert "spark_home_set(installed_spark_home)" in runner
-    assert runner.index("spark_install_tar(") < runner.index("spark_home_set(")
+    assert "Sys.setenv(SPARK_HOME = installed_spark_home)" in runner
+    assert runner.index("spark_install_tar(") < runner.index("Sys.setenv(")
     assert 'spark_home = Sys.getenv("SPARK_HOME")' in generator
 
 

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -218,7 +218,7 @@ def test_ci_image_tag_matches_dependency_hash():
     expected_tag = ci_image.calculate_tag(REPO_ROOT)
     assert data["variables"]["CI_IMAGE_TAG"] == expected_tag
     assert ci_container["image"].rsplit(":", 1)[1] == expected_tag
-    assert ci_container["type"].lower() == "acr"
+    assert ci_container["type"] == "acr"
     assert ci_container["azureSubscription"] == "SynapseML Build"
     assert ci_container["resourceGroup"] == "marhamil-mmlspark"
     assert ci_container["registry"] == "mmlsparkmcr"

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -120,6 +120,25 @@ def test_ci_image_tag_matches_dependency_hash():
     assert ci_container["image"].rsplit(":", 1)[1] == expected_tag
 
 
+def test_containerized_jobs_do_not_apt_install():
+    """The CI image already ships system packages and drops its apt lists.
+
+    A containerized job that still runs `apt-get install` fails at runtime with
+    "Unable to locate package", so install into the image instead.
+    """
+    data = yaml.safe_load(_pipeline_text())
+    offenders = [
+        job.get("job")
+        for job in _jobs(data["jobs"])
+        if job.get("container")
+        and "apt-get install" in yaml.safe_dump(job.get("steps", []))
+    ]
+    assert not offenders, (
+        "tools/docker/ci/Dockerfile removes /var/lib/apt/lists, so apt-get install "
+        f"cannot resolve packages inside the container: {offenders}"
+    )
+
+
 def test_sbt_cache_template_exists_and_parses():
     assert SBT_CACHE_TPL.exists()
     data = yaml.safe_load(SBT_CACHE_TPL.read_text())

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -6,7 +6,6 @@ bootstrap inputs, and the duplicated inline retry blocks were replaced by the
 shared helper. Run with: ``python -m pytest tools/ci/tests/test_pipeline_yaml.py``.
 """
 
-import hashlib
 import os
 import re
 import shutil
@@ -17,10 +16,27 @@ from pathlib import Path
 import pytest
 import yaml
 
+from tools.ci import ci_image
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
 BUILD_SBT = REPO_ROOT / "build.sbt"
 PIPELINE = REPO_ROOT / "pipeline.yaml"
 CI_DOCKERFILE = REPO_ROOT / "tools" / "docker" / "ci" / "Dockerfile"
+R_TEST_GEN = (
+    REPO_ROOT
+    / "core"
+    / "src"
+    / "test"
+    / "scala"
+    / "com"
+    / "microsoft"
+    / "azure"
+    / "synapse"
+    / "ml"
+    / "codegen"
+    / "RTestGen.scala"
+)
+R_TEST_RUNNER = REPO_ROOT / "tools" / "tests" / "run_r_tests.R"
 SBT_CACHE_TPL = REPO_ROOT / "templates" / "sbt_cache.yml"
 SBT_RETRY = REPO_ROOT / "tools" / "ci" / "sbt_retry.sh"
 SBT_VERSION = REPO_ROOT / "tools" / "ci" / "get_sbt_version.sh"
@@ -45,30 +61,6 @@ _INVOKES_SBT = re.compile(r"(?<![\w./-])sbt\s")
 
 def _pipeline_text():
     return PIPELINE.read_text()
-
-
-def _ci_image_dependency_tag():
-    inputs = [
-        # .dockerignore selects the build context, so it can change the built
-        # image without changing any file listed below.
-        REPO_ROOT / ".dockerignore",
-        REPO_ROOT / "environment.yml",
-        REPO_ROOT / "build.sbt",
-        REPO_ROOT / "sonatype.sbt",
-        CI_DOCKERFILE,
-    ]
-    project_inputs = subprocess.check_output(
-        ["git", "-C", str(REPO_ROOT), "ls-files", "--", "project"], text=True
-    ).splitlines()
-    inputs.extend(REPO_ROOT / path for path in sorted(project_inputs))
-    manifest = b"".join(
-        (
-            f"{hashlib.sha256(path.read_bytes()).hexdigest()}  "
-            f"{path.relative_to(REPO_ROOT).as_posix()}\n"
-        ).encode()
-        for path in inputs
-    )
-    return "ci-" + hashlib.sha256(manifest).hexdigest()[:12]
 
 
 def _jobs(node):
@@ -223,9 +215,123 @@ def test_ci_image_tag_matches_dependency_hash():
         for container in data["resources"]["containers"]
         if container["container"] == "ci"
     )
-    expected_tag = _ci_image_dependency_tag()
+    expected_tag = ci_image.calculate_tag(REPO_ROOT)
     assert data["variables"]["CI_IMAGE_TAG"] == expected_tag
     assert ci_container["image"].rsplit(":", 1)[1] == expected_tag
+    assert ci_container["type"].lower() == "acr"
+    assert ci_container["azureSubscription"] == "SynapseML Build"
+    assert ci_container["resourceGroup"] == "marhamil-mmlspark"
+    assert ci_container["registry"] == "mmlsparkmcr"
+    assert ci_container["repository"] == "synapseml/ci"
+    assert "endpoint" not in ci_container
+
+
+def test_ci_image_bootstraps_with_the_existing_arm_connection():
+    data = yaml.safe_load(_pipeline_text())
+    jobs = {j.get("job"): j for j in _jobs(data["jobs"])}
+    build_image = jobs["BuildCIImage"]
+
+    condition = build_image["condition"]
+    assert "variables.isPR" in condition
+    assert "System.PullRequest.IsFork" in condition
+    assert "not(failed())" not in condition
+
+    build_steps = [
+        step
+        for step in build_image["steps"]
+        if step.get("displayName") == "Build or reuse CI image"
+    ]
+    assert len(build_steps) == 1
+    build_step = build_steps[0]
+    assert build_step["task"] == "AzureCLI@2"
+    assert build_step["inputs"]["azureSubscription"] == "SynapseML Build"
+    script = build_step["inputs"]["inlineScript"]
+    assert "az acr login --name" in script
+    assert "python3 tools/ci/ci_image.py tag" in script
+    assert "python3 tools/ci/ci_image.py java-version" in script
+    assert "python3 tools/ci/ci_image.py spark-version" in script
+    assert "python3 tools/ci/ci_image.py spark-sha512" in script
+    assert "--build-arg JAVA_VERSION=" in script
+    assert "--build-arg SPARK_VERSION=" in script
+    assert "--build-arg SPARK_SHA512=" in script
+    assert not any(step.get("task") == "Docker@2" for step in build_image["steps"])
+
+
+def test_fork_image_guard_rejects_unpublishable_input_changes():
+    data = yaml.safe_load(_pipeline_text())
+    jobs = {j.get("job"): j for j in _jobs(data["jobs"])}
+    guard = jobs["ValidateCIImageForFork"]
+
+    assert "System.PullRequest.IsFork" in guard["condition"]
+    assert "'True'" in guard["condition"]
+    guard_step = next(
+        step
+        for step in guard["steps"]
+        if step.get("displayName") == "Reject unpublished fork image changes"
+    )
+    script = guard_step["bash"]
+    assert "SYSTEM_PULLREQUEST_TARGETBRANCH" in script
+    assert "tools/ci/ci_image.py inputs" in script
+    assert '"$target_ref...HEAD"' in script
+    assert "tools/docker/ci/**" in script
+
+
+def test_containerized_jobs_can_reuse_the_target_image_for_forks():
+    data = yaml.safe_load(_pipeline_text())
+    jobs = {j.get("job"): j for j in _jobs(data["jobs"])}
+    consumers = [
+        job
+        for job in jobs.values()
+        if job.get("container") == "ci" and job["job"] != "BuildCIImage"
+    ]
+    assert consumers
+    for job in consumers:
+        depends_on = job.get("dependsOn", [])
+        if isinstance(depends_on, str):
+            depends_on = [depends_on]
+        assert "BuildCIImage" in depends_on
+        assert "ValidateCIImageForFork" in depends_on
+        condition = job.get("condition", "")
+        assert "not(failed())" in condition
+        assert "not(canceled())" in condition
+
+
+def test_ci_dockerfile_uses_branch_runtime_and_writable_shared_cache():
+    dockerfile = CI_DOCKERFILE.read_text()
+
+    assert (
+        "FROM ubuntu:22.04@sha256:"
+        "2edbbc5dc405e9612ba3584ce95480277e3eb374407b5505fe26f17df77c7dbc" in dockerfile
+    )
+    for build_argument in (
+        "JAVA_VERSION",
+        "SPARK_VERSION",
+        "SPARK_SHA512",
+        "TORCH_VERSION",
+        "TORCHVISION_VERSION",
+    ):
+        assert f"ARG {build_argument}" in dockerfile
+    assert "temurin-8-jdk" not in dockerfile
+    assert "torch-2.1.0" not in dockerfile
+    assert "torchvision-0.16.0" not in dockerfile
+    assert "torch.__version__" in dockerfile
+    assert "torchvision.__version__" in dockerfile
+    assert "sbt --batch" not in dockerfile
+    assert 'chown -R 1001:0 "$COURSIER_CACHE"' in dockerfile
+    assert 'chmod -R u+rwX,go+rX,go-w "$COURSIER_CACHE"' in dockerfile
+
+
+def test_dataset_cache_recovers_from_a_partial_local_download():
+    build = BUILD_SBT.read_text()
+    get_datasets = build.split("getDatasetsTask := {", 1)[1].split(
+        "val genBuildInfo", 1
+    )[0]
+
+    assert "if (!datasetDir.value.exists())" in get_datasets
+    assert "if (f.exists()) f.delete()" in get_datasets
+    assert 'sys.env.getOrElse("DATASET_CACHE", "/opt/datasets")' in get_datasets
+    assert get_datasets.index("f.delete()") < get_datasets.index("Files.copy")
+    assert get_datasets.index("Files.copy") < get_datasets.index("UnzipUtils.unzip")
 
 
 def test_containerized_jobs_do_not_apt_install():
@@ -370,7 +476,8 @@ def test_databricks_e2e_uses_fail_open_pr_impact_detection():
 
     for job, suite in ((databricks_cpu, "Cpu"), (databricks_gpu, "Gpu")):
         condition = job["condition"]
-        assert "succeeded()" in condition
+        assert "not(failed())" in condition
+        assert "not(canceled())" in condition
         assert "variables.runTests" in condition
         assert "parameters.testDatabricksE2E" in condition
         assert (
@@ -423,7 +530,8 @@ def test_fabric_e2e_keeps_key_vault_authentication_and_blocks_forks():
     fabric_e2e = jobs["FabricE2E"]
 
     condition = fabric_e2e["condition"]
-    assert "succeeded()" in condition
+    assert "not(failed())" in condition
+    assert "not(canceled())" in condition
     assert "variables.runTests" in condition
     assert "parameters.testFabricE2E" in condition
     assert "System.PullRequest.IsFork" in condition
@@ -1757,6 +1865,14 @@ def test_style_does_not_restore_the_full_conda_environment():
         assert "black[jupyter]==22.3.0" in python_style["bash"]
 
 
+def test_r_tests_use_the_preinstalled_spark_distribution():
+    runner = R_TEST_RUNNER.read_text()
+    generator = R_TEST_GEN.read_text()
+
+    assert 'if (!nzchar(Sys.getenv("SPARK_HOME", "")))' in runner
+    assert 'spark_home = Sys.getenv("SPARK_HOME")' in generator
+
+
 def test_every_sbt_running_job_waits_for_the_prewarm_cache():
     """Each sbt job must restore the cache after the required prewarm job."""
     data = yaml.safe_load(_pipeline_text())
@@ -1779,6 +1895,24 @@ def test_every_sbt_running_job_waits_for_the_prewarm_cache():
             continue
         steps = job.get("steps", [])
         texts = flatten(steps)
+        expanded_templates = []
+        for step in steps:
+            if not isinstance(step, dict) or not step.get("template"):
+                continue
+            template = Path(step["template"])
+            template_path = REPO_ROOT / template
+            if not template_path.exists() and len(template.parts) == 1:
+                template_path = REPO_ROOT / "templates" / template
+            if template_path.exists():
+                template_steps = yaml.safe_load(template_path.read_text()).get(
+                    "steps", []
+                )
+                texts.extend(flatten(template_steps))
+                expanded_templates.extend(
+                    nested.get("template")
+                    for nested in template_steps
+                    if isinstance(nested, dict) and nested.get("template")
+                )
         runs_sbt = any(
             _INVOKES_SBT.search(t) or t.strip().startswith("sbt") or "sbt_retry.sh" in t
             for t in texts
@@ -1788,12 +1922,19 @@ def test_every_sbt_running_job_waits_for_the_prewarm_cache():
             for s in steps
             if isinstance(s, dict) and s.get("template")
         ]
-        uses_cache = "templates/sbt_cache.yml" in templates
+        uses_cache = (
+            "templates/sbt_cache.yml" in templates
+            or "sbt_cache.yml" in expanded_templates
+        )
         depends_on = job.get("dependsOn", [])
         if isinstance(depends_on, str):
             depends_on = [depends_on]
         condition = job.get("condition")
-        gated_by_success = condition is None or "succeeded()" in condition
+        gated_by_success = (
+            condition is None
+            or "succeeded()" in condition
+            or ("not(failed())" in condition and "not(canceled())" in condition)
+        )
         if runs_sbt and (
             not uses_cache
             or "BuildAndCacheSbt" not in depends_on

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -6,6 +6,7 @@ bootstrap inputs, and the duplicated inline retry blocks were replaced by the
 shared helper. Run with: ``python -m pytest tools/ci/tests/test_pipeline_yaml.py``.
 """
 
+import hashlib
 import os
 import re
 import shutil
@@ -19,6 +20,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[3]
 BUILD_SBT = REPO_ROOT / "build.sbt"
 PIPELINE = REPO_ROOT / "pipeline.yaml"
+CI_DOCKERFILE = REPO_ROOT / "tools" / "docker" / "ci" / "Dockerfile"
 SBT_CACHE_TPL = REPO_ROOT / "templates" / "sbt_cache.yml"
 SBT_RETRY = REPO_ROOT / "tools" / "ci" / "sbt_retry.sh"
 SBT_VERSION = REPO_ROOT / "tools" / "ci" / "get_sbt_version.sh"
@@ -43,6 +45,27 @@ _INVOKES_SBT = re.compile(r"(?<![\w./-])sbt\s")
 
 def _pipeline_text():
     return PIPELINE.read_text()
+
+
+def _ci_image_dependency_tag():
+    inputs = [
+        REPO_ROOT / "environment.yml",
+        REPO_ROOT / "build.sbt",
+        REPO_ROOT / "sonatype.sbt",
+        CI_DOCKERFILE,
+    ]
+    project_inputs = subprocess.check_output(
+        ["git", "-C", str(REPO_ROOT), "ls-files", "--", "project"], text=True
+    ).splitlines()
+    inputs.extend(REPO_ROOT / path for path in sorted(project_inputs))
+    manifest = b"".join(
+        (
+            f"{hashlib.sha256(path.read_bytes()).hexdigest()}  "
+            f"{path.relative_to(REPO_ROOT).as_posix()}\n"
+        ).encode()
+        for path in inputs
+    )
+    return "ci-" + hashlib.sha256(manifest).hexdigest()[:12]
 
 
 def _jobs(node):
@@ -188,6 +211,18 @@ def test_build_has_canonical_maven_central_fallback():
         rf"(?:\+=\s*{resolver}|\+\+=\s*Seq\s*\([^)]*{resolver}[^)]*\))"
     )
     assert len(re.findall(active_setting, build, flags=re.DOTALL)) == 1
+
+
+def test_ci_image_tag_matches_dependency_hash():
+    data = yaml.safe_load(_pipeline_text())
+    ci_container = next(
+        container
+        for container in data["resources"]["containers"]
+        if container["container"] == "ci"
+    )
+    expected_tag = _ci_image_dependency_tag()
+    assert data["variables"]["CI_IMAGE_TAG"] == expected_tag
+    assert ci_container["image"].rsplit(":", 1)[1] == expected_tag
 
 
 def test_sbt_cache_template_exists_and_parses():

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -28,6 +28,11 @@ RELEASE_COMPAT_PREREQUISITES = (
     REPO_ROOT / ".pipelines" / "release-compat-prerequisites.txt"
 )
 
+# Matches a real `sbt <args>` invocation while ignoring filenames that merely end
+# in ".sbt" (e.g. `sha256sum build.sbt sonatype.sbt ...`), which would otherwise
+# make any job that hashes the build files look like it runs sbt.
+_INVOKES_SBT = re.compile(r"(?<![\w./-])sbt\s")
+
 
 def _pipeline_text():
     return PIPELINE.read_text()
@@ -518,7 +523,14 @@ def test_publish_jobs_resolve_and_preserve_package_versions():
     publish = jobs["Publish"]
     publish_steps = publish["steps"]
     assert any(step.get("task") == "MavenAuthenticate@0" for step in publish_steps)
-    assert any(step.get("template") == "templates/conda.yml" for step in publish_steps)
+    # When Publish runs in the prebuilt CI container the synapseml conda env is
+    # baked into the image, so restoring it via templates/conda.yml would be a
+    # no-op at best. At worst it is destructive: conda.yml resolves
+    # $(CONDA_CACHE_DIR) to the hosted-agent path and runs `conda env remove`
+    # + `conda env create`, which would delete the prebaked env. Only require
+    # the template for a non-containerized job.
+    if not publish.get("container"):
+        assert any(step.get("template") == "templates/conda.yml" for step in publish_steps)
     assert any(step.get("template") == "templates/kv.yml" for step in publish_steps)
     version_step = next(
         step
@@ -581,7 +593,15 @@ def test_style_does_not_restore_the_full_conda_environment():
         for step in style["steps"]
         if step.get("displayName") == "Python Style Check"
     )
-    assert "black[jupyter]==22.3.0" in python_style["bash"]
+    # The formatter version must be pinned exactly. A containerized Style job
+    # inherits the pin from environment.yml, which the CI image bakes in, so
+    # re-installing it at step time would only add network flakiness. A
+    # non-containerized job has to pin it inline.
+    if style.get("container"):
+        env_text = (REPO_ROOT / "environment.yml").read_text(encoding="utf-8")
+        assert "black[jupyter]==22.3.0" in env_text
+    else:
+        assert "black[jupyter]==22.3.0" in python_style["bash"]
 
 
 def test_every_sbt_running_job_waits_for_the_prewarm_cache():
@@ -607,7 +627,7 @@ def test_every_sbt_running_job_waits_for_the_prewarm_cache():
         steps = job.get("steps", [])
         texts = flatten(steps)
         runs_sbt = any(
-            "sbt " in t or t.strip().startswith("sbt") or "sbt_retry.sh" in t
+            _INVOKES_SBT.search(t) or t.strip().startswith("sbt") or "sbt_retry.sh" in t
             for t in texts
         )
         templates = [

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -802,6 +802,20 @@ def test_internal_python_adapts_typing_package_data_to_current_codegen():
     assert "utils/typing_build_support.py" in script
 
 
+def test_internal_branch_selection_retries_transient_git_service_failures():
+    data = yaml.safe_load(_pipeline_text())
+    jobs = {j.get("job"): j for j in _jobs(data["jobs"])}
+    internal = jobs["InternalCompat"]
+    branch_step = next(
+        step
+        for step in internal["steps"]
+        if isinstance(step, dict)
+        and step.get("displayName") == "Select matching SynapseML-Internal branch"
+    )
+
+    assert branch_step["retryCountOnTaskFailure"] == 3
+
+
 def test_internal_python_isolates_typing_from_spark_tests():
     data = yaml.safe_load(_pipeline_text())
     jobs = {j.get("job"): j for j in _jobs(data["jobs"])}

--- a/tools/docker/ci/Dockerfile
+++ b/tools/docker/ci/Dockerfile
@@ -1,0 +1,111 @@
+# SynapseML CI Container Image
+# Pre-bakes all build dependencies so CI jobs start with a warm environment.
+# Rebuilt automatically by BuildCIImage when dependency files change.
+
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+# Temurin JDK 8 + system packages in a single layer to avoid redundant apt-get update.
+# JDK 8 required — JDK 11 has different CMYK JPEG handling in ImageIO.
+# Audio libs (libasound2, libpulse0) needed by Azure Speech SDK.
+# libssl1.1 needed by Azure Speech SDK (Ubuntu 22.04 ships OpenSSL 3.0 but SDK requires 1.x).
+RUN apt-get update && apt-get install -y --no-install-recommends curl wget git ca-certificates gnupg2 \
+    && wget -qO- https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor -o /usr/share/keyrings/adoptium.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(. /etc/os-release && echo $VERSION_CODENAME) main" \
+         > /etc/apt/sources.list.d/adoptium.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+         temurin-8-jdk \
+         openmpi-bin libopenmpi-dev \
+         ffmpeg libgstreamer1.0-0 \
+         gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly \
+         libasound2 libpulse0 \
+         graphviz doxygen \
+         build-essential cmake \
+         libssl-dev libffi-dev \
+         sudo \
+    && rm -rf /var/lib/apt/lists/* \
+    && wget -q https://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.24_amd64.deb -O /tmp/libssl1.1.deb \
+    && echo "7cf39d70a639017d1dd7c8d36daa2258063608688e449fddf40ffdd46f992a78  /tmp/libssl1.1.deb" | sha256sum -c - \
+    && dpkg -i /tmp/libssl1.1.deb \
+    && rm /tmp/libssl1.1.deb
+
+ENV JAVA_HOME=/usr/lib/jvm/temurin-8-jdk-amd64
+
+# Miniconda — pinned version for reproducible builds
+# conda 24.x does not require TOS acceptance (that was added in conda 25.x)
+RUN wget -q https://repo.anaconda.com/miniconda/Miniconda3-py311_24.11.1-0-Linux-x86_64.sh -O /tmp/miniconda.sh \
+    && bash /tmp/miniconda.sh -b -p /opt/conda \
+    && rm /tmp/miniconda.sh
+ENV PATH=/opt/conda/bin:$PATH
+ENV CONDA_CACHE_DIR=/opt/conda/envs
+
+# Azure CLI (installed into base conda python, not the synapseml env)
+RUN pip install --no-cache-dir azure-cli==2.60.0
+
+# Spark (pre-downloaded for R tests)
+ENV SPARK_VERSION=3.5.0
+ENV HADOOP_VERSION=3
+RUN wget -q "https://mmlspark.blob.core.windows.net/installers/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz" -O /tmp/spark.tgz \
+    && tar -xzf /tmp/spark.tgz -C /opt \
+    && rm /tmp/spark.tgz
+ENV SPARK_HOME=/opt/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}
+ENV PATH=${SPARK_HOME}/bin:$PATH
+
+# Node.js 16 (for website deployment)
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+    && apt-get install -y nodejs \
+    && npm install -g yarn \
+    && rm -rf /var/lib/apt/lists/*
+
+# SBT — set COURSIER_CACHE to shared location accessible by any UID (ADO uses UID 1001)
+ENV SBT_VERSION=1.10.11
+ENV COURSIER_CACHE=/opt/.cache/coursier
+RUN wget -q "https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" -O /tmp/sbt.tgz \
+    && tar -xzf /tmp/sbt.tgz -C /opt \
+    && rm /tmp/sbt.tgz \
+    && mkdir -p $COURSIER_CACHE
+ENV PATH=/opt/sbt/bin:$PATH
+
+# --- Cache boundary: layers below invalidate when dependency files change ---
+
+# Conda environment from environment.yml
+# Use PIP_NO_CACHE_DIR to save disk; CI is CPU-only so replace CUDA torch with CPU variant
+# Direct wheel URLs avoid --extra-index-url which violates CFS policy
+COPY environment.yml /tmp/environment.yml
+RUN PIP_NO_CACHE_DIR=1 conda env create -f /tmp/environment.yml \
+    && conda clean --all -y \
+    && rm /tmp/environment.yml \
+    && /opt/conda/envs/synapseml/bin/pip install --no-cache-dir --no-deps \
+         "https://download.pytorch.org/whl/cpu/torch-2.1.0%2Bcpu-cp311-cp311-linux_x86_64.whl" \
+         "https://download.pytorch.org/whl/cpu/torchvision-0.16.0%2Bcpu-cp311-cp311-linux_x86_64.whl" \
+    && /opt/conda/envs/synapseml/bin/pip uninstall -y triton \
+         nvidia-cublas-cu12 nvidia-cuda-cupti-cu12 nvidia-cuda-nvrtc-cu12 \
+         nvidia-cuda-runtime-cu12 nvidia-cudnn-cu12 nvidia-cufft-cu12 \
+         nvidia-curand-cu12 nvidia-cusolver-cu12 nvidia-cusparse-cu12 \
+         nvidia-nccl-cu12 nvidia-nvjitlink-cu12 nvidia-nvtx-cu12 2>/dev/null || true \
+    && chmod -R 755 /opt/conda/envs \
+    && chmod -R 777 /opt/conda/envs/synapseml/lib/R/library
+
+# Pre-fetch SBT plugins, all project dependency JARs, and compiler-bridge.
+# Copy the full project/ dir and build files so SBT can resolve the complete
+# dependency graph. This eliminates ~286 JAR downloads + compiler-bridge
+# compilation (~2-3 min) from every test job.
+COPY project/               /tmp/sbt-warmup/project/
+COPY build.sbt              /tmp/sbt-warmup/build.sbt
+COPY sonatype.sbt           /tmp/sbt-warmup/sonatype.sbt
+RUN cd /tmp/sbt-warmup \
+    && sbt --batch -Dsbt.supershell=false "update; Test/update" || true \
+    && rm -rf /tmp/sbt-warmup /tmp/.sbt \
+    && chmod -R 755 $COURSIER_CACHE
+
+# Pre-download test datasets (static tarball, ~50MB) to avoid downloading in every job
+ENV DATASET_CACHE=/opt/datasets
+RUN mkdir -p $DATASET_CACHE \
+    && wget -q "https://mmlspark.blob.core.windows.net/installers/datasets-2023-04-03.tgz" \
+         -O "$DATASET_CACHE/datasets-2023-04-03.tgz"
+
+# No ENTRYPOINT — ADO agent needs to control the process
+CMD ["bash"]

--- a/tools/docker/ci/Dockerfile
+++ b/tools/docker/ci/Dockerfile
@@ -87,7 +87,8 @@ RUN PIP_NO_CACHE_DIR=1 conda env create -f /tmp/environment.yml \
          nvidia-curand-cu12 nvidia-cusolver-cu12 nvidia-cusparse-cu12 \
          nvidia-nccl-cu12 nvidia-nvjitlink-cu12 nvidia-nvtx-cu12 2>/dev/null || true \
     && chmod -R 755 /opt/conda/envs \
-    && chmod -R 777 /opt/conda/envs/synapseml/lib/R/library
+    && chown -R 1001:0 /opt/conda/envs/synapseml/lib/R/library \
+    && chmod -R u+rwX,go+rX,go-w /opt/conda/envs/synapseml/lib/R/library
 
 # Pre-fetch SBT plugins, all project dependency JARs, and compiler-bridge.
 # Copy the full project/ dir and build files so SBT can resolve the complete

--- a/tools/docker/ci/Dockerfile
+++ b/tools/docker/ci/Dockerfile
@@ -54,7 +54,7 @@ RUN wget -q "https://mmlspark.blob.core.windows.net/installers/spark-${SPARK_VER
 ENV SPARK_HOME=/opt/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}
 ENV PATH=${SPARK_HOME}/bin:$PATH
 
-# SBT — set COURSIER_CACHE to shared location accessible by any UID (ADO uses UID 1001)
+# SBT — use a shared Coursier cache owned by ADO's remapped UID 1001
 ENV SBT_VERSION=1.10.11
 ENV COURSIER_CACHE=/opt/.cache/coursier
 RUN wget -q "https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" -O /tmp/sbt.tgz \
@@ -79,10 +79,9 @@ RUN PIP_NO_CACHE_DIR=1 conda env create -f /tmp/environment.yml \
          nvidia-cublas-cu12 nvidia-cuda-cupti-cu12 nvidia-cuda-nvrtc-cu12 \
          nvidia-cuda-runtime-cu12 nvidia-cudnn-cu12 nvidia-cufft-cu12 \
          nvidia-curand-cu12 nvidia-cusolver-cu12 nvidia-cusparse-cu12 \
-         nvidia-nccl-cu12 nvidia-nvjitlink-cu12 nvidia-nvtx-cu12 2>/dev/null || true \
-    && chmod -R 755 /opt/conda/envs \
-    && chown -R 1001:0 /opt/conda/envs/synapseml/lib/R/library \
-    && chmod -R u+rwX,go+rX,go-w /opt/conda/envs/synapseml/lib/R/library
+         nvidia-nccl-cu12 nvidia-nvjitlink-cu12 nvidia-nvtx-cu12 \
+    && chown -R 1001:0 /opt/conda/envs \
+    && chmod -R u+rwX,go+rX,go-w /opt/conda/envs
 
 # Pre-fetch SBT plugins, all project dependency JARs, and compiler-bridge.
 # Copy the full project/ dir and build files so SBT can resolve the complete
@@ -94,7 +93,8 @@ COPY sonatype.sbt           /tmp/sbt-warmup/sonatype.sbt
 RUN cd /tmp/sbt-warmup \
     && sbt --batch -Dsbt.supershell=false "update; Test/update" || true \
     && rm -rf /tmp/sbt-warmup /tmp/.sbt \
-    && chmod -R 755 $COURSIER_CACHE
+    && chown -R 1001:0 "$COURSIER_CACHE" \
+    && chmod -R u+rwX,go+rX,go-w "$COURSIER_CACHE"
 
 # Pre-download test datasets (static tarball, ~50MB) to avoid downloading in every job
 ENV DATASET_CACHE=/opt/datasets

--- a/tools/docker/ci/Dockerfile
+++ b/tools/docker/ci/Dockerfile
@@ -36,7 +36,10 @@ ENV JAVA_HOME=/usr/lib/jvm/temurin-8-jdk-amd64
 
 # Miniconda — pinned version for reproducible builds
 # conda 24.x does not require TOS acceptance (that was added in conda 25.x)
+# Digest is the one published by Anaconda on https://repo.anaconda.com/miniconda/ ; this
+# installer is executed as root, so verify before running it rather than after.
 RUN wget -q https://repo.anaconda.com/miniconda/Miniconda3-py311_24.11.1-0-Linux-x86_64.sh -O /tmp/miniconda.sh \
+    && echo "807774bae6cd87132094458217ebf713df436f64779faf9bb4c3d4b6615c1e3a  /tmp/miniconda.sh" | sha256sum -c - \
     && bash /tmp/miniconda.sh -b -p /opt/conda \
     && rm /tmp/miniconda.sh
 ENV PATH=/opt/conda/bin:$PATH
@@ -48,7 +51,12 @@ RUN pip install --no-cache-dir azure-cli==2.60.0
 # Spark (pre-downloaded for R tests)
 ENV SPARK_VERSION=3.5.0
 ENV HADOOP_VERSION=3
+# We fetch Spark from a blob mirror, so pin the digest Apache publishes for this exact
+# artifact (archive.apache.org/dist/spark/spark-3.5.0/...tgz.sha512). Bump both the version
+# ENVs and this digest together; a stale digest fails the build instead of silently
+# installing a different Spark.
 RUN wget -q "https://mmlspark.blob.core.windows.net/installers/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz" -O /tmp/spark.tgz \
+    && echo "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319  /tmp/spark.tgz" | sha512sum -c - \
     && tar -xzf /tmp/spark.tgz -C /opt \
     && rm /tmp/spark.tgz
 ENV SPARK_HOME=/opt/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}
@@ -57,7 +65,9 @@ ENV PATH=${SPARK_HOME}/bin:$PATH
 # SBT — use a shared Coursier cache owned by ADO's remapped UID 1001
 ENV SBT_VERSION=1.10.11
 ENV COURSIER_CACHE=/opt/.cache/coursier
+# Digest is the sbt-${SBT_VERSION}.tgz.sha256 asset published on the same GitHub release.
 RUN wget -q "https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" -O /tmp/sbt.tgz \
+    && echo "5034a64841b8a9cfb52a341e45b01df2b8c2ffaa87d8d2b0fe33c4cdcabd8f0c  /tmp/sbt.tgz" | sha256sum -c - \
     && tar -xzf /tmp/sbt.tgz -C /opt \
     && rm /tmp/sbt.tgz \
     && mkdir -p $COURSIER_CACHE

--- a/tools/docker/ci/Dockerfile
+++ b/tools/docker/ci/Dockerfile
@@ -96,11 +96,13 @@ RUN cd /tmp/sbt-warmup \
     && chown -R 1001:0 "$COURSIER_CACHE" \
     && chmod -R u+rwX,go+rX,go-w "$COURSIER_CACHE"
 
-# Pre-download test datasets (static tarball, ~50MB) to avoid downloading in every job
+# Pre-download test datasets (static tarball, ~117MB) to avoid downloading in every job
 ENV DATASET_CACHE=/opt/datasets
 RUN mkdir -p $DATASET_CACHE \
     && wget -q "https://mmlspark.blob.core.windows.net/installers/datasets-2023-04-03.tgz" \
-         -O "$DATASET_CACHE/datasets-2023-04-03.tgz"
+         -O "$DATASET_CACHE/datasets-2023-04-03.tgz" \
+    && echo "f8f8592c30451628ef3c0f63aab3b1f85d18acf6565de0b48086b273e94622fb  $DATASET_CACHE/datasets-2023-04-03.tgz" \
+         | sha256sum -c -
 
 # No ENTRYPOINT — ADO agent needs to control the process
 CMD ["bash"]

--- a/tools/docker/ci/Dockerfile
+++ b/tools/docker/ci/Dockerfile
@@ -2,14 +2,15 @@
 # Pre-bakes all build dependencies so CI jobs start with a warm environment.
 # Rebuilt automatically by BuildCIImage when dependency files change.
 
-FROM ubuntu:22.04
+FROM ubuntu:22.04@sha256:2edbbc5dc405e9612ba3584ce95480277e3eb374407b5505fe26f17df77c7dbc
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 
-# Temurin JDK 8 + system packages in a single layer to avoid redundant apt-get update.
-# JDK 8 required — JDK 11 has different CMYK JPEG handling in ImageIO.
+ARG JAVA_VERSION
+
+# The JDK version comes from templates/java_setup.yml on each release branch.
 # Audio libs (libasound2, libpulse0) needed by Azure Speech SDK.
 # libssl1.1 needed by Azure Speech SDK (Ubuntu 22.04 ships OpenSSL 3.0 but SDK requires 1.x).
 RUN apt-get update && apt-get install -y --no-install-recommends curl wget git ca-certificates gnupg2 \
@@ -17,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl wget git c
     && echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(. /etc/os-release && echo $VERSION_CODENAME) main" \
          > /etc/apt/sources.list.d/adoptium.list \
     && apt-get update && apt-get install -y --no-install-recommends \
-         temurin-8-jdk \
+         "temurin-${JAVA_VERSION}-jdk" \
          openmpi-bin libopenmpi-dev \
          ffmpeg libgstreamer1.0-0 \
          gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly \
@@ -32,7 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl wget git c
     && dpkg -i /tmp/libssl1.1.deb \
     && rm /tmp/libssl1.1.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/temurin-8-jdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/temurin-${JAVA_VERSION}-jdk-amd64
 
 # Miniconda — pinned version for reproducible builds
 # conda 24.x does not require TOS acceptance (that was added in conda 25.x)
@@ -48,15 +49,13 @@ ENV CONDA_CACHE_DIR=/opt/conda/envs
 # Azure CLI (installed into base conda python, not the synapseml env)
 RUN pip install --no-cache-dir azure-cli==2.60.0
 
-# Spark (pre-downloaded for R tests)
-ENV SPARK_VERSION=3.5.0
+# Spark (pre-downloaded for R tests). The version comes from build.sbt and the
+# checksum is the official Apache digest recorded in tools/ci/ci_image.py.
+ARG SPARK_VERSION
+ARG SPARK_SHA512
 ENV HADOOP_VERSION=3
-# We fetch Spark from a blob mirror, so pin the digest Apache publishes for this exact
-# artifact (archive.apache.org/dist/spark/spark-3.5.0/...tgz.sha512). Bump both the version
-# ENVs and this digest together; a stale digest fails the build instead of silently
-# installing a different Spark.
 RUN wget -q "https://mmlspark.blob.core.windows.net/installers/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz" -O /tmp/spark.tgz \
-    && echo "8883c67e0a138069e597f3e7d4edbbd5c3a565d50b28644aad02856a1ec1da7cb92b8f80454ca427118f69459ea326eaa073cf7b1a860c3b796f4b07c2101319  /tmp/spark.tgz" | sha512sum -c - \
+    && echo "${SPARK_SHA512}  /tmp/spark.tgz" | sha512sum -c - \
     && tar -xzf /tmp/spark.tgz -C /opt \
     && rm /tmp/spark.tgz
 ENV SPARK_HOME=/opt/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}
@@ -70,21 +69,29 @@ RUN wget -q "https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${
     && echo "5034a64841b8a9cfb52a341e45b01df2b8c2ffaa87d8d2b0fe33c4cdcabd8f0c  /tmp/sbt.tgz" | sha256sum -c - \
     && tar -xzf /tmp/sbt.tgz -C /opt \
     && rm /tmp/sbt.tgz \
-    && mkdir -p $COURSIER_CACHE
+    && mkdir -p "$COURSIER_CACHE" \
+    && chown -R 1001:0 "$COURSIER_CACHE" \
+    && chmod -R u+rwX,go+rX,go-w "$COURSIER_CACHE"
 ENV PATH=/opt/sbt/bin:$PATH
 
 # --- Cache boundary: layers below invalidate when dependency files change ---
 
 # Conda environment from environment.yml
-# Use PIP_NO_CACHE_DIR to save disk; CI is CPU-only so replace CUDA torch with CPU variant
-# Direct wheel URLs avoid --extra-index-url which violates CFS policy
+# Use PIP_NO_CACHE_DIR to save disk; CI is CPU-only, so replace the declared
+# CUDA wheels with the matching CPU builds for the branch's Python ABI.
+ARG TORCH_VERSION
+ARG TORCHVISION_VERSION
 COPY environment.yml /tmp/environment.yml
 RUN PIP_NO_CACHE_DIR=1 conda env create -f /tmp/environment.yml \
     && conda clean --all -y \
     && rm /tmp/environment.yml \
-    && /opt/conda/envs/synapseml/bin/pip install --no-cache-dir --no-deps \
-         "https://download.pytorch.org/whl/cpu/torch-2.1.0%2Bcpu-cp311-cp311-linux_x86_64.whl" \
-         "https://download.pytorch.org/whl/cpu/torchvision-0.16.0%2Bcpu-cp311-cp311-linux_x86_64.whl" \
+    && if [ "$(/opt/conda/envs/synapseml/bin/python -c 'import torch; print(torch.__version__)')" != "${TORCH_VERSION}+cpu" ] \
+         || [ "$(/opt/conda/envs/synapseml/bin/python -c 'import torchvision; print(torchvision.__version__)')" != "${TORCHVISION_VERSION}+cpu" ]; then \
+         /opt/conda/envs/synapseml/bin/pip install --no-cache-dir --no-deps --force-reinstall \
+           --index-url https://download.pytorch.org/whl/cpu \
+           "torch==${TORCH_VERSION}+cpu" \
+           "torchvision==${TORCHVISION_VERSION}+cpu"; \
+       fi \
     && /opt/conda/envs/synapseml/bin/pip uninstall -y triton \
          nvidia-cublas-cu12 nvidia-cuda-cupti-cu12 nvidia-cuda-nvrtc-cu12 \
          nvidia-cuda-runtime-cu12 nvidia-cudnn-cu12 nvidia-cufft-cu12 \
@@ -92,19 +99,6 @@ RUN PIP_NO_CACHE_DIR=1 conda env create -f /tmp/environment.yml \
          nvidia-nccl-cu12 nvidia-nvjitlink-cu12 nvidia-nvtx-cu12 \
     && chown -R 1001:0 /opt/conda/envs \
     && chmod -R u+rwX,go+rX,go-w /opt/conda/envs
-
-# Pre-fetch SBT plugins, all project dependency JARs, and compiler-bridge.
-# Copy the full project/ dir and build files so SBT can resolve the complete
-# dependency graph. This eliminates ~286 JAR downloads + compiler-bridge
-# compilation (~2-3 min) from every test job.
-COPY project/               /tmp/sbt-warmup/project/
-COPY build.sbt              /tmp/sbt-warmup/build.sbt
-COPY sonatype.sbt           /tmp/sbt-warmup/sonatype.sbt
-RUN cd /tmp/sbt-warmup \
-    && sbt --batch -Dsbt.supershell=false "update; Test/update" || true \
-    && rm -rf /tmp/sbt-warmup /tmp/.sbt \
-    && chown -R 1001:0 "$COURSIER_CACHE" \
-    && chmod -R u+rwX,go+rX,go-w "$COURSIER_CACHE"
 
 # Pre-download test datasets (static tarball, ~117MB) to avoid downloading in every job
 ENV DATASET_CACHE=/opt/datasets

--- a/tools/docker/ci/Dockerfile
+++ b/tools/docker/ci/Dockerfile
@@ -54,12 +54,6 @@ RUN wget -q "https://mmlspark.blob.core.windows.net/installers/spark-${SPARK_VER
 ENV SPARK_HOME=/opt/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}
 ENV PATH=${SPARK_HOME}/bin:$PATH
 
-# Node.js 16 (for website deployment)
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
-    && apt-get install -y nodejs \
-    && npm install -g yarn \
-    && rm -rf /var/lib/apt/lists/*
-
 # SBT — set COURSIER_CACHE to shared location accessible by any UID (ADO uses UID 1001)
 ENV SBT_VERSION=1.10.11
 ENV COURSIER_CACHE=/opt/.cache/coursier

--- a/tools/docker/ci/README.md
+++ b/tools/docker/ci/README.md
@@ -1,17 +1,22 @@
 # SynapseML CI image
 
 The Azure Pipelines jobs use a prebuilt image from
-`mmlsparkmcr.azurecr.io/synapseml/ci`. The image tag is an immutable digest of
-the Dockerfile and every file that controls its runtime. This keeps `master`
-and each Spark release branch independent: every branch publishes the Java,
-Spark, Python, and dependency versions declared on that branch.
+`mcr.microsoft.com/mmlspark/build-demo` with a `ci-*` tag. The tag is an
+immutable digest of the Dockerfile and every file that controls its runtime.
+This keeps `master` and each Spark release branch independent: every branch
+publishes the Java, Spark, Python, and dependency versions declared on that
+branch.
 
-The `BuildCIImage` job checks ACR for the content tag and only builds and pushes
-when it is missing. It authenticates through the existing `SynapseML Build`
-Azure Resource Manager service connection; no separate Docker registry service
-connection is needed. Same-repository PRs and shared branches can bootstrap a
-new tag. Fork PRs never receive registry credentials and must leave the image
-inputs unchanged; the pipeline reports an explicit error when they do not.
+The `BuildCIImage` job first reuses an existing public tag. If it is missing,
+the job checks the mapped
+`mmlsparkmcr.azurecr.io/public/mmlspark/build-demo` repository and only builds
+and pushes when needed. It authenticates through the existing `SynapseML Build`
+Azure Resource Manager service connection, then waits until MCR serves the same
+manifest digest. Consumer jobs pull the public MCR image without a separate
+Docker registry service connection. Same-repository PRs and shared branches can
+bootstrap a new tag. Fork PRs never receive registry credentials and must leave
+the image inputs unchanged; their guard also verifies that the corresponding
+public image is available before consumer jobs start.
 
 After changing an image input, synchronize both pipeline tag locations:
 

--- a/tools/docker/ci/README.md
+++ b/tools/docker/ci/README.md
@@ -1,8 +1,9 @@
 # SynapseML CI image
 
 The Azure Pipelines jobs use a prebuilt image from
-`mcr.microsoft.com/mmlspark/build-demo` with a `ci-*` tag. The tag is an
-immutable digest of the Dockerfile and every file that controls its runtime.
+`mcr.microsoft.com/mmlspark/build-demo` with a `ci-*` tag. The tag contains the
+first 12 hexadecimal characters of a SHA-256 digest of the Dockerfile and every
+file that controls its runtime.
 This keeps `master` and each Spark release branch independent: every branch
 publishes the Java, Spark, Python, and dependency versions declared on that
 branch.

--- a/tools/docker/ci/README.md
+++ b/tools/docker/ci/README.md
@@ -1,0 +1,33 @@
+# SynapseML CI image
+
+The Azure Pipelines jobs use a prebuilt image from
+`mmlsparkmcr.azurecr.io/synapseml/ci`. The image tag is an immutable digest of
+the Dockerfile and every file that controls its runtime. This keeps `master`
+and each Spark release branch independent: every branch publishes the Java,
+Spark, Python, and dependency versions declared on that branch.
+
+The `BuildCIImage` job checks ACR for the content tag and only builds and pushes
+when it is missing. It authenticates through the existing `SynapseML Build`
+Azure Resource Manager service connection; no separate Docker registry service
+connection is needed. Same-repository PRs and shared branches can bootstrap a
+new tag. Fork PRs never receive registry credentials and must leave the image
+inputs unchanged; the pipeline reports an explicit error when they do not.
+
+After changing an image input, synchronize both pipeline tag locations:
+
+```bash
+python tools/ci/ci_image.py update
+```
+
+Useful checks:
+
+```bash
+python tools/ci/ci_image.py tag
+python tools/ci/ci_image.py check
+python tools/ci/ci_image.py spark-version
+python tools/ci/ci_image.py java-version
+```
+
+`check` fails when either pipeline location is stale or the two locations
+disagree. `update` does not publish the image; the next trusted pipeline run
+does that automatically.

--- a/tools/tests/run_r_tests.R
+++ b/tools/tests/run_r_tests.R
@@ -4,7 +4,16 @@ if (!require("sparklyr")) {
 }
 
 if (!nzchar(Sys.getenv("SPARK_HOME", ""))) {
-  spark_install_tar(paste(getwd(), "/../../../../../../spark-3.5.0-bin-hadoop3.tgz", sep = ""))
+  spark_archive <- paste(getwd(), "/../../../../../../spark-3.5.0-bin-hadoop3.tgz", sep = "")
+  spark_install_tar(spark_archive)
+  installed_spark_home <- file.path(
+    spark_install_dir(),
+    tools::file_path_sans_ext(basename(spark_archive))
+  )
+  if (!dir.exists(installed_spark_home)) {
+    stop("Unable to locate Spark after installing ", spark_archive)
+  }
+  spark_home_set(installed_spark_home)
 }
 
 options("testthat.output_file" = "../../../../r-test-results.xml")

--- a/tools/tests/run_r_tests.R
+++ b/tools/tests/run_r_tests.R
@@ -13,7 +13,7 @@ if (!nzchar(Sys.getenv("SPARK_HOME", ""))) {
   if (!dir.exists(installed_spark_home)) {
     stop("Unable to locate Spark after installing ", spark_archive)
   }
-  spark_home_set(installed_spark_home)
+  Sys.setenv(SPARK_HOME = installed_spark_home)
 }
 
 options("testthat.output_file" = "../../../../r-test-results.xml")

--- a/tools/tests/run_r_tests.R
+++ b/tools/tests/run_r_tests.R
@@ -3,7 +3,9 @@ if (!require("sparklyr")) {
   library("sparklyr")
 }
 
-spark_install_tar(paste(getwd(), "/../../../../../../spark-3.5.0-bin-hadoop3.tgz", sep = ""))
+if (!nzchar(Sys.getenv("SPARK_HOME", ""))) {
+  spark_install_tar(paste(getwd(), "/../../../../../../spark-3.5.0-bin-hadoop3.tgz", sep = ""))
+}
 
 options("testthat.output_file" = "../../../../r-test-results.xml")
 devtools::test(reporter = JunitReporter$new())


### PR DESCRIPTION
## Summary

This is primarily a **reproducibility, branch-parity, and failure-isolation change, not a demonstrated end-to-end speed optimization**. It replaces mutable per-job environment assembly with an immutable, content-addressed, branch-specific image published at `mcr.microsoft.com/mmlspark/build-demo` under collision-resistant `ci-*` tags.

Trusted same-repository runs bootstrap a missing image through the existing `SynapseML Build` ARM service connection. Every consumer, including fork PRs, then pulls the same public image without registry credentials. Each branch derives its own Java, Spark, Spark checksum, Python, CPU PyTorch, and torchvision inputs instead of silently sharing one mutable environment.

This strengthens release validation, but it does **not** publish Maven artifacts or replace the Maven release process.

## Measured impact

The current-system baseline is the median of three successful warm-cache runs from PR #2678: [`233044790`](https://dev.azure.com/msdata/A365/_build/results?buildId=233044790), [`233072646`](https://dev.azure.com/msdata/A365/_build/results?buildId=233072646), and [`233083244`](https://dev.azure.com/msdata/A365/_build/results?buildId=233083244). That PR changed product/test code but not CI provisioning. The proposed measurement is exact-head build [`233211895`](https://dev.azure.com/msdata/A365/_build/results?buildId=233211895).

| Metric | Current warm-cache baseline | PR #2529 | Change |
| --- | ---: | ---: | ---: |
| End-to-end wall time | 75.25 min (71.38-81.69) | 74.68 min | -0.57 min (-0.75%); effectively flat |
| Completed jobs | 65 | 69 | +4 |
| Total agent-job time | 1,250.27 min | 1,459.19 min | +208.92 min (+16.71%) |

There is no demonstrated overall speedup. The wall-clock result is effectively unchanged, while aggregate agent consumption increased. All 63 Conda environment-creation tasks across the three baseline runs were skipped because the cache was warm. A warm Conda cache restore took a 1.42-minute median across 21 legs per baseline build; the proposed run initialized containers 63 times at a 2.49-minute median. Container startup is therefore slower than the current warm-cache provisioning path.

Selected same-name lanes show mixed results (negative change is faster):

| Job | Baseline median | PR #2529 | Change |
| --- | ---: | ---: | ---: |
| PythonTests core | 33.03 min | 25.70 min | -7.34 min (-22%) |
| PythonTests lightgbm | 26.04 min | 20.39 min | -5.65 min (-22%) |
| UnitTests core | 12.71 min | 14.50 min | +1.79 min (+14%) |
| UnitTests onnx | 16.25 min | 24.54 min | +8.29 min (+51%) |
| UnitTests opencv | 15.48 min | 16.06 min | +0.58 min (+4%) |
| RTests core | 22.35 min | 27.28 min | +4.93 min (+22%) |
| RTests lightgbm | 18.77 min | 19.74 min | +0.97 min (+5%) |
| Databricks CPU shard 1 | 24.61 min | 27.44 min | +2.83 min (+12%) |
| Databricks GPU | 72.51 min | 72.14 min | -0.37 min (-1%) |

The Databricks GPU job remained the critical path in every sampled build, so faster Python lanes did not materially reduce end-to-end latency. This is a same-period comparison, not a controlled A/B: this PR runs four additional jobs and adds compatibility tests, while the baseline PR has different product/test content. Cold-cache performance is also unmeasured because none of the sampled baseline runs rebuilt Conda. The supported conclusion is that warm-cache latency is flat and warm-cache agent cost is higher.

## Value delivered

- **Reproducibility:** the image tag is derived from effective environment inputs, so every lane uses one identifiable toolchain instead of depending on mutable cache state.
- **Branch parity:** `master` and Spark release branches derive Java, Spark, Python, and CPU PyTorch versions from their own checked-out configuration.
- **Fork parity and credential isolation:** trusted jobs publish through ACR, while same-repository and fork consumers pull the identical public MCR image anonymously.
- **Failure isolation:** package and toolchain provisioning happens during explicit image bootstrap rather than being re-resolved independently inside test lanes; each lane still pays image pull and initialization cost.
- **Release compatibility:** Java 8 bytecode/API checks, Spark-branch replay checks, R runtime wiring, and split Internal Scala/Python validation catch release-breaking drift before publication.

## Costs and limitations

- The measured warm-cache run used 16.71% more aggregate agent time and started four more jobs.
- MCR/ACR availability, image maintenance, image pulls, and MCR propagation become CI dependencies; cold-path performance has not been benchmarked against a real Conda cache miss.
- Fork PRs cannot change image inputs until a trusted maintainer publishes the corresponding immutable image.
- Spark 4.1 replay still has branch-specific conflicts that require manual resolution; the advisory job exposes rather than resolves them.

## How it works

- Derives the image tag from every effective image input and validates both pipeline tag locations.
- Derives Java, Spark, Spark checksum, PyTorch, and torchvision values from the checked-out branch.
- Reuses an existing public MCR tag immediately; otherwise builds or reuses the matching `public/mmlspark/build-demo` ACR manifest.
- Waits for MCR to expose the exact ACR manifest digest before dependent jobs can start.
- Keeps registry credentials out of consumer and fork jobs; fork guards reject image-input changes and retry public tag verification.
- Preserves shared sbt caches, preloads the checksummed test dataset, and uses the image-provided Spark distribution for R tests.

## Supported branches

The same implementation was replayed against the current Spark 4.0 and Spark 4.1 branch tips. Their image tags and runtime arguments are derived independently, preserving Java 17 and each branch's Spark, Python, and CPU PyTorch versions. Shared release branches still receive this change by merging `master`, not by rebasing.

## Exact-head fixes

- Compiles published Java and Scala main classes against Java 8 APIs. Java `--release 8` preserves class-file version 52, while Scala `-release:8` prevents linkage to Java 9+ covariant NIO signatures such as `FloatBuffer.rewind(): FloatBuffer`.
- Scopes both release flags to `Compile / compile`, preserving newer JDK APIs used by test sources on Spark 4 branches.
- Adds bytecode regressions for both class-file compatibility and every ONNX `java.nio.*Buffer.rewind` descriptor.
- Explicitly exports `SPARK_HOME` after R fallback archive installation.
- Uses deterministic malformed Spark image metadata for the OpenCV decoding-error fixture.
- Retries anonymous MCR manifest lookup for fork PRs before diagnosing the immutable image as unavailable.
- Isolates synthetic release-replay Git commands from inherited repository-routing variables so worktree validation cannot mutate the outer repository.
- Removes obsolete CMS JVM switches from every SBT lane so branch-derived Java 17 images start reliably.
- Retries authenticated SynapseML-Internal branch selection after transient Azure Repos failures.
- Preserves complete target history for fork image-input guards so triple-dot diffs always have a merge base.
- Documents that compact CI tags use the first 12 hexadecimal characters of the SHA-256 input digest.
- Uses immutable public image tag `ci-3d044ca3829c`.

## Validation

- Rebased onto `master` at `101fcbf2d54eaccf60c06df2f3834e865b8d2ba6` (23 commits ahead, 0 behind).
- Azure build [`233104290`](https://dev.azure.com/msdata/A365/_build/results?buildId=233104290) proved public MCR bootstrap and anonymous consumption; ACR and MCR served the same digest for `ci-112db6614927`.
- Azure build [`233129194`](https://dev.azure.com/msdata/A365/_build/results?buildId=233129194) on `ec73e2dff8837f89f996dabec0e38d97760ae5c9` passed 64 of 69 jobs. Its two Databricks ONNX failures isolated Scala linkage to post-Java-8 `Buffer.rewind` signatures; the prior `NativeLoader.class` error was gone.
- Azure build [`233170287`](https://dev.azure.com/msdata/A365/_build/results?buildId=233170287) on `4793757eb4e3a4d56fd1dd928de30a2ba445099b` passed 68 of 69 jobs. All six R lanes, OpenCV, ONNX, Python LightGBM, both SynapseML-Internal lanes, and every Databricks CPU/GPU lane passed. The only failure was the explicitly advisory Spark 4.1 replay conflict.
- Azure build [`233187512`](https://dev.azure.com/msdata/A365/_build/results?buildId=233187512) on `a36c93bea41e10eec28e70d1f973444d943cf567` passed 67 of 69 jobs. The expected advisory Spark 4.1 replay conflicted; the only unexpected failure was an Azure Repos HTTP 503 before Internal Python tests began, so `5dea7f8001` added native retries.
- Azure build [`233199475`](https://dev.azure.com/msdata/A365/_build/results?buildId=233199475) on `bf1ad75b79a8dd3d06515a4bfa733c4bf51df553` completed with 68 of 69 jobs succeeded; only the explicitly advisory Spark 4.1 replay conflict failed. Its tree `8117edf747b827e49f9831c4eb27defe9ce6630d` is identical to rebased head `23ab45522041dfaec0f0a440e27f6eb5da0c52f5`.
- Spark 3.5 / Scala 2.12 / JDK 11: full style, compile, test compile, and focused NativeLoader, ONNX, and OpenCV regressions passed.
- Spark 4.0 and Spark 4.1 / Scala 2.13 / JDK 17: full style, compile, test compile, and focused NativeLoader, ONNX, and OpenCV regressions passed on both port branches.
- Every compiled ONNX rewind descriptor returns `java.nio.Buffer`, and `NativeLoader.class` remains major version 52 on all three branches.
- Current pipeline contract tests: 57 passed, 27 skipped. The Git-environment isolation and JDK-portability regressions passed under WSL, and Black 22.3.0 left the changed test unchanged.
- ACR and public MCR expose `ci-3d044ca3829c` at the identical digest `sha256:3b4d52ba7701923ade3a869d83a10fb1e9c112100afb95f6ae1b4d60613bdd14`.

Final exact-head Azure build [`233211895`](https://dev.azure.com/msdata/A365/_build/results?buildId=233211895) completed with 68 of 69 jobs succeeded; only the explicitly advisory Spark 4.1 replay conflict failed. The required aggregate Azure, WIP, and CLA checks are green, and automated review [`5048260215`](https://github.com/microsoft/SynapseML/pull/2529#pullrequestreview-5048260215) reports no findings on final head `23ab45522041dfaec0f0a440e27f6eb5da0c52f5`.

