### PR TITLE
ci: add advisory SynapseML-Internal compatibility check to OSS pipeline

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1,5 +1,11 @@
 resources:
-- repo: self
+  repositories:
+  - repository: self
+    type: self
+  - repository: SynapseML-Internal
+    type: git
+    name: A365/SynapseML-Internal
+    ref: master
 
 trigger:
   branches:
@@ -915,5 +921,209 @@ jobs:
       displayName: 'Publish $(RELEASE_BRANCH) Test Results'
       inputs:
         testResultsFiles: '**/test-reports/TEST-*.xml'
+        failTaskOnFailedTests: false
+      condition: succeededOrFailed()
+- job: InternalCompat
+  displayName: 'SynapseML-Internal Compatibility Check'
+  cancelTimeoutInMinutes: 0
+  timeoutInMinutes: 90
+  continueOnError: true
+  pool:
+    vmImage: $(UBUNTU_VERSION)
+  steps:
+    - checkout: self
+    - checkout: SynapseML-Internal
+    - task: AzureCLI@2
+      displayName: 'Publish OSS to local Maven'
+      timeoutInMinutes: 20
+      inputs:
+        azureSubscription: 'SynapseML Build'
+        scriptLocation: inlineScript
+        scriptType: bash
+        inlineScript: |
+          set -e
+          cd $(Build.SourcesDirectory)/SynapseML
+          export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
+          OSS_VERSION=$(sbt -no-colors "core/version" 2>&1 | grep '^\[info\] [0-9]' | tail -1 | sed 's/\[info\] //')
+          echo "OSS version: $OSS_VERSION"
+          if [ -z "$OSS_VERSION" ]; then
+            echo "##vso[task.logissue type=error]Failed to determine OSS version"
+            exit 1
+          fi
+          echo "##vso[task.setvariable variable=OSS_VERSION]$OSS_VERSION"
+          sbt publishM2
+    - bash: |
+        set -e
+        cd $(Build.SourcesDirectory)/SynapseML-Internal
+
+        echo "=== Retargeting Internal to OSS version $(OSS_VERSION) ==="
+        [ -n "$(OSS_VERSION)" ] || { echo "##vso[task.logissue type=error]OSS_VERSION is not set"; exit 1; }
+        sed -i 's|val synapseMLVersion = ".*"|val synapseMLVersion = "$(OSS_VERSION)"|' build.sbt
+        sed -i '/^resolvers ++= Seq(/a\  Resolver.mavenLocal,' build.sbt
+
+        echo "=== Modified build.sbt ==="
+        grep -n 'synapseMLVersion' build.sbt
+        grep -n -A4 'resolvers ++=' build.sbt
+      displayName: 'Retarget Internal to this build'
+    - task: AzureCLI@2
+      displayName: 'Compile Internal against OSS'
+      timeoutInMinutes: 15
+      inputs:
+        azureSubscription: 'SynapseML Build'
+        scriptLocation: inlineScript
+        scriptType: bash
+        inlineScript: |
+          set -e
+          cd $(Build.SourcesDirectory)/SynapseML-Internal
+          export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
+          echo "Compiling SynapseML-Internal against OSS $(OSS_VERSION)..."
+          sbt compile Test/compile
+    - bash: |
+        echo "##vso[task.prependpath]$CONDA/bin"
+      displayName: 'Add conda to PATH'
+    - bash: |
+        sudo chown -R $(whoami):$(id -ng) $(CONDA_CACHE_DIR)
+      displayName: 'Fix conda directory permissions'
+    - task: PipAuthenticate@1
+      displayName: 'Private Conda Feed Authentication'
+      inputs:
+        artifactFeeds: 'A365/Synapse-Conda'
+    - bash: |
+        conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
+        conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
+      displayName: 'Accept Anaconda TOS'
+    - bash: |
+        echo "=== Disk space BEFORE cleanup ==="
+        df -h / | grep -E 'Filesystem|/$'
+        echo "Removing unused pre-installed SDKs and runtimes..."
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /usr/share/dotnet || true
+        sudo rm -rf /opt/ghc || true
+        sudo rm -rf /usr/local/share/boost || true
+        docker system prune -af --volumes 2>/dev/null || true
+        echo "=== Disk space AFTER cleanup ==="
+        df -h / | grep -E 'Filesystem|/$'
+      displayName: 'Free disk space (remove unused SDKs)'
+    - bash: |
+        set -e
+        conda env create --yes -f $(Build.SourcesDirectory)/SynapseML-Internal/environment.yaml -v || \
+          conda env create --yes -f $(Build.SourcesDirectory)/SynapseML-Internal/environment.yaml -v
+        conda clean --all -y
+        pip cache purge
+      displayName: 'Create Internal conda env'
+    - task: AzureKeyVault@2
+      displayName: 'Fetch AI service secrets'
+      retryCountOnTaskFailure: 3
+      inputs:
+        azureSubscription: 'SynapseML Build'
+        keyVaultName: mmlspark-keys
+    - template: templates/fabric_kv.yml
+    - task: AzureCLI@2
+      displayName: 'Run Internal Scala tests'
+      timeoutInMinutes: 60
+      inputs:
+        azureSubscription: 'SynapseML Build'
+        scriptLocation: inlineScript
+        scriptType: bash
+        inlineScript: |
+          set -e
+          cd $(Build.SourcesDirectory)/SynapseML-Internal
+          eval "$(conda shell.bash hook)"
+          conda activate synapseml-internal
+          export CREATE_SEMPY_WRITER=false
+          export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
+          echo "Running Internal tests against OSS $(OSS_VERSION)..."
+          FAILURES=0
+          for pkg in spark.aifunc powerbi ebm predict nbtest; do
+            echo "=== Testing $pkg ==="
+            if ! sbt "testOnly com.microsoft.azure.synapse.ml.$pkg.**"; then
+              echo "##vso[task.logissue type=warning]$pkg tests failed"
+              FAILURES=$((FAILURES + 1))
+            fi
+          done
+          if [ $FAILURES -gt 0 ]; then
+            echo "##vso[task.logissue type=warning]$FAILURES test package(s) failed"
+            exit 1
+          fi
+      env:
+        INTEGRATION_ENV: $(sempy-integration-region)
+        INTEGRATION_ACCOUNT: $(sempy-integration-account)
+        INTEGRATION_CERTIFICATE: $(sempy-integration-certificate)
+    - task: AzureCLI@2
+      displayName: 'Package Internal Python against OSS'
+      timeoutInMinutes: 15
+      inputs:
+        azureSubscription: 'SynapseML Build'
+        scriptLocation: inlineScript
+        scriptType: bash
+        inlineScript: |
+          set -e
+          cd $(Build.SourcesDirectory)/SynapseML-Internal
+          eval "$(conda shell.bash hook)"
+          conda activate synapseml-internal
+          export CREATE_SEMPY_WRITER=false
+          export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
+          echo "Packaging Internal Python against OSS $(OSS_VERSION)..."
+          sbt packagePython
+          sbt publishM2
+      condition: succeededOrFailed()
+    - task: AzureCLI@2
+      displayName: 'Run Internal Python tests (AIFunc)'
+      timeoutInMinutes: 30
+      inputs:
+        azureSubscription: 'SynapseML Build'
+        scriptLocation: inlineScript
+        scriptType: bash
+        inlineScript: |
+          set -e
+          cd $(Build.SourcesDirectory)/SynapseML-Internal
+          eval "$(conda shell.bash hook)"
+          conda activate synapseml-internal
+          export CREATE_SEMPY_WRITER=false
+          export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
+          echo "Running Internal Python tests against OSS $(OSS_VERSION)..."
+          FAILURES=0
+          for suite in AIFuncPandas AIFuncPandasMultimodal AIFuncPySpark AIFuncPySparkMultimodal; do
+            echo "=== Testing Python $suite ==="
+            if ! sbt "testPython${suite}"; then
+              echo "##vso[task.logissue type=warning]Python $suite tests failed"
+              FAILURES=$((FAILURES + 1))
+            fi
+          done
+          if [ $FAILURES -gt 0 ]; then
+            echo "##vso[task.logissue type=warning]$FAILURES Python test suite(s) failed"
+            exit 1
+          fi
+      condition: succeededOrFailed()
+    - task: AzureCLI@2
+      displayName: 'Run Internal Python tests (ExcludeAIFunc)'
+      timeoutInMinutes: 30
+      inputs:
+        azureSubscription: 'SynapseML Build'
+        scriptLocation: inlineScript
+        scriptType: bash
+        inlineScript: |
+          set -e
+          cd $(Build.SourcesDirectory)/SynapseML-Internal
+          eval "$(conda shell.bash hook)"
+          conda activate synapseml-internal
+          export CREATE_SEMPY_WRITER=false
+          export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
+          echo "Creating MLflow model fixtures..."
+          python ./src/test/python/make_mlflow_models.py
+          echo "Running ExcludeAIFunc Python tests against OSS $(OSS_VERSION)..."
+          sbt testPythonExcludeAIFunc
+      condition: succeededOrFailed()
+    - task: PublishTestResults@2
+      displayName: 'Publish Internal Scala Test Results'
+      inputs:
+        testResultsFiles: '**/test-reports/TEST-*.xml'
+        failTaskOnFailedTests: false
+      condition: succeededOrFailed()
+    - task: PublishTestResults@2
+      displayName: 'Publish Internal Python Test Results'
+      inputs:
+        testResultsFiles: '**/python-test-*.xml'
+        searchFolder: '$(Build.SourcesDirectory)/SynapseML-Internal'
         failTaskOnFailedTests: false
       condition: succeededOrFailed()

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1309,6 +1309,7 @@ jobs:
         INTEGRATION_ENV: $(sempy-integration-region)
         INTEGRATION_ACCOUNT: $(sempy-integration-account)
         INTEGRATION_CERTIFICATE: $(sempy-integration-certificate)
