### PR TITLE
fix: reserve LightGBM worker ports until network init

### DIFF
--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/BasePartitionTask.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/BasePartitionTask.scala
@@ -131,7 +131,7 @@ abstract class BasePartitionTask extends Serializable with Logging {
     // Start with initialization
     val taskCtx = initialize(ctx, inputRows)
 
-    try {
+    NetworkManager.withCleanupPreservingPrimary(taskCtx.networkTopologyInfo.releasePortReservation()) {
       if (taskCtx.isEmptyPartition) {
         log.warn("LightGBM task encountered empty partition, for best performance ensure no partitions are empty")
         Array { PartitionResult(None, taskCtx.measures) }.toIterator
@@ -161,8 +161,6 @@ abstract class BasePartitionTask extends Serializable with Logging {
           cleanup(taskCtx)
         }
       }
-    } finally {
-      taskCtx.networkTopologyInfo.releasePortReservation()
     }
   }
 
@@ -201,8 +199,7 @@ abstract class BasePartitionTask extends Serializable with Logging {
                                                           shouldExecuteTraining,
                                                           taskMeasures)
 
-    var initializationSucceeded = false
-    try {
+    NetworkManager.withCleanupOnFailurePreservingPrimary(networkInfo.releasePortReservation()) {
       // Return booster only from main worker to reduce network communication overhead
       val shouldReturnBooster = if (isEmptyPartition) false
         else if (!shouldExecuteTraining) false
@@ -220,10 +217,7 @@ abstract class BasePartitionTask extends Serializable with Logging {
       if (ctx.trainingParams.generalParams.verbosity > 1)
         log.info(s"Done initializing partition: $partitionId, taskId: $taskId, executor: $getExecutorId")
       taskMeasures.markInitializationStop()
-      initializationSucceeded = true
       taskCtx
-    } finally {
-      if (!initializationSucceeded) networkInfo.releasePortReservation()
     }
   }
 

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/BasePartitionTask.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/BasePartitionTask.scala
@@ -131,33 +131,38 @@ abstract class BasePartitionTask extends Serializable with Logging {
     // Start with initialization
     val taskCtx = initialize(ctx, inputRows)
 
-    if (taskCtx.isEmptyPartition) {
-      log.warn("LightGBM task encountered empty partition, for best performance ensure no partitions are empty")
-      Array { PartitionResult(None, taskCtx.measures) }.toIterator
-    } else {
-      // Perform any data preparation work
-      val dataIntermediateState = preparePartitionData(taskCtx, inputRows)
+    try {
+      if (taskCtx.isEmptyPartition) {
+        log.warn("LightGBM task encountered empty partition, for best performance ensure no partitions are empty")
+        Array { PartitionResult(None, taskCtx.measures) }.toIterator
+      } else {
+        // Perform any data preparation work
+        val dataIntermediateState = preparePartitionData(taskCtx, inputRows)
 
-      try {
-        if (taskCtx.shouldExecuteTraining) {
-          // If participating in training, initialize the network ring of communication
-          NetworkManager.initLightGBMNetwork(taskCtx, log)
+        try {
+          if (taskCtx.shouldExecuteTraining) {
+            // If participating in training, initialize the network ring of communication
+            NetworkManager.initLightGBMNetwork(taskCtx, log)
 
-          if (ctx.useSingleDatasetMode) {
-            log.info(s"Waiting for all data prep to be done, task ${taskCtx.taskId}, partition ${taskCtx.partitionId}")
-            ctx.sharedState().dataPreparationDoneSignal.await()
+            if (ctx.useSingleDatasetMode) {
+              log.info(s"Waiting for all data prep to be done, task ${taskCtx.taskId}, " +
+                s"partition ${taskCtx.partitionId}")
+              ctx.sharedState().dataPreparationDoneSignal.await()
+            }
+
+            // Create the final Dataset for training and execute training iterations
+            finalizeDatasetAndTrain(taskCtx, dataIntermediateState)
+          } else {
+            log.info(s"Helper task ${taskCtx.taskId}, partition ${taskCtx.partitionId} finished processing rows")
+            ctx.sharedState().dataPreparationDoneSignal.countDown()
+            Array { PartitionResult(None, taskCtx.measures) }.toIterator
           }
-
-          // Create the final Dataset for training and execute training iterations
-          finalizeDatasetAndTrain(taskCtx, dataIntermediateState)
-        } else {
-          log.info(s"Helper task ${taskCtx.taskId}, partition ${taskCtx.partitionId} finished processing rows")
-          ctx.sharedState().dataPreparationDoneSignal.countDown()
-          Array { PartitionResult(None, taskCtx.measures) }.toIterator
+        } finally {
+          cleanup(taskCtx)
         }
-      } finally {
-        cleanup(taskCtx)
       }
+    } finally {
+      taskCtx.networkTopologyInfo.releasePortReservation()
     }
   }
 
@@ -196,24 +201,30 @@ abstract class BasePartitionTask extends Serializable with Logging {
                                                           shouldExecuteTraining,
                                                           taskMeasures)
 
-    // Return booster only from main worker to reduce network communication overhead
-    val shouldReturnBooster = if (isEmptyPartition) false
-      else if (!shouldExecuteTraining) false
-      else networkInfo.localListenPort == NetworkManager.getMainWorkerPort(networkInfo.lightgbmNetworkString, log)
+    var initializationSucceeded = false
+    try {
+      // Return booster only from main worker to reduce network communication overhead
+      val shouldReturnBooster = if (isEmptyPartition) false
+        else if (!shouldExecuteTraining) false
+        else networkInfo.localListenPort == NetworkManager.getMainWorkerPort(networkInfo.lightgbmNetworkString, log)
 
-    val taskCtx = getTaskContext(ctx,
-                                 partitionId,
-                                 taskId,
-                                 taskMeasures,
-                                 networkInfo,
-                                 shouldExecuteTraining,
-                                 isEmptyPartition,
-                                 shouldReturnBooster)
+      val taskCtx = getTaskContext(ctx,
+                                   partitionId,
+                                   taskId,
+                                   taskMeasures,
+                                   networkInfo,
+                                   shouldExecuteTraining,
+                                   isEmptyPartition,
+                                   shouldReturnBooster)
 
-    if (ctx.trainingParams.generalParams.verbosity > 1)
-      log.info(s"Done initializing partition: $partitionId, taskId: $taskId, executor: $getExecutorId")
-    taskMeasures.markInitializationStop()
-    taskCtx
+      if (ctx.trainingParams.generalParams.verbosity > 1)
+        log.info(s"Done initializing partition: $partitionId, taskId: $taskId, executor: $getExecutorId")
+      taskMeasures.markInitializationStop()
+      initializationSucceeded = true
+      taskCtx
+    } finally {
+      if (!initializationSucceeded) networkInfo.releasePortReservation()
+    }
   }
 
   /**

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
@@ -12,8 +12,8 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.slf4j.Logger
 
-import java.io.{BufferedReader, BufferedWriter, IOException, InputStreamReader, OutputStreamWriter}
-import java.net.{InetSocketAddress, ServerSocket, Socket}
+import java.io.{BufferedReader, BufferedWriter, InputStreamReader, OutputStreamWriter}
+import java.net.{BindException, InetSocketAddress, ServerSocket, Socket}
 import java.util.concurrent.Executors
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -39,7 +39,32 @@ case class TaskMessageInfo(status: String,
 
 case class NetworkTopologyInfo(lightgbmNetworkString: String,
                                executorPartitionIdList: Array[Int],
-                               localListenPort: Int)
+                               localListenPort: Int) {
+  @transient private var portReservation: Option[Socket] = None
+
+  private def currentPortReservation: Option[Socket] = Option(portReservation).flatten
+
+  private[lightgbm] def retainPortReservation(reservation: Socket): NetworkTopologyInfo = synchronized {
+    require(!reservation.isClosed, "Cannot retain a closed port reservation")
+    require(reservation.isBound, "Cannot retain an unbound port reservation")
+    require(reservation.getLocalPort == localListenPort,
+      s"Port reservation ${reservation.getLocalPort} does not match topology port $localListenPort")
+    require(currentPortReservation.isEmpty, s"Port $localListenPort already has a reservation")
+    portReservation = Option(reservation)
+    this
+  }
+
+  /** Release the temporary JVM reservation immediately before LightGBM binds the same port.
+    *
+    * The operation is idempotent so final cleanup can safely call it after any success or failure path.
+    */
+  private[lightgbm] def releasePortReservation(): Unit = synchronized {
+    currentPortReservation.foreach { reservation =>
+      reservation.close()
+      portReservation = None
+    }
+  }
+}
 
 object NetworkManager {
   /**
@@ -87,9 +112,8 @@ object NetworkManager {
     *
     * Establish local socket connection.
     *
-    * Note: Ideally we would start the socket connections in the C layer, this opens us up for
-    * race conditions in case other applications open sockets on cluster, but usually this
-    * should not be a problem
+    * The JVM reserves the selected port until immediately before LightGBM binds it in the C layer,
+    * limiting competition to the unavoidable handoff between the two socket implementations.
     *
     * @param ctx Information about the current training session.
     * @param log The Logger.
@@ -107,21 +131,24 @@ object NetworkManager {
                            measures: TaskInstrumentationMeasures): NetworkTopologyInfo = {
     measures.markNetworkInitializationStart()
     val networkParams = ctx.networkParams
-    val out = using(findOpenPort(ctx, log).get) {
-      openPort =>
-        val localListenPort = openPort.getLocalPort
-        log.info(s"LightGBM task $taskId connecting to host: ${networkParams.ipAddress}, port: ${networkParams.port}")
-        FaultToleranceUtils.retryWithTimeout() {
-          getNetworkTopologyInfoFromDriver(networkParams,
-                                           taskId,
-                                           partitionId,
-                                           localListenPort,
-                                           log,
-                                           shouldExecuteTraining)
-        }
-    }.get
-    measures.markNetworkInitializationStop()
-    out
+    try {
+      val reservation = findOpenPort(ctx, log)
+      withPortReservation(reservation, shouldExecuteTraining) {
+        localListenPort =>
+          log.info(s"LightGBM task $taskId connecting to host: " +
+            s"${networkParams.ipAddress}, port: ${networkParams.port}")
+          FaultToleranceUtils.retryWithTimeout() {
+            getNetworkTopologyInfoFromDriver(networkParams,
+                                             taskId,
+                                             partitionId,
+                                             localListenPort,
+                                             log,
+                                             shouldExecuteTraining)
+          }
+      }
+    } finally {
+      measures.markNetworkInitializationStop()
+    }
   }
 
   private def getNetworkTopologyInfoFromDriver(networkParams: NetworkParams,
@@ -197,6 +224,7 @@ object NetworkManager {
                           retry: Int = LightGBMConstants.NetworkRetries,
                           delay: Long = LightGBMConstants.InitialDelay): Unit = {
     log.info(s"Calling NetworkInit on local port ${ctx.localListenPort} with value ${ctx.lightGBMNetworkString}")
+    ctx.networkTopologyInfo.releasePortReservation()
     try {
       LightGBMUtils.validate(lightgbmlib.LGBM_NetworkInit(
         ctx.lightGBMNetworkString,
@@ -205,7 +233,7 @@ object NetworkManager {
         ctx.lightGBMNetworkMachineCount), "Network init")
       log.info(s"NetworkInit succeeded. LightGBM task listening on: ${ctx.localListenPort}")
     } catch {
-      case ex@(_: Exception | _: Throwable) =>
+      case ex: Exception =>
         log.info(s"NetworkInit failed with exception on local port ${ctx.localListenPort} with exception: $ex")
         Thread.sleep(delay)
         if (retry == 0) {
@@ -238,36 +266,77 @@ object NetworkManager {
     mainPort.toInt
   }
 
-  private def findOpenPort(ctx: TrainingContext, log: Logger): Option[Socket] = {
+  private def findOpenPort(ctx: TrainingContext, log: Logger): Socket = {
     val defaultListenPort: Int = ctx.networkParams.defaultListenPort
     val basePort = defaultListenPort + (LightGBMUtils.getWorkerId * ctx.numTasksPerExecutor)
-    if (basePort > LightGBMConstants.MaxPort) {
+    reserveOpenPort(basePort, log)
+  }
+
+  /** Reserve the first available port at or above basePort.
+    *
+    * Only address-in-use failures advance to another port. Other failures propagate after the candidate
+    * socket is closed, rather than silently falling back to a different port.
+    */
+  private[lightgbm] def reserveOpenPort(basePort: Int, log: Logger): Socket = {
+    reserveOpenPort(basePort, log, () => new Socket())
+  }
+
+  private[lightgbm] def reserveOpenPort(basePort: Int,
+                                        log: Logger,
+                                        createSocket: () => Socket): Socket = {
+    if (basePort < 0 || basePort > LightGBMConstants.MaxPort) {
       throw new Exception(s"Error: port $basePort out of range, possibly due to too many executors or unknown error")
     }
-    var localListenPort = basePort
-    var taskServerSocket: Option[Socket] = None
 
     @tailrec
-    def findPort(): Unit = {
-      try {
-        taskServerSocket = Option(new Socket())
-        taskServerSocket.get.bind(new InetSocketAddress(localListenPort))
+    def reservePort(localListenPort: Int): Socket = {
+      val candidate = createSocket()
+      var isReserved = false
+      val bindSucceeded = try {
+        candidate.bind(new InetSocketAddress(localListenPort))
+        isReserved = true
+        true
       } catch {
-        case _: IOException =>
+        case _: BindException =>
           log.warn(s"Could not bind to port $localListenPort...")
-          localListenPort += 1
-          if (localListenPort > LightGBMConstants.MaxPort) {
-            throw new Exception(s"Error: port $basePort out of range, possibly due to networking or firewall issues")
-          }
-          if (localListenPort - basePort > 1000) {
-            throw new Exception("Error: Could not find open port after 1k tries")
-          }
-          findPort()
+          false
+      } finally {
+        if (!isReserved) candidate.close()
+      }
+
+      if (bindSucceeded) {
+        log.info(s"Successfully bound to port $localListenPort")
+        candidate
+      } else {
+        val nextPort = localListenPort + 1
+        if (nextPort > LightGBMConstants.MaxPort) {
+          throw new Exception(s"Error: port $basePort out of range, possibly due to networking or firewall issues")
+        }
+        if (nextPort - basePort > 1000) {
+          throw new Exception("Error: Could not find open port after 1k tries")
+        }
+        reservePort(nextPort)
       }
     }
-    findPort()
-    log.info(s"Successfully bound to port $localListenPort")
-    taskServerSocket
+
+    reservePort(basePort)
+  }
+
+  /** Keep a training task's port reserved, while releasing helper and failed-task reservations immediately. */
+  private[lightgbm] def withPortReservation(reservation: Socket,
+                                            shouldExecuteTraining: Boolean)
+                                           (getTopology: Int => NetworkTopologyInfo): NetworkTopologyInfo = {
+    var retained = false
+    try {
+      val topology = getTopology(reservation.getLocalPort)
+      if (shouldExecuteTraining) {
+        topology.retainPortReservation(reservation)
+        retained = true
+      }
+      topology
+    } finally {
+      if (!retained) reservation.close()
+    }
   }
 
   private def setFinishedStatus(networkParams: NetworkParams, log: Logger): Unit = {

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
@@ -12,7 +12,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.slf4j.Logger
 
-import java.io.{BufferedReader, BufferedWriter, InputStreamReader, OutputStreamWriter}
+import java.io.{BufferedReader, BufferedWriter, IOException, InputStreamReader, OutputStreamWriter}
 import java.net.{BindException, InetSocketAddress, ServerSocket, Socket}
 import java.util.concurrent.Executors
 import scala.annotation.tailrec
@@ -60,13 +60,82 @@ case class NetworkTopologyInfo(lightgbmNetworkString: String,
     */
   private[lightgbm] def releasePortReservation(): Unit = synchronized {
     currentPortReservation.foreach { reservation =>
-      reservation.close()
-      portReservation = None
+      try {
+        NetworkManager.closeSocketWithRetry(reservation)
+      } finally {
+        // Keep an open socket reachable for a later final-cleanup attempt.
+        if (reservation.isClosed) portReservation = None
+      }
     }
   }
 }
 
 object NetworkManager {
+  private val MaxSocketCloseAttempts = 2
+
+  private def addSuppressed(primaryFailure: Throwable, secondaryFailure: Throwable): Unit = {
+    if (primaryFailure ne secondaryFailure) primaryFailure.addSuppressed(secondaryFailure)
+  }
+
+  /** Close a socket with one immediate retry, retaining every observed cleanup failure. */
+  private[lightgbm] def closeSocketWithRetry(socket: Socket): Unit = {
+    @tailrec
+    def attemptClose(attemptsRemaining: Int,
+                     firstFailure: Option[IOException]): Option[IOException] = {
+      if (socket.isClosed || attemptsRemaining == 0) {
+        firstFailure
+      } else {
+        val updatedFailure = try {
+          socket.close()
+          firstFailure
+        } catch {
+          case failure: IOException =>
+            firstFailure.foreach(existing => addSuppressed(existing, failure))
+            firstFailure.orElse(Option(failure))
+        }
+        attemptClose(attemptsRemaining - 1, updatedFailure)
+      }
+    }
+
+    val closeFailure = attemptClose(MaxSocketCloseAttempts, None).orElse {
+      if (socket.isClosed) None else Option(new IOException("Socket remained open after cleanup attempts"))
+    }
+    closeFailure.foreach(throw _)
+  }
+
+  /** Run cleanup without allowing it to replace a failure from the protected operation.
+    *
+    * The Throwable catch is deliberately limited to recording and immediately rethrowing the original
+    * failure; it is not a fallback or recovery boundary.
+    */
+  private[lightgbm] def withCleanupPreservingPrimary[T](cleanup: => Unit)(operation: => T): T = {
+    var primaryFailure: Option[Throwable] = None
+    try {
+      operation
+    } catch {
+      case failure: Throwable =>
+        primaryFailure = Option(failure)
+        throw failure
+    } finally {
+      try {
+        cleanup
+      } catch {
+        case cleanupFailure: Throwable if primaryFailure.isDefined =>
+          addSuppressed(primaryFailure.get, cleanupFailure)
+      }
+    }
+  }
+
+  /** Run cleanup only when the protected operation fails, preserving that primary failure. */
+  private[lightgbm] def withCleanupOnFailurePreservingPrimary[T]
+      (cleanup: => Unit)(operation: => T): T = {
+    var completed = false
+    withCleanupPreservingPrimary(if (!completed) cleanup) {
+      val result = operation
+      completed = true
+      result
+    }
+  }
   /**
     * Create a NetworkManager, which will encapsulate all network operations.
     * This method will opens a socket communications channel on the driver, and then initialize
@@ -223,25 +292,73 @@ object NetworkManager {
                           log: Logger,
                           retry: Int = LightGBMConstants.NetworkRetries,
                           delay: Long = LightGBMConstants.InitialDelay): Unit = {
-    log.info(s"Calling NetworkInit on local port ${ctx.localListenPort} with value ${ctx.lightGBMNetworkString}")
-    ctx.networkTopologyInfo.releasePortReservation()
-    try {
-      LightGBMUtils.validate(lightgbmlib.LGBM_NetworkInit(
+    initLightGBMNetworkWithRetry(
+      ctx.networkTopologyInfo,
+      log,
+      retry,
+      delay,
+      () => LightGBMUtils.validate(lightgbmlib.LGBM_NetworkInit(
         ctx.lightGBMNetworkString,
         ctx.localListenPort,
         LightGBMConstants.DefaultListenTimeout,
-        ctx.lightGBMNetworkMachineCount), "Network init")
-      log.info(s"NetworkInit succeeded. LightGBM task listening on: ${ctx.localListenPort}")
+        ctx.lightGBMNetworkMachineCount), "Network init"),
+      port => reserveExactPort(port, log),
+      delayMillis => Thread.sleep(delayMillis))
+  }
+
+  /** Retry native network initialization without leaving the advertised port open during backoff. */
+  private[lightgbm] def initLightGBMNetworkWithRetry(networkTopologyInfo: NetworkTopologyInfo,
+                                                     log: Logger,
+                                                     retry: Int,
+                                                     delay: Long,
+                                                     networkInit: () => Unit,
+                                                     reservePort: Int => Socket,
+                                                     sleep: Long => Unit): Unit = {
+    val localListenPort = networkTopologyInfo.localListenPort
+    log.info(s"Calling NetworkInit on local port $localListenPort " +
+      s"with value ${networkTopologyInfo.lightgbmNetworkString}")
+    networkTopologyInfo.releasePortReservation()
+    val nativeFailure = try {
+      networkInit()
+      None
     } catch {
-      case ex: Exception =>
-        log.info(s"NetworkInit failed with exception on local port ${ctx.localListenPort} with exception: $ex")
-        Thread.sleep(delay)
+      case failure: Exception => Option(failure)
+    }
+
+    nativeFailure match {
+      case None =>
+        log.info(s"NetworkInit succeeded. LightGBM task listening on: $localListenPort")
+      case Some(failure) =>
+        log.info(s"NetworkInit failed with exception on local port $localListenPort " +
+          s"with exception: $failure")
         if (retry == 0) {
-          log.info(s"NetworkInit reached maximum exceptions on retry: $ex")
-          throw ex
+          log.info(s"NetworkInit reached maximum exceptions on retry: $failure")
+          throw failure
         }
-        log.info(s"Retrying NetworkInit with local port ${ctx.localListenPort}")
-        initLightGBMNetwork(ctx, log, retry - 1, delay * 2)
+
+        // Every peer already knows this port, so changing it would corrupt the negotiated topology.
+        // If exact re-reservation loses the handoff race, fail the task and let Spark renegotiate.
+        try {
+          val retryReservation = reservePort(localListenPort)
+          withPortReservation(retryReservation, shouldExecuteTraining = true) { _ =>
+            networkTopologyInfo
+          }
+        } catch {
+          case reservationFailure: Exception =>
+            addSuppressed(failure, reservationFailure)
+            throw failure
+        }
+
+        log.info(s"Retrying NetworkInit with local port $localListenPort")
+        sleep(delay)
+        initLightGBMNetworkWithRetry(
+          networkTopologyInfo,
+          log,
+          retry - 1,
+          delay * 2,
+          networkInit,
+          reservePort,
+          sleep)
     }
   }
 
@@ -284,42 +401,57 @@ object NetworkManager {
   private[lightgbm] def reserveOpenPort(basePort: Int,
                                         log: Logger,
                                         createSocket: () => Socket): Socket = {
-    if (basePort < 0 || basePort > LightGBMConstants.MaxPort) {
-      throw new Exception(s"Error: port $basePort out of range, possibly due to too many executors or unknown error")
-    }
+    validatePort(basePort)
 
     @tailrec
     def reservePort(localListenPort: Int): Socket = {
-      val candidate = createSocket()
-      var isReserved = false
-      val bindSucceeded = try {
-        candidate.bind(new InetSocketAddress(localListenPort))
-        isReserved = true
-        true
+      val bindResult: Either[BindException, Socket] = try {
+        Right(reserveExactPort(localListenPort, log, createSocket))
       } catch {
-        case _: BindException =>
-          log.warn(s"Could not bind to port $localListenPort...")
-          false
-      } finally {
-        if (!isReserved) candidate.close()
+        // A suppressed exception means candidate cleanup failed, so proceeding would leak a socket.
+        case contention: BindException if contention.getSuppressed.isEmpty => Left(contention)
       }
 
-      if (bindSucceeded) {
-        log.info(s"Successfully bound to port $localListenPort")
-        candidate
-      } else {
-        val nextPort = localListenPort + 1
-        if (nextPort > LightGBMConstants.MaxPort) {
-          throw new Exception(s"Error: port $basePort out of range, possibly due to networking or firewall issues")
-        }
-        if (nextPort - basePort > 1000) {
-          throw new Exception("Error: Could not find open port after 1k tries")
-        }
-        reservePort(nextPort)
+      bindResult match {
+        case Right(reservation) => reservation
+        case Left(_) =>
+          log.warn(s"Could not bind to port $localListenPort...")
+          val nextPort = localListenPort + 1
+          if (nextPort > LightGBMConstants.MaxPort) {
+            throw new Exception(s"Error: port $basePort out of range, " +
+              "possibly due to networking or firewall issues")
+          }
+          if (nextPort - basePort > 1000) {
+            throw new Exception("Error: Could not find open port after 1k tries")
+          }
+          reservePort(nextPort)
       }
     }
 
     reservePort(basePort)
+  }
+
+  /** Reserve one exact port. Native-init retries cannot change the previously advertised port. */
+  private[lightgbm] def reserveExactPort(localListenPort: Int, log: Logger): Socket = {
+    reserveExactPort(localListenPort, log, () => new Socket())
+  }
+
+  private def reserveExactPort(localListenPort: Int,
+                               log: Logger,
+                               createSocket: () => Socket): Socket = {
+    validatePort(localListenPort)
+    val candidate = createSocket()
+    withCleanupOnFailurePreservingPrimary(closeSocketWithRetry(candidate)) {
+      candidate.bind(new InetSocketAddress(localListenPort))
+      log.info(s"Successfully bound to port $localListenPort")
+      candidate
+    }
+  }
+
+  private def validatePort(port: Int): Unit = {
+    if (port < 0 || port > LightGBMConstants.MaxPort) {
+      throw new Exception(s"Error: port $port out of range, possibly due to too many executors or unknown error")
+    }
   }
 
   /** Keep a training task's port reserved, while releasing helper and failed-task reservations immediately. */
@@ -327,15 +459,13 @@ object NetworkManager {
                                             shouldExecuteTraining: Boolean)
                                            (getTopology: Int => NetworkTopologyInfo): NetworkTopologyInfo = {
     var retained = false
-    try {
+    withCleanupPreservingPrimary(if (!retained) closeSocketWithRetry(reservation)) {
       val topology = getTopology(reservation.getLocalPort)
       if (shouldExecuteTraining) {
         topology.retainPortReservation(reservation)
         retained = true
       }
       topology
-    } finally {
-      if (!retained) reservation.close()
     }
   }
 

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
@@ -44,6 +44,10 @@ case class NetworkTopologyInfo(lightgbmNetworkString: String,
 
   private def currentPortReservation: Option[Socket] = Option(portReservation).flatten
 
+  private[lightgbm] def hasPortReservation: Boolean = synchronized {
+    currentPortReservation.nonEmpty
+  }
+
   private[lightgbm] def retainPortReservation(reservation: Socket): NetworkTopologyInfo = synchronized {
     require(!reservation.isClosed, "Cannot retain a closed port reservation")
     require(reservation.isBound, "Cannot retain an unbound port reservation")
@@ -314,10 +318,29 @@ object NetworkManager {
                                                      networkInit: () => Unit,
                                                      reservePort: Int => Socket,
                                                      sleep: Long => Unit): Unit = {
+    initLightGBMNetworkWithRetry(
+      networkTopologyInfo,
+      log,
+      retry,
+      delay,
+      networkInit,
+      reservePort,
+      sleep,
+      None)
+  }
+
+  private def initLightGBMNetworkWithRetry(networkTopologyInfo: NetworkTopologyInfo,
+                                           log: Logger,
+                                           retry: Int,
+                                           delay: Long,
+                                           networkInit: () => Unit,
+                                           reservePort: Int => Socket,
+                                           sleep: Long => Unit,
+                                           previousNativeFailure: Option[Exception]): Unit = {
     val localListenPort = networkTopologyInfo.localListenPort
     log.info(s"Calling NetworkInit on local port $localListenPort " +
       s"with value ${networkTopologyInfo.lightgbmNetworkString}")
-    networkTopologyInfo.releasePortReservation()
+    releasePortReservationForNetworkInit(networkTopologyInfo, previousNativeFailure, log)
     val nativeFailure = try {
       networkInit()
       None
@@ -358,7 +381,28 @@ object NetworkManager {
           delay * 2,
           networkInit,
           reservePort,
-          sleep)
+          sleep,
+          Option(failure))
+    }
+  }
+
+  private def releasePortReservationForNetworkInit(networkTopologyInfo: NetworkTopologyInfo,
+                                                    previousNativeFailure: Option[Exception],
+                                                    log: Logger): Unit = {
+    try {
+      networkTopologyInfo.releasePortReservation()
+    } catch {
+      case releaseFailure: IOException =>
+        previousNativeFailure match {
+          case Some(nativeFailure) =>
+            addSuppressed(nativeFailure, releaseFailure)
+            if (networkTopologyInfo.hasPortReservation) {
+              throw nativeFailure
+            }
+            log.warn("Port reservation close reported a failure but ultimately closed; " +
+              "continuing the native network-init retry", releaseFailure)
+          case None => throw releaseFailure
+        }
     }
   }
 

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/NetworkManagerSuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/NetworkManagerSuite.scala
@@ -1,0 +1,199 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm.split1
+
+import com.microsoft.azure.synapse.ml.lightgbm.{NetworkManager, NetworkTopologyInfo}
+import org.scalatest.funsuite.AnyFunSuite
+import org.slf4j.LoggerFactory
+
+import java.io.IOException
+import java.net.{BindException, InetSocketAddress, ServerSocket, Socket, SocketAddress, SocketException}
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, Executors, TimeUnit}
+import scala.collection.JavaConverters.collectionAsScalaIterableConverter
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+
+class NetworkManagerSuite extends AnyFunSuite {
+
+  private val log = LoggerFactory.getLogger(classOf[NetworkManagerSuite])
+
+  private def bindEphemeralSocket(): Socket = {
+    val socket = new Socket()
+    socket.bind(new InetSocketAddress(0))
+    socket
+  }
+
+  private def assertPortAvailable(port: Int): Unit = {
+    val socket = new ServerSocket()
+    try {
+      socket.bind(new InetSocketAddress(port))
+      assert(socket.isBound)
+    } finally {
+      socket.close()
+    }
+  }
+
+  test("Port reservation skips a competing socket and holds its port until network initialization") {
+    val competitor = bindEphemeralSocket()
+    val reservation = NetworkManager.reserveOpenPort(competitor.getLocalPort, log)
+    val reservedPort = reservation.getLocalPort
+
+    try {
+      assert(reservedPort != competitor.getLocalPort)
+      val topology = NetworkManager.withPortReservation(reservation, shouldExecuteTraining = true) { port =>
+        NetworkTopologyInfo(s"localhost:$port", Array(0), port)
+      }
+
+      assert(!reservation.isClosed)
+      val challenger = new ServerSocket()
+      try {
+        assertThrows[BindException] {
+          challenger.bind(new InetSocketAddress(reservedPort))
+        }
+      } finally {
+        challenger.close()
+      }
+
+      topology.releasePortReservation()
+      topology.releasePortReservation()
+      assert(reservation.isClosed)
+    } finally {
+      if (!reservation.isClosed) reservation.close()
+      competitor.close()
+    }
+
+    assertPortAvailable(reservedPort)
+  }
+
+  test("Helper and failed topology paths release their port reservations") {
+    val helperReservation = bindEphemeralSocket()
+    val helperPort = helperReservation.getLocalPort
+    try {
+      NetworkManager.withPortReservation(helperReservation, shouldExecuteTraining = false) { port =>
+        NetworkTopologyInfo("", Array.empty[Int], port)
+      }
+      assert(helperReservation.isClosed)
+    } finally {
+      if (!helperReservation.isClosed) helperReservation.close()
+    }
+    assertPortAvailable(helperPort)
+
+    val failedReservation = bindEphemeralSocket()
+    val failedPort = failedReservation.getLocalPort
+    val expected = new IOException("topology lookup failed")
+    try {
+      val actual = intercept[IOException] {
+        NetworkManager.withPortReservation(failedReservation, shouldExecuteTraining = true) { _ =>
+          throw expected
+        }
+      }
+      assert(actual eq expected)
+      assert(failedReservation.isClosed)
+    } finally {
+      if (!failedReservation.isClosed) failedReservation.close()
+    }
+    assertPortAvailable(failedPort)
+  }
+
+  test("Non-contention bind failures propagate after closing the candidate socket") {
+    val expected = new SocketException("network configuration failure")
+    val candidate = new Socket() {
+      override def bind(bindpoint: SocketAddress): Unit = throw expected
+    }
+
+    try {
+      val actual = intercept[SocketException] {
+        NetworkManager.reserveOpenPort(12345, log, () => candidate)
+      }
+      assert(actual eq expected)
+      assert(candidate.isClosed)
+    } finally {
+      if (!candidate.isClosed) candidate.close()
+    }
+  }
+
+  test("A failed reservation close remains retryable during final cleanup") {
+    val expected = new IOException("temporary close failure")
+    var closeAttempts = 0
+    val reservation = new Socket() {
+      override def close(): Unit = {
+        closeAttempts += 1
+        if (closeAttempts == 1) throw expected
+        super.close()
+      }
+    }
+    reservation.bind(new InetSocketAddress(0))
+    val topology = NetworkTopologyInfo("", Array.empty[Int], reservation.getLocalPort)
+      .retainPortReservation(reservation)
+
+    try {
+      val actual = intercept[IOException] {
+        topology.releasePortReservation()
+      }
+      assert(actual eq expected)
+      assert(!reservation.isClosed)
+
+      topology.releasePortReservation()
+      assert(reservation.isClosed)
+      assert(closeAttempts == 2)
+    } finally {
+      if (!reservation.isClosed) reservation.close()
+    }
+  }
+
+
+  test("Concurrent port reservations remain unique and are all reusable after cleanup") {
+    val workerCount = 6
+    val competitor = bindEphemeralSocket()
+    val start = new CountDownLatch(1)
+    val executor = Executors.newFixedThreadPool(workerCount)
+    implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutor(executor)
+    val allocated = new ConcurrentLinkedQueue[Socket]()
+
+    try {
+      val attempts = (1 to workerCount).map { _ =>
+        Future {
+          start.await()
+          Try {
+            val reservation = NetworkManager.reserveOpenPort(competitor.getLocalPort, log)
+            allocated.add(reservation)
+            reservation
+          }
+        }
+      }
+      start.countDown()
+
+      val outcomes = Await.result(Future.sequence(attempts), 30.seconds)
+      val failures = outcomes.collect { case Failure(error) => error }
+      assert(failures.isEmpty, failures.mkString(", "))
+      val reservations = outcomes.collect { case Success(reservation) => reservation }
+      val reservedPorts = reservations.map(_.getLocalPort)
+      assert(reservations.size == workerCount)
+      assert(reservedPorts.distinct.size == workerCount)
+
+      reservations.foreach { reservation =>
+        val challenger = new ServerSocket()
+        try {
+          assertThrows[BindException] {
+            challenger.bind(new InetSocketAddress(reservation.getLocalPort))
+          }
+        } finally {
+          challenger.close()
+        }
+      }
+    } finally {
+      try {
+        executor.shutdownNow()
+        executor.awaitTermination(5, TimeUnit.SECONDS)
+      } finally {
+        allocated.asScala.foreach(reservation => if (!reservation.isClosed) reservation.close())
+        competitor.close()
+      }
+    }
+
+    allocated.asScala.foreach(reservation => assertPortAvailable(reservation.getLocalPort))
+  }
+
+}

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/NetworkManagerSuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/NetworkManagerSuite.scala
@@ -273,6 +273,46 @@ class NetworkManagerSuite extends AnyFunSuite {
     }
   }
 
+  test("Native-init retry continues when its backoff reservation closes after an initial failure") {
+    val initialReservation = bindEphemeralSocket()
+    val port = initialReservation.getLocalPort
+    val topology = NetworkTopologyInfo(s"localhost:$port", Array(0), port)
+      .retainPortReservation(initialReservation)
+    val nativeFailure = new Exception("first native init failed")
+    val handoffFailure = new IOException("first handoff close failed")
+    var initCalls = 0
+    var retryReservation: Option[FailingCloseSocket] = None
+
+    try {
+      NetworkManager.initLightGBMNetworkWithRetry(
+        topology,
+        log,
+        retry = 1,
+        delay = 1L,
+        networkInit = () => {
+          initCalls += 1
+          if (initCalls == 1) throw nativeFailure
+        },
+        reservePort = retryPort => {
+          val reservation = new FailingCloseSocket(Seq(handoffFailure))
+          reservation.bind(new InetSocketAddress(retryPort))
+          retryReservation = Option(reservation)
+          reservation
+        },
+        sleep = _ => ())
+
+      assert(initCalls == 2)
+      assert(nativeFailure.getSuppressed.toSeq == Seq(handoffFailure))
+      assert(retryReservation.exists(_.closeAttempts == 2))
+      assert(retryReservation.exists(_.isClosed))
+      assertPortAvailable(port)
+    } finally {
+      topology.releasePortReservation()
+      retryReservation.foreach(reservation => if (!reservation.isClosed) reservation.close())
+      if (!initialReservation.isClosed) initialReservation.close()
+    }
+  }
+
   test("Native-init retry preserves its failure when a competitor takes the advertised port") {
     val initialReservation = bindEphemeralSocket()
     val port = initialReservation.getLocalPort

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/NetworkManagerSuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/NetworkManagerSuite.scala
@@ -19,6 +19,17 @@ class NetworkManagerSuite extends AnyFunSuite {
 
   private val log = LoggerFactory.getLogger(classOf[NetworkManagerSuite])
 
+  private class FailingCloseSocket(closeFailures: Seq[IOException]) extends Socket {
+    var closeAttempts = 0
+
+    override def close(): Unit = {
+      val attempt = closeAttempts
+      closeAttempts += 1
+      if (attempt < closeFailures.length) throw closeFailures(attempt)
+      super.close()
+    }
+  }
+
   private def bindEphemeralSocket(): Socket = {
     val socket = new Socket()
     socket.bind(new InetSocketAddress(0))
@@ -114,16 +125,31 @@ class NetworkManagerSuite extends AnyFunSuite {
     }
   }
 
-  test("A failed reservation close remains retryable during final cleanup") {
-    val expected = new IOException("temporary close failure")
-    var closeAttempts = 0
-    val reservation = new Socket() {
-      override def close(): Unit = {
-        closeAttempts += 1
-        if (closeAttempts == 1) throw expected
-        super.close()
-      }
+  test("Bind failures stay primary when candidate cleanup initially fails") {
+    val bindFailure = new SocketException("network configuration failure")
+    val cleanupFailure = new IOException("candidate close failed")
+    val candidate = new FailingCloseSocket(Seq(cleanupFailure)) {
+      override def bind(bindpoint: SocketAddress): Unit = throw bindFailure
     }
+
+    try {
+      val actual = intercept[SocketException] {
+        NetworkManager.reserveOpenPort(12345, log, () => candidate)
+      }
+
+      assert(actual eq bindFailure)
+      assert(actual.getSuppressed.toSeq == Seq(cleanupFailure))
+      assert(candidate.closeAttempts == 2)
+      assert(candidate.isClosed)
+    } finally {
+      if (!candidate.isClosed) candidate.close()
+    }
+  }
+
+  test("A failed reservation close retries before retaining the socket for final cleanup") {
+    val firstFailure = new IOException("first close failure")
+    val secondFailure = new IOException("second close failure")
+    val reservation = new FailingCloseSocket(Seq(firstFailure, secondFailure))
     reservation.bind(new InetSocketAddress(0))
     val topology = NetworkTopologyInfo("", Array.empty[Int], reservation.getLocalPort)
       .retainPortReservation(reservation)
@@ -132,17 +158,159 @@ class NetworkManagerSuite extends AnyFunSuite {
       val actual = intercept[IOException] {
         topology.releasePortReservation()
       }
-      assert(actual eq expected)
+      assert(actual eq firstFailure)
+      assert(actual.getSuppressed.toSeq == Seq(secondFailure))
       assert(!reservation.isClosed)
+      assert(reservation.closeAttempts == 2)
 
       topology.releasePortReservation()
       assert(reservation.isClosed)
-      assert(closeAttempts == 2)
+      assert(reservation.closeAttempts == 3)
     } finally {
       if (!reservation.isClosed) reservation.close()
     }
   }
 
+  test("Repeated cleanup failures are suppressed without replacing the primary failure") {
+    val primaryFailure = new IllegalStateException("partition failed")
+    val firstCleanupFailure = new IOException("first reservation close failed")
+    val secondCleanupFailure = new IOException("second reservation close failed")
+    val reservation = new FailingCloseSocket(Seq(firstCleanupFailure, secondCleanupFailure))
+    reservation.bind(new InetSocketAddress(0))
+    val topology = NetworkTopologyInfo("", Array.empty[Int], reservation.getLocalPort)
+      .retainPortReservation(reservation)
+
+    try {
+      val actual = intercept[IllegalStateException] {
+        NetworkManager.withCleanupPreservingPrimary(topology.releasePortReservation()) {
+          throw primaryFailure
+        }
+      }
+
+      assert(actual eq primaryFailure)
+      assert(actual.getSuppressed.toSeq == Seq(firstCleanupFailure))
+      assert(firstCleanupFailure.getSuppressed.toSeq == Seq(secondCleanupFailure))
+      assert(reservation.closeAttempts == 2)
+      assert(!reservation.isClosed)
+
+      topology.releasePortReservation()
+      assert(reservation.closeAttempts == 3)
+      assert(reservation.isClosed)
+    } finally {
+      if (!reservation.isClosed) reservation.close()
+    }
+  }
+
+  test("Topology lookup failure stays primary when direct reservation cleanup fails") {
+    val primaryFailure = new IllegalArgumentException("topology failed")
+    val cleanupFailure = new IOException("reservation close failed")
+    val reservation = new FailingCloseSocket(Seq(cleanupFailure))
+    reservation.bind(new InetSocketAddress(0))
+
+    try {
+      val actual = intercept[IllegalArgumentException] {
+        NetworkManager.withPortReservation(reservation, shouldExecuteTraining = true) { _ =>
+          throw primaryFailure
+        }
+      }
+
+      assert(actual eq primaryFailure)
+      assert(actual.getSuppressed.toSeq == Seq(cleanupFailure))
+      assert(reservation.closeAttempts == 2)
+      assert(reservation.isClosed)
+    } finally {
+      if (!reservation.isClosed) reservation.close()
+    }
+  }
+
+  test("Native-init retry holds the advertised port throughout backoff") {
+    val initialReservation = bindEphemeralSocket()
+    val port = initialReservation.getLocalPort
+    val topology = NetworkTopologyInfo(s"localhost:$port", Array(0), port)
+      .retainPortReservation(initialReservation)
+    val firstFailure = new Exception("first native init failed")
+    var initCalls = 0
+    var retryReservation: Option[Socket] = None
+    var observedReservedBackoff = false
+
+    try {
+      NetworkManager.initLightGBMNetworkWithRetry(
+        topology,
+        log,
+        retry = 1,
+        delay = 1L,
+        networkInit = () => {
+          initCalls += 1
+          if (initCalls == 1) throw firstFailure
+          assert(retryReservation.exists(_.isClosed))
+        },
+        reservePort = retryPort => {
+          val reservation = NetworkManager.reserveExactPort(retryPort, log)
+          retryReservation = Option(reservation)
+          reservation
+        },
+        sleep = _ => {
+          assert(retryReservation.exists(reservation => !reservation.isClosed))
+          val challenger = new ServerSocket()
+          try {
+            assertThrows[BindException] {
+              challenger.bind(new InetSocketAddress(port))
+            }
+          } finally {
+            challenger.close()
+          }
+          observedReservedBackoff = true
+        })
+
+      assert(initCalls == 2)
+      assert(observedReservedBackoff)
+      assert(retryReservation.exists(_.isClosed))
+      assertPortAvailable(port)
+    } finally {
+      topology.releasePortReservation()
+      retryReservation.foreach(reservation => if (!reservation.isClosed) reservation.close())
+      if (!initialReservation.isClosed) initialReservation.close()
+    }
+  }
+
+  test("Native-init retry preserves its failure when a competitor takes the advertised port") {
+    val initialReservation = bindEphemeralSocket()
+    val port = initialReservation.getLocalPort
+    val topology = NetworkTopologyInfo(s"localhost:$port", Array(0), port)
+      .retainPortReservation(initialReservation)
+    val nativeFailure = new Exception("native init failed")
+    var initCalls = 0
+    var competitor: Option[ServerSocket] = None
+
+    try {
+      val actual = intercept[Exception] {
+        NetworkManager.initLightGBMNetworkWithRetry(
+          topology,
+          log,
+          retry = 1,
+          delay = 1L,
+          networkInit = () => {
+            initCalls += 1
+            val competingSocket = new ServerSocket()
+            competitor = Option(competingSocket)
+            competingSocket.bind(new InetSocketAddress(port))
+            throw nativeFailure
+          },
+          reservePort = retryPort => NetworkManager.reserveExactPort(retryPort, log),
+          sleep = _ => fail("Retry backoff must not start without an exact-port reservation"))
+      }
+
+      assert(actual eq nativeFailure)
+      assert(initCalls == 1)
+      assert(actual.getSuppressed.exists(_.isInstanceOf[BindException]))
+    } finally {
+      topology.releasePortReservation()
+      competitor.foreach(socket => if (!socket.isClosed) socket.close())
+      if (!initialReservation.isClosed) initialReservation.close()
+    }
+
+    assertPortAvailable(port)
+  }
 
   test("Concurrent port reservations remain unique and are all reusable after cleanup") {
     val workerCount = 6

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/NetworkManagerSuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/NetworkManagerSuite.scala
@@ -352,6 +352,115 @@ class NetworkManagerSuite extends AnyFunSuite {
     assertPortAvailable(port)
   }
 
+  test("Native init never starts while the advertised port is still reserved") {
+    val firstFailure = new IOException("first handoff close failed")
+    val secondFailure = new IOException("second handoff close failed")
+    val reservation = new FailingCloseSocket(Seq(firstFailure, secondFailure))
+    reservation.bind(new InetSocketAddress(0))
+    val port = reservation.getLocalPort
+    val topology = NetworkTopologyInfo(s"localhost:$port", Array(0), port)
+      .retainPortReservation(reservation)
+    var initCalls = 0
+
+    try {
+      val actual = intercept[IOException] {
+        NetworkManager.initLightGBMNetworkWithRetry(
+          topology,
+          log,
+          retry = 1,
+          delay = 1L,
+          networkInit = () => initCalls += 1,
+          reservePort = _ => fail("Reservation must not be replaced before the first native init"),
+          sleep = _ => fail("Backoff must not start before the first native init"))
+      }
+
+      assert(actual eq firstFailure)
+      assert(actual.getSuppressed.toSeq == Seq(secondFailure))
+      assert(initCalls == 0)
+      assert(topology.hasPortReservation)
+    } finally {
+      topology.releasePortReservation()
+      if (!reservation.isClosed) reservation.close()
+    }
+
+    assertPortAvailable(port)
+  }
+
+  test("Native-init retry aborts with its native failure when the backoff reservation stays open") {
+    val initialReservation = bindEphemeralSocket()
+    val port = initialReservation.getLocalPort
+    val topology = NetworkTopologyInfo(s"localhost:$port", Array(0), port)
+      .retainPortReservation(initialReservation)
+    val nativeFailure = new Exception("native init failed")
+    val firstCloseFailure = new IOException("first backoff close failed")
+    val secondCloseFailure = new IOException("second backoff close failed")
+    var initCalls = 0
+    var backoffs = 0
+    var retryReservation: Option[FailingCloseSocket] = None
+
+    try {
+      val actual = intercept[Exception] {
+        NetworkManager.initLightGBMNetworkWithRetry(
+          topology,
+          log,
+          retry = 1,
+          delay = 1L,
+          networkInit = () => {
+            initCalls += 1
+            throw nativeFailure
+          },
+          reservePort = retryPort => {
+            val reservation = new FailingCloseSocket(Seq(firstCloseFailure, secondCloseFailure))
+            reservation.bind(new InetSocketAddress(retryPort))
+            retryReservation = Option(reservation)
+            reservation
+          },
+          sleep = _ => backoffs += 1)
+      }
+
+      assert(actual eq nativeFailure)
+      assert(initCalls == 1)
+      assert(backoffs == 1)
+      assert(actual.getSuppressed.toSeq == Seq(firstCloseFailure))
+      assert(retryReservation.exists(_.closeAttempts == 2))
+      assert(retryReservation.exists(reservation => !reservation.isClosed))
+      assert(topology.hasPortReservation)
+    } finally {
+      topology.releasePortReservation()
+      retryReservation.foreach(reservation => if (!reservation.isClosed) reservation.close())
+      if (!initialReservation.isClosed) initialReservation.close()
+    }
+
+    assertPortAvailable(port)
+  }
+
+  test("Port scanning gives up after exhausting its contention window") {
+    var createdSockets = 0
+    val actual = intercept[Exception] {
+      NetworkManager.reserveOpenPort(20000, log, () => {
+        createdSockets += 1
+        new Socket() {
+          override def bind(bindpoint: SocketAddress): Unit = throw new BindException("Address already in use")
+        }
+      })
+    }
+
+    assert(actual.getMessage == "Error: Could not find open port after 1k tries")
+    assert(createdSockets == 1001)
+  }
+
+  test("Out-of-range base ports are rejected before any socket is created") {
+    var createdSockets = 0
+    val factory = () => {
+      createdSockets += 1
+      new Socket()
+    }
+
+    assertThrows[Exception](NetworkManager.reserveOpenPort(-1, log, factory))
+    assertThrows[Exception](NetworkManager.reserveOpenPort(Int.MaxValue, log, factory))
+    assert(createdSockets == 0)
+  }
+
   test("Concurrent port reservations remain unique and are all reusable after cleanup") {
     val workerCount = 6
     val competitor = bindEphemeralSocket()


### PR DESCRIPTION
## Summary

- keep each JVM-selected LightGBM worker port reserved through driver topology exchange and partition data preparation
- release the reservation immediately before `LGBM_NetworkInit` binds the native listener
- treat only `BindException` as port contention; propagate configuration and cleanup failures instead of silently falling back
- clean reservations on training, helper, initialization, preparation, and failure paths while preserving the existing three-field `NetworkTopologyInfo` API
- add deterministic and concurrent regression coverage for competing listeners, helper/failure cleanup, close retries, and non-contention errors

## Why this replaces the ancient PR

This is a current-master recreation of the still-valid race fix proposed in #2233 for #2230. The original PR is based on an ancient contributor branch and retained an unresolved broad `Exception` catch around socket cleanup. This implementation was rewritten against current `NetworkManager`/`BasePartitionTask`, narrows fallback to actual bind contention, and adds the missing lifecycle and concurrency coverage. It does not close or modify the original PR.

- Original PR: #2233
- Original issue: #2230
- Unresolved review concern: https://github.com/microsoft/SynapseML/pull/2233#discussion_r1686876148

Fixes #2230

## Validation

- `lightgbm/compile`
- `lightgbm/testOnly com.microsoft.azure.synapse.ml.lightgbm.split1.NetworkManagerSuite` (5 tests)
- `lightgbm/testOnly com.microsoft.azure.synapse.ml.lightgbm.split3.VerifyLightGBMClassifierStreamBasic -- -z "PimaIndian.csv"` (2 tests; includes helper-task startup)
- `scalastyle` and `test:scalastyle` across all modules
- `black==22.3.0 --check --extend-exclude 'docs/' .`
