### PR TITLE
ci: use pre-installed Azure CLI in ADO jobs

### DIFF
--- a/templates/update_cli.yml
+++ b/templates/update_cli.yml
@@ -1,12 +1,10 @@
 steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.8'
+      versionSpec: '3.10'
       architecture: 'x64'
   - task: JavaToolInstaller@0
     inputs:
       versionSpec: '8'
       jdkArchitectureOption: 'x64'
       jdkSourceOption: 'PreInstalled'
-  - bash: pip install azure-cli==2.60.0
-    displayName: 'Upgrade Azure CLI'

--- a/templates/update_cli.yml
+++ b/templates/update_cli.yml
@@ -9,5 +9,3 @@ steps:
       versionSpec: '8'
       jdkArchitectureOption: 'x64'
       jdkSourceOption: 'PreInstalled'
-  - bash: python -m pip install azure-cli==2.88.0
-    displayName: 'Install Azure CLI'


### PR DESCRIPTION
## Problem

`master` now uses cached Python 3.11 in `templates/update_cli.yml`, so the original Python upgrade in this PR is obsolete. The shared template still runs `python -m pip install azure-cli==2.88.0` in every job that includes it, even though the Microsoft-hosted Ubuntu 22.04 image already includes Azure CLI 2.88.0.

## Change

- Rebase onto the latest `master`
- Keep the cached Python 3.11 setup from `master`
- Remove the per-job Azure CLI pip install

## Validation and impact

- Fresh [`/azp run` build 229176406](https://msdata.visualstudio.com/b9b2accc-2d1c-45b3-9d24-0eb5d78cc47f/_build/results?buildId=229176406) passed all 65 jobs with no failed tasks.
- The refreshed timeline contains zero `Install Azure CLI` tasks; authenticated `AzureCLI@2` tasks succeeded with the hosted CLI.
- In comparison build 228845851, 62 `Install Azure CLI` tasks averaged 50.8 seconds each (3,151 seconds / 52.5 agent-minutes total).
- In the refreshed run, the next setup task started a median 0.0 seconds after `JavaToolInstaller`, confirming roughly 51 seconds saved per affected job. Because jobs run in parallel, the expected wall-clock critical-path saving is about one minute.