+        INTEGRATION_WORKSPACE_PREFIX: $(sempy-integration-workspace-prefix)
     - task: AzureCLI@2
       displayName: 'Package Internal Python against OSS'
       timeoutInMinutes: 15

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1161,7 +1161,10 @@ jobs:
   # there rather than failing every external contribution.
   condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))
   cancelTimeoutInMinutes: 0
-  timeoutInMinutes: 90
+  # Measured on build 230962458: conda env 6.4m + compile 1.5m + package 1.2m +
+  # Scala tests ~34m + ExcludeAIFunc. 90 min was not enough and the job was
+  # killed mid-step; 120 leaves headroom now that the live-service suites are gone.
+  timeoutInMinutes: 120
   pool:
     vmImage: $(UBUNTU_VERSION)
   steps:
@@ -1279,31 +1282,27 @@ jobs:
           export CREATE_SEMPY_WRITER=false
           export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
           echo "Running Internal tests against OSS $(OSS_VERSION)..."
-          # Blocking tier: pure compatibility signal. These exercise Internal code
-          # against the OSS API surface and depend on no external state, so a
-          # failure here means this OSS change genuinely broke Internal.
-          BLOCKING_PKGS="spark.aifunc ebm predict"
-          # Advisory tier: these drive live external services (PowerBI XMLA needs a
-          # populated workspace; nbtest submits Spark Job Definitions to live Fabric
-          # capacity). They fail for environmental reasons unrelated to the OSS diff,
-          # so they are reported but must not gate the PR.
-          ADVISORY_PKGS="powerbi nbtest"
+          # Only the deterministic packages run here. They exercise Internal code
+          # against the OSS API surface with no external state, so a failure means
+          # this OSS change genuinely broke Internal.
+          #
+          # powerbi and nbtest are deliberately NOT run: they drive live services
+          # (PowerBI XMLA needs a populated workspace; nbtest submits Spark Job
+          # Definitions to live Fabric capacity) and fail here for environmental
+          # reasons regardless of the OSS diff. Running them anyway cost ~4 min and
+          # produced only ignorable warnings. That live E2E coverage belongs in
+          # SynapseML-Internal's own nightly pipeline, which has the workspaces,
+          # sample datasets and capacity provisioned.
           FAILURES=0
-          for pkg in $BLOCKING_PKGS; do
-            echo "=== Testing $pkg (blocking) ==="
+          for pkg in spark.aifunc ebm predict; do
+            echo "=== Testing $pkg ==="
             if ! sbt "testOnly com.microsoft.azure.synapse.ml.$pkg.**"; then
               echo "##vso[task.logissue type=error]$pkg tests failed - OSS change breaks Internal"
               FAILURES=$((FAILURES + 1))
             fi
           done
-          for pkg in $ADVISORY_PKGS; do
-            echo "=== Testing $pkg (advisory, live-service dependent) ==="
-            if ! sbt "testOnly com.microsoft.azure.synapse.ml.$pkg.**"; then
-              echo "##vso[task.logissue type=warning]$pkg tests failed (advisory - depends on live services, not gating)"
-            fi
-          done
           if [ $FAILURES -gt 0 ]; then
-            echo "##vso[task.logissue type=error]$FAILURES blocking test package(s) failed"
+            echo "##vso[task.logissue type=error]$FAILURES test package(s) failed"
             exit 1
           fi
       env:
@@ -1328,31 +1327,12 @@ jobs:
           sbt packagePython
           sbt publishM2
       condition: succeededOrFailed()
-    - task: AzureCLI@2
-      displayName: 'Run Internal Python tests (AIFunc)'
-      timeoutInMinutes: 30
-      inputs:
-        azureSubscription: 'SynapseML Build'
-        scriptLocation: inlineScript
-        scriptType: bash
-        inlineScript: |
-          set -e
-          cd $(Build.SourcesDirectory)/SynapseML-Internal
-          eval "$(conda shell.bash hook)"
-          conda activate synapseml-internal
-          export CREATE_SEMPY_WRITER=false
-          export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
-          echo "Running Internal Python tests against OSS $(OSS_VERSION)..."
-          # Advisory: every AIFunc suite invokes live Azure OpenAI endpoints, so
-          # failures reflect service/quota/model availability rather than whether
-          # this OSS change is compatible with Internal. Reported, never gating.
-          for suite in AIFuncPandas AIFuncPandasMultimodal AIFuncPySpark AIFuncPySparkMultimodal; do
-            echo "=== Testing Python $suite (advisory, live-service dependent) ==="
-            if ! sbt "testPython${suite}"; then
-              echo "##vso[task.logissue type=warning]Python $suite tests failed (advisory - live AI service, not gating)"
-            fi
-          done
-      condition: succeededOrFailed()
+    # NOTE: 'Run Internal Python tests (AIFunc)' was intentionally removed. All four
+    # AIFunc suites call live Azure OpenAI endpoints, so they measure service and
+    # quota availability rather than OSS/Internal compatibility. They took ~23 min
+    # of the job's budget and were the main reason it hit its timeout before the
+    # gating ExcludeAIFunc step could finish. They remain covered by
+    # SynapseML-Internal's own pipeline.
     - task: AzureCLI@2
       displayName: 'Run Internal Python tests (ExcludeAIFunc)'
       timeoutInMinutes: 30

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1241,10 +1241,12 @@ jobs:
         sed -i '/^resolvers ++= Seq(/a\  Resolver.mavenLocal,' build.sbt
 
         # A silent no-op here would compile Internal against the *published* OSS build and
