### PR TITLE
chore: migrate SynapseML skills to Copilot path

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,7 @@
+# Agent configuration
+
+Copilot CLI discovers project skills from `.github/skills/<skill-name>/`.
+
+Do not add `SKILL.md` files under `.agents/skills/`. Keep repo-versioned skills in `.github/skills/` so Copilot CLI can load them consistently.
+
+This directory remains only as a compatibility pointer for agents or tools that inspect `.agents`.

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,10 @@
+# Skills moved
+
+Repo-versioned skills for Copilot CLI live in `.github/skills/`.
+
+Use these paths instead:
+
+- `.github/skills/code-review/`
+- `.github/skills/synapseml-local-setup/`
+
+Do not add `SKILL.md` files in this directory.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Quick review checklist for python and scala code changes before callings it done.
+description: Review SynapseML Python and Scala code changes. Use before finalizing PR reviews or implementation changes to check security, compatibility, style, generated code, and targeted tests.
 ---
 
 # Code Review
@@ -21,8 +21,8 @@ Use this skill when reviewing SynapseML changes.
 Apply when changes touch serialization, I/O, network, or authentication code.
 
 ### Deserialization (CWE-502)
-- [ ] No raw `ObjectInputStream.readObject()` — use `SafeObjectInputStream` with an allowlist
-- [ ] `resolveClass` allowlist validates array component types — never allowlist the `[` prefix
+- [ ] No raw `ObjectInputStream.readObject()`: use `SafeObjectInputStream` with an allowlist
+- [ ] `resolveClass` allowlist validates array component types. Never allowlist the `[` prefix
       directly; array handling must extract and validate the component class name
 - [ ] `resolveProxyClass` is overridden to block or validate dynamic proxy interfaces
 - [ ] Allowlist uses package-prefix matching, not blocklisting
@@ -46,7 +46,7 @@ Apply when changes modify public classes, traits, or companion objects.
 
 ### Binary Compatibility (JVM)
 - [ ] No method signature changes on existing public methods (default parameters
-      generate synthetic bridges — use explicit overloads instead)
+      generate synthetic bridges; use explicit overloads instead)
 - [ ] No removed or renamed public classes, traits, or objects
 - [ ] Companion object `extends DefaultParamsReadable[T]` preserved if it existed
 
@@ -61,7 +61,7 @@ Apply when changes modify public classes, traits, or companion objects.
 - [ ] `Wrappable` trait mixed in if the class needs a Python wrapper
 - [ ] `SynapseMLLogging` trait mixed in; `logClass()` called in constructor
 - [ ] No wildcard imports where explicit imports suffice (`java.io._` → named imports)
-- [ ] No RDD API usage — DataFrame/Dataset only
+- [ ] No RDD API usage. Use DataFrame/Dataset only
 - [ ] Lines ≤ 120 chars, files ≤ 800 lines
 
 ## Python Checklist


### PR DESCRIPTION
## Summary
Migrates the remaining SynapseML repo skill to the documented Copilot CLI project-skill path and leaves `.agents` as a pointer-only compatibility directory.

## What changed
- Moved `code-review` from `.agents/skills/code-review/` to `.github/skills/code-review/`.
- Added `.agents/README.md` to point agents at `.github/skills/`.
- Added `.agents/skills/README.md` so tools that inspect the old directory see the new source of truth.
- Kept `synapseml-local-setup` under `.github/skills/` from the prior merged skill PR.

## Validation
- `git diff --check`
- Confirmed no `SKILL.md` files remain under `.agents/`.
- Confirmed changed files contain no em dash characters.
- Confirmed skill frontmatter names match their directory names.
