### PR TITLE
ci: remove redundant authentication and Conda setup

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -176,17 +176,16 @@ jobs:
     vmImage: $(UBUNTU_VERSION)
   steps:
     - template: templates/sbt_cache.yml
-    - task: AzureCLI@2
+    - bash: sbt scalastyle test:scalastyle
       displayName: 'Scala Style Check'
+    - task: UsePythonVersion@0
       inputs:
-        azureSubscription: 'SynapseML Build'
-        scriptLocation: inlineScript
-        scriptType: bash
-        inlineScript: 'sbt scalastyle test:scalastyle'
-    - template: templates/conda.yml
+        versionSpec: '3.11'
+        architecture: 'x64'
+        disableDownloadFromRegistry: true
     - bash: |
         set -e
-        source activate synapseml
+        python -m pip install -q 'black[jupyter]==22.3.0'
         black --diff --color . && black --check -q .
       displayName: 'Python Style Check'
 - ${{ if eq(parameters.publishArtifacts, true) }}:
@@ -342,16 +341,11 @@ jobs:
     vmImage: ubuntu-22.04
   steps:
     - template: templates/sbt_cache.yml
-    - task: AzureCLI@2
+    - bash: |
+        VERSION=$(sbt "core/version" | tail -1 |  cut -d' ' -f2 | sed 's/\x1b\[[0-9;]*m//g')
+        echo '##vso[task.setvariable variable=version]'$VERSION
+        echo '##vso[task.setvariable variable=gittag]'$(git tag -l --points-at HEAD)
       displayName: 'Get Docker Tag + Version'
-      inputs:
-        azureSubscription: 'SynapseML Build'
-        scriptLocation: inlineScript
-        scriptType: bash
-        inlineScript: |
-          VERSION=$(sbt "core/version" | tail -1 |  cut -d' ' -f2 | sed 's/\x1b\[[0-9;]*m//g')
-          echo '##vso[task.setvariable variable=version]'$VERSION
-          echo '##vso[task.setvariable variable=gittag]'$(git tag -l --points-at HEAD)
     # Build all images (runs on every build to validate Dockerfiles)
     - task: Docker@2
       displayName: Demo Image Build
@@ -544,18 +538,13 @@ jobs:
     - template: templates/update_cli.yml
     - template: templates/conda.yml
     - template: templates/kv.yml
-    - task: AzureCLI@2
+    - bash: |
+        source activate synapseml
+        if [ "$(runCoverage)" = "True" ]; then COV_CMD="coverage"; else COV_CMD=""; fi
+        sbt $COV_CMD getDatasets installPipPackage
+        sbt publishM2
       displayName: 'Install and package deps'
       timeoutInMinutes: 40
-      inputs:
-        azureSubscription: 'SynapseML Build'
-        scriptLocation: inlineScript
-        scriptType: bash
-        inlineScript: |
-          source activate synapseml
-          if [ "$(runCoverage)" = "True" ]; then COV_CMD="coverage"; else COV_CMD=""; fi
-          sbt $COV_CMD getDatasets installPipPackage
-          sbt publishM2
     - task: AzureCLI@2
       displayName: 'Test Python Code'
       retryCountOnTaskFailure: 1
@@ -591,14 +580,9 @@ jobs:
         testResultsFiles: '**/python-test-*.xml'
         failTaskOnFailedTests: true
       condition: succeededOrFailed()
-    - task: AzureCLI@2
+    - bash: sbt coverageReport
       displayName: 'Generate Codecov report'
       retryCountOnTaskFailure: 1