-        # report a false green, so verify both edits actually landed.
-        grep -q 'val synapseMLVersion = "$(OSS_VERSION)"' build.sbt || {
+        # report a false green, so verify both edits actually landed. Use fixed-string
+        # matching: the version contains dots, which as a regex would match any character
+        # and could accept a line the sed above never wrote.
+        grep -qF 'val synapseMLVersion = "$(OSS_VERSION)"' build.sbt || {
           echo "##vso[task.logissue type=error]Failed to retarget synapseMLVersion"; exit 1; }
-        grep -q 'Resolver.mavenLocal,' build.sbt || {
+        grep -qF 'Resolver.mavenLocal,' build.sbt || {
           echo "##vso[task.logissue type=error]Failed to add Resolver.mavenLocal"; exit 1; }
 
         echo "=== Modified build.sbt ==="

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1181,14 +1181,25 @@ jobs:
           set -e
           cd $(Build.SourcesDirectory)/SynapseML
           export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
-          OSS_VERSION=$(sbt -no-colors "core/version" 2>&1 | grep '^\[info\] [0-9]' | tail -1 | sed 's/\[info\] //')
+          # The version string embeds an HHmm timestamp and is recomputed on every
+          # sbt invocation, so querying the version and publishing in two separate
+          # invocations can yield two different versions when they straddle a minute
+          # boundary. Run both in ONE sbt session so the version is computed once.
+          if ! SBT_OUT="$(sbt -no-colors "core/version" publishM2 2>&1)"; then
+            echo "$SBT_OUT"
+            echo "##vso[task.logissue type=error]sbt core/version publishM2 failed"
+            exit 1
+          fi
+          echo "$SBT_OUT"
+          OSS_VERSION=$(echo "$SBT_OUT" | grep -m1 '^\[info\] [0-9]' | sed 's/\[info\] //')
           echo "OSS version: $OSS_VERSION"
           if [ -z "$OSS_VERSION" ]; then
             echo "##vso[task.logissue type=error]Failed to determine OSS version"
             exit 1
           fi
           echo "##vso[task.setvariable variable=OSS_VERSION]$OSS_VERSION"
-          sbt publishM2
+          echo "=== published OSS versions in ~/.m2 ==="
+          ls "$HOME/.m2/repository/com/microsoft/azure/" 2>/dev/null || true
     - bash: |
         set -e
         cd $(Build.SourcesDirectory)/SynapseML-Internal
@@ -1325,8 +1336,15 @@ jobs:
           export CREATE_SEMPY_WRITER=false
           export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
           echo "Packaging Internal Python against OSS $(OSS_VERSION)..."
-          sbt packagePython
-          sbt publishM2
+          # packagePython and publishM2 MUST share one sbt session. Internal's version
+          # embeds an HHmm timestamp, so separate invocations can differ by a minute:
+          # packagePython bakes the jar coordinate into the generated Python package,
+          # publishM2 then publishes a *different* version, and the Spark launch inside
+          # make_mlflow_models.py fails to resolve it - surfacing only as an opaque
+          # JAVA_GATEWAY_EXITED. Observed: packaged 1022, published 1023.
+          sbt packagePython publishM2
+          echo "=== published Internal versions in ~/.m2 ==="
+          ls -d "$HOME"/.m2/repository/com/microsoft/azure/*-internal_2.12/*/ 2>/dev/null || true
       condition: succeededOrFailed()
     # NOTE: 'Run Internal Python tests (AIFunc)' was intentionally removed. All four
     # AIFunc suites call live Azure OpenAI endpoints, so they measure service and

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1347,8 +1347,26 @@ jobs:
           conda activate synapseml-internal
           export CREATE_SEMPY_WRITER=false
           export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
+          # The fixture script builds several models in-process and then launches a
+          # JVM for a Spark session. That launch failed once with JAVA_GATEWAY_EXITED,
+          # which pyspark reports without surfacing any JVM stderr, so record the
+          # agent state first to make a repeat diagnosable rather than a mystery.
+          echo "=== agent state before Spark JVM launch ==="
+          free -m || true
+          df -h /home/vsts /tmp || true
+          echo "JAVA_HOME=${JAVA_HOME:-<unset>}"
+          java -version 2>&1 || true
+          echo "residual JVMs: $(pgrep -c java || echo 0)"
+          echo "==========================================="
           echo "Creating MLflow model fixtures..."
-          python ./src/test/python/make_mlflow_models.py
+          # Launching the gateway is the one step here that is known to fail
+          # intermittently, so give it a second attempt before failing the job.
+          if ! python ./src/test/python/make_mlflow_models.py; then
+            echo "##vso[task.logissue type=warning]MLflow fixture generation failed; retrying once"
+            free -m || true
+            sleep 30
+            python ./src/test/python/make_mlflow_models.py
+          fi
           echo "Running ExcludeAIFunc Python tests against OSS $(OSS_VERSION)..."
           sbt testPythonExcludeAIFunc
       condition: succeededOrFailed()

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1277,6 +1277,17 @@ jobs:
             echo "##vso[task.logissue type=error]Failed to determine the OSS version from sbt output"
             exit 1
           fi
+          # Every later step interpolates this value into bash, sed and grep. The grep
+          # above only anchors the start of the token, so constrain the whole thing to
+          # characters that are inert in all three contexts: that removes any way for a
+          # crafted version string in build.sbt to smuggle a command substitution or a
+          # sed delimiter through the Azure Pipelines macro expander.
+          case "$OSS_VERSION" in
+            *[!A-Za-z0-9._+-]*)
+              echo "##vso[task.logissue type=error]OSS version '$OSS_VERSION' contains unexpected characters"
+              exit 1
+              ;;
+          esac
           echo "##vso[task.setvariable variable=OSS_VERSION]$OSS_VERSION"
           echo "=== published OSS versions in ~/.m2 ==="
           ls "$HOME/.m2/repository/com/microsoft/azure/" 2>/dev/null || true
@@ -1284,21 +1295,24 @@ jobs:
         set -e
         cd $(Agent.BuildDirectory)/s-internal
 
-        echo "=== Retargeting Internal to OSS version $(OSS_VERSION) ==="
-        [ -n "$(OSS_VERSION)" ] || { echo "##vso[task.logissue type=error]OSS_VERSION is not set"; exit 1; }
+        # $OSS_VERSION is read as a bash environment variable rather than the
+        # $(OSS_VERSION) macro: macros are pasted in as raw text before bash parses the
+        # script, so a version string containing $() or backticks would execute.
+        echo "=== Retargeting Internal to OSS version $OSS_VERSION ==="
+        [ -n "${OSS_VERSION:-}" ] || { echo "##vso[task.logissue type=error]OSS_VERSION is not set"; exit 1; }
         grep -q '^val synapseMLVersion = ' build.sbt || {
           echo "##vso[task.logissue type=error]synapseMLVersion not found in Internal build.sbt"; exit 1; }
         grep -q '^resolvers ++= Seq(' build.sbt || {
           echo "##vso[task.logissue type=error]resolvers block not found in Internal build.sbt"; exit 1; }
 
-        sed -i 's|val synapseMLVersion = ".*"|val synapseMLVersion = "$(OSS_VERSION)"|' build.sbt
+        sed -i "s|val synapseMLVersion = \".*\"|val synapseMLVersion = \"${OSS_VERSION}\"|" build.sbt
         sed -i '/^resolvers ++= Seq(/a\  Resolver.mavenLocal,' build.sbt
 
         # A silent no-op here would compile Internal against the *published* OSS build and
         # report a false green, so verify both edits actually landed. Use fixed-string
         # matching: the version contains dots, which as a regex would match any character
         # and could accept a line the sed above never wrote.
-        grep -qF 'val synapseMLVersion = "$(OSS_VERSION)"' build.sbt || {
+        grep -qF "val synapseMLVersion = \"${OSS_VERSION}\"" build.sbt || {
           echo "##vso[task.logissue type=error]Failed to retarget synapseMLVersion"; exit 1; }
         grep -qF 'Resolver.mavenLocal,' build.sbt || {
           echo "##vso[task.logissue type=error]Failed to add Resolver.mavenLocal"; exit 1; }
@@ -1318,7 +1332,7 @@ jobs:
           set -e
           cd $(Agent.BuildDirectory)/s-internal
           export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
-          echo "Compiling SynapseML-Internal against OSS $(OSS_VERSION)..."
+          echo "Compiling SynapseML-Internal against OSS $OSS_VERSION..."
           sbt compile Test/compile
     - bash: |
         echo "##vso[task.prependpath]$CONDA/bin"
@@ -1374,7 +1388,7 @@ jobs:
           conda activate synapseml-internal
           export CREATE_SEMPY_WRITER=false
           export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
-          echo "Running Internal tests against OSS $(OSS_VERSION)..."
+          echo "Running Internal tests against OSS $OSS_VERSION..."
           # Only the reproducible packages run here. They exercise Internal code against
           # the OSS API surface, so a failure is most often a genuine break. They are not
           # hermetic -- spark.aifunc calls live AI services and takes ~23 min -- which is
@@ -1431,7 +1445,7 @@ jobs:
           conda activate synapseml-internal
           export CREATE_SEMPY_WRITER=false
           export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
-          echo "Packaging Internal Python against OSS $(OSS_VERSION)..."
+          echo "Packaging Internal Python against OSS $OSS_VERSION..."
           # packagePython and publishM2 MUST share one sbt session. Internal's version
           # embeds an HHmm timestamp, so separate invocations can differ by a minute:
           # packagePython bakes the jar coordinate into the generated Python package,
@@ -1482,7 +1496,7 @@ jobs:
             sleep 30
             python ./src/test/python/make_mlflow_models.py
           fi
-          echo "Running ExcludeAIFunc Python tests against OSS $(OSS_VERSION)..."
+          echo "Running ExcludeAIFunc Python tests against OSS $OSS_VERSION..."
           sbt testPythonExcludeAIFunc
       condition: succeededOrFailed()
     - task: PublishTestResults@2

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1155,9 +1155,19 @@ jobs:
       condition: and(succeededOrFailed(), eq(variables.releaseCompatRequired, 'true'))
 - job: InternalCompat
   displayName: 'SynapseML-Internal Compatibility Check'
+  # Scoped to PR builds, matching ReleaseBranchCompat above: this validates that a
+  # proposed change still compiles Internal, which is only actionable while the
+  # change can still be revised. System.PullRequest.* is empty on non-PR builds, so
+  # the IsFork check alone would let this 120-minute, secret-consuming job run on
+  # every master push and nightly build.
   # SynapseML-Internal is a private repo. Fork PRs cannot authenticate to it, so skip the job
   # there rather than failing every external contribution.
-  condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))
+  condition: >-
+    and(
+      succeeded(),
+      eq(variables.isPR, true),
+      ne(variables['System.PullRequest.IsFork'], 'True')
+    )
   cancelTimeoutInMinutes: 0
   # Measured on build 230962458: conda env 6.4m + compile 1.5m + package 1.2m +
   # Scala tests ~34m + ExcludeAIFunc. 90 min was not enough and the job was
