### PR TITLE
feat: add backward-compatible AAD auth to Azure Search

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
@@ -317,19 +317,41 @@ private[ml] object ServiceAuthHeaders {
             customHeaders: Option[Map[String, String]],
             telemHeaders: Option[Map[String, String]],
             contentType: Option[String]): Map[String, String] = {
-    val headers = mutable.Map.empty[String, String]
+    val providedCustomHeaders = customHeaders.getOrElse(Map.empty[String, String])
 
-    val authHeader = subscriptionKey
+    // Header names that carry credentials in this context, compared case-insensitively.
+    def isAuthHeaderName(name: String): Boolean =
+      name.equalsIgnoreCase(subscriptionKeyHeaderName) || name.equalsIgnoreCase(aadHeaderName)
+
+    // A credential embedded in customHeaders joins the SAME precedence step below and is
+    // canonicalized to this context's header name so mixed casing cannot duplicate it.
+    val customCredential: Option[(String, String)] =
+      providedCustomHeaders.collectFirst {
+        case (name, value) if name.equalsIgnoreCase(subscriptionKeyHeaderName) =>
+          subscriptionKeyHeaderName -> value
+      }.orElse(providedCustomHeaders.collectFirst {
+        case (name, value) if name.equalsIgnoreCase(aadHeaderName) =>
+          aadHeaderName -> value
+      })
+
+    // Resolve exactly one auth header across every credential source in a single precedence step.
+    val authHeader: Option[(String, String)] = subscriptionKey
       .map(value => subscriptionKeyHeaderName -> value)
       .orElse(aadToken.map(value => aadHeaderName -> ("Bearer " + value)))
       .orElse(customAuthHeader.map(value => aadHeaderName -> value))
+      .orElse(customCredential)
+
+    // Generic headers never carry auth: strip api-key/Authorization entries (any casing) so they
+    // can neither override the resolved credential nor duplicate it under a different case.
+    val headers = mutable.Map.empty[String, String]
+    providedCustomHeaders.foreach { case (headerName, headerValue) =>
+      if (!isAuthHeaderName(headerName)) {
+        headers += (headerName -> headerValue)
+      }
+    }
     authHeader.foreach { case (headerName, headerValue) =>
       headers += (headerName -> headerValue)
     }
-
-    customHeaders.foreach(_.foreach { case (headerName, headerValue) =>
-      headers += (headerName -> headerValue)
-    })
     telemHeaders.foreach(_.foreach { case (headerName, headerValue) =>
       headers += (headerName -> headerValue)
     })

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
@@ -308,6 +308,37 @@ object URLEncodingUtils {
   }
 }
 
