### PR TITLE
ci: extend CI coverage (CodeQL, PR validation, dependency review) to spark4.1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,11 +13,11 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "spark4.1" ]
     paths-ignore: [ "**.md" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: [ "master", "spark4.1" ]
     paths-ignore: [ "**.md" ]
   schedule:
     - cron: '17 7 * * 3'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "spark4.1" ]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -2,7 +2,7 @@ name: PR Validation
 
 on:
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "spark4.1" ]
     paths-ignore: [ "**.md", "docs/**", "website/**" ]
 
 jobs:


### PR DESCRIPTION
## Why

Three workflows were gated to `master` only, so the **actively published `spark4.1` release branch** was missing checks that `master` gets on every PR. Release branches take cherry-picked fixes and occasional direct commits — none of it was being scanned or validated.

```
PR targeting master          PR targeting spark4.1  (before)
---------------------        ------------------------------
CodeQL            ✅          CodeQL             ✗
PR Validation     ✅          PR Validation      ✅ (see note)
Dependency Review ✅          Dependency Review  ✗
```

## What changed

Four lines across three files.

| Workflow | What it does | Was | Now |
| --- | --- | --- | --- |
| `codeql.yml` | SAST / security scanning | `master` | `master`, `spark4.1` |
| `pr-validation.yml` | Python style, Scala style, compile | `master` | `master`, `spark4.1` |
| `dependency-review.yml` | Supply-chain vulnerability review | `master` | `master`, `spark4.1` |

`on.<event>.branches` matches the pull request's **base** branch, so adding `spark4.1` is precisely what makes these run for PRs targeting it.

## The `pr-validation` case is a latent regression, not just a gap

`spark4.1` **already carries** `branches: [ "master", "spark4.1" ]`, but `master` still had `[ "master" ]`:

| Branch | `pr-validation.yml` filter |
| --- | --- |
| `spark4.1` | `[ "master", "spark4.1" ]` ✅ |
| `master` | `[ "master" ]` ❌ |

That drift is a trap: **the next time `master` is synced into `spark4.1`, master's narrower filter overwrites it and silently disables style + compile validation on spark4.1 PRs.** Aligning `master` removes it.

## Deliberately not changed

Scope is kept to where it pays off — scanning branches nobody ships costs CI minutes and produces alerts nobody acts on.

| Item | Why not |
| --- | --- |
| `spark3.5` | `master` now tracks Spark 3.5, so that code is already covered via `master` |
| `spark4.0` | Not actively published |
| `spark3.1`–`spark3.4` | Unmaintained |
| `check-dead-links.yml` | Scans the **deployed website's sitemap** (built from `master`); it inspects nothing from the PR, so it would add CI time on release-branch PRs for no signal |
| `scorecards.yml` | OpenSSF Scorecard is designed to assess the default branch |
| `website-deploy.yml` | Already runs `pull_request` on all branches; deployment should stay `master`-only |

## One note on rollout

For `pull_request` events GitHub reads the workflow file from the PR's **head** branch. Since contributors branch from the branch they target, these filters take full effect on `spark4.1` once this change is synced into that branch. The change is still correct and necessary on `master` — it's the prerequisite, and it's what stops the `pr-validation` regression above.

## Checklist

- [x] All three workflows parse cleanly; verified no duplicate YAML keys
- [x] `spark4.1` confirmed to exist on the remote
- [x] Compared every workflow's triggers on `master` vs `spark4.1` to find the full gap set
- [x] Net diff is 4 lines; no change to any job's steps, permissions, or secrets
- [x] Rebased onto current `master`