@@ -1200,10 +1210,11 @@ jobs:
           echo "$SBT_OUT"
           # tools/ci/get_sbt_version.sh is not reused here: it runs its own sbt
           # invocation, which is precisely the second invocation this step exists to
-          # avoid. Mirror its parsing and validation inline instead of loosely
-          # grepping, so a stray "[info] <digit>..." line cannot be mistaken for the
-          # version and silently retarget Internal at an artifact that was never
-          # published.
+          # avoid. Its parsing and validation are mirrored inline instead. The regex
+          # is anchored to the start of the line and requires a version-shaped token,
+          # so a stray "[info] <digit>..." line elsewhere in the output cannot be
+          # mistaken for the version and silently retarget Internal at an artifact
+          # that was never published.
           OSS_VERSION=$(echo "$SBT_OUT" | sed 's/\x1b\[[0-9;]*m//g' \
             | grep -m1 -E '^\[info\] ([0-9]+\.[0-9]+|HEAD-)' | cut -d' ' -f2)
           echo "OSS version: $OSS_VERSION"

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1279,16 +1279,31 @@ jobs:
           export CREATE_SEMPY_WRITER=false
           export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
           echo "Running Internal tests against OSS $(OSS_VERSION)..."
+          # Blocking tier: pure compatibility signal. These exercise Internal code
+          # against the OSS API surface and depend on no external state, so a
+          # failure here means this OSS change genuinely broke Internal.
+          BLOCKING_PKGS="spark.aifunc ebm predict"
+          # Advisory tier: these drive live external services (PowerBI XMLA needs a
+          # populated workspace; nbtest submits Spark Job Definitions to live Fabric
+          # capacity). They fail for environmental reasons unrelated to the OSS diff,
+          # so they are reported but must not gate the PR.
+          ADVISORY_PKGS="powerbi nbtest"
           FAILURES=0
-          for pkg in spark.aifunc powerbi ebm predict nbtest; do
-            echo "=== Testing $pkg ==="
+          for pkg in $BLOCKING_PKGS; do
+            echo "=== Testing $pkg (blocking) ==="
             if ! sbt "testOnly com.microsoft.azure.synapse.ml.$pkg.**"; then
-              echo "##vso[task.logissue type=warning]$pkg tests failed"
+              echo "##vso[task.logissue type=error]$pkg tests failed - OSS change breaks Internal"
               FAILURES=$((FAILURES + 1))
             fi
           done
+          for pkg in $ADVISORY_PKGS; do
+            echo "=== Testing $pkg (advisory, live-service dependent) ==="
+            if ! sbt "testOnly com.microsoft.azure.synapse.ml.$pkg.**"; then
+              echo "##vso[task.logissue type=warning]$pkg tests failed (advisory - depends on live services, not gating)"
+            fi
+          done
           if [ $FAILURES -gt 0 ]; then
-            echo "##vso[task.logissue type=warning]$FAILURES test package(s) failed"
+            echo "##vso[task.logissue type=error]$FAILURES blocking test package(s) failed"
             exit 1
           fi
       env:
@@ -1328,18 +1343,15 @@ jobs:
           export CREATE_SEMPY_WRITER=false
           export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
           echo "Running Internal Python tests against OSS $(OSS_VERSION)..."
-          FAILURES=0
+          # Advisory: every AIFunc suite invokes live Azure OpenAI endpoints, so
+          # failures reflect service/quota/model availability rather than whether
+          # this OSS change is compatible with Internal. Reported, never gating.
           for suite in AIFuncPandas AIFuncPandasMultimodal AIFuncPySpark AIFuncPySparkMultimodal; do
-            echo "=== Testing Python $suite ==="
+            echo "=== Testing Python $suite (advisory, live-service dependent) ==="
             if ! sbt "testPython${suite}"; then
-              echo "##vso[task.logissue type=warning]Python $suite tests failed"
-              FAILURES=$((FAILURES + 1))
+              echo "##vso[task.logissue type=warning]Python $suite tests failed (advisory - live AI service, not gating)"
             fi
           done
