### PR TITLE
ci: remove unnecessary conda env and Azure auth from Style job

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -101,17 +101,11 @@ jobs:
   pool:
     vmImage: $(UBUNTU_VERSION)
   steps:
-    - task: AzureCLI@2
+    - bash: sbt scalastyle test:scalastyle
       displayName: 'Scala Style Check'
-      inputs:
-        azureSubscription: 'SynapseML Build'
-        scriptLocation: inlineScript
-        scriptType: bash
-        inlineScript: 'sbt scalastyle test:scalastyle'
-    - template: templates/conda.yml
     - bash: |
         set -e
-        source activate synapseml
+        pip install -q "black[jupyter]==22.3.0"
         black --diff --color . && black --check -q .
       displayName: 'Python Style Check'
 - ${{ if eq(parameters.publishArtifacts, true) }}:

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -103,6 +103,10 @@ jobs:
   steps:
     - bash: sbt scalastyle test:scalastyle
       displayName: 'Scala Style Check'
+    - task: UsePythonVersion@0
+      displayName: 'Use Python 3'
+      inputs:
+        versionSpec: '3.10'
     - bash: |
         set -e
         pip install -q "black[jupyter]==22.3.0"


### PR DESCRIPTION
## What changes are proposed in this pull request?

Removes unnecessary dependencies from the CI Style job:

- **AzureCLI@2 wrapper** → plain `bash` step for `sbt scalastyle`. The Azure auth is not needed — `Secrets.scala` values are all `lazy val` and never accessed during scalastyle.
- **Full conda environment** (R, torch, horovod, pyspark, langchain, etc.) → `pip install black[jupyter]==22.3.0`. The only tool needed is black.

### Validation

Tested in a clean container (`eclipse-temurin:8-jdk-jammy`):
- `sbt scalastyle test:scalastyle` — ✅ passes without Azure CLI or conda
- `black --check` — ✅ identical results (233 .py + 57 .ipynb files) with pip-only install

### History

Python style checking was originally added via `pip install -r requirements.txt` (PR #1520, Jun 2022). The conda template was added later during a refactor — not for any functional reason.

## How is this patch tested?

The PR CI itself validates this change — if the Style job passes, the change works.