### PR TITLE
fix: preserve partition topology when counting Spark rows

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/ClusterUtil.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/ClusterUtil.scala
@@ -7,7 +7,6 @@ import java.net.InetAddress
 import org.apache.http.conn.util.InetAddressUtils
 import org.apache.spark.SparkContext
 import org.apache.spark.injections.BlockManagerUtils
-import org.apache.spark.sql.functions.typedLit
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 import org.slf4j.Logger
 
@@ -41,12 +40,13 @@ object ClusterUtil {
   /** Get number of rows per partition of a dataframe.  Note that this will execute a full
     * distributed Spark app query.
     * @param df The dataframe.
+    * @param labelCol Retained for API compatibility. Projecting it could change the adaptive partition topology.
     * @return The number of rows per partition (where partitionId is the array index).
     */
   def getNumRowsPerPartition(df: DataFrame, labelCol: Column): Array[Long] = {
-    val indexedRowCounts: Array[(Int, Long)] = df
-      .select(typedLit(0.toByte))
-      .rdd
+    // Use the DataFrame's own RDD so adaptive execution cannot produce a different
+    // partition topology for a projected counting query.
+    val indexedRowCounts: Array[(Int, Long)] = df.rdd
       .mapPartitionsWithIndex({case (i,rows) => Iterator((i,rows.size.toLong))}, true)
       .collect()
     // Get an array where the index is implicitly the partition id

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/core/utils/VerifyClusterUtil.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/core/utils/VerifyClusterUtil.scala
@@ -4,6 +4,7 @@
 package com.microsoft.azure.synapse.ml.core.utils
 
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import org.apache.spark.sql.functions.{col, expr, first, lit}
 import org.slf4j.LoggerFactory
 
 class VerifyClusterUtil extends TestBase {
@@ -14,5 +15,40 @@ class VerifyClusterUtil extends TestBase {
     assert(ClusterUtil.getDefaultNumExecutorCores(spark, log, Option("yarn")) == 1)
     assert(ClusterUtil.getDefaultNumExecutorCores(spark, log, Option("spark://localhost:7077")) ==
       ClusterUtil.getJVMCPUs(spark))
+  }
+
+  test("Verify row counts preserve the DataFrame partition topology") {
+    // Isolate SQL settings without closing TestBase's shared SparkContext.
+    val adaptiveSpark = spark.newSession()
+    val partitionCount = 20
+    adaptiveSpark.conf.set("spark.sql.adaptive.enabled", value = true)
+    adaptiveSpark.conf.set("spark.sql.adaptive.coalescePartitions.enabled", value = true)
+    adaptiveSpark.conf.set("spark.sql.adaptive.coalescePartitions.parallelismFirst", value = false)
+    adaptiveSpark.conf.set("spark.sql.adaptive.advisoryPartitionSizeInBytes", 64 * 1024)
+    adaptiveSpark.conf.set("spark.sql.adaptive.coalescePartitions.minPartitionSize", 1)
+    adaptiveSpark.conf.set("spark.sql.shuffle.partitions", partitionCount)
+
+    val payloadExpression = (0 until 2)
+      .map(index => s"sha2(concat(cast(id as string), ':$index'), 256)")
+      .mkString("concat(", ",", ")")
+    val dataframe = adaptiveSpark.range(0L, 40000L, 1L, partitionCount)
+      .select((col("id") % 20000).as("key"), expr(payloadExpression).as("payload"))
+      .groupBy("key")
+      .agg(first("payload").as("payload"))
+
+    val expected = dataframe.rdd
+      .mapPartitionsWithIndex { case (index, rows) => Iterator(index -> rows.size.toLong) }
+      .collect()
+      .sortBy(_._1)
+      .map(_._2)
+    val projected = dataframe.select(lit(0)).rdd
+      .mapPartitions(rows => Iterator(rows.size.toLong))
+      .collect()
+    val actual = ClusterUtil.getNumRowsPerPartition(dataframe, lit(0))
+
+    assert(projected.length < expected.length,
+      s"Fixture must expose adaptive coalescing: ${projected.length} projected vs ${expected.length} actual")
+    assert(actual.sameElements(expected),
+      s"Expected partition counts ${expected.mkString(",")}, got ${actual.mkString(",")}")
   }
 }


### PR DESCRIPTION
## Summary

Fix per-partition row counting so it preserves the exact partition topology used by downstream LightGBM training tasks.

Fixes #2278.

This replaces only the proven intent behind #2282; it does not reuse that PR's corrupted diff or modify the old PR.

## Root cause and primary failure

`ClusterUtil.getNumRowsPerPartition` counted a separate `df.select(lit(0))` query. With adaptive execution enabled, Spark can coalesce that cheap projected query differently from the real training DataFrame.

A current-master AQE fixture produced:

- real DataFrame: 20 partitions
- projected counting query: 4 partitions
- real task IDs indexing the shortened array: primary `ArrayIndexOutOfBoundsException`, including `Index 18 out of bounds for length 4`

That is the same partition-ID-shaped failure reported in #2278. Once a worker dies on this index access, the remaining LightGBM workers report secondary connection failures.

## Change

Count on the original DataFrame RDD rather than constructing a separately optimized literal projection. This intentionally trades projection pruning for the required topology correctness.

The regression test:

1. creates a 20-partition shuffle whose full rows remain above AQE's coalescing target;
2. proves the old literal projection coalesces to fewer partitions; and
3. verifies returned counts exactly match every real DataFrame partition.

## Separately investigated hypotheses

- **Feature width:** malformed short dense rows can independently fail in `SampledData.pushRow`, but no evidence ties inconsistent feature widths to #2278, so no unrelated validation change is included.
- **Barrier/network startup:** the existing barrier `TrainValidationSplit` test passes; connection errors follow the primary task failure rather than precede it.
- **Native pointer lifecycle:** the 300-iteration custom-objective path remains functional. The cleanup proposed in #2282 cannot explain a partition-index exception, and no stable native-memory regression was established, so it is not included.

## Validation

- `core/testOnly com.microsoft.azure.synapse.ml.core.utils.VerifyClusterUtil`
- `core/compile`, `core/Test/compile`
- `core/scalastyle`, `core/Test/scalastyle`
- `lightgbm/Test/compile`
- `lightgbm/scalastyle`, `lightgbm/Test/scalastyle`
- LightGBM streaming barrier `TrainValidationSplit` test
- LightGBM streaming custom-loss test (300 iterations)

## Review

- No public method signatures changed.
- No serialization, authentication, network, file, or secret-handling behavior changed.
- The test uses an isolated Spark session and adds no external service dependency.