-          if [ $FAILURES -gt 0 ]; then
-            echo "##vso[task.logissue type=warning]$FAILURES Python test suite(s) failed"
-            exit 1
-          fi
       condition: succeededOrFailed()
     - task: AzureCLI@2
       displayName: 'Run Internal Python tests (ExcludeAIFunc)'

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -3,6 +3,9 @@ resources:
   - repository: SynapseML-Internal
     type: git
     name: A365/SynapseML-Internal
+    # Queue-time default only. `ref` is resolved before any job runs, so it cannot depend on
+    # the branch under test; the InternalCompat job re-points this checkout at the Internal
+    # branch matching the OSS target branch. See 'Select matching SynapseML-Internal branch'.
     ref: master
 
 trigger:
@@ -1194,6 +1197,48 @@ jobs:
       path: s
     - checkout: SynapseML-Internal
       path: s-internal
+      # Required by 'Select matching SynapseML-Internal branch' below: without persisted
+      # credentials the follow-up fetch cannot authenticate to this private repo.
+      persistCredentials: true
+    # Internal mirrors this repo's branch names 1:1 (master, spark3.5, spark4.0, spark4.1),
+    # so the OSS branch under test decides which Internal branch is the correct comparison
+    # point: master pairs with Internal master (both Spark 3.5), spark4.1 with Internal
+    # spark4.1. Validating a Spark 4.1 PR against Internal master would compile a Spark 3.5
+    # tree against Spark 4.1 artifacts, which cannot resolve -- a permanent red on that
+    # branch rather than a real signal.
+    - bash: |
+        set -euo pipefail
+        cd $(Agent.BuildDirectory)/s-internal
+
+        # Read the target branch from the environment rather than a $() macro: macros are
+        # substituted as raw text into the script, and git permits ';' and quotes in ref
+        # names, so a crafted branch name would otherwise be executable.
+        OSS_TARGET="${SYSTEM_PULLREQUEST_TARGETBRANCH:-}"
+        OSS_TARGET="${OSS_TARGET#refs/heads/}"
+        if [ -z "$OSS_TARGET" ]; then
+          echo "##vso[task.logissue type=error]System.PullRequest.TargetBranch is empty; this job is PR-only"
+          exit 1
+        fi
+
+        # Identity mapping: OSS and Internal use the same branch names, so a branch added to
+        # the pr: trigger list is paired correctly without touching this step.
+        INTERNAL_BRANCH="$OSS_TARGET"
+
+        # Fall back rather than fail: this job is advisory, and Internal may not have cut a
+        # counterpart branch yet. The warning keeps the mismatch visible, because a silent
+        # fallback would report a result that actually validated a different Spark line.
+        if ! git ls-remote --exit-code --heads origin "$INTERNAL_BRANCH" >/dev/null 2>&1; then
+          echo "##vso[task.logissue type=warning]SynapseML-Internal has no '$INTERNAL_BRANCH' branch; falling back to master. This PR targets OSS '$OSS_TARGET', so treat any failure here as unverified."
+          INTERNAL_BRANCH=master
+        fi
+
+        echo "OSS target branch '$OSS_TARGET' -> SynapseML-Internal '$INTERNAL_BRANCH'"
+        git fetch --no-tags origin "$INTERNAL_BRANCH"
+        git checkout --force FETCH_HEAD
+        echo "##vso[task.setvariable variable=INTERNAL_BRANCH]$INTERNAL_BRANCH"
+        echo "=== SynapseML-Internal now at $INTERNAL_BRANCH ==="
+        git log --oneline -1
+      displayName: 'Select matching SynapseML-Internal branch'
     - template: templates/sbt_cache.yml
     - task: AzureCLI@2
       displayName: 'Publish OSS to local Maven'
@@ -1352,6 +1397,19 @@ jobs:
           done
           if [ $FAILURES -gt 0 ]; then
             echo "##vso[task.logissue type=error]$FAILURES test package(s) failed"
+            exit 1
+          fi
+
+          # sbt `testOnly` exits 0 when its filter matches nothing, so an Internal package
+          # rename would turn this job into a permanently green no-op. The version retarget
+          # above is guarded against exactly this class of false green; the tests were not.
+          # Count what actually ran instead of trusting the exit status. grep -o emits one
+          # match per line, so several <testsuite> elements sharing a line all count.
+          TEST_COUNT=$(find . -path '*/test-reports/TEST-*.xml' -exec grep -ho 'tests="[0-9]*"' {} + \
+            | tr -dc '0-9\n' | awk '{n += $1} END {print n + 0}')
+          echo "Scala tests executed: $TEST_COUNT"
+          if [ "${TEST_COUNT:-0}" -lt 150 ]; then
+            echo "##vso[task.logissue type=error]Only $TEST_COUNT Scala tests ran (expected ~211); the testOnly filter matched little or nothing, so this result is not a real signal"
             exit 1
           fi
       env:

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1169,6 +1169,14 @@ jobs:
       ne(variables['System.PullRequest.IsFork'], 'True')
     )
   cancelTimeoutInMinutes: 0
+  # Advisory, not a merge gate. The Internal repo moves independently of this one, so a red
+  # here is as often "Internal's own snapshot did not resolve today" as it is a real break --
+  # build 230974877 went red with `unresolved dependency: ...-internal_2.12 ... not found` on a
+  # PR that changes only pipeline.yaml. Without this, InternalCompat rolls up into the required
+  # `microsoft.SynapseML` check and a transient Internal problem blocks unrelated OSS merges.
+  # This still surfaces as its own red check run, so the signal is not lost, matching how
+  # ReleaseBranchCompat above is configured.
+  continueOnError: true
   # Measured on build 230962458: conda env 6.4m + compile 1.5m + package 1.2m +
   # Scala tests ~34m + ExcludeAIFunc. 90 min was not enough and the job was
   # killed mid-step; 120 leaves headroom now that the live-service suites are gone.
@@ -1198,10 +1206,10 @@ jobs:
           set -e
           cd $(Build.SourcesDirectory)
           export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
-          # The version string embeds an HHmm timestamp and is recomputed on every
-          # sbt invocation, so querying the version and publishing in two separate
-          # invocations can yield two different versions when they straddle a minute
-          # boundary. Run both in ONE sbt session so the version is computed once.
+          # The version string is recomputed on every sbt invocation and embeds an HHmm
+          # timestamp whenever the tree is dirty, so querying the version and publishing in
+          # two separate invocations can yield two different versions when they straddle a
+          # minute boundary. Run both in ONE sbt session so the version is computed once.
           if ! SBT_OUT="$(sbt -no-colors "core/version" publishM2 2>&1)"; then
             echo "$SBT_OUT"
             echo "##vso[task.logissue type=error]sbt core/version publishM2 failed"
@@ -1218,9 +1226,10 @@ jobs:
           OSS_VERSION=$(echo "$SBT_OUT" | sed 's/\x1b\[[0-9;]*m//g' \
             | grep -m1 -E '^\[info\] ([0-9]+\.[0-9]+|HEAD-)' | cut -d' ' -f2)
           echo "OSS version: $OSS_VERSION"
-          if [ -z "$OSS_VERSION" ] || [[ "$OSS_VERSION" =~ [[:space:]] ]] \
-             || [[ ! "$OSS_VERSION" =~ ^([0-9]+\.[0-9]+|HEAD-) ]]; then
-            echo "##vso[task.logissue type=error]Failed to determine a valid OSS version (got: '$OSS_VERSION')"
+          # The grep above already constrains the shape, so an empty result is the only
+          # way this can go wrong: it means no line matched.
+          if [ -z "$OSS_VERSION" ]; then
+            echo "##vso[task.logissue type=error]Failed to determine the OSS version from sbt output"
             exit 1
           fi
           echo "##vso[task.setvariable variable=OSS_VERSION]$OSS_VERSION"