-      inputs:
-        azureSubscription: 'SynapseML Build'
-        scriptLocation: inlineScript
-        scriptType: bash
-        inlineScript: 'sbt coverageReport'
       condition: and(succeededOrFailed(), eq(variables.runCoverage, true))
     - ${{ if or(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/tags/')) }}:
       - template: templates/codecov.yml
@@ -628,25 +612,20 @@ jobs:
     - template: templates/update_cli.yml
     - template: templates/conda.yml
     - template: templates/kv.yml
-    - task: AzureCLI@2
+    - bash: |
+        set -e
+        export SBT_OPTS="-Xms2G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
+        source activate synapseml
+        bash tools/ci/sbt_retry.sh setup
+        sbt codegen
+        sbt publishM2
+        SPARK_VERSION=3.5.0
+        HADOOP_VERSION=3
+        # wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
+        wget https://mmlspark.blob.core.windows.net/installers/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
       displayName: 'Prepare for tests'
       retryCountOnTaskFailure: 1
       timeoutInMinutes: 60
-      inputs:
-        azureSubscription: 'SynapseML Build'
-        scriptLocation: inlineScript
-        scriptType: bash
-        inlineScript: |
-          set -e
-          export SBT_OPTS="-Xms2G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss5M  -Duser.timezone=GMT"
-          source activate synapseml
-          bash tools/ci/sbt_retry.sh setup
-          sbt codegen
-          sbt publishM2
-          SPARK_VERSION=3.5.0
-          HADOOP_VERSION=3
-          # wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
-          wget https://mmlspark.blob.core.windows.net/installers/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
     - task: AzureCLI@2
       displayName: 'Test R Code'
       retryCountOnTaskFailure: 3
@@ -666,25 +645,12 @@ jobs:
         testResultsFiles: '**/r-test-*.xml'
         failTaskOnFailedTests: true
       condition: succeededOrFailed()
-    - task: AzureCLI@2
+    - bash: sbt coverageReport
       retryCountOnTaskFailure: 1
       displayName: 'Generate Codecov report'
-      inputs:
-        azureSubscription: 'SynapseML Build'
-        scriptLocation: inlineScript
-        scriptType: bash
-        inlineScript: 'sbt coverageReport'
       condition: and(succeededOrFailed(), eq(variables.runCoverage, true))
     - ${{ if or(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/tags/')) }}:
       - template: templates/codecov.yml
-
-- job: BuildAndCacheCondaEnv
-  cancelTimeoutInMinutes: 0
-  condition: eq(variables.runTests, 'True')
-  pool:
-    vmImage: $(UBUNTU_VERSION)
-  steps:
-    - template: templates/conda.yml
 
 - job: WebsiteSamplesTests
   dependsOn: BuildAndCacheSbt
@@ -715,14 +681,9 @@ jobs:
         testResultsFiles: '**/website-test-result.xml'
         failTaskOnFailedTests: true
       condition: succeededOrFailed()
-    - task: AzureCLI@2
+    - bash: sbt coverageReport
       displayName: 'Generate Codecov report'
       retryCountOnTaskFailure: 1
-      inputs:
-        azureSubscription: 'SynapseML Build'
-        scriptLocation: inlineScript
-        scriptType: bash
-        inlineScript: 'sbt coverageReport'
       condition: and(succeededOrFailed(), eq(variables.runCoverage, true))
     - ${{ if or(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/tags/')) }}:
       - template: templates/codecov.yml
@@ -851,19 +812,14 @@ jobs:
   steps:
     - template: templates/sbt_cache.yml
     - template: templates/update_cli.yml
-    - task: AzureCLI@2
+    - bash: |
+        (timeout 30s pip install requests) || (echo "retrying" && timeout 30s pip install requests)
+        (${FFMPEG:-false} && sudo apt-get update && \
+        sudo apt-get install ffmpeg libgstreamer1.0-0 \
+        gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly -y)
+        bash tools/ci/sbt_retry.sh setup
       displayName: 'Setup repo'
       retryCountOnTaskFailure: 1
-      inputs:
-        azureSubscription: 'SynapseML Build'
-        scriptLocation: inlineScript
-        scriptType: bash
-        inlineScript: |
-          (timeout 30s pip install requests) || (echo "retrying" && timeout 30s pip install requests)
-          (${FFMPEG:-false} && sudo apt-get update && \
-          sudo apt-get install ffmpeg libgstreamer1.0-0 \
-          gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly -y)
-          bash tools/ci/sbt_retry.sh setup
     - task: AzureCLI@2
       displayName: 'Unit Test'
       retryCountOnTaskFailure: 1
@@ -886,14 +842,9 @@ jobs:
         testResultsFiles: '**/test-reports/TEST-*.xml'
         failTaskOnFailedTests: true
       condition: succeededOrFailed()
-    - task: AzureCLI@2
+    - bash: sbt coverageReport
       displayName: 'Generate Codecov report'
       retryCountOnTaskFailure: 1
-      inputs:
-        azureSubscription: 'SynapseML Build'
-        scriptLocation: inlineScript
-        scriptType: bash
-        inlineScript: 'sbt coverageReport'
       condition: and(succeededOrFailed(), eq(variables.runCoverage, true))
     - ${{ if or(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/tags/')) }}:
       - task: AzureKeyVault@2

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -98,7 +98,7 @@ def test_prewarm_job_present():
     data = yaml.safe_load(_pipeline_text())
     jobs = {j.get("job"): j for j in _jobs(data["jobs"])}
     assert "BuildAndCacheSbt" in jobs
-    assert "BuildAndCacheCondaEnv" in jobs  # existing prewarm preserved
+    assert "BuildAndCacheCondaEnv" not in jobs
     prewarm = jobs["BuildAndCacheSbt"]
     assert "condition" not in prewarm, "prewarm must run whenever sbt jobs can run"
     warm_steps = [
@@ -235,6 +235,42 @@ def test_acr_cleanup_is_schedule_only_and_uses_dedicated_identity():
     assert "pip install" not in script
     assert "clean-acr-connection-string" not in script
     assert "python tools/acr/clean_acr.py" in script
+
+
+def test_non_azure_setup_steps_do_not_authenticate_with_azure_cli():
+    data = yaml.safe_load(_pipeline_text())
+    jobs = {j.get("job"): j for j in _jobs(data["jobs"])}
+    expected_bash_steps = {
+        "Style": {"Scala Style Check"},
+        "BuildDocker": {"Get Docker Tag + Version"},
+        "PythonTests": {"Install and package deps", "Generate Codecov report"},
+        "RTests": {"Prepare for tests", "Generate Codecov report"},
+        "WebsiteSamplesTests": {"Generate Codecov report"},
+        "UnitTests": {"Setup repo", "Generate Codecov report"},
+    }
+
+    for job_name, display_names in expected_bash_steps.items():
+        steps = jobs[job_name]["steps"]
+        for display_name in display_names:
+            step = next(
+                step for step in steps if step.get("displayName") == display_name
+            )
+            assert "bash" in step, f"{job_name}/{display_name} should be a Bash step"
+            assert step.get("task") != "AzureCLI@2"
+
+
+def test_style_does_not_restore_the_full_conda_environment():
+    data = yaml.safe_load(_pipeline_text())
+    jobs = {j.get("job"): j for j in _jobs(data["jobs"])}
+    style = jobs["Style"]
+    templates = [step.get("template") for step in style["steps"] if "template" in step]
+    assert "templates/conda.yml" not in templates
+    python_style = next(
+        step
+        for step in style["steps"]
+        if step.get("displayName") == "Python Style Check"
+    )
+    assert "black[jupyter]==22.3.0" in python_style["bash"]
 
 
 def test_every_sbt_running_job_waits_for_the_prewarm_cache():


### PR DESCRIPTION
## Related Issues/PRs

- External foundation: #2581
- Parent stack layer: #2584
- Native stack: #2586

## What changes are proposed?

- Run setup, coverage, style, and version-discovery commands as Bash where no Azure authentication is consumed.
- Keep AzureCLI tasks only for work that actually calls authenticated Azure services.
- Remove the standalone Conda cache job, which was not a dependency and could not prevent concurrent cold-cache environment creation.
- Run Style on hosted Python 3.11 with pinned `black[jupyter]==22.3.0` instead of restoring the full 8.6 GB Conda cache.

## Measured validation

Compared with baseline ADO build 229176406:

- AzureCLI task records: **183 → 74** (**109 fewer**, about **60%**).
- Conda-named task records: **96 → 88**.
- Standalone Conda warmup: **3.43 minutes → removed**.
- Style: **5.51 → 3.08 minutes** (about **44% faster**).
- Comparable full run 229198643 used **1,095.1 vs 1,229.7 agent-minutes**, saving **134.6 agent-minutes** (about **10.9%**) despite adding two visible release-compat jobs.

Final build [229205405](https://msdata.visualstudio.com/b9b2accc-2d1c-45b3-9d24-0eb5d78cc47f/_build/results?buildId=229205405) passed all 67 jobs. Its 104-minute GPU leg demonstrates the larger saving available when CPU-only changes skip GPU through #2582.

## How is this patch tested?

- [x] Pipeline-shape tests ensure AzureCLI remains where required and the standalone Conda warmup is absent.
- [x] Full stack validation: 35 Python tests, Black, ScalaStyle, YAML parsing, and whitespace checks.
- [x] Full ADO validation passed.

## Dependencies / feature surface

- [x] No dependency changes.
- [x] Low-risk CI performance improvements only.