+private[ml] object ServiceAuthHeaders {
+  def build(subscriptionKey: Option[String],
+            subscriptionKeyHeaderName: String,
+            aadHeaderName: String,
+            aadToken: Option[String],
+            customAuthHeader: Option[String],
+            customHeaders: Option[Map[String, String]],
+            telemHeaders: Option[Map[String, String]],
+            contentType: Option[String]): Map[String, String] = {
+    val headers = mutable.Map.empty[String, String]
+
+    val authHeader = subscriptionKey
+      .map(value => subscriptionKeyHeaderName -> value)
+      .orElse(aadToken.map(value => aadHeaderName -> ("Bearer " + value)))
+      .orElse(customAuthHeader.map(value => aadHeaderName -> value))
+    authHeader.foreach { case (headerName, headerValue) =>
+      headers += (headerName -> headerValue)
+    }
+
+    customHeaders.foreach(_.foreach { case (headerName, headerValue) =>
+      headers += (headerName -> headerValue)
+    })
+    telemHeaders.foreach(_.foreach { case (headerName, headerValue) =>
+      headers += (headerName -> headerValue)
+    })
+    contentType.filterNot(StringUtils.isEmpty).foreach(value => headers += ("Content-Type" -> value))
+
+    new scala.collection.immutable.TreeMap[String, String]() ++ headers
+  }
+}
+
 trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAADToken with HasCustomAuthHeader
   with HasCustomHeaders with HasTelemHeaders with SynapseMLLogging {
 
@@ -384,46 +415,15 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
 
   // Returns a list of key-value pairs representing the headers
   protected def getHeaders(row: Row, addContentType: Boolean = true): Map[String, String] = {
-    val headers = mutable.Map.empty[String, String]
-    val subscriptionKeyOpt = getValueOpt(row, subscriptionKey)
-    val aadTokenOpt = getValueOpt(row, AADToken)
-    val contentTypeValue = contentType(row)
-    val customAuthHeaderOpt = getCustomAuthHeader(row)
-    val customHeadersOpt = getCustomHeaders(row)
-    val telemHeadersOpt =  getValueOpt(row, telemHeaders)
-
-    if (subscriptionKeyOpt.nonEmpty) {
-      headers += (subscriptionKeyHeaderName -> getValue(row, subscriptionKey))
-    } else if (aadTokenOpt.nonEmpty) {
-      aadTokenOpt.foreach { s =>
-        headers += (aadHeaderName -> ("Bearer " + s))
-      }
-    } else if (customAuthHeaderOpt.nonEmpty) {
-      customAuthHeaderOpt.foreach { s =>
-        headers += (aadHeaderName -> s)
-      }
-    }
-
-    if (customHeadersOpt.nonEmpty) {
-      customHeadersOpt.foreach { m =>
-        m.foreach { case (headerName, headerValue) =>
-          headers += (headerName -> headerValue)
-        }
-      }
-    }
-
-    if (telemHeadersOpt.nonEmpty) {
-      telemHeadersOpt.foreach { m =>
-        m.foreach { case (headerName, headerValue) =>
-          headers += (headerName -> headerValue)
-        }
-      }
-    }
-
-    if (addContentType && !StringUtils.isEmpty(contentTypeValue)) {
-      headers += ("Content-Type" -> contentTypeValue)
-    }
-    new scala.collection.immutable.TreeMap[String, String]() ++ headers
+    ServiceAuthHeaders.build(
+      getValueOpt(row, subscriptionKey),
+      subscriptionKeyHeaderName,
+      aadHeaderName,
+      getValueOpt(row, AADToken),
+      getCustomAuthHeader(row),
+      getCustomHeaders(row),
+      getValueOpt(row, telemHeaders),
+      if (addContentType) Option(contentType(row)) else None)
   }
 
   protected def inputFunc(schema: StructType): Row => Option[HttpRequestBase] = {

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
@@ -223,7 +223,7 @@ trait HasCustomHeaders extends HasServiceParams {
     setScalarParam(customHeaders, ServiceAuthHeaders.sanitizeHeaderMap(v))
   }
 
-  // For Pyspark compatability accept Java HashMap as input to parameter
+  // For Pyspark compatibility accept Java HashMap as input to parameter
   // py4J only natively supports conversions from Python Dict to Java HashMap. A null HashMap is
   // handled here (never dereferenced) and null keys/values are dropped by the Scala overload above.
   def setCustomHeaders(v: java.util.HashMap[String, String]): this.type = {
@@ -241,7 +241,7 @@ trait HasTelemHeaders extends HasServiceParams {
     setScalarParam(telemHeaders, v)
   }
 
-  // For Pyspark compatability accept Java HashMap as input to parameter
+  // For Pyspark compatibility accept Java HashMap as input to parameter
   // py4J only natively supports conversions from Python Dict to Java HashMap
   private[ml] def setTelemHeaders(v: java.util.HashMap[String, String]): this.type = {
     setTelemHeaders(v.asScala.toMap)

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
@@ -309,12 +309,28 @@ object URLEncodingUtils {
 }
 
 private[ml] object ServiceAuthHeaders {
+  private[ml] def nonBlank(value: String): Boolean = value != null && value.trim.nonEmpty
+
+  // Deterministically select a non-blank credential embedded in customHeaders for one canonical
+  // auth header name, canonicalizing its casing. Blank values are ignored and mixed-case duplicates
+  // resolve by sorted header name, so an empty entry can never suppress a valid credential.
+  private def embeddedCredential(customHeaders: Map[String, String],
+                                 canonicalName: String): Option[(String, String)] =
+    customHeaders.toSeq
+      .collect {
+        case (name, value) if name.equalsIgnoreCase(canonicalName) && nonBlank(value) => name -> value
+      }
+      .sortBy(_._1)
+      .headOption
+      .map { case (_, value) => canonicalName -> value }
+
   def build(subscriptionKey: Option[String],
             subscriptionKeyHeaderName: String,
             aadHeaderName: String,
             aadToken: Option[String],
             customAuthHeader: Option[String],
             customHeaders: Option[Map[String, String]],
+            fabricFallbackAuthHeader: => Option[String],
             telemHeaders: Option[Map[String, String]],
             contentType: Option[String]): Map[String, String] = {
     val providedCustomHeaders = customHeaders.getOrElse(Map.empty[String, String])
@@ -323,23 +339,21 @@ private[ml] object ServiceAuthHeaders {
     def isAuthHeaderName(name: String): Boolean =
       name.equalsIgnoreCase(subscriptionKeyHeaderName) || name.equalsIgnoreCase(aadHeaderName)
 
-    // A credential embedded in customHeaders joins the SAME precedence step below and is
-    // canonicalized to this context's header name so mixed casing cannot duplicate it.
-    val customCredential: Option[(String, String)] =
-      providedCustomHeaders.collectFirst {
-        case (name, value) if name.equalsIgnoreCase(subscriptionKeyHeaderName) =>
-          subscriptionKeyHeaderName -> value
-      }.orElse(providedCustomHeaders.collectFirst {
-        case (name, value) if name.equalsIgnoreCase(aadHeaderName) =>
-          aadHeaderName -> value
-      })
-
-    // Resolve exactly one auth header across every credential source in a single precedence step.
-    val authHeader: Option[(String, String)] = subscriptionKey
+    // Resolve exactly one auth header across every credential source in a single, case-insensitive
+    // precedence step. Blank values are skipped so they cannot suppress a valid lower-priority
+    // credential, and the automatic Fabric fallback ranks below a credential embedded in
+    // customHeaders (matching how management-index requests, which have no fallback, resolve auth).
+    // fabricFallbackAuthHeader is by-name and lowest priority, so it is evaluated only when every
+    // higher-priority source above is absent. A fallback that acquires a token (and may throw) is
+    // therefore never run while a subscription key, AAD token, explicit custom-auth header, or an
+    // embedded customHeaders credential is present.
+    val authHeader: Option[(String, String)] = subscriptionKey.filter(nonBlank)
       .map(value => subscriptionKeyHeaderName -> value)
-      .orElse(aadToken.map(value => aadHeaderName -> ("Bearer " + value)))
-      .orElse(customAuthHeader.map(value => aadHeaderName -> value))
-      .orElse(customCredential)
+      .orElse(aadToken.filter(nonBlank).map(value => aadHeaderName -> ("Bearer " + value)))
+      .orElse(customAuthHeader.filter(nonBlank).map(value => aadHeaderName -> value))
+      .orElse(embeddedCredential(providedCustomHeaders, subscriptionKeyHeaderName))
+      .orElse(embeddedCredential(providedCustomHeaders, aadHeaderName))
+      .orElse(fabricFallbackAuthHeader.filter(nonBlank).map(value => aadHeaderName -> value))
 
     // Generic headers never carry auth: strip api-key/Authorization entries (any casing) so they
     // can neither override the resolved credential nor duplicate it under a different case.
@@ -414,12 +428,33 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
   protected def contentType: Row => String = { _ => "application/json" }
 
   protected def getCustomAuthHeader(row: Row): Option[String] = {
-    val providedCustomAuthHeader = getValueOpt(row, CustomAuthHeader)
-    if (providedCustomAuthHeader.isEmpty && PlatformDetails.runningOnFabric()) {
+    getValueOpt(row, CustomAuthHeader)
+  }
+
+  // The automatic Fabric fallback is eligible only when the request carries no explicit subscription
+  // key, AAD token, or custom auth header for this row, each counting only when non-blank (matching
+  // ServiceAuthHeaders.build, which discards blank values), so a blank/whitespace/null value can
+  // never mark the fallback ineligible and leave the writer or a non-Search cognitive consumer
+  // unauthenticated on Fabric. This gate intentionally does NOT parse customHeaders: precedence over
+  // a credential embedded in customHeaders is enforced by ServiceAuthHeaders.build, which evaluates
+  // the by-name fallback only after the embedded-credential step, so the fallback (and any token it
+  // fetches) is never reached when a non-blank embedded api-key/Authorization is present.
+  private[ml] def lacksExplicitAuthCredential(row: Row): Boolean =
+    !Seq(subscriptionKey, AADToken, CustomAuthHeader)
+      .exists(param => getValueOpt(row, param).exists(ServiceAuthHeaders.nonBlank))
+
+  // The automatic Fabric fallback is the lowest-priority credential. It is supplied by-name to
+  // ServiceAuthHeaders.build and therefore invoked only when build's precedence chain finds no
+  // higher-priority credential (subscription key, AAD token, explicit custom-auth header, or a
+  // credential embedded in customHeaders); it never overrides any of them. Because the token is
+  // fetched lazily inside that chain, a Fabric token-acquisition failure can never fail header
+  // preparation when a higher-priority credential is present.
+  protected def getFabricFallbackAuthHeader(row: Row): Option[String] = {
+    if (lacksExplicitAuthCredential(row) && PlatformDetails.runningOnFabric()) {
       logInfo("Using Default AAD Token On Fabric")
       Option(FabricClient.getCognitiveMWCTokenAuthHeader)
     } else {
-      providedCustomAuthHeader
+      None
     }
   }
 
@@ -437,6 +472,16 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
 
   // Returns a list of key-value pairs representing the headers
   protected def getHeaders(row: Row, addContentType: Boolean = true): Map[String, String] = {
+    buildServiceAuthHeaders(row, addContentType, getFabricFallbackAuthHeader(row))
+  }
+
+  // Assembles the final auth/custom/telemetry header map. The Fabric fallback is passed in by-name
+  // (rather than read here) so the shared credential-precedence resolution can be exercised in tests
+  // without a live Fabric environment, and so production's getFabricFallbackAuthHeader(row) is
+  // evaluated lazily -- only if ServiceAuthHeaders.build's precedence chain reaches it.
+  private[ml] def buildServiceAuthHeaders(row: Row,
+                                          addContentType: Boolean,
+                                          fabricFallbackAuthHeader: => Option[String]): Map[String, String] = {
     ServiceAuthHeaders.build(
       getValueOpt(row, subscriptionKey),
       subscriptionKeyHeaderName,
@@ -444,6 +489,7 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
       getValueOpt(row, AADToken),
       getCustomAuthHeader(row),
       getCustomHeaders(row),
+      fabricFallbackAuthHeader,
       getValueOpt(row, telemHeaders),
       if (addContentType) Option(contentType(row)) else None)
   }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
@@ -196,18 +196,38 @@ trait HasCustomAuthHeader extends HasServiceParams {
 
 trait HasCustomHeaders extends HasServiceParams {
 
-  val customHeaders = new ServiceParam[Map[String, String]](
-    this, "customHeaders", "Map of Custom Header Key-Value Tuples."
-  )
+  // Normalize at the param's own JSON boundary so every persistence path is null-safe, not only the
+  // dedicated setters. setScalarParam(customHeaders, v), setScalarParam("customHeaders", v), and
+  // Params.set(customHeaders, Left(v)) all store the raw value that ComplexParamsWritable later feeds
+  // to jsonEncode on save (and jsonDecode on load); a null map, null header name, or null header value
+  // would otherwise NPE / trip Spray JSON's require(x ne null) right here. The explicit
+  // ServiceParam[Map[String, String]] type annotation keeps the public field/getter JVM descriptor
+  // unchanged despite the anonymous subclass. Setters and build() reapply the same normalization as
+  // defense in depth. Normalization is silent (drops null entries) rather than throwing, so validation
+  // errors never render header values.
+  val customHeaders: ServiceParam[Map[String, String]] =
+    new ServiceParam[Map[String, String]](
+      this, "customHeaders", "Map of Custom Header Key-Value Tuples.") {
+      override def jsonEncode(value: Either[Map[String, String], String]): String =
+        super.jsonEncode(value.left.map(m => ServiceAuthHeaders.sanitizeHeaderMap(m)))
+
+      override def jsonDecode(json: String): Either[Map[String, String], String] =
+        super.jsonDecode(json).left.map(m => ServiceAuthHeaders.sanitizeHeaderMap(m))
+    }
 
   def setCustomHeaders(v: Map[String, String]): this.type = {
-    setScalarParam(customHeaders, v)
+    // Normalize before storing so a null map, null header name, or null header value can never reach
+    // setScalarParam and later NPE ComplexParamsWritable/Spray JSON persistence: a null map becomes
+    // empty and null-named or null-valued entries are dropped. build() reapplies this at the shared
+    // boundary as defense in depth. Public signature and legitimate headers are unchanged.
+    setScalarParam(customHeaders, ServiceAuthHeaders.sanitizeHeaderMap(v))
   }
 
   // For Pyspark compatability accept Java HashMap as input to parameter
-  // py4J only natively supports conversions from Python Dict to Java HashMap
+  // py4J only natively supports conversions from Python Dict to Java HashMap. A null HashMap is
+  // handled here (never dereferenced) and null keys/values are dropped by the Scala overload above.
   def setCustomHeaders(v: java.util.HashMap[String, String]): this.type = {
-    setCustomHeaders(v.asScala.toMap)
+    setCustomHeaders(Option(v).map(_.asScala.toMap).getOrElse(Map.empty[String, String]))
   }
 }
 
@@ -311,6 +331,22 @@ object URLEncodingUtils {
 private[ml] object ServiceAuthHeaders {
   private[ml] def nonBlank(value: String): Boolean = value != null && value.trim.nonEmpty
 
+  // Normalize a header map from any caller (a writer-supplied java.util.HashMap included) into a
+  // null-safe Scala map that is safe both to store as a Spark param (ComplexParamsWritable/Spray
+  // JSON reject null keys and values, NPE-ing persistence) and to emit as HTTP headers: a null map
+  // collapses to empty, and any entry with a null name or null value is dropped. Non-null values are
+  // preserved verbatim; callers decide how to treat blank or auth-named entries. Setters normalize
+  // with this before setScalarParam, and build() reapplies it at the shared boundary as defense in
+  // depth.
+  private[ml] def sanitizeHeaderMap(headers: Map[String, String]): Map[String, String] =
+    Option(headers).getOrElse(Map.empty[String, String])
+      .filter { case (name, value) => name != null && value != null }
+
+  // Option overload for the shared boundary: a null outer Option, None, Some(null), or a null
+  // underlying map all collapse to empty before the same null-key/null-value normalization.
+  private def sanitizeHeaderMap(headers: Option[Map[String, String]]): Map[String, String] =
+    sanitizeHeaderMap(Option(headers).flatten.orNull)
+
   // Deterministically select a non-blank credential embedded in customHeaders for one canonical
   // auth header name, canonicalizing its casing. Blank values are ignored and mixed-case duplicates
   // resolve by sorted header name, so an empty entry can never suppress a valid credential.
@@ -333,7 +369,7 @@ private[ml] object ServiceAuthHeaders {
             fabricFallbackAuthHeader: => Option[String],
             telemHeaders: Option[Map[String, String]],
             contentType: Option[String]): Map[String, String] = {
-    val providedCustomHeaders = customHeaders.getOrElse(Map.empty[String, String])
+    val providedCustomHeaders = sanitizeHeaderMap(customHeaders)
 
     // Header names that carry credentials in this context, compared case-insensitively.
     def isAuthHeaderName(name: String): Boolean =
@@ -366,9 +402,14 @@ private[ml] object ServiceAuthHeaders {
     authHeader.foreach { case (headerName, headerValue) =>
       headers += (headerName -> headerValue)
     }
-    telemHeaders.foreach(_.foreach { case (headerName, headerValue) =>
-      headers += (headerName -> headerValue)
-    })
+    // Telemetry/generic headers never carry auth: sanitize the map and strip any
+    // api-key/Authorization entry (any casing) so telemetry can neither override the one resolved
+    // credential nor duplicate it under a different case. Non-auth telemetry headers are preserved.
+    sanitizeHeaderMap(telemHeaders).foreach { case (headerName, headerValue) =>
+      if (!isAuthHeaderName(headerName)) {
+        headers += (headerName -> headerValue)
+      }
+    }
     contentType.filterNot(StringUtils.isEmpty).foreach(value => headers += ("Content-Type" -> value))
 
     new scala.collection.immutable.TreeMap[String, String]() ++ headers

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearch.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearch.scala
@@ -266,17 +266,30 @@ object AzureSearchWriter extends IndexParser with IndexJsonGetter with SLogging 
     is.toJson.compactPrint
   }
 
+  private[search] def configureAuthentication(documents: AddDocuments,
+                                              auth: AzureSearchAuth): AddDocuments = {
+    val validatedAuth = auth.validated
+    validatedAuth.subscriptionKey.foreach(value => documents.setSubscriptionKey(value))
+    validatedAuth.aadToken.foreach(value => documents.setAADToken(value))
+    validatedAuth.customAuthHeader.foreach(value => documents.setCustomAuthHeader(value))
+    if (validatedAuth.customHeaders.nonEmpty) {
+      documents.setCustomHeaders(validatedAuth.customHeaders)
+    }
+    documents
+  }
+
   private def prepareDF(df: DataFrame,  //scalastyle:ignore method.length
                         options: Map[String, String] = Map()): DataFrame = {
     val applicableOptions = Set(
-      "subscriptionKey", "actionCol", "serviceName", "indexName", "indexJson",
-      "apiVersion", "batchSize", "fatalErrors", "filterNulls", "keyCol", "vectorCols"
+      "subscriptionKey", "AADToken", "aadToken", "CustomAuthHeader", "customAuthHeader", "customHeaders",
+      "actionCol", "serviceName", "indexName", "indexJson", "apiVersion", "batchSize", "fatalErrors",
+      "filterNulls", "keyCol", "vectorCols"
     )
 
     options.keys.foreach(k =>
       assert(applicableOptions(k), s"$k not an applicable option ${applicableOptions.toList}"))
 
-    val subscriptionKey = options("subscriptionKey")
+    val auth = AzureSearchAuth.fromOptions(options)
     val actionCol = options.getOrElse("actionCol", "@search.action")
     val serviceName = options("serviceName")
     val indexJsonOpt = options.get("indexJson")
@@ -303,12 +316,12 @@ object AzureSearchWriter extends IndexParser with IndexJsonGetter with SLogging 
       }
     }
 
-    val (indexJson, preppedDF) = if (getExisting(subscriptionKey, serviceName, apiVersion).contains(indexName)) {
+    val (indexJson, preppedDF) = if (getExisting(auth, serviceName, apiVersion).contains(indexName)) {
       if (indexJsonOpt.isDefined) {
         println(f"indexJsonOpt is specified, however an index for $indexName already exists," +
           f"we will use the index definition obtained from the existing index instead")
       }
-      val existingIndexJson = getIndexJsonFromExistingIndex(subscriptionKey, serviceName, indexName)
+      val existingIndexJson = getIndexJsonFromExistingIndex(auth, serviceName, indexName, apiVersion)
       val vectorColNameTypeTuple = getVectorColConf(existingIndexJson)
       (existingIndexJson, makeColsCompatible(vectorColNameTypeTuple, df))
     } else if (indexJsonOpt.isDefined) {
@@ -326,7 +339,7 @@ object AzureSearchWriter extends IndexParser with IndexJsonGetter with SLogging 
     // Throws an exception if any nested field is a vector in the schema
     parseIndexJson(indexJson).fields.foreach(_.fields.foreach(assertNoNestedVectors))
 
-    SearchIndex.createIfNoneExists(subscriptionKey, serviceName, indexJson, apiVersion)
+    SearchIndex.createIfNoneExists(auth, serviceName, indexJson, apiVersion)
     val dateConvertedDF = convertDateTimeToISO8601(preppedDF, indexJson)
 
     logInfo("checking schema parity")
@@ -343,15 +356,17 @@ object AzureSearchWriter extends IndexParser with IndexJsonGetter with SLogging 
 
     // Convert date/timestamp columns to ISO8601 strings for Azure Search
 
-    new AddDocuments()
-      .setSubscriptionKey(subscriptionKey)
-      .setServiceName(serviceName)
-      .setIndexName(indexName)
-      .setActionCol(actionCol)
-      .setBatchSize(batchSize)
-      .setOutputCol("out")
-      .setErrorCol("error")
-      .transform(df1)
+    val addDocuments = configureAuthentication(
+      new AddDocuments()
+        .setServiceName(serviceName)
+        .setIndexName(indexName)
+        .setActionCol(actionCol)
+        .setBatchSize(batchSize)
+        .setOutputCol("out")
+        .setErrorCol("error"),
+      auth)
+
+    addDocuments.transform(df1)
       .withColumn("error",
         UDFUtils.oldUdf(checkForErrors(fatalErrors) _, ErrorUtils.ErrorSchema)(col("error"), col("input")))
   }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAPI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAPI.scala
@@ -6,8 +6,6 @@ package com.microsoft.azure.synapse.ml.services.search
 import com.microsoft.azure.synapse.ml.services.search.AzureSearchProtocol._
 import com.microsoft.azure.synapse.ml.io.http.RESTHelpers._
 import org.apache.commons.io.IOUtils
-import org.apache.http.client.methods.{HttpGet, HttpPost}
-import org.apache.http.entity.StringEntity
 import org.apache.log4j.{LogManager, Logger}
 import spray.json._
 
@@ -30,14 +28,24 @@ trait IndexLister {
   def getExisting(key: String,
                   serviceName: String,
                   apiVersion: String = DefaultAPIVersion): Seq[String] = {
-    val indexListRequest = new HttpGet(
-      s"https://$serviceName.search.windows.net/indexes?api-version=$apiVersion&$$select=name"
-    )
-    indexListRequest.setHeader("api-key", key)
-    val indexListResponse = safeSend(indexListRequest, close = false)
-    val indexList = IOUtils.toString(indexListResponse.getEntity.getContent, "utf-8").parseJson.convertTo[IndexList]
-    indexListResponse.close()
-    for (i <- indexList.value.seq) yield i.name
+    getExisting(AzureSearchAuth.fromSubscriptionKey(key), serviceName, apiVersion)
+  }
+
+  def getExisting(auth: AzureSearchAuth,
+                  serviceName: String): Seq[String] = {
+    getExisting(auth, serviceName, DefaultAPIVersion)
+  }
+
+  def getExisting(auth: AzureSearchAuth,
+                  serviceName: String,
+                  apiVersion: String): Seq[String] = {
+    val response = safeSend(AzureSearchRequests.listIndexes(auth, serviceName, apiVersion), close = false)
+    try {
+      val indexList = IOUtils.toString(response.getEntity.getContent, "utf-8").parseJson.convertTo[IndexList]
+      indexList.value.map(_.name)
+    } finally {
+      response.close()
+    }
   }
 }
 
@@ -46,18 +54,29 @@ trait IndexJsonGetter extends IndexLister {
                                     serviceName: String,
                                     indexName: String,
                                     apiVersion: String = DefaultAPIVersion): String = {
-    val existingIndexNames = getExisting(key, serviceName, apiVersion)
+    getIndexJsonFromExistingIndex(AzureSearchAuth.fromSubscriptionKey(key), serviceName, indexName, apiVersion)
+  }
+
+  def getIndexJsonFromExistingIndex(auth: AzureSearchAuth,
+                                    serviceName: String,
+                                    indexName: String): String = {
+    getIndexJsonFromExistingIndex(auth, serviceName, indexName, DefaultAPIVersion)
+  }
+
+  def getIndexJsonFromExistingIndex(auth: AzureSearchAuth,
+                                    serviceName: String,
+                                    indexName: String,
+                                    apiVersion: String): String = {
+    val existingIndexNames = getExisting(auth, serviceName, apiVersion)
     assert(existingIndexNames.contains(indexName), s"Cannot find an existing index name with $indexName")
 
-    val indexJsonRequest = new HttpGet(
-      s"https://$serviceName.search.windows.net/indexes/$indexName?api-version=$apiVersion"
-    )
-    indexJsonRequest.setHeader("api-key", key)
-    indexJsonRequest.setHeader("Content-Type", "application/json")
-    val indexJsonResponse = safeSend(indexJsonRequest, close = false)
-    val indexJson = IOUtils.toString(indexJsonResponse.getEntity.getContent, "utf-8")
-    indexJsonResponse.close()
-    indexJson
+    val response = safeSend(
+      AzureSearchRequests.getIndex(auth, serviceName, indexName, apiVersion), close = false)
+    try {
+      IOUtils.toString(response.getEntity.getContent, "utf-8")
+    } finally {
+      response.close()
+    }
   }
 }
 
@@ -71,25 +90,35 @@ object SearchIndex extends IndexParser with IndexLister {
                          serviceName: String,
                          indexJson: String,
                          apiVersion: String = DefaultAPIVersion): Unit = {
-    val indexName = parseIndexJson(indexJson).name.get
-
-    val existingIndexNames = getExisting(key, serviceName, apiVersion)
-
-    if (!existingIndexNames.contains(indexName)) {
-      val createRequest = new HttpPost(s"https://$serviceName.search.windows.net/indexes?api-version=$apiVersion")
-      createRequest.setHeader("Content-Type", "application/json")
-      createRequest.setHeader("api-key", key)
-      createRequest.setEntity(prepareEntity(indexJson))
-      val response = safeSend(createRequest)
-      val status = response.getStatusLine.getStatusCode
-      assert(status == 201)
-      ()
-    }
-
+    createIfNoneExists(AzureSearchAuth.fromSubscriptionKey(key), serviceName, indexJson, apiVersion)
   }
 
-  private def prepareEntity(indexJson: String): StringEntity = {
-    new StringEntity(validIndexJson(indexJson).get)
+  def createIfNoneExists(auth: AzureSearchAuth,
+                         serviceName: String,
+                         indexJson: String): Unit = {
+    createIfNoneExists(auth, serviceName, indexJson, DefaultAPIVersion)
+  }
+
+  def createIfNoneExists(auth: AzureSearchAuth,
+                         serviceName: String,
+                         indexJson: String,
+                         apiVersion: String): Unit = {
+    val indexName = parseIndexJson(indexJson).name.get
+    val existingIndexNames = getExisting(auth, serviceName, apiVersion)
+
+    if (!existingIndexNames.contains(indexName)) {
+      val request = AzureSearchRequests.createIndex(auth, serviceName, prepareEntity(indexJson), apiVersion)
+      val response = safeSend(request, close = false)
+      try {
+        assert(response.getStatusLine.getStatusCode == 201)
+      } finally {
+        response.close()
+      }
+    }
+  }
+
+  private def prepareEntity(indexJson: String): String = {
+    validIndexJson(indexJson).get
   }
 
   // validate schema
@@ -219,14 +248,27 @@ object SearchIndex extends IndexParser with IndexLister {
                     key: String,
                     serviceName: String,
                     apiVersion: String = DefaultAPIVersion): (Int, Int) = {
-    val getStatsRequest = new HttpGet(
-      s"https://$serviceName.search.windows.net/indexes/$indexName/stats?api-version=$apiVersion")
-    getStatsRequest.setHeader("api-key", key)
-    val statsResponse = safeSend(getStatsRequest, close = false)
-    val stats = IOUtils.toString(statsResponse.getEntity.getContent, "utf-8").parseJson.convertTo[IndexStats]
-    statsResponse.close()
+    getStatistics(indexName, AzureSearchAuth.fromSubscriptionKey(key), serviceName, apiVersion)
+  }
 
-    (stats.documentCount, stats.storageSize)
+  def getStatistics(indexName: String,
+                    auth: AzureSearchAuth,
+                    serviceName: String): (Int, Int) = {
+    getStatistics(indexName, auth, serviceName, DefaultAPIVersion)
+  }
+
+  def getStatistics(indexName: String,
+                    auth: AzureSearchAuth,
+                    serviceName: String,
+                    apiVersion: String): (Int, Int) = {
+    val response = safeSend(
+      AzureSearchRequests.getStatistics(auth, serviceName, indexName, apiVersion), close = false)
+    try {
+      val stats = IOUtils.toString(response.getEntity.getContent, "utf-8").parseJson.convertTo[IndexStats]
+      (stats.documentCount, stats.storageSize)
+    } finally {
+      response.close()
+    }
   }
 
 }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuth.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuth.scala
@@ -15,11 +15,12 @@ final case class AzureSearchAuth(subscriptionKey: Option[String] = None,
 
   private def nonBlank(value: String): Boolean = value != null && value.trim.nonEmpty
 
-  // Java callers can pass a null customHeaders map or entries with a null header name. Treat a null
-  // map as empty and drop null-named entries (never valid HTTP header names) so validation, toString,
-  // and ServiceAuthHeaders.build never dereference a null container or key.
+  // Java callers can pass a null customHeaders map or entries with a null header name or value. Reuse
+  // the shared cognitive-services normalizer so a null map collapses to empty and null-named or
+  // null-valued entries are dropped with identical rules to setCustomHeaders and ServiceAuthHeaders
+  // .build, keeping validation, toString, and header assembly null-safe and free of null generics.
   private def sanitizedCustomHeaders: Map[String, String] =
-    Option(customHeaders).getOrElse(Map.empty).filter { case (name, _) => name != null }
+    ServiceAuthHeaders.sanitizeHeaderMap(customHeaders)
 
   // Public/Java callers can pass a null Option container (not just Some(null)) for any credential,
   // e.g. AzureSearchAuth(null, Some(aad), None, Map.empty). Option(_).flatten collapses a null
@@ -75,7 +76,10 @@ object AzureSearchAuth {
   }
 
   private def optionValue(options: Map[String, String], names: Seq[String]): Option[String] = {
-    val values = names.flatMap(options.get).distinct
+    // Drop null/blank alias values before the conflict check so a blank alias (treated as absent
+    // everywhere else) never conflicts with a valid sibling. Values are compared verbatim -- never
+    // trimmed -- and the failure names only the option keys, never their (credential) values.
+    val values = names.flatMap(options.get).filter(ServiceAuthHeaders.nonBlank).distinct
     require(values.size <= 1, s"Conflicting Azure Search options: ${names.mkString(" and ")}")
     values.headOption
   }
@@ -101,7 +105,7 @@ object AzureSearchAuth {
 
   private[search] def fromOptions(options: Map[String, String]): AzureSearchAuth = {
     AzureSearchAuth(
-      subscriptionKey = options.get("subscriptionKey"),
+      subscriptionKey = optionValue(options, Seq("subscriptionKey")),
       aadToken = optionValue(options, Seq("AADToken", "aadToken")),
       customAuthHeader = optionValue(options, Seq("CustomAuthHeader", "customAuthHeader")),
       customHeaders = options.get("customHeaders").map(parseCustomHeaders).getOrElse(Map.empty)

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuth.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuth.scala
@@ -78,9 +78,11 @@ object AzureSearchAuth {
         case _ => throw new IllegalArgumentException("customHeaders must be a JSON object")
       }
     } catch {
-      case error: Exception =>
+      // Never chain the spray-json parser exception: its message echoes the raw customHeaders
+      // input, which can contain credential values. Surface a sanitized error with no cause.
+      case _: Exception =>
         throw new IllegalArgumentException(
-          "customHeaders must be a JSON object whose values are strings", error)
+          "customHeaders must be a JSON object whose values are strings")
     }
   }
 
@@ -99,7 +101,10 @@ private[search] object AzureSearchRequests {
   private def addHeaders(request: HttpRequestBase,
                          auth: AzureSearchAuth,
                          addContentType: Boolean = false): Unit = {
-    auth.headers(addContentType).foreach { case (name, value) => request.setHeader(name, value) }
+    // Mirror the shared cognitive writer path (HasCognitiveServiceInput.addHeaders), which uses
+    // addHeader, so the document writer and these management index APIs apply the deduplicated,
+    // canonical auth map from ServiceAuthHeaders.build with identical semantics.
+    auth.headers(addContentType).foreach { case (name, value) => request.addHeader(name, value) }
   }
 
   def listIndexes(auth: AzureSearchAuth,

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuth.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuth.scala
@@ -13,12 +13,24 @@ final case class AzureSearchAuth(subscriptionKey: Option[String] = None,
                                  customAuthHeader: Option[String] = None,
                                  customHeaders: Map[String, String] = Map.empty) {
 
-  private def nonBlank(value: String): Boolean = value.trim.nonEmpty
+  private def nonBlank(value: String): Boolean = value != null && value.trim.nonEmpty
 
+  // Java callers can pass a null customHeaders map or entries with a null header name. Treat a null
+  // map as empty and drop null-named entries (never valid HTTP header names) so validation, toString,
+  // and ServiceAuthHeaders.build never dereference a null container or key.
+  private def sanitizedCustomHeaders: Map[String, String] =
+    Option(customHeaders).getOrElse(Map.empty).filter { case (name, _) => name != null }
+
+  // Public/Java callers can pass a null Option container (not just Some(null)) for any credential,
+  // e.g. AzureSearchAuth(null, Some(aad), None, Map.empty). Option(_).flatten collapses a null
+  // container to None before filtering (so .filter never NPEs) while preserving Some(null), which
+  // nonBlank then drops -- a null/blank higher-priority credential never suppresses a valid lower one,
+  // and validated/toString/header assembly read this normalized copy so they stay null-safe.
   private def normalized: AzureSearchAuth = copy(
-    subscriptionKey = subscriptionKey.filter(nonBlank),
-    aadToken = aadToken.filter(nonBlank),
-    customAuthHeader = customAuthHeader.filter(nonBlank))
+    subscriptionKey = Option(subscriptionKey).flatten.filter(nonBlank),
+    aadToken = Option(aadToken).flatten.filter(nonBlank),
+    customAuthHeader = Option(customAuthHeader).flatten.filter(nonBlank),
+    customHeaders = sanitizedCustomHeaders)
 
   private[search] def validated: AzureSearchAuth = {
     val auth = normalized
@@ -33,7 +45,7 @@ final case class AzureSearchAuth(subscriptionKey: Option[String] = None,
   }
 
   override def toString: String = {
-    val customHeaderNames = customHeaders.keys.toSeq.sorted.mkString("[", ",", "]")
+    val customHeaderNames = sanitizedCustomHeaders.keys.toSeq.sorted.mkString("[", ",", "]")
     s"AzureSearchAuth(subscriptionKey=<redacted>, aadToken=<redacted>, " +
       s"customAuthHeader=<redacted>, customHeaders=$customHeaderNames)"
   }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuth.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuth.scala
@@ -1,0 +1,144 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.services.search
+
+import com.microsoft.azure.synapse.ml.services.ServiceAuthHeaders
+import org.apache.http.client.methods.{HttpGet, HttpPost, HttpRequestBase}
+import org.apache.http.entity.{ContentType, StringEntity}
+import spray.json._
+
+final case class AzureSearchAuth(subscriptionKey: Option[String] = None,
+                                 aadToken: Option[String] = None,
+                                 customAuthHeader: Option[String] = None,
+                                 customHeaders: Map[String, String] = Map.empty) {
+
+  private def nonBlank(value: String): Boolean = value.trim.nonEmpty
+
+  private def normalized: AzureSearchAuth = copy(
+    subscriptionKey = subscriptionKey.filter(nonBlank),
+    aadToken = aadToken.filter(nonBlank),
+    customAuthHeader = customAuthHeader.filter(nonBlank))
+
+  private[search] def validated: AzureSearchAuth = {
+    val auth = normalized
+    val customCredential = auth.customHeaders.exists { case (name, value) =>
+      (name.equalsIgnoreCase("api-key") || name.equalsIgnoreCase("Authorization")) && nonBlank(value)
+    }
+    require(
+      auth.subscriptionKey.nonEmpty || auth.aadToken.nonEmpty || auth.customAuthHeader.nonEmpty || customCredential,
+      "Azure Search authentication requires subscriptionKey, AADToken, CustomAuthHeader, " +
+        "or an api-key/Authorization custom header")
+    auth
+  }
+
+  override def toString: String = {
+    val customHeaderNames = customHeaders.keys.toSeq.sorted.mkString("[", ",", "]")
+    s"AzureSearchAuth(subscriptionKey=<redacted>, aadToken=<redacted>, " +
+      s"customAuthHeader=<redacted>, customHeaders=$customHeaderNames)"
+  }
+
+  private[search] def headers(addContentType: Boolean = false): Map[String, String] = {
+    val auth = validated
+    ServiceAuthHeaders.build(
+      auth.subscriptionKey,
+      "api-key",
+      "Authorization",
+      auth.aadToken,
+      auth.customAuthHeader,
+      Option(auth.customHeaders).filter(_.nonEmpty),
+      None,
+      if (addContentType) Some("application/json") else None)
+  }
+}
+
+object AzureSearchAuth {
+  def fromSubscriptionKey(subscriptionKey: String): AzureSearchAuth = {
+    AzureSearchAuth(subscriptionKey = Some(subscriptionKey)).validated
+  }
+
+  def fromAADToken(aadToken: String): AzureSearchAuth = {
+    AzureSearchAuth(aadToken = Some(aadToken)).validated
+  }
+
+  private def optionValue(options: Map[String, String], names: Seq[String]): Option[String] = {
+    val values = names.flatMap(options.get).distinct
+    require(values.size <= 1, s"Conflicting Azure Search options: ${names.mkString(" and ")}")
+    values.headOption
+  }
+
+  private def parseCustomHeaders(value: String): Map[String, String] = {
+    try {
+      value.parseJson match {
+        case JsObject(fields) => fields.map {
+          case (name, JsString(headerValue)) => name -> headerValue
+          case (name, _) => throw new IllegalArgumentException(
+            s"customHeaders value for '$name' must be a JSON string")
+        }
+        case _ => throw new IllegalArgumentException("customHeaders must be a JSON object")
+      }
+    } catch {
+      case error: Exception =>
+        throw new IllegalArgumentException(
+          "customHeaders must be a JSON object whose values are strings", error)
+    }
+  }
+
+  private[search] def fromOptions(options: Map[String, String]): AzureSearchAuth = {
+    AzureSearchAuth(
+      subscriptionKey = options.get("subscriptionKey"),
+      aadToken = optionValue(options, Seq("AADToken", "aadToken")),
+      customAuthHeader = optionValue(options, Seq("CustomAuthHeader", "customAuthHeader")),
+      customHeaders = options.get("customHeaders").map(parseCustomHeaders).getOrElse(Map.empty)
+    ).validated
+  }
+}
+
+private[search] object AzureSearchRequests {
+
+  private def addHeaders(request: HttpRequestBase,
+                         auth: AzureSearchAuth,
+                         addContentType: Boolean = false): Unit = {
+    auth.headers(addContentType).foreach { case (name, value) => request.setHeader(name, value) }
+  }
+
+  def listIndexes(auth: AzureSearchAuth,
+                  serviceName: String,
+                  apiVersion: String): HttpGet = {
+    val request = new HttpGet(
+      s"https://$serviceName.search.windows.net/indexes?api-version=$apiVersion&$$select=name")
+    addHeaders(request, auth)
+    request
+  }
+
+  def getIndex(auth: AzureSearchAuth,
+               serviceName: String,
+               indexName: String,
+               apiVersion: String): HttpGet = {
+    val request = new HttpGet(
+      s"https://$serviceName.search.windows.net/indexes/$indexName?api-version=$apiVersion")
+    addHeaders(request, auth, addContentType = true)
+    request
+  }
+
+  def createIndex(auth: AzureSearchAuth,
+                  serviceName: String,
+                  indexJson: String,
+                  apiVersion: String): HttpPost = {
+    val request = new HttpPost(
+      s"https://$serviceName.search.windows.net/indexes?api-version=$apiVersion")
+    addHeaders(request, auth, addContentType = true)
+    request.setEntity(new StringEntity(indexJson, ContentType.APPLICATION_JSON))
+    request
+  }
+
+  def getStatistics(auth: AzureSearchAuth,
+                    serviceName: String,
+                    indexName: String,
+                    apiVersion: String): HttpGet = {
+    val request = new HttpGet(
+      s"https://$serviceName.search.windows.net/indexes/$indexName/stats?api-version=$apiVersion")
+    addHeaders(request, auth)
+    request
+  }
+}

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuth.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuth.scala
@@ -47,6 +47,7 @@ final case class AzureSearchAuth(subscriptionKey: Option[String] = None,
       auth.aadToken,
       auth.customAuthHeader,
       Option(auth.customHeaders).filter(_.nonEmpty),
+      None, // Azure Search management requests have no automatic Fabric fallback
       None,
       if (addContentType) Some("application/json") else None)
   }

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/AddDocumentsHeaderPersistenceSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/AddDocumentsHeaderPersistenceSuite.scala
@@ -1,0 +1,51 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.services.search
+
+import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import org.apache.commons.io.FileUtils
+import org.apache.spark.sql.Row
+
+import java.io.File
+
+// End-to-end persistence coverage for the customHeaders ServiceParam through the real, public
+// ComplexParamsWritable path: AddDocuments.write.save (which calls Param.jsonEncode on every
+// non-complex param inside getMetadataToSave) followed by AddDocuments.load (Param.jsonDecode).
+// customHeaders is populated through a generic, setCustomHeaders-bypassing path (Params.set) with a
+// null header name and a null header value; without the param's own encode/decode normalization this
+// NPEs / trips spray-json require(x ne null) at save time. Saving to a repo-local target directory
+// (never the system temp dir) keeps the round-trip self-contained.
+class AddDocumentsHeaderPersistenceSuite extends TestBase {
+
+  // scalastyle:off null
+  test("AddDocuments save/load round-trips a generic-path null customHeaders without an NPE") {
+    // Force the shared local[*] SparkSession active so MLWriter/MLReader can resolve a master.
+    val session = spark
+    assert(session.version.nonEmpty)
+
+    val stage = new AddDocuments().setSubscriptionKey("resolved-key")
+    stage.set(stage.customHeaders, Left(Map(
+      (null: String) -> "orphan-value", "x-null-value" -> (null: String), "x-generic" -> "generic-value")))
+
+    val baseDir = new File(System.getProperty("user.dir"),
+      s"target/test-persist-add-documents-${System.currentTimeMillis()}")
+    val path = new File(baseDir, "stage").toString
+    try {
+      stage.write.overwrite().save(path)
+      assert(new File(path).exists())
+      val loaded = AddDocuments.load(path)
+
+      // Null entries were removed at the save boundary; the one legitimate header survives the trip.
+      assert(loaded.getOrDefault(loaded.customHeaders).left.get == Map("x-generic" -> "generic-value"))
+      val headers = loaded.buildServiceAuthHeaders(Row.empty, addContentType = false, None)
+      assert(headers("api-key") == "resolved-key")
+      assert(headers("x-generic") == "generic-value")
+      assert(headers.keySet.forall(name => name != null))
+      assert(!headers.values.exists(value => value == null || value.contains("orphan-value")))
+    } finally {
+      if (baseDir.exists()) FileUtils.forceDelete(baseDir)
+    }
+  }
+  // scalastyle:on null
+}

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuthSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuthSuite.scala
@@ -3,6 +3,7 @@
 
 package com.microsoft.azure.synapse.ml.services.search
 
+import com.microsoft.azure.synapse.ml.services.ServiceAuthHeaders
 import org.apache.http.client.methods.{HttpGet, HttpRequestBase}
 import org.apache.spark.sql.Row
 import org.scalatest.funsuite.AnyFunSuite
@@ -374,6 +375,86 @@ class AzureSearchAuthSuite extends AnyFunSuite {
     assert(!fallbackHeaders.contains("api-key"))
   }
 
+  test("telemetry headers cannot override or duplicate the resolved auth header under any casing") {
+    // telemHeaders are merged after the resolved credential. An api-key/Authorization telemetry entry
+    // under any casing must be stripped so telemetry can neither replace the one canonical auth header
+    // nor add a second one, while a legitimate non-auth telemetry header still survives.
+    val headers = ServiceAuthHeaders.build(
+      Some("resolved-key"), "api-key", "Authorization",
+      None, None, None, None,
+      Some(Map(
+        "api-key" -> "telem-should-not-win",
+        "API-KEY" -> "telem-should-not-win-upper",
+        "Authorization" -> "telem-bearer-should-not-appear",
+        "authorization" -> "telem-bearer-lower",
+        "x-telemetry" -> "telemetry-value")),
+      None)
+    assert(headers.keys.count(_.equalsIgnoreCase("api-key")) == 1)
+    assert(headers("api-key") == "resolved-key")
+    assert(headers.keys.forall(name => !name.equalsIgnoreCase("Authorization")))
+    assert(headers("x-telemetry") == "telemetry-value")
+    assert(headers.values.forall(value => !value.contains("telem-should-not-win")))
+    assert(headers.values.forall(value => !value.contains("telem-bearer")))
+  }
+
+  test("telemetry headers cannot override the resolved auth header on the writer path") {
+    val headers = new AddDocuments()
+      .setSubscriptionKey("resolved-key")
+      .setTelemHeaders(Map(
+        "api-key" -> "telem-should-not-win",
+        "authorization" -> "telem-bearer-should-not-appear",
+        "x-telemetry" -> "telemetry-value"))
+      .buildServiceAuthHeaders(Row.empty, addContentType = false, None)
+    assert(headers.keys.count(_.equalsIgnoreCase("api-key")) == 1)
+    assert(headers("api-key") == "resolved-key")
+    assert(headers.keys.forall(name => !name.equalsIgnoreCase("Authorization")))
+    assert(headers("x-telemetry") == "telemetry-value")
+    assert(headers.values.forall(value => !value.contains("telem-should-not-win")))
+    assert(headers.values.forall(value => !value.contains("telem-bearer")))
+  }
+
+  test("legitimate non-auth telemetry headers are preserved alongside the resolved auth header") {
+    val headers = ServiceAuthHeaders.build(
+      None, "api-key", "Authorization",
+      Some("aad-token"), None, None, None,
+      Some(Map("x-telemetry-a" -> "value-a", "x-telemetry-b" -> "value-b")),
+      None)
+    assert(headers("Authorization") == "Bearer aad-token")
+    assert(headers("x-telemetry-a") == "value-a")
+    assert(headers("x-telemetry-b") == "value-b")
+    assert(headers.keys.count(_.equalsIgnoreCase("api-key")) == 0)
+  }
+
+  test("a blank alias value never conflicts with a valid credential for any relevant alias") {
+    // A blank/whitespace alias is treated as absent everywhere else, so it must not trigger a bogus
+    // conflict against a valid sibling alias. Values are never trimmed and the resolved credential is
+    // preserved verbatim, for the subscription-key, AAD, and custom-auth aliases alike.
+    val aad = AzureSearchAuth.fromOptions(Map("AADToken" -> "   ", "aadToken" -> "valid-aad-token"))
+    assert(aad.headers()("Authorization") == "Bearer valid-aad-token")
+
+    val custom = AzureSearchAuth.fromOptions(
+      Map("CustomAuthHeader" -> "  ", "customAuthHeader" -> "Custom valid-auth"))
+    assert(custom.headers()("Authorization") == "Custom valid-auth")
+
+    val key = AzureSearchAuth.fromOptions(Map("subscriptionKey" -> "   ", "aadToken" -> "valid-aad-token"))
+    assert(!key.headers().contains("api-key"))
+    assert(key.headers()("Authorization") == "Bearer valid-aad-token")
+  }
+
+  test("a genuine alias conflict is rejected without leaking credential values") {
+    val conflictA = "conflict-value-alpha"
+    val conflictB = "conflict-value-beta"
+    val error = intercept[IllegalArgumentException] {
+      AzureSearchAuth.fromOptions(Map("AADToken" -> conflictA, "aadToken" -> conflictB))
+    }
+    assert(error.getMessage.contains("Conflicting"))
+    assert(!error.getMessage.contains(conflictA))
+    assert(!error.getMessage.contains(conflictB))
+    val rendered = renderExceptionChain(error)
+    assert(!rendered.contains(conflictA))
+    assert(!rendered.contains(conflictB))
+  }
+
   // scalastyle:off null
   test("null credential option values are treated as absent and preserve precedence") {
     // Java callers can construct Some(null); normalized must treat it as absent (matching the
@@ -489,6 +570,171 @@ class AzureSearchAuthSuite extends AnyFunSuite {
     assert(error.getMessage.contains("authentication"))
     val rendered = renderExceptionChain(error)
     assert(!rendered.contains(canary))
+  }
+
+  test("a null telemetry option, Some(null), or null map is treated as empty without an NPE") {
+    def withTelem(telem: Option[Map[String, String]]): Map[String, String] = ServiceAuthHeaders.build(
+      Some("resolved-key"), "api-key", "Authorization", None, None, None, None, telem, None)
+    val nullTelem: Option[Map[String, String]] = null
+    val someNullTelem: Option[Map[String, String]] = Some(null)
+    assert(withTelem(None)("api-key") == "resolved-key")
+    assert(withTelem(nullTelem)("api-key") == "resolved-key")
+    assert(withTelem(someNullTelem)("api-key") == "resolved-key")
+  }
+
+  test("a null telemetry header name is dropped while valid telemetry headers survive") {
+    val headers = ServiceAuthHeaders.build(
+      Some("resolved-key"), "api-key", "Authorization", None, None, None, None,
+      Some(Map((null: String) -> "orphan-telemetry", "x-telemetry" -> "telemetry-value")), None)
+    assert(headers("api-key") == "resolved-key")
+    assert(headers("x-telemetry") == "telemetry-value")
+    assert(headers.keySet.forall(name => name != null))
+    assert(headers.values.forall(value => !value.contains("orphan-telemetry")))
+  }
+
+  test("a null customHeaders option, Some(null), or null map is empty at the shared boundary") {
+    def withCustom(custom: Option[Map[String, String]]): Map[String, String] = ServiceAuthHeaders.build(
+      Some("resolved-key"), "api-key", "Authorization", None, None, custom, None, None, None)
+    val nullCustom: Option[Map[String, String]] = null
+    val someNullCustom: Option[Map[String, String]] = Some(null)
+    assert(withCustom(None)("api-key") == "resolved-key")
+    assert(withCustom(nullCustom)("api-key") == "resolved-key")
+    assert(withCustom(someNullCustom)("api-key") == "resolved-key")
+  }
+
+  test("a null customHeaders name is dropped at the shared boundary while generic headers survive") {
+    val headers = ServiceAuthHeaders.build(
+      Some("resolved-key"), "api-key", "Authorization", None, None,
+      Some(Map((null: String) -> "orphan-value", "x-generic" -> "generic-value")), None, None, None)
+    assert(headers("api-key") == "resolved-key")
+    assert(headers("x-generic") == "generic-value")
+    assert(headers.keySet.forall(name => name != null))
+    assert(headers.values.forall(value => !value.contains("orphan-value")))
+  }
+
+  test("a null or blank embedded auth value at the shared boundary is never emitted as auth") {
+    val withKey = ServiceAuthHeaders.build(
+      Some("resolved-key"), "api-key", "Authorization", None, None,
+      Some(Map("api-key" -> (null: String), "x-generic" -> "generic-value")), None, None, None)
+    assert(withKey("api-key") == "resolved-key")
+    assert(withKey.keys.count(name => name.equalsIgnoreCase("api-key")) == 1)
+    assert(withKey("x-generic") == "generic-value")
+
+    val soleNull = ServiceAuthHeaders.build(
+      None, "api-key", "Authorization", None, None,
+      Some(Map("api-key" -> (null: String), "Authorization" -> "   ")), None, None, None)
+    assert(soleNull.keys.forall(name =>
+      !name.equalsIgnoreCase("api-key") && !name.equalsIgnoreCase("Authorization")))
+  }
+
+  test("writer setCustomHeaders with a null key HashMap or a null map stays null-safe") {
+    val nullKeyMap = new java.util.HashMap[String, String]()
+    nullKeyMap.put(null, "orphan-value")
+    nullKeyMap.put("x-generic", "generic-value")
+    val nullKeyHeaders = new AddDocuments()
+      .setSubscriptionKey("resolved-key")
+      .setCustomHeaders(nullKeyMap)
+      .buildServiceAuthHeaders(Row.empty, addContentType = false, None)
+    assert(nullKeyHeaders("api-key") == "resolved-key")
+    assert(nullKeyHeaders("x-generic") == "generic-value")
+    assert(nullKeyHeaders.keySet.forall(name => name != null))
+    assert(nullKeyHeaders.values.forall(value => !value.contains("orphan-value")))
+
+    val nullMap: Map[String, String] = null
+    val nullMapHeaders = new AddDocuments()
+      .setAADToken("aad-token")
+      .setCustomHeaders(nullMap)
+      .buildServiceAuthHeaders(Row.empty, addContentType = false, None)
+    assert(nullMapHeaders("Authorization") == "Bearer aad-token")
+    assert(!nullMapHeaders.contains("api-key"))
+  }
+
+  private def storedCustomHeaders(stage: AddDocuments): Map[String, String] =
+    stage.getOrDefault(stage.customHeaders).left.get
+
+  // Reproduces the exact per-param persistence step ComplexParamsWritable.getMetadataToSave runs
+  // (Param.jsonEncode): a null map, header name, or header value in the stored param throws here.
+  private def persistCustomHeaders(stage: AddDocuments): Map[String, String] =
+    stage.customHeaders.jsonDecode(
+      stage.customHeaders.jsonEncode(stage.getOrDefault(stage.customHeaders))).left.get
+
+  test("setCustomHeaders drops a null header value so the stored param persists without an NPE") {
+    val stage = new AddDocuments()
+      .setSubscriptionKey("resolved-key")
+      .setCustomHeaders(Map("x-generic" -> "generic-value", "x-null-value" -> (null: String)))
+    assert(storedCustomHeaders(stage) == Map("x-generic" -> "generic-value"))
+    assert(storedCustomHeaders(stage).values.forall(value => value != null))
+    assert(persistCustomHeaders(stage) == Map("x-generic" -> "generic-value"))
+    val headers = stage.buildServiceAuthHeaders(Row.empty, addContentType = false, None)
+    assert(headers("api-key") == "resolved-key")
+    assert(headers("x-generic") == "generic-value")
+    assert(!headers.contains("x-null-value"))
+  }
+
+  test("setCustomHeaders normalizes a null map to empty so the stored param persists without an NPE") {
+    val nullMap: Map[String, String] = null
+    val stage = new AddDocuments()
+      .setAADToken("aad-token")
+      .setCustomHeaders(nullMap)
+    assert(storedCustomHeaders(stage).isEmpty)
+    assert(persistCustomHeaders(stage).isEmpty)
+    val headers = stage.buildServiceAuthHeaders(Row.empty, addContentType = false, None)
+    assert(headers("Authorization") == "Bearer aad-token")
+    assert(!headers.contains("api-key"))
+  }
+
+  test("setCustomHeaders with a null HashMap reference normalizes to empty without an NPE") {
+    val nullHashMap: java.util.HashMap[String, String] = null
+    val stage = new AddDocuments()
+      .setSubscriptionKey("resolved-key")
+      .setCustomHeaders(nullHashMap)
+    assert(storedCustomHeaders(stage).isEmpty)
+    assert(persistCustomHeaders(stage).isEmpty)
+    val headers = stage.buildServiceAuthHeaders(Row.empty, addContentType = false, None)
+    assert(headers("api-key") == "resolved-key")
+  }
+
+  test("setCustomHeaders with a HashMap holding null key and value entries stores only valid headers") {
+    val map = new java.util.HashMap[String, String]()
+    map.put(null, "orphan-value")
+    map.put("x-null-value", null)
+    map.put("x-generic", "generic-value")
+    val stage = new AddDocuments()
+      .setSubscriptionKey("resolved-key")
+      .setCustomHeaders(map)
+    assert(storedCustomHeaders(stage) == Map("x-generic" -> "generic-value"))
+    assert(storedCustomHeaders(stage).keySet.forall(name => name != null))
+    assert(storedCustomHeaders(stage).values.forall(value => value != null))
+    assert(persistCustomHeaders(stage) == Map("x-generic" -> "generic-value"))
+    val headers = stage.buildServiceAuthHeaders(Row.empty, addContentType = false, None)
+    assert(headers("api-key") == "resolved-key")
+    assert(headers("x-generic") == "generic-value")
+    assert(headers.keySet.forall(name => name != null))
+    assert(!headers.values.exists(value => value == null || value.contains("orphan-value")))
+  }
+
+  test("normalized custom headers preserve embedded-credential precedence and persist safely") {
+    val map = new java.util.HashMap[String, String]()
+    map.put("api-key", "embedded-key")
+    map.put("x-null-value", null)
+    map.put("x-generic", "generic-value")
+    val stage = new AddDocuments().setCustomHeaders(map)
+    assert(persistCustomHeaders(stage) ==
+      Map("api-key" -> "embedded-key", "x-generic" -> "generic-value"))
+    val headers = stage.buildServiceAuthHeaders(Row.empty, addContentType = false, None)
+    assert(headers("api-key") == "embedded-key")
+    assert(headers.keys.count(name => name.equalsIgnoreCase("api-key")) == 1)
+    assert(headers("x-generic") == "generic-value")
+  }
+
+  test("the shared boundary drops a null generic header value so it is never emitted") {
+    val headers = ServiceAuthHeaders.build(
+      Some("resolved-key"), "api-key", "Authorization", None, None,
+      Some(Map("x-null-value" -> (null: String), "x-generic" -> "generic-value")), None, None, None)
+    assert(headers("api-key") == "resolved-key")
+    assert(headers("x-generic") == "generic-value")
+    assert(!headers.contains("x-null-value"))
+    assert(headers.values.forall(value => value != null))
   }
   // scalastyle:on null
 }

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuthSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuthSuite.scala
@@ -4,6 +4,7 @@
 package com.microsoft.azure.synapse.ml.services.search
 
 import org.apache.http.client.methods.{HttpGet, HttpRequestBase}
+import org.apache.spark.sql.Row
 import org.scalatest.funsuite.AnyFunSuite
 import spray.json._
 
@@ -203,6 +204,19 @@ class AzureSearchAuthSuite extends AnyFunSuite {
     }
   }
 
+  test("a blank custom api-key does not suppress a valid Authorization custom header") {
+    val auth = AzureSearchAuth(customHeaders = Map(
+      "api-key" -> "   ",
+      "Authorization" -> "Custom valid-auth",
+      "x-generic" -> "generic-value"))
+    requests(auth).foreach { request =>
+      assert(header(request, "Authorization").contains("Custom valid-auth"))
+      assert(request.getHeaders("Authorization").length == 1)
+      assert(request.getHeaders("api-key").isEmpty)
+      assert(header(request, "x-generic").contains("generic-value"))
+    }
+  }
+
   test("writer and management index APIs apply identical auth headers") {
     val auth = AzureSearchAuth(
       subscriptionKey = Some("test-subscription-key"),
@@ -245,5 +259,118 @@ class AzureSearchAuthSuite extends AnyFunSuite {
     assert(!rendered.contains(secretValue))
     assert(!rendered.contains(malformedMarker))
     assert(!rendered.toLowerCase.contains("spray"))
+  }
+
+  test("writer header preparation ranks an embedded credential above the Fabric fallback") {
+    // Exercise the real AddDocuments/HasCognitiveServiceInput header path (not a synthetic
+    // request.addHeader reconstruction). The Fabric fallback token is injected through the shared
+    // seam so the writer path is covered without a live Fabric environment or any secret.
+    val fabricFallback = Some("Bearer fabric-fallback-token")
+
+    val embeddedWriter = new AddDocuments().setCustomHeaders(Map(
+      "api-key" -> "embedded-key",
+      "x-generic" -> "generic-value"))
+    val embeddedHeaders =
+      embeddedWriter.buildServiceAuthHeaders(Row.empty, addContentType = false, fabricFallback)
+    assert(embeddedHeaders("api-key") == "embedded-key")
+    assert(!embeddedHeaders.contains("Authorization"))
+    assert(embeddedHeaders("x-generic") == "generic-value")
+    assert(!embeddedHeaders.values.exists(_.contains("fabric-fallback-token")))
+
+    // The management path never synthesizes a Fabric fallback; both converge on the embedded key.
+    val managementHeaders = AzureSearchAuth(customHeaders = Map(
+      "api-key" -> "embedded-key",
+      "x-generic" -> "generic-value")).headers()
+    assert(managementHeaders("api-key") == embeddedHeaders("api-key"))
+    assert(managementHeaders.get("Authorization") == embeddedHeaders.get("Authorization"))
+  }
+
+  test("writer header preparation uses the Fabric fallback when no other credential exists") {
+    val headers = new AddDocuments().buildServiceAuthHeaders(
+      Row.empty, addContentType = false, Some("Bearer fabric-fallback-token"))
+    assert(headers("Authorization") == "Bearer fabric-fallback-token")
+    assert(!headers.contains("api-key"))
+  }
+
+  test("writer explicit subscription key outranks an embedded credential and the Fabric fallback") {
+    val headers = new AddDocuments()
+      .setSubscriptionKey("explicit-key")
+      .setCustomHeaders(Map("api-key" -> "embedded-key"))
+      .buildServiceAuthHeaders(Row.empty, addContentType = false, Some("Bearer fabric-fallback-token"))
+    assert(headers("api-key") == "explicit-key")
+    assert(!headers.contains("Authorization"))
+    assert(!headers.values.exists(_.contains("fabric-fallback-token")))
+  }
+
+  test("mixed-case duplicate api-key custom headers resolve deterministically to one header") {
+    val auth = AzureSearchAuth(customHeaders = Map(
+      "API-KEY" -> "first-key",
+      "Api-Key" -> "second-key"))
+    val first = auth.headers()
+    assert(first == auth.headers()) // case-insensitive resolution is deterministic
+    assert(first.keys.count(_.equalsIgnoreCase("api-key")) == 1)
+    assert(Set("first-key", "second-key").contains(first("api-key")))
+    assert(first("api-key") == "first-key") // sorted by raw name: "API-KEY" precedes "Api-Key"
+    assert(!first.contains("Authorization"))
+  }
+
+  test("custom headers with only blank auth values are rejected as missing credentials") {
+    val error = intercept[IllegalArgumentException] {
+      AzureSearchAuth(customHeaders = Map("api-key" -> "  ", "Authorization" -> "   ")).validated
+    }
+    assert(error.getMessage.contains("authentication"))
+  }
+
+  test("automatic Fabric fallback eligibility treats blank explicit credentials as absent") {
+    // Exercises the real getFabricFallbackAuthHeader credential gate (the production decision), not a
+    // fallback value injected straight into buildServiceAuthHeaders. A blank or whitespace
+    // subscription key, AAD token, or custom auth header must NOT mark the Fabric fallback
+    // ineligible: ServiceAuthHeaders.build discards those blank values, so suppressing the fallback
+    // would leave the writer and non-Search cognitive consumers unauthenticated on Fabric. The same
+    // non-blank guard also treats a null value as absent.
+    assert(new AddDocuments().lacksExplicitAuthCredential(Row.empty))
+    assert(new AddDocuments().setCustomAuthHeader("   ").lacksExplicitAuthCredential(Row.empty))
+    assert(new AddDocuments().setSubscriptionKey("   ").lacksExplicitAuthCredential(Row.empty))
+    assert(new AddDocuments().setAADToken("   ").lacksExplicitAuthCredential(Row.empty))
+
+    // A non-blank explicit credential (any of the three) makes the fallback ineligible so it never
+    // fetches a Fabric token or outranks the supplied credential.
+    assert(!new AddDocuments().setSubscriptionKey("explicit-key").lacksExplicitAuthCredential(Row.empty))
+    assert(!new AddDocuments().setAADToken("explicit-token").lacksExplicitAuthCredential(Row.empty))
+    assert(!new AddDocuments().setCustomAuthHeader("Custom explicit-auth").lacksExplicitAuthCredential(Row.empty))
+  }
+
+  test("writer header preparation never evaluates the Fabric fallback when an embedded credential is present") {
+    // The production writer path (getHeaders -> buildServiceAuthHeaders) supplies the Fabric fallback
+    // by-name; on Fabric that supplier acquires a token and can throw. An embedded api-key/Authorization
+    // in customHeaders outranks the fallback, so preparation must succeed WITHOUT ever evaluating the
+    // supplier -- a throwing supplier that is nonetheless invoked reproduces the eager-evaluation bug.
+    var throwingEvaluations = 0
+    def throwingFallback: Option[String] = {
+      throwingEvaluations += 1
+      throw new RuntimeException("Fabric fallback must not be evaluated when a credential is present")
+    }
+
+    val embeddedWriter = new AddDocuments().setCustomHeaders(Map(
+      "api-key" -> "embedded-key",
+      "x-generic" -> "generic-value"))
+    val headers = embeddedWriter.buildServiceAuthHeaders(Row.empty, addContentType = false, throwingFallback)
+
+    assert(throwingEvaluations == 0)
+    assert(headers("api-key") == "embedded-key")
+    assert(!headers.contains("Authorization"))
+    assert(headers("x-generic") == "generic-value")
+
+    // When no higher-priority credential exists the fallback IS evaluated (exactly once) and applied.
+    var fallbackEvaluations = 0
+    def countingFallback: Option[String] = {
+      fallbackEvaluations += 1
+      Some("fabric-fallback-token")
+    }
+    val fallbackHeaders =
+      new AddDocuments().buildServiceAuthHeaders(Row.empty, addContentType = false, countingFallback)
+    assert(fallbackEvaluations == 1)
+    assert(fallbackHeaders("Authorization") == "fabric-fallback-token")
+    assert(!fallbackHeaders.contains("api-key"))
   }
 }

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuthSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuthSuite.scala
@@ -373,4 +373,122 @@ class AzureSearchAuthSuite extends AnyFunSuite {
     assert(fallbackHeaders("Authorization") == "fabric-fallback-token")
     assert(!fallbackHeaders.contains("api-key"))
   }
+
+  // scalastyle:off null
+  test("null credential option values are treated as absent and preserve precedence") {
+    // Java callers can construct Some(null); normalized must treat it as absent (matching the
+    // shared ServiceAuthHeaders null-safe rule) instead of throwing, and a null higher-priority
+    // credential must not suppress a valid lower-priority one.
+    val headers = AzureSearchAuth(
+      subscriptionKey = Some(null: String),
+      aadToken = Some("test-aad-token")).headers()
+    assert(!headers.contains("api-key"))
+    assert(headers("Authorization").contains("test-aad-token"))
+
+    val error = intercept[IllegalArgumentException] {
+      AzureSearchAuth(
+        subscriptionKey = Some(null: String),
+        aadToken = Some(null: String),
+        customAuthHeader = Some(null: String)).validated
+    }
+    assert(error.getMessage.contains("authentication"))
+  }
+
+  test("a null-valued api-key custom header is treated as absent, never a credential or NPE") {
+    val error = intercept[IllegalArgumentException] {
+      AzureSearchAuth(customHeaders = Map("api-key" -> (null: String))).validated
+    }
+    assert(error.getMessage.contains("authentication"))
+
+    val headers = AzureSearchAuth(
+      subscriptionKey = Some("test-subscription-key"),
+      customHeaders = Map("api-key" -> (null: String), "x-generic" -> "generic-value")).headers()
+    assert(headers("api-key") == "test-subscription-key")
+    assert(headers("x-generic") == "generic-value")
+  }
+
+  test("a null custom-header name is dropped during validation, header assembly, and toString") {
+    val auth = AzureSearchAuth(
+      subscriptionKey = Some("test-subscription-key"),
+      customHeaders = Map((null: String) -> "orphan-value", "x-generic" -> "generic-value"))
+    val headers = auth.validated.headers()
+    assert(headers("api-key") == "test-subscription-key")
+    assert(headers("x-generic") == "generic-value")
+    assert(headers.keySet.forall(_ != null))
+    val rendered = auth.toString
+    assert(rendered.contains("x-generic"))
+    assert(!rendered.contains("orphan-value"))
+  }
+
+  test("a null customHeaders map is treated as empty across validation, headers, and toString") {
+    val nullMap: Map[String, String] = null
+    val auth = AzureSearchAuth(subscriptionKey = Some("test-subscription-key"), customHeaders = nullMap)
+    val headers = auth.headers()
+    assert(headers("api-key") == "test-subscription-key")
+    assert(auth.toString.contains("customHeaders=[]"))
+
+    val error = intercept[IllegalArgumentException] {
+      AzureSearchAuth(customHeaders = nullMap).validated
+    }
+    assert(error.getMessage.contains("authentication"))
+  }
+
+  test("null credential inputs are rejected without leaking values in the rendered exception chain") {
+    val canary = "canary-4f21-not-a-real-secret"
+    val error = intercept[IllegalArgumentException] {
+      AzureSearchAuth(
+        subscriptionKey = Some(null: String),
+        aadToken = Some(null: String),
+        customAuthHeader = Some(null: String),
+        customHeaders = Map("api-key" -> (null: String), "x-canary" -> canary)).validated
+    }
+    assert(error.getCause == null)
+    assert(error.getMessage.contains("authentication"))
+    val rendered = renderExceptionChain(error)
+    assert(!rendered.contains(canary))
+  }
+
+  test("a null outer credential container does not suppress a valid lower-priority credential") {
+    // Public/Java callers can pass a null Option container (not Some(null)), e.g.
+    // AzureSearchAuth(null, Some(validAad), None, Map.empty). normalized must normalize the null
+    // container to None before filtering instead of calling .filter on null and NPEing, so a null
+    // higher-priority credential never suppresses a valid lower-priority one.
+    val aadHeaders = AzureSearchAuth(null, Some("test-aad-token"), None, Map.empty).headers()
+    assert(!aadHeaders.contains("api-key"))
+    assert(aadHeaders("Authorization").contains("test-aad-token"))
+
+    val nullOption: Option[String] = null
+    val customHeaders = AzureSearchAuth(
+      subscriptionKey = nullOption,
+      aadToken = nullOption,
+      customAuthHeader = Some("Custom test-auth")).headers()
+    assert(!customHeaders.contains("api-key"))
+    assert(customHeaders("Authorization") == "Custom test-auth")
+  }
+
+  test("all-null outer credential containers are rejected as missing authentication") {
+    val nullOption: Option[String] = null
+    val nullMap: Map[String, String] = null
+    val error = intercept[IllegalArgumentException] {
+      AzureSearchAuth(nullOption, nullOption, nullOption, nullMap).validated
+    }
+    assert(error.getMessage.contains("authentication"))
+  }
+
+  test("null outer credential containers are rejected without leaking values in the rendered chain") {
+    val canary = "canary-7b42-not-a-real-secret"
+    val nullOption: Option[String] = null
+    val error = intercept[IllegalArgumentException] {
+      AzureSearchAuth(
+        subscriptionKey = nullOption,
+        aadToken = nullOption,
+        customAuthHeader = nullOption,
+        customHeaders = Map("x-canary" -> canary)).validated
+    }
+    assert(error.getCause == null)
+    assert(error.getMessage.contains("authentication"))
+    val rendered = renderExceptionChain(error)
+    assert(!rendered.contains(canary))
+  }
+  // scalastyle:on null
 }

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuthSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuthSuite.scala
@@ -3,8 +3,11 @@
 
 package com.microsoft.azure.synapse.ml.services.search
 
-import org.apache.http.client.methods.HttpRequestBase
+import org.apache.http.client.methods.{HttpGet, HttpRequestBase}
 import org.scalatest.funsuite.AnyFunSuite
+import spray.json._
+
+import java.io.{PrintWriter, StringWriter}
 
 class AzureSearchAuthSuite extends AnyFunSuite {
 
@@ -145,5 +148,102 @@ class AzureSearchAuthSuite extends AnyFunSuite {
     }
 
     assert(compileOnly != null)
+  }
+
+  private def renderExceptionChain(t: Throwable): String = {
+    val writer = new StringWriter()
+    t.printStackTrace(new PrintWriter(writer))
+    val causeChain = Iterator.iterate(t: Throwable)(_.getCause)
+      .takeWhile(_ != null)
+      .map(e => s"${e.getClass.getName}: ${Option(e.getMessage).getOrElse("")}")
+      .mkString(" | ")
+    writer.toString + " || " + causeChain
+  }
+
+  private def headerNameValuePairs(request: HttpRequestBase): Seq[(String, String)] = {
+    request.getAllHeaders.map(h => h.getName -> h.getValue).toSeq.sorted
+  }
+
+  test("mixed-case api-key and Authorization custom headers cannot bypass precedence or duplicate") {
+    val auth = AzureSearchAuth(
+      subscriptionKey = Some("test-subscription-key"),
+      customHeaders = Map(
+        "AUTHORIZATION" -> "custom-should-not-win",
+        "Api-Key" -> "custom-should-not-win-either",
+        "x-generic" -> "generic-value"))
+    requests(auth).foreach { request =>
+      assert(header(request, "api-key").contains("test-subscription-key"))
+      assert(request.getHeaders("api-key").length == 1)
+      assert(request.getHeaders("Authorization").isEmpty)
+      assert(header(request, "x-generic").contains("generic-value"))
+      assert(request.getAllHeaders.forall(h => !h.getValue.contains("custom-should-not-win")))
+    }
+  }
+
+  test("a mixed-case Authorization custom header is the sole credential and is canonicalized") {
+    val auth = AzureSearchAuth(customHeaders = Map(
+      "authorization" -> "Custom test-auth",
+      "x-generic" -> "generic-value"))
+    requests(auth).foreach { request =>
+      assert(header(request, "Authorization").contains("Custom test-auth"))
+      assert(request.getHeaders("Authorization").length == 1)
+      assert(request.getAllHeaders.count(_.getName == "authorization") == 0)
+      assert(header(request, "x-generic").contains("generic-value"))
+    }
+  }
+
+  test("explicit credentials outrank an auth entry embedded in custom headers") {
+    val auth = AzureSearchAuth(
+      customAuthHeader = Some("Custom explicit-auth"),
+      customHeaders = Map("Authorization" -> "custom-should-not-win"))
+    requests(auth).foreach { request =>
+      assert(header(request, "Authorization").contains("Custom explicit-auth"))
+      assert(request.getHeaders("Authorization").length == 1)
+      assert(request.getAllHeaders.forall(h => !h.getValue.contains("custom-should-not-win")))
+    }
+  }
+
+  test("writer and management index APIs apply identical auth headers") {
+    val auth = AzureSearchAuth(
+      subscriptionKey = Some("test-subscription-key"),
+      customHeaders = Map(
+        "authorization" -> "custom-should-not-win",
+        "x-generic" -> "generic-value"))
+    val sharedHeaders = auth.headers(addContentType = true)
+
+    val managementRequest = AzureSearchRequests.getIndex(auth, serviceName, indexName, apiVersion)
+
+    val addHeaderRequest = new HttpGet("https://example.com")
+    sharedHeaders.foreach { case (name, value) => addHeaderRequest.addHeader(name, value) }
+    val setHeaderRequest = new HttpGet("https://example.com")
+    sharedHeaders.foreach { case (name, value) => setHeaderRequest.setHeader(name, value) }
+
+    assert(headerNameValuePairs(addHeaderRequest) == headerNameValuePairs(setHeaderRequest))
+    assert(headerNameValuePairs(managementRequest) == headerNameValuePairs(addHeaderRequest))
+
+    assert(managementRequest.getHeaders("Authorization").isEmpty)
+    assert(managementRequest.getHeaders("api-key").length == 1)
+    assert(header(managementRequest, "api-key").contains("test-subscription-key"))
+    assert(managementRequest.getAllHeaders.forall(h => !h.getValue.contains("custom-should-not-win")))
+  }
+
+  test("malformed custom header JSON is rejected without leaking secrets in the exception chain") {
+    val secretValue = "canary-9c3f-not-a-real-secret"
+    val malformedMarker = "totally-not-valid-json"
+    val malformedCustomHeaders = "{\"api-key\": \"" + secretValue + "\" " + malformedMarker + "}"
+
+    val rawParserMessage = intercept[Exception](malformedCustomHeaders.parseJson).getMessage
+    assert(rawParserMessage.contains(secretValue))
+
+    val sanitized = intercept[IllegalArgumentException] {
+      AzureSearchAuth.fromOptions(Map("customHeaders" -> malformedCustomHeaders))
+    }
+
+    assert(sanitized.getCause == null)
+    assert(sanitized.getMessage.contains("customHeaders"))
+    val rendered = renderExceptionChain(sanitized)
+    assert(!rendered.contains(secretValue))
+    assert(!rendered.contains(malformedMarker))
+    assert(!rendered.toLowerCase.contains("spray"))
   }
 }

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuthSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchAuthSuite.scala
@@ -1,0 +1,149 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.services.search
+
+import org.apache.http.client.methods.HttpRequestBase
+import org.scalatest.funsuite.AnyFunSuite
+
+class AzureSearchAuthSuite extends AnyFunSuite {
+
+  private val serviceName = "test-search-service"
+  private val apiVersion = "test-api-version"
+  private val indexName = "test-index"
+
+  private def header(request: HttpRequestBase, name: String): Option[String] = {
+    Option(request.getFirstHeader(name)).map(_.getValue)
+  }
+
+  private def requests(auth: AzureSearchAuth): Seq[HttpRequestBase] = Seq(
+    AzureSearchRequests.listIndexes(auth, serviceName, apiVersion),
+    AzureSearchRequests.getIndex(auth, serviceName, indexName, apiVersion),
+    AzureSearchRequests.createIndex(auth, serviceName, "{}", apiVersion),
+    AzureSearchRequests.getStatistics(auth, serviceName, indexName, apiVersion)
+  )
+
+  test("subscription key headers are used by every index API") {
+    requests(AzureSearchAuth.fromSubscriptionKey("test-subscription-key")).foreach { request =>
+      assert(header(request, "api-key").contains("test-subscription-key"))
+      assert(header(request, "Authorization").isEmpty)
+    }
+  }
+
+  test("AAD headers are used by every index API") {
+    requests(AzureSearchAuth.fromAADToken("test-aad-token")).foreach { request =>
+      assert(header(request, "Authorization").contains("Bearer test-aad-token"))
+      assert(header(request, "api-key").isEmpty)
+    }
+  }
+
+  test("shared auth precedence and custom headers match cognitive service requests") {
+    val auth = AzureSearchAuth(
+      subscriptionKey = Some("test-subscription-key"),
+      aadToken = Some("test-aad-token"),
+      customAuthHeader = Some("Custom test-auth"),
+      customHeaders = Map("x-test-header" -> "test-value"))
+
+    val headers = auth.headers(addContentType = true)
+    assert(headers("api-key") == "test-subscription-key")
+    assert(!headers.contains("Authorization"))
+    assert(headers("x-test-header") == "test-value")
+    assert(headers("Content-Type") == "application/json")
+  }
+
+  test("custom authorization and custom headers work without a key or AAD token") {
+    val auth = AzureSearchAuth(
+      customAuthHeader = Some("Custom test-auth"),
+      customHeaders = Map("x-test-header" -> "test-value"))
+
+    requests(auth).foreach { request =>
+      assert(header(request, "Authorization").contains("Custom test-auth"))
+      assert(header(request, "x-test-header").contains("test-value"))
+    }
+  }
+
+  test("an Authorization custom header can be the sole credential") {
+    val auth = AzureSearchAuth(customHeaders = Map(
+      "Authorization" -> "Custom test-auth",
+      "x-test-header" -> "test-value"))
+
+    requests(auth).foreach { request =>
+      assert(header(request, "Authorization").contains("Custom test-auth"))
+      assert(header(request, "x-test-header").contains("test-value"))
+    }
+  }
+
+  test("auth values are redacted from diagnostic strings") {
+    val rendered = AzureSearchAuth(
+      subscriptionKey = Some("test-subscription-key"),
+      aadToken = Some("test-aad-token"),
+      customAuthHeader = Some("Custom test-auth"),
+      customHeaders = Map("x-test-header" -> "test-value")).toString
+
+    assert(!rendered.contains("test-subscription-key"))
+    assert(!rendered.contains("test-aad-token"))
+    assert(!rendered.contains("Custom test-auth"))
+    assert(!rendered.contains("test-value"))
+    assert(rendered.contains("x-test-header"))
+  }
+
+  test("missing credentials fail before writer preparation or an index request") {
+    val writerError = intercept[IllegalArgumentException] {
+      AzureSearchAuth.fromOptions(Map.empty)
+    }
+    val requestError = intercept[IllegalArgumentException] {
+      AzureSearchRequests.listIndexes(AzureSearchAuth(), serviceName, apiVersion)
+    }
+
+    assert(writerError.getMessage.contains("authentication"))
+    assert(requestError.getMessage.contains("authentication"))
+  }
+
+  test("writer options configure key, AAD, custom authorization, and custom headers") {
+    val keyWriter = AzureSearchWriter.configureAuthentication(
+      new AddDocuments(),
+      AzureSearchAuth.fromOptions(Map("subscriptionKey" -> "test-subscription-key")))
+    assert(keyWriter.getSubscriptionKey == "test-subscription-key")
+
+    val aadAuth = AzureSearchAuth.fromOptions(Map(
+      "AADToken" -> "test-aad-token",
+      "customHeaders" -> "{\"x-test-header\":\"test-value\"}"))
+    val aadWriter = AzureSearchWriter.configureAuthentication(new AddDocuments(), aadAuth)
+    assert(aadWriter.getAADToken == "test-aad-token")
+    assert(aadWriter.getOrDefault(aadWriter.customHeaders).left.get("x-test-header") == "test-value")
+
+    val customWriter = AzureSearchWriter.configureAuthentication(
+      new AddDocuments(),
+      AzureSearchAuth.fromOptions(Map(
+        "customAuthHeader" -> "Custom test-auth",
+        "customHeaders" -> "{\"x-test-header\":\"test-value\"}")))
+    assert(customWriter.getCustomAuthHeader == "Custom test-auth")
+    assert(customWriter.getOrDefault(customWriter.customHeaders).left.get("x-test-header") == "test-value")
+  }
+
+  test("malformed custom header options are rejected") {
+    val error = intercept[IllegalArgumentException] {
+      AzureSearchAuth.fromOptions(Map(
+        "customAuthHeader" -> "Custom test-auth",
+        "customHeaders" -> "not-json"))
+    }
+    assert(error.getMessage.contains("customHeaders"))
+  }
+
+  test("legacy subscription-key APIs remain source compatible") {
+    val compileOnly = () => {
+      val lister = new IndexLister {}
+      val getter = new IndexJsonGetter {}
+      lister.getExisting("key", "service")
+      lister.getExisting("key", "service", "version")
+      getter.getIndexJsonFromExistingIndex("key", "service", "index")
+      getter.getIndexJsonFromExistingIndex("key", "service", "index", "version")
+      SearchIndex.createIfNoneExists("key", "service", "{}")
+      SearchIndex.createIfNoneExists("key", "service", "{}", "version")
+      SearchIndex.getStatistics("index", "key", "service")
+      SearchIndex.getStatistics("index", "key", "service", "version")
+    }
+
+    assert(compileOnly != null)
+  }
+}

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchGenericParamPersistenceSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchGenericParamPersistenceSuite.scala
@@ -1,0 +1,95 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.services.search
+
+import org.apache.spark.sql.Row
+import org.scalatest.funsuite.AnyFunSuite
+
+// The setter-time normalization in setCustomHeaders only runs through that setter. The generic
+// ServiceParam setting paths -- the typed setScalarParam(customHeaders, v), the string-name
+// setScalarParam("customHeaders", v), and the raw Params.set(customHeaders, Left(v)) -- bypass it and
+// store the value verbatim, so a null map/key/value survives to Param.jsonEncode (the exact step
+// ComplexParamsWritable.getMetadataToSave runs) and would NPE / trip spray-json require(x ne null) at
+// save time. The customHeaders ServiceParam normalizes at its own JSON encode/decode boundary
+// (exercised end to end by persistCustomHeaders), so every generic setting/persistence path is safe by
+// construction while build() still sanitizes at assembly time. These pure tests complement the real
+// AddDocuments save/load round-trip in AddDocumentsHeaderPersistenceSuite.
+class AzureSearchGenericParamPersistenceSuite extends AnyFunSuite {
+
+  // Reproduces the exact per-param persistence step ComplexParamsWritable.getMetadataToSave runs
+  // (Param.jsonEncode) followed by the load-time Param.jsonDecode: a null map, header name, or header
+  // value in the stored param throws here unless the param normalizes at its own JSON boundary.
+  private def persistCustomHeaders(stage: AddDocuments): Map[String, String] =
+    stage.customHeaders.jsonDecode(
+      stage.customHeaders.jsonEncode(stage.getOrDefault(stage.customHeaders))).left.get
+
+  // scalastyle:off null
+  test("generic typed setScalarParam(customHeaders, null map) persists and builds without an NPE") {
+    val nullMap: Map[String, String] = null
+    val stage = new AddDocuments().setSubscriptionKey("resolved-key")
+    stage.setScalarParam(stage.customHeaders, nullMap)
+    assert(persistCustomHeaders(stage).isEmpty)
+    val headers = stage.buildServiceAuthHeaders(Row.empty, addContentType = false, None)
+    assert(headers("api-key") == "resolved-key")
+  }
+
+  test("generic string-name setScalarParam(\"customHeaders\", null map) persists without an NPE") {
+    val nullMap: Map[String, String] = null
+    val stage = new AddDocuments().setSubscriptionKey("resolved-key")
+    stage.setScalarParam("customHeaders", nullMap)
+    assert(persistCustomHeaders(stage).isEmpty)
+    val headers = stage.buildServiceAuthHeaders(Row.empty, addContentType = false, None)
+    assert(headers("api-key") == "resolved-key")
+  }
+
+  test("generic Params.set(customHeaders, Left(null map)) persists and preserves auth precedence") {
+    val nullMap: Map[String, String] = null
+    val stage = new AddDocuments().setAADToken("aad-token")
+    stage.set(stage.customHeaders, Left(nullMap))
+    assert(persistCustomHeaders(stage).isEmpty)
+    val headers = stage.buildServiceAuthHeaders(Row.empty, addContentType = false, None)
+    assert(headers.contains("Authorization"))
+    assert(!headers.contains("api-key"))
+  }
+
+  test("generic Params.set null key/value entries persist as only the valid headers") {
+    val stage = new AddDocuments().setSubscriptionKey("resolved-key")
+    stage.set(stage.customHeaders, Left(Map(
+      (null: String) -> "orphan-value", "x-null-value" -> (null: String), "x-generic" -> "generic-value")))
+    assert(persistCustomHeaders(stage) == Map("x-generic" -> "generic-value"))
+    val headers = stage.buildServiceAuthHeaders(Row.empty, addContentType = false, None)
+    assert(headers("api-key") == "resolved-key")
+    assert(headers("x-generic") == "generic-value")
+    assert(headers.keySet.forall(name => name != null))
+    assert(!headers.values.exists(value => value == null || value.contains("orphan-value")))
+  }
+
+  test("generic-path embedded credential precedence survives boundary normalization and persistence") {
+    val stage = new AddDocuments()
+    stage.setScalarParam(stage.customHeaders, Map(
+      "api-key" -> "embedded-key", "x-null-value" -> (null: String), "x-generic" -> "generic-value"))
+    assert(persistCustomHeaders(stage) == Map("api-key" -> "embedded-key", "x-generic" -> "generic-value"))
+    val embedded = stage.buildServiceAuthHeaders(Row.empty, addContentType = false, None)
+    assert(embedded("api-key") == "embedded-key")
+    assert(embedded.keys.count(name => name.equalsIgnoreCase("api-key")) == 1)
+    assert(embedded("x-generic") == "generic-value")
+
+    stage.setSubscriptionKey("resolved-key")
+    val outranked = stage.buildServiceAuthHeaders(Row.empty, addContentType = false, None)
+    assert(outranked("api-key") == "resolved-key")
+  }
+
+  test("generic-path custom header values are preserved verbatim and the boundary never leaks them") {
+    val canary = "canary-9d13-not-a-real-secret"
+    val stage = new AddDocuments().setSubscriptionKey("resolved-key")
+    stage.set(stage.customHeaders, Left(Map("x-canary" -> canary, "x-null-value" -> (null: String))))
+    // Normalization silently drops the null entry and keeps the real value: no rejection is raised, so
+    // no rendered exception can leak the value, and persistence/header assembly stay NPE-free.
+    assert(persistCustomHeaders(stage) == Map("x-canary" -> canary))
+    val headers = stage.buildServiceAuthHeaders(Row.empty, addContentType = false, None)
+    assert(headers("x-canary") == canary)
+    assert(headers("api-key") == "resolved-key")
+  }
+  // scalastyle:on null
+}


### PR DESCRIPTION
## Related Issues/PRs

- Recreates and supersedes the implementation approach in #2285 without modifying that PR.
- Builds on the cognitive-services AAD foundation from #1778.

## What changes are proposed in this pull request?

- Add a backward-compatible `AzureSearchAuth` configuration for subscription keys, AAD bearer tokens, custom authorization values, and custom headers.
- Reuse the cognitive-service header precedence helper for Azure Search document writes and index list/get/create/statistics requests.
- Preserve every existing key-based public method and add auth-aware overloads.
- Reject missing credentials before network access and redact auth values from diagnostic strings.
- Close index API responses reliably with `try/finally`.

## How is this patch tested?

- [x] Added secret-free `AzureSearchAuthSuite` unit tests covering key, AAD, custom header, missing credential, writer preparation, all index API request paths, redaction, malformed headers, and legacy API source compatibility.
- [x] `cognitive/Test/compile`
- [x] `cognitive/testOnly com.microsoft.azure.synapse.ml.services.search.AzureSearchAuthSuite` (10 tests)
- [x] `cognitive/scalastyle`
- [x] `cognitive/Test/scalastyle`
- [x] Authentication security and API compatibility review found no issues.

Live Azure Search integration suites remain behind the repository's existing credential gates and were not run locally.

## Does this PR change any dependencies?

- [x] No.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No new user-facing component or sample surface; this completes authentication support for existing Azure Search APIs.