@@ -1321,9 +1330,10 @@ jobs:
           export CREATE_SEMPY_WRITER=false
           export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
           echo "Running Internal tests against OSS $(OSS_VERSION)..."
-          # Only the deterministic packages run here. They exercise Internal code
-          # against the OSS API surface with no external state, so a failure means
-          # this OSS change genuinely broke Internal.
+          # Only the reproducible packages run here. They exercise Internal code against
+          # the OSS API surface, so a failure is most often a genuine break. They are not
+          # hermetic -- spark.aifunc calls live AI services and takes ~23 min -- which is
+          # part of why this job is advisory rather than a merge gate.
           #
           # powerbi and nbtest are deliberately NOT run: they drive live services
           # (PowerBI XMLA needs a populated workspace; nbtest submits Spark Job
@@ -1421,6 +1431,9 @@ jobs:
       displayName: 'Publish Internal Scala Test Results'
       inputs:
         testResultsFiles: '**/test-reports/TEST-*.xml'
+        # Without this the task searches the OSS checkout, which has no Internal
+        # results, and silently publishes nothing.
+        searchFolder: '$(Agent.BuildDirectory)/s-internal'
         failTaskOnFailedTests: false
       condition: succeededOrFailed()
     - task: PublishTestResults@2

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1,5 +1,11 @@
 resources:
-- repo: self
+  repositories:
+  - repository: self
+    type: self
+  - repository: SynapseML-Internal
+    type: git
+    name: A365/SynapseML-Internal
+    ref: master
 
 trigger:
   branches:
@@ -1149,3 +1155,221 @@ jobs:
         testResultsFiles: '**/test-reports/TEST-*.xml'
         failTaskOnFailedTests: false
       condition: and(succeededOrFailed(), eq(variables.releaseCompatRequired, 'true'))
+- job: InternalCompat
+  displayName: 'SynapseML-Internal Compatibility Check'
+  # SynapseML-Internal is a private repo. Fork PRs cannot authenticate to it, so skip the job
+  # there rather than failing every external contribution.
+  condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))
+  cancelTimeoutInMinutes: 0
+  timeoutInMinutes: 90
+  pool:
+    vmImage: $(UBUNTU_VERSION)
+  steps:
+    - checkout: self
+    - checkout: SynapseML-Internal
+    - task: AzureCLI@2
+      displayName: 'Publish OSS to local Maven'
+      timeoutInMinutes: 20
+      inputs:
+        azureSubscription: 'SynapseML Build'
+        scriptLocation: inlineScript
+        scriptType: bash
+        inlineScript: |
+          set -e
+          cd $(Build.SourcesDirectory)/SynapseML
+          export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
+          OSS_VERSION=$(sbt -no-colors "core/version" 2>&1 | grep '^\[info\] [0-9]' | tail -1 | sed 's/\[info\] //')
+          echo "OSS version: $OSS_VERSION"
+          if [ -z "$OSS_VERSION" ]; then
+            echo "##vso[task.logissue type=error]Failed to determine OSS version"
+            exit 1
+          fi
+          echo "##vso[task.setvariable variable=OSS_VERSION]$OSS_VERSION"
+          sbt publishM2
+    - bash: |
+        set -e
+        cd $(Build.SourcesDirectory)/SynapseML-Internal
+
+        echo "=== Retargeting Internal to OSS version $(OSS_VERSION) ==="
+        [ -n "$(OSS_VERSION)" ] || { echo "##vso[task.logissue type=error]OSS_VERSION is not set"; exit 1; }
+        grep -q '^val synapseMLVersion = ' build.sbt || {
+          echo "##vso[task.logissue type=error]synapseMLVersion not found in Internal build.sbt"; exit 1; }
+        grep -q '^resolvers ++= Seq(' build.sbt || {
+          echo "##vso[task.logissue type=error]resolvers block not found in Internal build.sbt"; exit 1; }
+
+        sed -i 's|val synapseMLVersion = ".*"|val synapseMLVersion = "$(OSS_VERSION)"|' build.sbt
+        sed -i '/^resolvers ++= Seq(/a\  Resolver.mavenLocal,' build.sbt
+
+        # A silent no-op here would compile Internal against the *published* OSS build and
+        # report a false green, so verify both edits actually landed.
+        grep -q 'val synapseMLVersion = "$(OSS_VERSION)"' build.sbt || {
+          echo "##vso[task.logissue type=error]Failed to retarget synapseMLVersion"; exit 1; }
+        grep -q 'Resolver.mavenLocal,' build.sbt || {
+          echo "##vso[task.logissue type=error]Failed to add Resolver.mavenLocal"; exit 1; }
+
+        echo "=== Modified build.sbt ==="
+        grep -n 'synapseMLVersion' build.sbt
+        grep -n -A4 'resolvers ++=' build.sbt
+      displayName: 'Retarget Internal to this build'
+    - task: AzureCLI@2
+      displayName: 'Compile Internal against OSS'
+      timeoutInMinutes: 15
+      inputs:
+        azureSubscription: 'SynapseML Build'
+        scriptLocation: inlineScript
+        scriptType: bash
+        inlineScript: |
+          set -e
+          cd $(Build.SourcesDirectory)/SynapseML-Internal
+          export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
+          echo "Compiling SynapseML-Internal against OSS $(OSS_VERSION)..."
+          sbt compile Test/compile
+    - bash: |
+        echo "##vso[task.prependpath]$CONDA/bin"
+      displayName: 'Add conda to PATH'
+    - bash: |
+        sudo chown -R $(whoami):$(id -ng) $(CONDA_CACHE_DIR)
+      displayName: 'Fix conda directory permissions'
+    - task: PipAuthenticate@1
+      displayName: 'Private Conda Feed Authentication'
+      inputs:
+        artifactFeeds: 'A365/Synapse-Conda'
+    - bash: |
+        conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
+        conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
+      displayName: 'Accept Anaconda TOS'
+    - bash: |
+        echo "=== Disk space BEFORE cleanup ==="
+        df -h / | grep -E 'Filesystem|/$'
+        echo "Removing unused pre-installed SDKs and runtimes..."
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /usr/share/dotnet || true
+        sudo rm -rf /opt/ghc || true
+        sudo rm -rf /usr/local/share/boost || true
+        docker system prune -af --volumes 2>/dev/null || true
+        echo "=== Disk space AFTER cleanup ==="
+        df -h / | grep -E 'Filesystem|/$'
+      displayName: 'Free disk space (remove unused SDKs)'
+    - bash: |
+        set -e
+        conda env create --yes -f $(Build.SourcesDirectory)/SynapseML-Internal/environment.yaml -v || \
+          conda env create --yes -f $(Build.SourcesDirectory)/SynapseML-Internal/environment.yaml -v
+        conda clean --all -y
+        pip cache purge
+      displayName: 'Create Internal conda env'
+    - task: AzureKeyVault@2
+      displayName: 'Fetch AI service secrets'
+      retryCountOnTaskFailure: 3
+      inputs:
+        azureSubscription: 'SynapseML Build'
+        keyVaultName: mmlspark-keys
+    - template: templates/fabric_kv.yml
+    - task: AzureCLI@2
+      displayName: 'Run Internal Scala tests'
+      timeoutInMinutes: 60
+      inputs:
+        azureSubscription: 'SynapseML Build'
+        scriptLocation: inlineScript
+        scriptType: bash
+        inlineScript: |
+          set -e
+          cd $(Build.SourcesDirectory)/SynapseML-Internal
+          eval "$(conda shell.bash hook)"
+          conda activate synapseml-internal
+          export CREATE_SEMPY_WRITER=false
+          export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
+          echo "Running Internal tests against OSS $(OSS_VERSION)..."
+          FAILURES=0
+          for pkg in spark.aifunc powerbi ebm predict nbtest; do
+            echo "=== Testing $pkg ==="
+            if ! sbt "testOnly com.microsoft.azure.synapse.ml.$pkg.**"; then
+              echo "##vso[task.logissue type=warning]$pkg tests failed"
+              FAILURES=$((FAILURES + 1))
+            fi
+          done
+          if [ $FAILURES -gt 0 ]; then
+            echo "##vso[task.logissue type=warning]$FAILURES test package(s) failed"
+            exit 1
+          fi
+      env:
+        INTEGRATION_ENV: $(sempy-integration-region)
+        INTEGRATION_ACCOUNT: $(sempy-integration-account)
+        INTEGRATION_CERTIFICATE: $(sempy-integration-certificate)
+    - task: AzureCLI@2
+      displayName: 'Package Internal Python against OSS'
+      timeoutInMinutes: 15
+      inputs:
+        azureSubscription: 'SynapseML Build'
+        scriptLocation: inlineScript
+        scriptType: bash
+        inlineScript: |
+          set -e
+          cd $(Build.SourcesDirectory)/SynapseML-Internal
+          eval "$(conda shell.bash hook)"
+          conda activate synapseml-internal
+          export CREATE_SEMPY_WRITER=false
+          export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
+          echo "Packaging Internal Python against OSS $(OSS_VERSION)..."
+          sbt packagePython
+          sbt publishM2
+      condition: succeededOrFailed()
+    - task: AzureCLI@2
+      displayName: 'Run Internal Python tests (AIFunc)'
+      timeoutInMinutes: 30
+      inputs:
+        azureSubscription: 'SynapseML Build'
+        scriptLocation: inlineScript
+        scriptType: bash
+        inlineScript: |
+          set -e
+          cd $(Build.SourcesDirectory)/SynapseML-Internal
+          eval "$(conda shell.bash hook)"
+          conda activate synapseml-internal
+          export CREATE_SEMPY_WRITER=false
+          export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
+          echo "Running Internal Python tests against OSS $(OSS_VERSION)..."
+          FAILURES=0
+          for suite in AIFuncPandas AIFuncPandasMultimodal AIFuncPySpark AIFuncPySparkMultimodal; do
+            echo "=== Testing Python $suite ==="
+            if ! sbt "testPython${suite}"; then
+              echo "##vso[task.logissue type=warning]Python $suite tests failed"
+              FAILURES=$((FAILURES + 1))
+            fi
+          done
+          if [ $FAILURES -gt 0 ]; then
+            echo "##vso[task.logissue type=warning]$FAILURES Python test suite(s) failed"
+            exit 1
+          fi
+      condition: succeededOrFailed()
+    - task: AzureCLI@2
+      displayName: 'Run Internal Python tests (ExcludeAIFunc)'
+      timeoutInMinutes: 30
+      inputs:
+        azureSubscription: 'SynapseML Build'
+        scriptLocation: inlineScript
+        scriptType: bash
+        inlineScript: |
+          set -e
+          cd $(Build.SourcesDirectory)/SynapseML-Internal
+          eval "$(conda shell.bash hook)"
+          conda activate synapseml-internal
+          export CREATE_SEMPY_WRITER=false
+          export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
+          echo "Creating MLflow model fixtures..."
+          python ./src/test/python/make_mlflow_models.py
+          echo "Running ExcludeAIFunc Python tests against OSS $(OSS_VERSION)..."
+          sbt testPythonExcludeAIFunc
+      condition: succeededOrFailed()
+    - task: PublishTestResults@2
+      displayName: 'Publish Internal Scala Test Results'
+      inputs:
+        testResultsFiles: '**/test-reports/TEST-*.xml'
+        failTaskOnFailedTests: false
+      condition: succeededOrFailed()
+    - task: PublishTestResults@2
+      displayName: 'Publish Internal Python Test Results'
+      inputs:
+        testResultsFiles: '**/python-test-*.xml'
+        searchFolder: '$(Build.SourcesDirectory)/SynapseML-Internal'
+        failTaskOnFailedTests: false
+      condition: succeededOrFailed()

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1,7 +1,5 @@
 resources:
   repositories:
