### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,6 @@ val coreDependencies = Seq(
   "org.apache.spark" %% "spark-core" % sparkVersion % "compile" exclude("com.google.protobuf", "protobuf-java"),
   "org.apache.spark" %% "spark-mllib" % sparkVersion % "compile",
   "org.apache.spark" %% "spark-avro" % sparkVersion % "compile",
-  "org.apache.spark" %% "spark-tags" % sparkVersion % "test",
   "com.globalmentor" % "hadoop-bare-naked-local-fs" % "0.1.0" % "test",
   "org.scalatest" %% "scalatest" % "3.2.14" % "test")
 val extraDependencies = Seq(
@@ -54,8 +53,8 @@ val extraDependencies = Seq(
   "org.scalactic" %% "scalactic" % "3.2.14",
   "io.spray" %% "spray-json" % "1.3.5",
   "com.jcraft" % "jsch" % "0.1.54",
-  "org.apache.httpcomponents.client5" % "httpclient5" % "5.1.3",
-  "org.apache.httpcomponents" % "httpmime" % "4.5.13",
+  "org.apache.httpcomponents" % "httpclient" % "4.5.13",
+  "org.apache.httpcomponents" % "httpmime" % "4.5.13" % "test",
   "com.linkedin.isolation-forest" %% "isolation-forest_3.5.0" % "3.0.5"
     exclude("com.google.protobuf", "protobuf-java") exclude("org.apache.spark", "spark-mllib_2.12")
     exclude("org.apache.spark", "spark-core_2.12") exclude("org.apache.spark", "spark-avro_2.12")

--- a/environment.yml
+++ b/environment.yml
@@ -24,8 +24,6 @@ dependencies:
     - nbconvert
     - nbformat
     - pyyaml
-    - PyGithub
-    - tqdm
     - ipython
     - pytest-codeblocks
     - azure-storage-blob
@@ -48,9 +46,7 @@ dependencies:
     - huggingface-hub==0.26.0
     - langchain==0.0.152
     - openai==0.27.5
-    - black==22.3.0
     - black[jupyter]==22.3.0
-    - mistletoe
     - markdownify
     - pypandoc
     - traitlets


### PR DESCRIPTION
## Summary

Remove packages with zero imports across the entire codebase.

### environment.yml
- **PyGithub**: no `import github` found anywhere in the repo
- **tqdm**: no direct imports — still available as transitive dep of `transformers` (v4.67.3)
- **mistletoe**: markdown parser with zero imports — docs use docusaurus/sphinx
- **black==22.3.0**: duplicate of `black[jupyter]==22.3.0` (superset)

### build.sbt
- **httpclient5** (5.1.3): zero imports of `org.apache.hc.client5` — codebase uses v4 API (`org.apache.http`)
- **spark-tags**: zero imports of `org.apache.spark.tags` (exclusion rule kept to prevent transitive pull)
- **httpmime**: moved to `% "test"` scope — only imported in `FabricOperations` test
- **httpclient** (4.5.13): added explicitly — was a silent transitive dep of httpmime, needed in compile scope by `RESTUtils`, `HTTPSchema`, `HTTPClients`, `ClusterUtil`

## Validation (CI-mirror container: ubuntu:22.04, conda 24.11.1, JDK 11)

| Check | Result |
|-------|--------|
| `conda env create` | ✅ |
| `sbt compile` | ✅ (0 errors) |
| `sbt Test/compile` | ✅ (0 errors) |
| `sbt scalastyle; Test/scalastyle` | ✅ |
| `black --check` | ✅ (176 files unchanged) |
| `mistletoe` removed | ✅ not installed |
| `PyGithub` removed | ✅ not installed |
| `tqdm` still works transitively | ✅ via transformers |