-  - repository: self
-    type: self
   - repository: SynapseML-Internal
     type: git
     name: A365/SynapseML-Internal
@@ -1165,11 +1163,20 @@ jobs:
   # Scala tests ~34m + ExcludeAIFunc. 90 min was not enough and the job was
   # killed mid-step; 120 leaves headroom now that the live-service suites are gone.
   timeoutInMinutes: 120
+  dependsOn: BuildAndCacheSbt
   pool:
     vmImage: $(UBUNTU_VERSION)
   steps:
+    # Explicit paths: a multi-repo job otherwise nests every repo under a folder
+    # named after it, which moves the OSS root off $(Build.SourcesDirectory). That
+    # would leave templates/sbt_cache.yml resolving its cache keys and
+    # tools/ci/sbt_retry.sh against a directory with no build definition, so this
+    # job would silently cold-bootstrap sbt instead of sharing the prewarmed cache.
     - checkout: self
+      path: s
     - checkout: SynapseML-Internal
+      path: s-internal
+    - template: templates/sbt_cache.yml
     - task: AzureCLI@2
       displayName: 'Publish OSS to local Maven'
       timeoutInMinutes: 20
@@ -1179,7 +1186,7 @@ jobs:
         scriptType: bash
         inlineScript: |
           set -e
-          cd $(Build.SourcesDirectory)/SynapseML
+          cd $(Build.SourcesDirectory)
           export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
           # The version string embeds an HHmm timestamp and is recomputed on every
           # sbt invocation, so querying the version and publishing in two separate
@@ -1191,10 +1198,18 @@ jobs:
             exit 1
           fi
           echo "$SBT_OUT"
-          OSS_VERSION=$(echo "$SBT_OUT" | grep -m1 '^\[info\] [0-9]' | sed 's/\[info\] //')
+          # tools/ci/get_sbt_version.sh is not reused here: it runs its own sbt
+          # invocation, which is precisely the second invocation this step exists to
+          # avoid. Mirror its parsing and validation inline instead of loosely
+          # grepping, so a stray "[info] <digit>..." line cannot be mistaken for the
+          # version and silently retarget Internal at an artifact that was never
+          # published.
+          OSS_VERSION=$(echo "$SBT_OUT" | sed 's/\x1b\[[0-9;]*m//g' \
+            | grep -m1 -E '^\[info\] ([0-9]+\.[0-9]+|HEAD-)' | cut -d' ' -f2)
           echo "OSS version: $OSS_VERSION"
-          if [ -z "$OSS_VERSION" ]; then
-            echo "##vso[task.logissue type=error]Failed to determine OSS version"
+          if [ -z "$OSS_VERSION" ] || [[ "$OSS_VERSION" =~ [[:space:]] ]] \
+             || [[ ! "$OSS_VERSION" =~ ^([0-9]+\.[0-9]+|HEAD-) ]]; then
+            echo "##vso[task.logissue type=error]Failed to determine a valid OSS version (got: '$OSS_VERSION')"
             exit 1
           fi
           echo "##vso[task.setvariable variable=OSS_VERSION]$OSS_VERSION"
@@ -1202,7 +1217,7 @@ jobs:
           ls "$HOME/.m2/repository/com/microsoft/azure/" 2>/dev/null || true
     - bash: |
         set -e
-        cd $(Build.SourcesDirectory)/SynapseML-Internal
+        cd $(Agent.BuildDirectory)/s-internal
 
         echo "=== Retargeting Internal to OSS version $(OSS_VERSION) ==="
         [ -n "$(OSS_VERSION)" ] || { echo "##vso[task.logissue type=error]OSS_VERSION is not set"; exit 1; }
@@ -1234,7 +1249,7 @@ jobs:
         scriptType: bash
         inlineScript: |
           set -e
-          cd $(Build.SourcesDirectory)/SynapseML-Internal
+          cd $(Agent.BuildDirectory)/s-internal
           export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
           echo "Compiling SynapseML-Internal against OSS $(OSS_VERSION)..."
           sbt compile Test/compile
@@ -1266,8 +1281,8 @@ jobs:
       displayName: 'Free disk space (remove unused SDKs)'
     - bash: |
         set -e
-        conda env create --yes -f $(Build.SourcesDirectory)/SynapseML-Internal/environment.yaml -v || \
-          conda env create --yes -f $(Build.SourcesDirectory)/SynapseML-Internal/environment.yaml -v
+        conda env create --yes -f $(Agent.BuildDirectory)/s-internal/environment.yaml -v || \
+          conda env create --yes -f $(Agent.BuildDirectory)/s-internal/environment.yaml -v
         conda clean --all -y
         pip cache purge
       displayName: 'Create Internal conda env'
@@ -1287,7 +1302,7 @@ jobs:
         scriptType: bash
         inlineScript: |
           set -e
-          cd $(Build.SourcesDirectory)/SynapseML-Internal
+          cd $(Agent.BuildDirectory)/s-internal
           eval "$(conda shell.bash hook)"
           conda activate synapseml-internal
           export CREATE_SEMPY_WRITER=false
@@ -1330,7 +1345,7 @@ jobs:
         scriptType: bash
         inlineScript: |
           set -e
-          cd $(Build.SourcesDirectory)/SynapseML-Internal
+          cd $(Agent.BuildDirectory)/s-internal
           eval "$(conda shell.bash hook)"
           conda activate synapseml-internal
           export CREATE_SEMPY_WRITER=false
@@ -1361,7 +1376,7 @@ jobs:
         scriptType: bash
         inlineScript: |
           set -e
-          cd $(Build.SourcesDirectory)/SynapseML-Internal
+          cd $(Agent.BuildDirectory)/s-internal
           eval "$(conda shell.bash hook)"
           conda activate synapseml-internal
           export CREATE_SEMPY_WRITER=false
@@ -1399,6 +1414,6 @@ jobs:
       displayName: 'Publish Internal Python Test Results'
       inputs:
         testResultsFiles: '**/python-test-*.xml'
-        searchFolder: '$(Build.SourcesDirectory)/SynapseML-Internal'
+        searchFolder: '$(Agent.BuildDirectory)/s-internal'
         failTaskOnFailedTests: false
       condition: succeededOrFailed()


### PR DESCRIPTION
Adds a `SynapseML-Internal Compatibility Check` job to the OSS pipeline, so a PR that breaks the downstream Internal repo is visible here rather than discovered days later during a release.

## What it does

1. Checks out `A365/SynapseML-Internal` alongside the OSS repo (`resources.repositories`, authenticated by the build identity — no PAT, no service connection).
2. Publishes the PR's own OSS build to the agent's local Maven repo.
3. Rewrites Internal's `build.sbt` to resolve against that exact version, plus `Resolver.mavenLocal`.
4. Compiles Internal and runs `spark.aifunc`, `ebm`, `predict` and the `ExcludeAIFunc` Python suite.

## It genuinely runs

Verified end to end on build [231214128](https://msdata.visualstudio.com/A365/_build/results?buildId=231214128) (`refs/pull/2542/merge`, 65 min, all 36 steps green):

- fetch: `git remote add origin https://msdata.visualstudio.com/A365/_git/SynapseML-Internal` → `git checkout --force fb9d3f3a52…`
- retarget: `val synapseMLVersion = "1.1.3-63-542d2b49-SNAPSHOT"` + `Resolver.mavenLocal,` — the token `542d2b49` **is this PR's own merge SHA**, and that version exists nowhere but this agent's `~/.m2`, so successful resolution proves it built against this PR and not against a published artifact
- publish: `published synapseml-core_2.12 to file:/home/vsts/.m2/…/1.1.3-63-542d2b49-SNAPSHOT/…jar`
- compile: `compiling 84 Scala sources`, `compiling 44 Scala sources to …/test-classes` → `[success]`
- tests: `spark.aifunc` 129 passed, `ebm` 71, `predict` 11 — 211 Scala tests — plus Python `26 passed, 2 skipped in 866.06s`

No early `exit 0`, no always-false condition, nothing masked. It is not a no-op.

## It does not block merges

`continueOnError: true`, matching the sibling `ReleaseBranchCompat` job.

Without it the job rolls up into the required `microsoft.SynapseML` check. A/B on this same pipeline:

| Build | Failing job | `continueOnError` | Build result | Required `microsoft.SynapseML` |
|---|---|---|---|---|
| 230974877 | InternalCompat | none | `failed` | **failure → blocks** |
| 231256998 | ReleaseBranchCompat | `true` | `partiallySucceeded` | **success → does not block** |

`partiallySucceeded → success` held on 5 of 5 sampled builds. The job still surfaces as its own red check run, so the signal is not lost.

This matters because Internal moves independently of this repo, so a red here is as often Internal's own problem as it is a real break. Build 230974877 went red with `unresolved dependency: …-internal_2.12;1.1.3.1-7-6e9864ad-…-SNAPSHOT: not found` → `JAVA_GATEWAY_EXITED` on a PR that changes nothing but `pipeline.yaml` — it could not possibly have broken Internal. An advisory check that is occasionally wrong is useful; a required check that is occasionally wrong stops the repo.

## Also fixed here

**Scala results were being silently discarded.** `Publish Internal Scala Test Results` had no `searchFolder`, so it searched the OSS checkout and logged `##[warning]No test result files matching '[ '**/test-reports/TEST-*.xml' ]' were found.` All 211 Scala results were thrown away while the Python step, which does set `searchFolder`, published its 28.

**Two comments contradicted the logs.** The OSS version does not always embed an HHmm timestamp — the observed value is `1.1.3-63-542d2b49-SNAPSHOT`, no timestamp, because the OSS tree is clean; it is Internal that gets one, since the retarget `sed -i` dirties that tree. And the Scala suites are not free of external state: `spark.aifunc` calls live AI services for 22m39s, which is itself part of the argument for the job being advisory.

**Unreachable validation removed.** `cut -d' ' -f2` cannot emit whitespace, and the leading `grep -m1 -E '^\[info\] ([0-9]+\.[0-9]+|HEAD-)'` already guarantees the shape the following regex re-tested, so only the empty case could ever fire. Verified against real and malformed sbt output.

## Scope

`pipeline.yaml` only. The KeyVault / `fabric_kv.yml` / `INTEGRATION_*` block is load-bearing and stays — `ebm` and `predict` extend `HasSparkSession`, which reads `FabricTestConstants.INTEGRATION_WORKSPACE_ID`, and `INTEGRATION_ACCOUNT` throws when unset.

Fork PRs skip the job: `SynapseML-Internal` is private and fork builds cannot authenticate to it, so skipping beats failing every external contribution. It is also PR-only, matching `ReleaseBranchCompat` — `System.PullRequest.*` is empty on non-PR builds, so an `IsFork` check alone would let this 120-minute, secret-consuming job run on every master push and nightly.
