### PR TITLE
feat: add persisted top-K categorical lumping

### DIFF
--- a/core/src/main/python/synapse/ml/stages/LumpFeaturesModel.py
+++ b/core/src/main/python/synapse/ml/stages/LumpFeaturesModel.py
@@ -1,0 +1,29 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+import json
+import sys
+
+if sys.version >= "3":
+    basestring = str
+
+from synapse.ml.core.schema.Utils import *
+from synapse.ml.stages._LumpFeaturesModel import _LumpFeaturesModel
+
+
+@inherit_doc
+class LumpFeaturesModel(_LumpFeaturesModel):
+    def getKeptValues(self):
+        """Returns the values LumpFeatures learned to retain, per rule column.
+
+        Every value not listed here is replaced with otherValue at transform time, so this is the
+        authoritative view of what the fitted model will keep. Use it to audit a fit before scoring:
+        a column whose list is much shorter than its top-K means the frequency filters (minCount,
+        minFreq) removed the tail, and an empty list means every value gets lumped.
+
+        Returns:
+
+            dict: map from rule column name to its retained values, ordered by descending
+                frequency in the fitting data and then ascending value.
+        """
+        return json.loads(self._call_java("getKeptValuesAsJson"))

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/stages/LumpFeatures.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/stages/LumpFeatures.scala
@@ -133,7 +133,7 @@ class LumpFeatures(override val uid: String)
           .collect()
           .map(_.getString(0))
           .toList
-        (name, top.toJson.compactPrint)
+        (name, LumpFeaturesModel.encodeKept(k, top))
       }
 
       new LumpFeaturesModel(uid)
@@ -159,7 +159,52 @@ class LumpFeatures(override val uid: String)
   override def transformSchema(schema: StructType): StructType = validateAndTransformSchema(schema)
 }
 
-object LumpFeaturesModel extends DefaultParamsReadable[LumpFeaturesModel]
+object LumpFeaturesModel extends DefaultParamsReadable[LumpFeaturesModel] {
+
+  /** Encode a column fitted state as a JSON object recording both the fitted top-K and the retained
+    * values so a fitted model can later reject any incompatible lumpRules change. */
+  private[stages] def encodeKept(topK: Int, values: Seq[String]): String =
+    JsObject("topK" -> JsNumber(topK), "values" -> JsArray(values.map(JsString(_)).toVector)).compactPrint
+
+  /** Decode a column fitted state into its fitted top-K and retained values, failing clearly when the
+    * stored JSON is malformed or not the expected object shape. */
+  private[stages] def decodeKept(name: String, json: String): (Int, Seq[String]) = {
+    parseKeptJson(name, json) match {
+      case JsObject(fields) => (decodeTopK(name, json, fields), decodeValueList(name, json, fields))
+      case _ =>
+        throw new IllegalArgumentException(
+          s"keptValuesJson for column '$name' must be a JSON object with topK and values fields: '$json'.")
+    }
+  }
+
+  private def parseKeptJson(name: String, json: String): JsValue =
+    try json.parseJson
+    catch {
+      case NonFatal(e) =>
+        throw new IllegalArgumentException(s"keptValuesJson for column '$name' is not valid JSON: '$json'.", e)
+    }
+
+  private def decodeTopK(name: String, json: String, fields: Map[String, JsValue]): Int =
+    fields.get("topK") match {
+      case Some(JsNumber(n)) if n.isValidInt => n.toInt
+      case _ =>
+        throw new IllegalArgumentException(
+          s"keptValuesJson for column '$name' must contain an integer topK field: '$json'.")
+    }
+
+  private def decodeValueList(name: String, json: String, fields: Map[String, JsValue]): Seq[String] =
+    fields.get("values") match {
+      case Some(JsArray(elems)) => elems.map {
+        case JsString(v) => v
+        case other =>
+          throw new IllegalArgumentException(
+            s"keptValuesJson values for column '$name' must be strings but found: ${other.compactPrint}.")
+      }.toList
+      case _ =>
+        throw new IllegalArgumentException(
+          s"keptValuesJson for column '$name' must contain a string-array values field: '$json'.")
+    }
+}
 
 /** Model produced by [[LumpFeatures]]. Replaces, in place, every non-retained value in each rule
   * column with otherValue while retaining the learned top-K values unchanged.
@@ -172,8 +217,9 @@ class LumpFeaturesModel(override val uid: String)
 
   val keptValuesJson: StringStringMapParam = new StringStringMapParam(
     this, "keptValuesJson",
-    "Learned retained values per column, encoded as a map from column name to a JSON array of strings " +
-      "ordered by descending frequency then ascending value. Populated by LumpFeatures during fit.")
+    "Learned model-only state per column, encoded as a map from column name to a JSON object holding the " +
+      "fitted top-K (field topK) and the retained values array (field values) ordered by descending " +
+      "frequency then ascending value. Populated by LumpFeatures during fit and immutable thereafter.")
 
   def getKeptValuesJson: Map[String, String] = get(keptValuesJson).getOrElse(Map.empty)
 
@@ -183,30 +229,50 @@ class LumpFeaturesModel(override val uid: String)
     set(keptValuesJson, value.asScala.toMap)
 
   def getKeptValues: Map[String, Seq[String]] =
-    getKeptValuesJson.map { case (name, json) => (name, decodeValues(name, json)) }
+    decodedKept.map { case (name, (_, values)) => (name, values) }
 
-  private def decodeValues(name: String, json: String): Seq[String] = {
-    try {
-      json.parseJson.convertTo[List[String]]
-    } catch {
-      case NonFatal(e) =>
-        throw new IllegalArgumentException(
-          s"keptValuesJson for column '$name' is not a valid JSON array of strings: '$json'.", e)
+  private def decodedKept: Map[String, (Int, Seq[String])] =
+    getKeptValuesJson.map { case (name, json) => (name, LumpFeaturesModel.decodeKept(name, json)) }
+
+  /** The fitted top-K per column recorded at fit time; a fitted model keeps lumpRules equal to this. */
+  private def getFittedTopK: Map[String, Int] =
+    decodedKept.map { case (name, (topK, _)) => (name, topK) }
+
+  private def guardLumpRulesChange(value: Map[String, Int]): Unit = {
+    if (isDefined(keptValuesJson)) {
+      val fitted = getFittedTopK
+      require(value == fitted,
+        s"Cannot change lumpRules on a fitted LumpFeaturesModel. The model was fitted with top-K $fitted " +
+          s"but $value was requested; re-fit LumpFeatures to change the rules.")
     }
   }
+
+  override def setLumpRules(value: Map[String, Int]): this.type = {
+    guardLumpRulesChange(value)
+    set(lumpRules, value)
+  }
+
+  override def setLumpRules(value: java.util.HashMap[String, Int]): this.type =
+    setLumpRules(value.asScala.toMap)
+
+  override def setLumpRules(value: String): this.type =
+    setLumpRules(lumpRules.jsonDecode(value))
 
   protected def validateModelState(): Unit = {
     validateRules()
     val rules = getLumpRules
-    val kept = getKeptValues
+    val kept = decodedKept
     require(rules.keySet == kept.keySet,
       s"Model state is inconsistent with lumpRules: rule columns " +
         s"[${rules.keySet.toSeq.sorted.mkString(", ")}] do not match learned columns " +
         s"[${kept.keySet.toSeq.sorted.mkString(", ")}].")
     val other = getOtherValue
-    kept.foreach { case (name, values) =>
-      require(values.size <= rules(name),
-        s"Model retains ${values.size} values for column '$name' which exceeds its top-K of ${rules(name)}.")
+    kept.foreach { case (name, (topK, values)) =>
+      require(rules(name) == topK,
+        s"lumpRules top-K for column '$name' is ${rules(name)} but the model was fitted with top-K $topK. " +
+          "A fitted LumpFeaturesModel does not allow lumpRules to change after fit; re-fit to change rules.")
+      require(values.size <= topK,
+        s"Model retains ${values.size} values for column '$name' which exceeds its fitted top-K of $topK.")
       require(!values.contains(other),
         s"otherValue '$other' collides with a retained value in column '$name'. " +
           "Choose an otherValue that is not among the learned values.")
@@ -240,6 +306,9 @@ class LumpFeaturesModel(override val uid: String)
     if (declaredNullable) handled else coalesce(handled, lit(other))
   }
 
-  override def copy(extra: ParamMap): LumpFeaturesModel =
-    copyValues(new LumpFeaturesModel(uid), extra).setParent(parent)
+  override def copy(extra: ParamMap): LumpFeaturesModel = {
+    val copied = copyValues(new LumpFeaturesModel(uid), extra).setParent(parent)
+    if (copied.isDefined(copied.keptValuesJson)) copied.validateModelState()
+    copied
+  }
 }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/stages/LumpFeatures.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/stages/LumpFeatures.scala
@@ -206,7 +206,7 @@ class LumpFeatures(override val uid: String)
       val byColumn = ranked.filter(_.retained).groupBy(_.column)
       val keptJson = rules.map { case (name, k) =>
         val top = byColumn.getOrElse(name, Seq.empty).sortBy(_.rank).map(_.value).toList
-        (name, LumpFeaturesModel.encodeKept(k, top))
+        (name, LumpFeaturesModel.encodeKept(k, top, other))
       }
 
       val model = new LumpFeaturesModel(uid)
@@ -273,19 +273,45 @@ class LumpFeatures(override val uid: String)
 
 object LumpFeaturesModel extends DefaultParamsReadable[LumpFeaturesModel] {
 
-  /** Encode a column fitted state as a JSON object recording both the fitted top-K and the retained
-    * values so a fitted model can later reject any incompatible lumpRules change. */
-  private[stages] def encodeKept(topK: Int, values: Seq[String]): String =
-    JsObject("topK" -> JsNumber(topK), "values" -> JsArray(values.map(JsString(_)).toVector)).compactPrint
+  private[stages] case class KeptState(topK: Int, values: Seq[String], otherValue: Option[String])
 
-  /** Decode a column fitted state into its fitted top-K and retained values, failing clearly when the
-    * stored JSON is malformed or not the expected object shape. */
-  private[stages] def decodeKept(name: String, json: String): (Int, Seq[String]) = {
+  override def read: MLReader[LumpFeaturesModel] = {
+    val delegate = super.read
+    new MLReader[LumpFeaturesModel] {
+      override def load(path: String): LumpFeaturesModel = {
+        delegate.session(sparkSession)
+        delegate.load(path).prepareLoadedModel()
+      }
+    }
+  }
+
+  /** Encode a column's fitted state, including the reserved fallback that was collision-checked
+    * against the fitting data. Keeping it inside learned state avoids a separately clearable Param.
+    */
+  private[stages] def encodeKept(topK: Int, values: Seq[String], otherValue: String): String =
+    encodeKept(KeptState(topK, values, Some(otherValue)))
+
+  private[stages] def encodeKept(state: KeptState): String = {
+    val base = Map[String, JsValue](
+      "topK" -> JsNumber(state.topK),
+      "values" -> JsArray(state.values.map(JsString(_)).toVector))
+    val fields = state.otherValue.fold(base)(value => base + ("otherValue" -> JsString(value)))
+    JsObject(fields).compactPrint
+  }
+
+  /** Decode one column's state. otherValue is optional only for loading artifacts written before
+    * that fit-time invariant was persisted; the reader upgrades those entries before returning.
+    */
+  private[stages] def decodeKept(name: String, json: String): KeptState = {
     parseKeptJson(name, json) match {
-      case JsObject(fields) => (decodeTopK(name, json, fields), decodeValueList(name, json, fields))
+      case JsObject(fields) =>
+        KeptState(
+          decodeTopK(name, json, fields),
+          decodeValueList(name, json, fields),
+          decodeOtherValue(name, json, fields))
       case _ =>
         throw new IllegalArgumentException(
-          s"keptValuesJson for column '$name' must be a JSON object with topK and values fields: '$json'.")
+          s"keptValuesJson for column '$name' must be a JSON object with fitted state fields: '$json'.")
     }
   }
 
@@ -316,6 +342,15 @@ object LumpFeaturesModel extends DefaultParamsReadable[LumpFeaturesModel] {
         throw new IllegalArgumentException(
           s"keptValuesJson for column '$name' must contain a string-array values field: '$json'.")
     }
+
+  private def decodeOtherValue(name: String, json: String, fields: Map[String, JsValue]): Option[String] =
+    fields.get("otherValue") match {
+      case None => None
+      case Some(JsString(value)) => Some(value)
+      case _ =>
+        throw new IllegalArgumentException(
+          s"keptValuesJson for column '$name' must contain a string otherValue field when present: '$json'.")
+    }
 }
 
 /** Model produced by [[LumpFeatures]]. Replaces every non-retained value in each rule column with
@@ -333,18 +368,30 @@ class LumpFeaturesModel(override val uid: String)
   val keptValuesJson: StringStringMapParam = new StringStringMapParam(
     this, "keptValuesJson",
     "Learned model-only state per column, encoded as a map from column name to a JSON object holding the " +
-      "fitted top-K (field topK) and the retained values array (field values) ordered by descending " +
-      "frequency then ascending value. Populated by LumpFeatures during fit and immutable thereafter.")
+      "fitted top-K, retained values, and fit-time otherValue. Populated by LumpFeatures during fit and " +
+      "immutable thereafter.")
+
+  private var learnedStateSnapshot: Option[Map[String, String]] = None
+  private var otherValueWasSetWithLearnedState: Boolean = false
 
   def getKeptValuesJson: Map[String, String] = get(keptValuesJson).getOrElse(Map.empty)
 
-  def setKeptValuesJson(value: Map[String, String]): this.type = set(keptValuesJson, value)
+  private def learnedStateChangeMessage: String =
+    "Cannot change or clear keptValuesJson on a fitted LumpFeaturesModel; re-fit LumpFeatures to change learned state."
+
+  private def guardLearnedStateChange(value: Map[String, String]): Unit =
+    learnedStateSnapshot.foreach(expected => require(value == expected, learnedStateChangeMessage))
+
+  def setKeptValuesJson(value: Map[String, String]): this.type = {
+    guardLearnedStateChange(value)
+    set(keptValuesJson, value)
+  }
 
   def setKeptValuesJson(value: java.util.HashMap[String, String]): this.type =
-    set(keptValuesJson, value.asScala.toMap)
+    setKeptValuesJson(value.asScala.toMap)
 
   def getKeptValues: Map[String, Seq[String]] =
-    decodedKept.map { case (name, (_, values)) => (name, values) }
+    decodedKept.map { case (name, state) => (name, state.values) }
 
   /** The learned values per column as one JSON object mapping column name to its retained values.
     * Language wrappers cannot reliably read the keptValuesJson param map off the JVM object, so this
@@ -355,16 +402,16 @@ class LumpFeaturesModel(override val uid: String)
       (name, JsArray(values.map(JsString(_)).toVector): JsValue)
     }).compactPrint
 
-  private def decodedKept: Map[String, (Int, Seq[String])] =
+  private def decodedKept: Map[String, LumpFeaturesModel.KeptState] =
     getKeptValuesJson.map { case (name, json) => (name, LumpFeaturesModel.decodeKept(name, json)) }
 
   /** The fitted top-K per column recorded at fit time; a fitted model keeps lumpRules equal to this. */
-  private def getFittedTopK: Map[String, Int] =
-    decodedKept.map { case (name, (topK, _)) => (name, topK) }
+  private def getFittedTopK(kept: Map[String, LumpFeaturesModel.KeptState]): Map[String, Int] =
+    kept.map { case (name, state) => (name, state.topK) }
 
   private def guardLumpRulesChange(value: Map[String, Int]): Unit = {
     if (isDefined(keptValuesJson)) {
-      val fitted = getFittedTopK
+      val fitted = getFittedTopK(decodedKept)
       require(value == fitted,
         s"Cannot change lumpRules on a fitted LumpFeaturesModel. The model was fitted with top-K $fitted " +
           s"but $value was requested; re-fit LumpFeatures to change the rules.")
@@ -382,25 +429,131 @@ class LumpFeaturesModel(override val uid: String)
   override def setLumpRules(value: String): this.type =
     setLumpRules(lumpRules.jsonDecode(value))
 
-  protected def validateModelState(): Unit = {
+  private def incompatibleOtherValue(value: String, fitted: String): String =
+    s"Cannot change otherValue on a fitted LumpFeaturesModel. The model reserved '$fitted' during fit " +
+      s"but '$value' was requested; re-fit LumpFeatures to change the fallback value."
+
+  private def fittedOtherValue(kept: Map[String, LumpFeaturesModel.KeptState]): Option[String] = {
+    val present = kept.values.flatMap(_.otherValue).toSet
+    val missing = kept.collect { case (name, state) if state.otherValue.isEmpty => name }.toSeq.sorted
+    require(present.isEmpty || missing.isEmpty,
+      s"Model state is inconsistent: fit-time otherValue is missing for column(s) [${missing.mkString(", ")}].")
+    require(present.size <= 1,
+      s"Model state contains inconsistent fit-time otherValue entries [${present.toSeq.sorted.mkString(", ")}].")
+    present.headOption
+  }
+
+  private def decodedLearnedStateSnapshot: Option[Map[String, LumpFeaturesModel.KeptState]] =
+    learnedStateSnapshot.map(_.map { case (name, json) => (name, LumpFeaturesModel.decodeKept(name, json)) })
+
+  private def guardOtherValueChange(value: String): Unit =
+    decodedLearnedStateSnapshot.flatMap(fittedOtherValue).foreach { fitted =>
+      require(value == fitted, incompatibleOtherValue(value, fitted))
+    }
+
+  override def setOtherValue(value: String): this.type = {
+    guardOtherValueChange(value)
+    set(otherValue, value)
+  }
+
+  /** Spark mutates the ParamMap before this hook. Retain an internal snapshot so learned state can
+    * be restored after generic set/clear calls, and use its embedded fallback to protect otherValue.
+    */
+  override def onParamChange(param: Param[_]): Unit = {
+    if (keptValuesJson != null && learnedStateSnapshot != null && param == keptValuesJson) {
+      handleLearnedStateChange()
+    }
+    if (otherValue != null && learnedStateSnapshot != null && param == otherValue) {
+      handleOtherValueChange()
+    }
+  }
+
+  private def handleLearnedStateChange(): Unit = {
+    val current = get(keptValuesJson)
+    learnedStateSnapshot match {
+      case None =>
+        current.foreach { value =>
+          learnedStateSnapshot = Some(value)
+          otherValueWasSetWithLearnedState = isSet(otherValue)
+        }
+      case Some(expected) if current.contains(expected) =>
+      case Some(expected) =>
+        set(keptValuesJson, expected)
+        throw new IllegalArgumentException(learnedStateChangeMessage)
+    }
+  }
+
+  private def handleOtherValueChange(): Unit = {
+    decodedLearnedStateSnapshot.flatMap(fittedOtherValue).foreach { fitted =>
+      val current = getOtherValue
+      if (current != fitted && (isSet(otherValue) || otherValueWasSetWithLearnedState)) {
+        set(otherValue, fitted)
+        throw new IllegalArgumentException(incompatibleOtherValue(current, fitted))
+      }
+      if (current == fitted && isSet(otherValue)) {
+        otherValueWasSetWithLearnedState = true
+      }
+    }
+  }
+
+  private def validateModelState(kept: Map[String, LumpFeaturesModel.KeptState]): Unit = {
     validateRules()
     val rules = getLumpRules
-    val kept = decodedKept
     require(rules.keySet == kept.keySet,
       s"Model state is inconsistent with lumpRules: rule columns " +
         s"[${rules.keySet.toSeq.sorted.mkString(", ")}] do not match learned columns " +
         s"[${kept.keySet.toSeq.sorted.mkString(", ")}].")
     val other = getOtherValue
-    kept.foreach { case (name, (topK, values)) =>
-      require(rules(name) == topK,
-        s"lumpRules top-K for column '$name' is ${rules(name)} but the model was fitted with top-K $topK. " +
+    fittedOtherValue(kept).foreach { fitted =>
+      require(other == fitted, incompatibleOtherValue(other, fitted))
+    }
+    kept.foreach { case (name, state) =>
+      require(rules(name) == state.topK,
+        s"lumpRules top-K for column '$name' is ${rules(name)} but the model was fitted with top-K " +
+          s"${state.topK}. " +
           "A fitted LumpFeaturesModel does not allow lumpRules to change after fit; re-fit to change rules.")
-      require(values.size <= topK,
-        s"Model retains ${values.size} values for column '$name' which exceeds its fitted top-K of $topK.")
-      require(!values.contains(other),
+      require(state.values.size <= state.topK,
+        s"Model retains ${state.values.size} values for column '$name' which exceeds its fitted top-K " +
+          s"of ${state.topK}.")
+      require(!state.values.contains(other),
         s"otherValue '$other' collides with a retained value in column '$name'. " +
           "Choose an otherValue that is not among the learned values.")
     }
+  }
+
+  private def validatedModelState(): Map[String, LumpFeaturesModel.KeptState] = {
+    val kept = decodedKept
+    validateModelState(kept)
+    kept
+  }
+
+  protected def validateModelState(): Unit = {
+    validateModelState(decodedKept)
+  }
+
+  private def replaceLearnedState(value: Map[String, String]): Unit = {
+    learnedStateSnapshot = None
+    otherValueWasSetWithLearnedState = false
+    set(keptValuesJson, value)
+  }
+
+  private def upgradeLegacyState(
+      kept: Map[String, LumpFeaturesModel.KeptState]): Map[String, LumpFeaturesModel.KeptState] = {
+    if (kept.values.exists(_.otherValue.isEmpty)) {
+      val upgraded = kept.map { case (name, state) =>
+        (name, if (state.otherValue.isDefined) state else state.copy(otherValue = Some(getOtherValue)))
+      }
+      replaceLearnedState(upgraded.map { case (name, state) => (name, LumpFeaturesModel.encodeKept(state)) })
+      upgraded
+    } else {
+      kept
+    }
+  }
+
+  private[stages] def prepareLoadedModel(): LumpFeaturesModel = {
+    val kept = upgradeLegacyState(decodedKept)
+    validateModelState(kept)
+    this
   }
 
   override def transformSchema(schema: StructType): StructType = {
@@ -410,12 +563,13 @@ class LumpFeaturesModel(override val uid: String)
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     logTransform[DataFrame]({
-      transformSchema(dataset.schema)
+      val state = validatedModelState()
+      validateAndTransformSchema(dataset.schema)
       val other = getOtherValue
       val keepNulls = getHandleNull == "keep"
-      val kept = getKeptValues
       orderedOutputs.foldLeft(dataset.toDF()) { case (acc, (name, out)) =>
-        acc.withColumn(out, lumpExpr(name, kept.getOrElse(name, Seq.empty), other, keepNulls))
+        val values = state.get(name).map(_.values).getOrElse(Seq.empty)
+        acc.withColumn(out, lumpExpr(name, values, other, keepNulls))
       }
     }, dataset.columns.length)
   }
@@ -431,9 +585,17 @@ class LumpFeaturesModel(override val uid: String)
     else coalesce(retain, lit(other))
   }
 
+  private def guardLearnedStateCopy(extra: ParamMap): Unit = {
+    extra.get(keptValuesJson).foreach { requested =>
+      val fitted = learnedStateSnapshot.getOrElse(getKeptValuesJson)
+      require(requested == fitted, learnedStateChangeMessage)
+    }
+  }
+
   override def copy(extra: ParamMap): LumpFeaturesModel = {
+    guardLearnedStateCopy(extra)
     val copied = copyValues(new LumpFeaturesModel(uid), extra).setParent(parent)
-    if (copied.isDefined(copied.keptValuesJson)) copied.validateModelState()
+    if (copied.isDefined(copied.keptValuesJson)) copied.prepareLoadedModel()
     copied
   }
 }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/stages/LumpFeatures.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/stages/LumpFeatures.scala
@@ -1,0 +1,245 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.stages
+
+import com.microsoft.azure.synapse.ml.codegen.Wrappable
+import com.microsoft.azure.synapse.ml.logging.{FeatureNames, SynapseMLLogging}
+import com.microsoft.azure.synapse.ml.param.{StringIntMapParam, StringStringMapParam}
+import org.apache.spark.ml.param.{Param, ParamMap, ParamValidators}
+import org.apache.spark.ml.util._
+import org.apache.spark.ml.{Estimator, Model}
+import org.apache.spark.sql.functions.{asc, coalesce, col, count, desc, lit, when}
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{Column, DataFrame, Dataset}
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
+
+/** Parameters shared by [[LumpFeatures]] and [[LumpFeaturesModel]]. */
+trait LumpFeaturesParams extends Wrappable with DefaultParamsWritable {
+
+  val lumpRules: StringIntMapParam = new StringIntMapParam(
+    this, "lumpRules",
+    "Map from column name to the positive number of most-frequent values (top-K) to retain per column. " +
+      "Every other non-null value in each column is replaced with otherValue.")
+
+  def getLumpRules: Map[String, Int] = get(lumpRules).getOrElse(Map.empty)
+
+  def setLumpRules(value: Map[String, Int]): this.type = set(lumpRules, value)
+
+  def setLumpRules(value: java.util.HashMap[String, Int]): this.type = set(lumpRules, value.asScala.toMap)
+
+  def setLumpRules(value: String): this.type = set(lumpRules, lumpRules.jsonDecode(value))
+
+  val otherValue: Param[String] = new Param[String](
+    this, "otherValue",
+    "The single explicit replacement value used for every non-retained value (and, when handleNull is " +
+      "'other', for null) across all rule columns. Must be non-null and must not occur in any rule column.")
+
+  def getOtherValue: String = $(otherValue)
+
+  def setOtherValue(value: String): this.type = set(otherValue, value)
+
+  val handleNull: Param[String] = new Param[String](
+    this, "handleNull",
+    "How to treat null inputs in rule columns: 'keep' preserves null, 'other' maps null to otherValue. " +
+      "Unseen non-null values always map to otherValue.",
+    ParamValidators.inArray(Array("keep", "other")))
+
+  def getHandleNull: String = $(handleNull)
+
+  def setHandleNull(value: String): this.type = set(handleNull, value)
+
+  setDefault(otherValue -> "__other__", handleNull -> "keep")
+
+  protected def validateRules(): Unit = {
+    val rules = getLumpRules
+    require(rules.nonEmpty,
+      "lumpRules must be a non-empty map from column name to a positive top-K.")
+    rules.foreach { case (name, k) =>
+      require(Option(name).exists(_.nonEmpty),
+        "lumpRules contains an empty or null column name; every rule column name must be non-empty.")
+      require(k > 0,
+        s"lumpRules top-K for column '$name' must be a positive integer but was $k.")
+    }
+    require(Option(getOtherValue).isDefined,
+      "otherValue must be non-null.")
+  }
+
+  protected def validateAndTransformSchema(schema: StructType): StructType = {
+    validateRules()
+    val ruleCols = getLumpRules.keySet
+    ruleCols.foreach { name =>
+      require(schema.fieldNames.contains(name),
+        s"lumpRules references column '$name' which is not present in the input schema " +
+          s"[${schema.fieldNames.mkString(", ")}].")
+      val dt = schema(name).dataType
+      require(dt == StringType,
+        s"lumpRules column '$name' must be StringType for LumpFeatures v1 but was ${dt.simpleString}.")
+    }
+    val keepNulls = getHandleNull == "keep"
+    val fields = schema.fields.map { f =>
+      if (ruleCols.contains(f.name)) {
+        StructField(f.name, StringType, nullable = f.nullable && keepNulls, Metadata.empty)
+      } else {
+        f
+      }
+    }
+    StructType(fields)
+  }
+
+  /** Reference a top-level column by its literal name, backtick-quoting it and doubling any embedded
+    * backticks so names containing dots, backticks, or reserved words like `count` are never parsed
+    * as nested paths or interpreted as aggregate/reserved identifiers.
+    */
+  protected def litCol(name: String): Column = col("`" + name.replace("`", "``") + "`")
+}
+
+object LumpFeatures extends DefaultParamsReadable[LumpFeatures]
+
+/** Learns, per configured column, the top-K most frequent string values and produces a
+  * [[LumpFeaturesModel]] that replaces every other value with a single global otherValue.
+  */
+class LumpFeatures(override val uid: String)
+  extends Estimator[LumpFeaturesModel] with LumpFeaturesParams with SynapseMLLogging {
+  logClass(FeatureNames.Core)
+
+  def this() = this(Identifiable.randomUID("LumpFeatures"))
+
+  override def fit(dataset: Dataset[_]): LumpFeaturesModel = {
+    logFit({
+      transformSchema(dataset.schema)
+      val rules = getLumpRules
+      val other = getOtherValue
+      val df = dataset.toDF()
+
+      val collided = findOtherValueCollisions(df, rules.keys.toSeq, other)
+      require(collided.isEmpty,
+        s"otherValue '$other' collides with an existing value in rule column(s) " +
+          s"[${collided.sorted.mkString(", ")}]. Choose an otherValue that does not occur in the data.")
+
+      val valueAlias = "__lump_value__"
+      val countAlias = "__lump_count__"
+      val keptJson = rules.map { case (name, k) =>
+        val top = df.select(litCol(name).as(valueAlias))
+          .where(col(valueAlias).isNotNull)
+          .groupBy(col(valueAlias))
+          .agg(count(lit(1)).as(countAlias))
+          .orderBy(desc(countAlias), asc(valueAlias))
+          .limit(k)
+          .collect()
+          .map(_.getString(0))
+          .toList
+        (name, top.toJson.compactPrint)
+      }
+
+      new LumpFeaturesModel(uid)
+        .setLumpRules(rules)
+        .setOtherValue(other)
+        .setHandleNull(getHandleNull)
+        .setKeptValuesJson(keptJson)
+        .setParent(this)
+    }, dataset.columns.length)
+  }
+
+  private def findOtherValueCollisions(df: DataFrame, cols: Seq[String], other: String): Seq[String] = {
+    val aliases = cols.indices.map(i => s"__lump_collision_$i")
+    val exprs = cols.zip(aliases).map { case (c, a) =>
+      count(when(litCol(c) === lit(other), lit(1))).as(a)
+    }
+    val row = df.agg(exprs.head, exprs.tail: _*).collect().head
+    cols.zip(aliases).collect { case (c, a) if row.getAs[Long](a) > 0L => c }
+  }
+
+  override def copy(extra: ParamMap): LumpFeatures = defaultCopy(extra)
+
+  override def transformSchema(schema: StructType): StructType = validateAndTransformSchema(schema)
+}
+
+object LumpFeaturesModel extends DefaultParamsReadable[LumpFeaturesModel]
+
+/** Model produced by [[LumpFeatures]]. Replaces, in place, every non-retained value in each rule
+  * column with otherValue while retaining the learned top-K values unchanged.
+  */
+class LumpFeaturesModel(override val uid: String)
+  extends Model[LumpFeaturesModel] with LumpFeaturesParams with SynapseMLLogging {
+  logClass(FeatureNames.Core)
+
+  def this() = this(Identifiable.randomUID("LumpFeaturesModel"))
+
+  val keptValuesJson: StringStringMapParam = new StringStringMapParam(
+    this, "keptValuesJson",
+    "Learned retained values per column, encoded as a map from column name to a JSON array of strings " +
+      "ordered by descending frequency then ascending value. Populated by LumpFeatures during fit.")
+
+  def getKeptValuesJson: Map[String, String] = get(keptValuesJson).getOrElse(Map.empty)
+
+  def setKeptValuesJson(value: Map[String, String]): this.type = set(keptValuesJson, value)
+
+  def setKeptValuesJson(value: java.util.HashMap[String, String]): this.type =
+    set(keptValuesJson, value.asScala.toMap)
+
+  def getKeptValues: Map[String, Seq[String]] =
+    getKeptValuesJson.map { case (name, json) => (name, decodeValues(name, json)) }
+
+  private def decodeValues(name: String, json: String): Seq[String] = {
+    try {
+      json.parseJson.convertTo[List[String]]
+    } catch {
+      case NonFatal(e) =>
+        throw new IllegalArgumentException(
+          s"keptValuesJson for column '$name' is not a valid JSON array of strings: '$json'.", e)
+    }
+  }
+
+  protected def validateModelState(): Unit = {
+    validateRules()
+    val rules = getLumpRules
+    val kept = getKeptValues
+    require(rules.keySet == kept.keySet,
+      s"Model state is inconsistent with lumpRules: rule columns " +
+        s"[${rules.keySet.toSeq.sorted.mkString(", ")}] do not match learned columns " +
+        s"[${kept.keySet.toSeq.sorted.mkString(", ")}].")
+    val other = getOtherValue
+    kept.foreach { case (name, values) =>
+      require(values.size <= rules(name),
+        s"Model retains ${values.size} values for column '$name' which exceeds its top-K of ${rules(name)}.")
+      require(!values.contains(other),
+        s"otherValue '$other' collides with a retained value in column '$name'. " +
+          "Choose an otherValue that is not among the learned values.")
+    }
+  }
+
+  override def transformSchema(schema: StructType): StructType = {
+    validateModelState()
+    validateAndTransformSchema(schema)
+  }
+
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    logTransform[DataFrame]({
+      transformSchema(dataset.schema)
+      val other = getOtherValue
+      val keepNulls = getHandleNull == "keep"
+      getKeptValues.foldLeft(dataset.toDF()) { case (acc, (name, values)) =>
+        acc.withColumn(name, lumpExpr(name, values, other, keepNulls, acc.schema(name).nullable))
+      }
+    }, dataset.columns.length)
+  }
+
+  private def lumpExpr(name: String, values: Seq[String], other: String,
+                       keepNulls: Boolean, inputNullable: Boolean): Column = {
+    val retain =
+      if (values.isEmpty) lit(other)
+      else when(litCol(name).isin(values: _*), litCol(name)).otherwise(lit(other))
+    // For handleNull=keep, referencing the column in the null branch yields null without a null literal.
+    val handled = if (keepNulls) when(litCol(name).isNull, litCol(name)).otherwise(retain) else retain
+    val declaredNullable = inputNullable && keepNulls
+    if (declaredNullable) handled else coalesce(handled, lit(other))
+  }
+
+  override def copy(extra: ParamMap): LumpFeaturesModel =
+    copyValues(new LumpFeaturesModel(uid), extra).setParent(parent)
+}

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/stages/LumpFeatures.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/stages/LumpFeatures.scala
@@ -6,10 +6,12 @@ package com.microsoft.azure.synapse.ml.stages
 import com.microsoft.azure.synapse.ml.codegen.Wrappable
 import com.microsoft.azure.synapse.ml.logging.{FeatureNames, SynapseMLLogging}
 import com.microsoft.azure.synapse.ml.param.{StringIntMapParam, StringStringMapParam}
-import org.apache.spark.ml.param.{Param, ParamMap, ParamValidators}
+import org.apache.spark.ml.param.{DoubleParam, IntParam, Param, ParamMap, ParamValidators}
 import org.apache.spark.ml.util._
 import org.apache.spark.ml.{Estimator, Model}
-import org.apache.spark.sql.functions.{asc, coalesce, col, count, desc, lit, when}
+import org.apache.spark.sql.expressions.Window
+import org.apache.spark.sql.functions.{array, asc, coalesce, col, count, desc}
+import org.apache.spark.sql.functions.{explode, lit, row_number, struct, sum, typedLit, when}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Column, DataFrame, Dataset}
 import spray.json.DefaultJsonProtocol._
@@ -23,8 +25,9 @@ trait LumpFeaturesParams extends Wrappable with DefaultParamsWritable {
 
   val lumpRules: StringIntMapParam = new StringIntMapParam(
     this, "lumpRules",
-    "Map from column name to the positive number of most-frequent values (top-K) to retain per column. " +
-      "Every other non-null value in each column is replaced with otherValue.")
+    "Map from column name to the maximum number of most-frequent values (top-K) to retain per column. " +
+      "This is a cap, not the only criterion: a value is retained only if it also clears minCount and " +
+      "minFreq. Every value that is not retained is replaced with otherValue.")
 
   def getLumpRules: Map[String, Int] = get(lumpRules).getOrElse(Map.empty)
 
@@ -33,6 +36,20 @@ trait LumpFeaturesParams extends Wrappable with DefaultParamsWritable {
   def setLumpRules(value: java.util.HashMap[String, Int]): this.type = set(lumpRules, value.asScala.toMap)
 
   def setLumpRules(value: String): this.type = set(lumpRules, lumpRules.jsonDecode(value))
+
+  val outputCols: StringStringMapParam = new StringStringMapParam(
+    this, "outputCols",
+    "Optional map from a lumpRules column name to the column the lumped values are written to. " +
+      "Rule columns without an entry are replaced in place, which is the default and discards the " +
+      "original values. Naming a new destination keeps the raw column intact alongside the lumped one.")
+
+  def getOutputCols: Map[String, String] = get(outputCols).getOrElse(Map.empty)
+
+  def setOutputCols(value: Map[String, String]): this.type = set(outputCols, value)
+
+  def setOutputCols(value: java.util.HashMap[String, String]): this.type = set(outputCols, value.asScala.toMap)
+
+  def setOutputCols(value: String): this.type = set(outputCols, outputCols.jsonDecode(value))
 
   val otherValue: Param[String] = new Param[String](
     this, "otherValue",
@@ -65,30 +82,57 @@ trait LumpFeaturesParams extends Wrappable with DefaultParamsWritable {
       require(k > 0,
         s"lumpRules top-K for column '$name' must be a positive integer but was $k.")
     }
+    getOutputCols.foreach { case (name, out) =>
+      require(rules.contains(name),
+        s"outputCols references column '$name' which has no lumpRules entry " +
+          s"[${rules.keySet.toSeq.sorted.mkString(", ")}].")
+      require(Option(out).exists(_.nonEmpty),
+        s"outputCols destination for column '$name' must be a non-empty column name.")
+    }
+    val duplicated = orderedOutputs.map(_._2).groupBy(identity).collect { case (d, ds) if ds.size > 1 => d }
+    require(duplicated.isEmpty,
+      s"outputCols maps more than one rule column to destination(s) " +
+        s"[${duplicated.toSeq.sorted.mkString(", ")}]; every destination must be distinct.")
     require(Option(getOtherValue).isDefined,
       "otherValue must be non-null.")
   }
 
+  /** Every rule column paired with the column its lumped values are written to, in a deterministic
+    * order so transformSchema and transform always agree on where appended columns land.
+    */
+  protected def orderedOutputs: Seq[(String, String)] = {
+    val explicit = getOutputCols
+    getLumpRules.keys.toSeq.sorted.map(name => (name, explicit.getOrElse(name, name)))
+  }
+
+  /** A lumped column is always a plain string, and its nullability follows handleNull alone so the
+    * declared contract never depends on how the input schema happened to declare nullability. Input
+    * metadata is dropped because it describes the pre-lumping value set.
+    */
+  private def lumpedField(name: String, keepNulls: Boolean): StructField =
+    StructField(name, StringType, nullable = keepNulls, Metadata.empty)
+
   protected def validateAndTransformSchema(schema: StructType): StructType = {
     validateRules()
-    val ruleCols = getLumpRules.keySet
-    ruleCols.foreach { name =>
+    val outputs = orderedOutputs
+    outputs.foreach { case (name, out) =>
       require(schema.fieldNames.contains(name),
         s"lumpRules references column '$name' which is not present in the input schema " +
           s"[${schema.fieldNames.mkString(", ")}].")
       val dt = schema(name).dataType
       require(dt == StringType,
         s"lumpRules column '$name' must be StringType for LumpFeatures v1 but was ${dt.simpleString}.")
+      require(out == name || !schema.fieldNames.contains(out),
+        s"outputCols destination '$out' for rule column '$name' already exists in the input schema; " +
+          "choose a new name or drop the entry to replace the rule column in place.")
     }
     val keepNulls = getHandleNull == "keep"
-    val fields = schema.fields.map { f =>
-      if (ruleCols.contains(f.name)) {
-        StructField(f.name, StringType, nullable = f.nullable && keepNulls, Metadata.empty)
-      } else {
-        f
-      }
+    val replacedInPlace = outputs.collect { case (name, out) if name == out => name }.toSet
+    val retained = schema.fields.map { f =>
+      if (replacedInPlace.contains(f.name)) lumpedField(f.name, keepNulls) else f
     }
-    StructType(fields)
+    val appended = outputs.collect { case (name, out) if name != out => lumpedField(out, keepNulls) }
+    StructType(retained ++ appended)
   }
 
   /** Reference a top-level column by its literal name, backtick-quoting it and doubling any embedded
@@ -98,10 +142,24 @@ trait LumpFeaturesParams extends Wrappable with DefaultParamsWritable {
   protected def litCol(name: String): Column = col("`" + name.replace("`", "``") + "`")
 }
 
-object LumpFeatures extends DefaultParamsReadable[LumpFeatures]
+object LumpFeatures extends DefaultParamsReadable[LumpFeatures] {
 
-/** Learns, per configured column, the top-K most frequent string values and produces a
-  * [[LumpFeaturesModel]] that replaces every other value with a single global otherValue.
+  /** One distinct value of one rule column, with its rank inside that column and whether it survived
+    * the eligibility filters. Collected once per fit.
+    */
+  private[stages] case class RankedValue(column: String, value: String, rank: Int, retained: Boolean)
+}
+
+/** Learns, per configured column, which string values to retain and produces a [[LumpFeaturesModel]]
+  * that replaces every other value with a single global otherValue.
+  *
+  * A value is retained when it clears both eligibility filters (minCount and minFreq) and then falls
+  * inside its column's top-K from lumpRules. Filtering before capping is the order scikit-learn's
+  * OneHotEncoder uses for min_frequency and max_categories: the frequency thresholds decide which
+  * values are worth keeping at all, and top-K only bounds how many survive. Relying on top-K alone
+  * is unreliable for training, because it is blind to the shape of the distribution - it will lump
+  * healthy levels in a low-cardinality column, and in a very long-tailed column it can retain values
+  * that together cover almost none of the rows.
   */
 class LumpFeatures(override val uid: String)
   extends Estimator[LumpFeaturesModel] with LumpFeaturesParams with SynapseMLLogging {
@@ -109,49 +167,103 @@ class LumpFeatures(override val uid: String)
 
   def this() = this(Identifiable.randomUID("LumpFeatures"))
 
+  val minCount: IntParam = new IntParam(
+    this, "minCount",
+    "Minimum number of times a value must occur in the fitting data to be eligible for retention. " +
+      "Rarer values are lumped into otherValue. Applied before the lumpRules top-K cap. " +
+      "The default of 1 disables count-based lumping.",
+    ParamValidators.gtEq(1))
+
+  def getMinCount: Int = $(minCount)
+
+  def setMinCount(value: Int): this.type = set(minCount, value)
+
+  val minFreq: DoubleParam = new DoubleParam(
+    this, "minFreq",
+    "Minimum share of a column's non-null fitting rows a value must account for to be eligible for " +
+      "retention, in [0, 1]. Rarer values are lumped into otherValue. Applied before the lumpRules " +
+      "top-K cap. The default of 0.0 disables frequency-based lumping.",
+    ParamValidators.inRange(0.0, 1.0))
+
+  def getMinFreq: Double = $(minFreq)
+
+  def setMinFreq(value: Double): this.type = set(minFreq, value)
+
+  setDefault(minCount -> 1, minFreq -> 0.0)
+
   override def fit(dataset: Dataset[_]): LumpFeaturesModel = {
     logFit({
       transformSchema(dataset.schema)
       val rules = getLumpRules
       val other = getOtherValue
-      val df = dataset.toDF()
+      val ranked = rankValues(dataset.toDF(), rules, other)
 
-      val collided = findOtherValueCollisions(df, rules.keys.toSeq, other)
+      val collided = ranked.filter(_.value == other).map(_.column).distinct.sorted
       require(collided.isEmpty,
         s"otherValue '$other' collides with an existing value in rule column(s) " +
-          s"[${collided.sorted.mkString(", ")}]. Choose an otherValue that does not occur in the data.")
+          s"[${collided.mkString(", ")}]. Choose an otherValue that does not occur in the data.")
 
-      val valueAlias = "__lump_value__"
-      val countAlias = "__lump_count__"
+      val byColumn = ranked.filter(_.retained).groupBy(_.column)
       val keptJson = rules.map { case (name, k) =>
-        val top = df.select(litCol(name).as(valueAlias))
-          .where(col(valueAlias).isNotNull)
-          .groupBy(col(valueAlias))
-          .agg(count(lit(1)).as(countAlias))
-          .orderBy(desc(countAlias), asc(valueAlias))
-          .limit(k)
-          .collect()
-          .map(_.getString(0))
-          .toList
+        val top = byColumn.getOrElse(name, Seq.empty).sortBy(_.rank).map(_.value).toList
         (name, LumpFeaturesModel.encodeKept(k, top))
       }
 
-      new LumpFeaturesModel(uid)
+      val model = new LumpFeaturesModel(uid)
         .setLumpRules(rules)
         .setOtherValue(other)
         .setHandleNull(getHandleNull)
-        .setKeptValuesJson(keptJson)
-        .setParent(this)
+      get(outputCols).foreach(model.setOutputCols)
+      model.setKeptValuesJson(keptJson).setParent(this)
     }, dataset.columns.length)
   }
 
-  private def findOtherValueCollisions(df: DataFrame, cols: Seq[String], other: String): Seq[String] = {
-    val aliases = cols.indices.map(i => s"__lump_collision_$i")
-    val exprs = cols.zip(aliases).map { case (c, a) =>
-      count(when(litCol(c) === lit(other), lit(1))).as(a)
+  /** Rank every distinct non-null value of every rule column in a single pass.
+    *
+    * The rule columns are melted into (column, value) pairs so one aggregation serves all of them.
+    * That keeps the cost at one shuffle instead of a separate full scan per column and, more
+    * importantly, guarantees every column is learned from the same materialization of the input.
+    * Per-column jobs cannot promise that: against a non-deterministic upstream plan (a sample, rand,
+    * or an unordered limit) each column would be learned from different rows. Values equal to
+    * otherValue are always returned so the collision check reuses this same aggregation.
+    */
+  private def rankValues(df: DataFrame, rules: Map[String, Int], other: String): Seq[LumpFeatures.RankedValue] = {
+    val columnAlias = "__lump_column__"
+    val valueAlias = "__lump_value__"
+    val countAlias = "__lump_count__"
+    val totalAlias = "__lump_total__"
+    val rankAlias = "__lump_rank__"
+    val retainedAlias = "__lump_retained__"
+    val pairAlias = "__lump_pair__"
+    val cols = rules.keys.toSeq.sorted
+
+    val melted = df
+      .select(explode(array(cols.map(c => struct(lit(c).as(columnAlias), litCol(c).as(valueAlias))): _*))
+        .as(pairAlias))
+      .select(col(s"$pairAlias.$columnAlias").as(columnAlias), col(s"$pairAlias.$valueAlias").as(valueAlias))
+      .where(col(valueAlias).isNotNull)
+
+    val perColumn = Window.partitionBy(col(columnAlias))
+    val counted = melted
+      .groupBy(col(columnAlias), col(valueAlias))
+      .agg(count(lit(1)).as(countAlias))
+      .withColumn(totalAlias, sum(col(countAlias)).over(perColumn))
+      .withColumn(rankAlias, row_number().over(perColumn.orderBy(desc(countAlias), asc(valueAlias))))
+
+    // Eligibility can only reject a suffix of the count-descending order, so intersecting it with the
+    // rank cap is exactly "filter by frequency first, then keep at most K".
+    val topK = cols.foldLeft(lit(0)) { (fallback, c) =>
+      when(col(columnAlias) === lit(c), lit(rules(c))).otherwise(fallback)
     }
-    val row = df.agg(exprs.head, exprs.tail: _*).collect().head
-    cols.zip(aliases).collect { case (c, a) if row.getAs[Long](a) > 0L => c }
+    val eligible = col(countAlias) >= lit(getMinCount) && col(countAlias) >= col(totalAlias) * lit(getMinFreq)
+
+    counted
+      .withColumn(retainedAlias, col(rankAlias) <= topK && eligible)
+      .where(col(retainedAlias) || col(valueAlias) === lit(other))
+      .select(col(columnAlias), col(valueAlias), col(rankAlias), col(retainedAlias))
+      .collect()
+      .map(r => LumpFeatures.RankedValue(r.getString(0), r.getString(1), r.getInt(2), r.getBoolean(3)))
+      .toSeq
   }
 
   override def copy(extra: ParamMap): LumpFeatures = defaultCopy(extra)
@@ -206,12 +318,15 @@ object LumpFeaturesModel extends DefaultParamsReadable[LumpFeaturesModel] {
     }
 }
 
-/** Model produced by [[LumpFeatures]]. Replaces, in place, every non-retained value in each rule
-  * column with otherValue while retaining the learned top-K values unchanged.
+/** Model produced by [[LumpFeatures]]. Replaces every non-retained value in each rule column with
+  * otherValue, leaving the learned values unchanged. By default each rule column is rewritten in
+  * place; set outputCols to write the lumped values to new columns and keep the raw values.
   */
 class LumpFeaturesModel(override val uid: String)
   extends Model[LumpFeaturesModel] with LumpFeaturesParams with SynapseMLLogging {
   logClass(FeatureNames.Core)
+
+  override protected lazy val pyInternalWrapper: Boolean = true
 
   def this() = this(Identifiable.randomUID("LumpFeaturesModel"))
 
@@ -230,6 +345,15 @@ class LumpFeaturesModel(override val uid: String)
 
   def getKeptValues: Map[String, Seq[String]] =
     decodedKept.map { case (name, (_, values)) => (name, values) }
+
+  /** The learned values per column as one JSON object mapping column name to its retained values.
+    * Language wrappers cannot reliably read the keptValuesJson param map off the JVM object, so this
+    * gives Python and R callers a single well-defined way to inspect and audit what the model learned.
+    */
+  def getKeptValuesAsJson: String =
+    JsObject(getKeptValues.map { case (name, values) =>
+      (name, JsArray(values.map(JsString(_)).toVector): JsValue)
+    }).compactPrint
 
   private def decodedKept: Map[String, (Int, Seq[String])] =
     getKeptValuesJson.map { case (name, json) => (name, LumpFeaturesModel.decodeKept(name, json)) }
@@ -289,21 +413,22 @@ class LumpFeaturesModel(override val uid: String)
       transformSchema(dataset.schema)
       val other = getOtherValue
       val keepNulls = getHandleNull == "keep"
-      getKeptValues.foldLeft(dataset.toDF()) { case (acc, (name, values)) =>
-        acc.withColumn(name, lumpExpr(name, values, other, keepNulls, acc.schema(name).nullable))
+      val kept = getKeptValues
+      orderedOutputs.foldLeft(dataset.toDF()) { case (acc, (name, out)) =>
+        acc.withColumn(out, lumpExpr(name, kept.getOrElse(name, Seq.empty), other, keepNulls))
       }
     }, dataset.columns.length)
   }
 
-  private def lumpExpr(name: String, values: Seq[String], other: String,
-                       keepNulls: Boolean, inputNullable: Boolean): Column = {
+  private def lumpExpr(name: String, values: Seq[String], other: String, keepNulls: Boolean): Column = {
     val retain =
       if (values.isEmpty) lit(other)
       else when(litCol(name).isin(values: _*), litCol(name)).otherwise(lit(other))
-    // For handleNull=keep, referencing the column in the null branch yields null without a null literal.
-    val handled = if (keepNulls) when(litCol(name).isNull, litCol(name)).otherwise(retain) else retain
-    val declaredNullable = inputNullable && keepNulls
-    if (declaredNullable) handled else coalesce(handled, lit(other))
+    // The declared schema takes nullability from handleNull alone, so force the expression to agree
+    // regardless of how the input column declared itself: a typed null literal stays nullable even
+    // over a non-nullable input, and coalesce makes the non-null contract hold over a nullable one.
+    if (keepNulls) when(litCol(name).isNull, typedLit(Option.empty[String])).otherwise(retain)
+    else coalesce(retain, lit(other))
   }
 
   override def copy(extra: ParamMap): LumpFeaturesModel = {

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/stages/LumpFeaturesSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/stages/LumpFeaturesSuite.scala
@@ -10,6 +10,7 @@ import org.apache.spark.ml.util.MLReadable
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Column, DataFrame, Row}
+import spray.json._
 
 import java.io.File
 import scala.collection.JavaConverters._
@@ -303,6 +304,143 @@ class LumpFeaturesSuite extends EstimatorFuzzing[LumpFeatures] with LumpFeatures
     jmap.put("f1", 2)
     intercept[IllegalArgumentException] { fitted().setLumpRules(jmap) }
     intercept[IllegalArgumentException] { fitted().setLumpRules("{\"f1\":2}") }
+  }
+
+  test("minCount lumps values below the count threshold before the top-K cap applies") {
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 3)).setMinCount(2).fit(df)
+    assert(model.getKeptValues("f1") == Seq("apple"))
+    assert(dump(model.transform(df), Seq("f1")) == List(other, other, "apple", "apple", "apple"))
+  }
+
+  test("minFreq lumps values below the frequency share before the top-K cap applies") {
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 3)).setMinFreq(0.25).fit(df)
+    assert(model.getKeptValues("f1") == Seq("apple"))
+    val permissive = new LumpFeatures().setLumpRules(Map("f1" -> 3)).setMinFreq(0.15).fit(df)
+    assert(permissive.getKeptValues("f1") == Seq("apple", "banana", "cherry"))
+  }
+
+  test("top-K still caps values that clear the frequency filters") {
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 1)).setMinCount(1).setMinFreq(0.1).fit(df)
+    assert(model.getKeptValues("f1") == Seq("apple"))
+  }
+
+  test("frequency filters are per column and are computed against non-null rows only") {
+    val dfN = Seq(("apple", "red"), ("apple", "red"), (null, "red"), ("banana", "blue"))
+      .toDF("f1", "f2")
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 3, "f2" -> 3)).setMinFreq(0.5).fit(dfN)
+    // f1 has 3 non-null rows, so apple (2/3) clears 0.5 and banana (1/3) does not.
+    assert(model.getKeptValues("f1") == Seq("apple"))
+    // f2 has 4 non-null rows, so red (3/4) clears 0.5 and blue (1/4) does not.
+    assert(model.getKeptValues("f2") == Seq("red"))
+  }
+
+  test("minCount and minFreq default to no-ops and reject out-of-range values") {
+    val est = new LumpFeatures().setLumpRules(Map("f1" -> 3))
+    assert(est.getMinCount == 1)
+    assert(est.getMinFreq == 0.0)
+    intercept[IllegalArgumentException] { est.setMinCount(0) }
+    intercept[IllegalArgumentException] { est.setMinFreq(-0.1) }
+    intercept[IllegalArgumentException] { est.setMinFreq(1.1) }
+    assert(est.fit(df).getKeptValues("f1") == Seq("apple", "banana", "cherry"))
+  }
+
+  test("multi-column fit agrees with fitting each column on its own") {
+    val rules = Map("f1" -> 2, "f2" -> 2)
+    val together = new LumpFeatures().setLumpRules(rules).fit(df).getKeptValues
+    rules.foreach { case (name, k) =>
+      val alone = new LumpFeatures().setLumpRules(Map(name -> k)).fit(df).getKeptValues(name)
+      assert(together(name) == alone, s"column $name disagreed between joint and single-column fits")
+    }
+  }
+
+  test("outputCols appends lumped columns and leaves the raw columns untouched") {
+    val model = new LumpFeatures()
+      .setLumpRules(Map("f1" -> 1))
+      .setOutputCols(Map("f1" -> "f1_lumped"))
+      .fit(df)
+    val out = model.transform(df)
+    assert(out.columns.toSeq == Seq("f1", "f2", "f1_lumped"))
+    assert(dump(out, Seq("f1", "f1_lumped")) == List(
+      "apple|apple", "apple|apple", "apple|apple", s"banana|$other", s"cherry|$other"))
+  }
+
+  test("outputCols mixes appended and in-place columns with a schema that matches transform") {
+    val model = new LumpFeatures()
+      .setLumpRules(Map("f1" -> 1, "f2" -> 1))
+      .setOutputCols(Map("f2" -> "f2_lumped"))
+      .fit(df)
+    val declared = model.transformSchema(df.schema)
+    assert(declared == model.transform(df).schema)
+    assert(declared.fieldNames.toSeq == Seq("f1", "f2", "f2_lumped"))
+    assert(dump(model.transform(df), Seq("f2", "f2_lumped")) == List(
+      s"blue|$other", s"green|$other", "red|red", "red|red", "red|red"))
+    assert(dump(model.transform(df), Seq("f1")) == List(other, other, "apple", "apple", "apple"))
+  }
+
+  test("outputCols rejects unknown sources, empty, duplicate, and pre-existing destinations") {
+    intercept[IllegalArgumentException] {
+      new LumpFeatures().setLumpRules(Map("f1" -> 1)).setOutputCols(Map("nope" -> "x")).fit(df)
+    }
+    intercept[IllegalArgumentException] {
+      new LumpFeatures().setLumpRules(Map("f1" -> 1)).setOutputCols(Map("f1" -> "")).fit(df)
+    }
+    intercept[IllegalArgumentException] {
+      new LumpFeatures().setLumpRules(Map("f1" -> 1, "f2" -> 1))
+        .setOutputCols(Map("f1" -> "z", "f2" -> "z")).fit(df)
+    }
+    intercept[IllegalArgumentException] {
+      new LumpFeatures().setLumpRules(Map("f1" -> 1)).setOutputCols(Map("f1" -> "f2")).fit(df)
+    }
+  }
+
+  test("outputCols survives fit, copy, and a save-load round-trip") {
+    val model = new LumpFeatures()
+      .setLumpRules(Map("f1" -> 1))
+      .setOutputCols(Map("f1" -> "f1_lumped"))
+      .fit(df)
+    assert(model.getOutputCols == Map("f1" -> "f1_lumped"))
+    assert(model.copy(new ParamMap()).getOutputCols == Map("f1" -> "f1_lumped"))
+    val path = new File(tmpDir.toFile, "lump-outputcols").toString
+    model.write.overwrite().save(path)
+    val loaded = LumpFeaturesModel.load(path)
+    assert(loaded.getOutputCols == Map("f1" -> "f1_lumped"))
+    assertDFEq(loaded.transform(df), model.transform(df))
+  }
+
+  test("outputCols accepts the Java HashMap and JSON-string setter overloads") {
+    val jmap = new java.util.HashMap[String, String]()
+    jmap.put("f1", "f1_lumped")
+    assert(new LumpFeatures().setOutputCols(jmap).getOutputCols == Map("f1" -> "f1_lumped"))
+    val fromJson = new LumpFeatures().setOutputCols("{\"f1\":\"f1_lumped\"}")
+    assert(fromJson.getOutputCols == Map("f1" -> "f1_lumped"))
+  }
+
+  test("declared nullability follows handleNull alone even for a non-nullable input column") {
+    val schema = StructType(Seq(StructField("f1", StringType, nullable = false)))
+    val rows = Seq(Row("apple"), Row("apple"), Row("banana"))
+    val dfNN = spark.createDataFrame(rows.asJava, schema)
+    assert(!dfNN.schema("f1").nullable)
+
+    val keepModel = new LumpFeatures().setLumpRules(Map("f1" -> 1)).setHandleNull("keep").fit(dfNN)
+    val declaredKeep = keepModel.transformSchema(dfNN.schema)
+    assert(declaredKeep == keepModel.transform(dfNN).schema)
+    assert(declaredKeep("f1").nullable)
+    assert(dump(keepModel.transform(dfNN), Seq("f1")) == List(other, "apple", "apple"))
+
+    val otherModel = new LumpFeatures().setLumpRules(Map("f1" -> 1)).setHandleNull("other").fit(dfNN)
+    val declaredOther = otherModel.transformSchema(dfNN.schema)
+    assert(declaredOther == otherModel.transform(dfNN).schema)
+    assert(!declaredOther("f1").nullable)
+    assert(dump(otherModel.transform(dfNN), Seq("f1")) == List(other, "apple", "apple"))
+  }
+
+  test("getKeptValuesAsJson gives language wrappers one document with the learned values") {
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 2, "f2" -> 1)).fit(df)
+    val expected = """{"f1":["apple","banana"],"f2":["red"]}"""
+    assert(model.getKeptValuesAsJson.parseJson == expected.parseJson)
+    val dfAllNull = Seq((null.asInstanceOf[String], "red")).toDF("f1", "f2")
+    val empty = new LumpFeatures().setLumpRules(Map("f1" -> 2)).fit(dfAllNull)
+    assert(empty.getKeptValuesAsJson.parseJson == """{"f1":[]}""".parseJson)
   }
 
   override def testObjects(): Seq[TestObject[LumpFeatures]] = Seq(

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/stages/LumpFeaturesSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/stages/LumpFeaturesSuite.scala
@@ -3,7 +3,8 @@
 
 package com.microsoft.azure.synapse.ml.stages
 
-import com.microsoft.azure.synapse.ml.core.test.fuzzing.{EstimatorFuzzing, TestObject}
+import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import com.microsoft.azure.synapse.ml.core.test.fuzzing.{EstimatorFuzzing, TestObject, TransformerFuzzing}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.util.MLReadable
 import org.apache.spark.sql.functions.col
@@ -13,12 +14,14 @@ import org.apache.spark.sql.{Column, DataFrame, Row}
 import java.io.File
 import scala.collection.JavaConverters._
 
-//scalastyle:off null
-class LumpFeaturesSuite extends EstimatorFuzzing[LumpFeatures] {
+/** Shared input fixture and projection helper used by both the estimator suite
+  * [[LumpFeaturesSuite]] and the model suite [[LumpFeaturesModelSuite]].
+  */
+trait LumpFeaturesTestData extends TestBase {
 
   import spark.implicits._
 
-  private lazy val df: DataFrame = Seq(
+  protected lazy val df: DataFrame = Seq(
     ("apple", "red"),
     ("apple", "red"),
     ("apple", "blue"),
@@ -26,14 +29,20 @@ class LumpFeaturesSuite extends EstimatorFuzzing[LumpFeatures] {
     ("cherry", "green")
   ).toDF("f1", "f2")
 
-  private val other = "__other__"
+  protected val other: String = "__other__"
 
-  private def dump(data: DataFrame, cols: Seq[String]): List[String] = {
+  protected def dump(data: DataFrame, cols: Seq[String]): List[String] = {
     val projected = data.select(cols.map(col): _*)
     projected.collect().map { r =>
       cols.indices.map(i => if (r.isNullAt(i)) "<null>" else r.get(i).toString).mkString("|")
     }.sorted.toList
   }
+}
+
+//scalastyle:off null
+class LumpFeaturesSuite extends EstimatorFuzzing[LumpFeatures] with LumpFeaturesTestData {
+
+  import spark.implicits._
 
   test("multi-column top-K retains learned values and lumps the rest") {
     val model = new LumpFeatures().setLumpRules(Map("f1" -> 1, "f2" -> 1)).fit(df)
@@ -242,5 +251,33 @@ class LumpFeaturesSuite extends EstimatorFuzzing[LumpFeatures] {
   override def reader: MLReadable[_] = LumpFeatures
 
   override def modelReader: MLReadable[_] = LumpFeaturesModel
+
+}
+
+/** Dedicated fuzzing suite for [[LumpFeaturesModel]]. LumpFeatures serializes fitted models, so the
+  * model needs its own Experiment/Serialization/Python/R fuzzer coverage. The estimator suite only
+  * registers a fuzzer for the estimator type, which left the model without any discovered fuzzer.
+  * The test object is a valid, manually constructed persisted model (learned levels supplied directly)
+  * paired with a deterministic input DataFrame.
+  */
+class LumpFeaturesModelSuite extends TransformerFuzzing[LumpFeaturesModel] with LumpFeaturesTestData {
+
+  private def persistedModel: LumpFeaturesModel = new LumpFeaturesModel()
+    .setLumpRules(Map("f1" -> 1, "f2" -> 1))
+    .setKeptValuesJson(Map("f1" -> "[\"apple\"]", "f2" -> "[\"red\"]"))
+    .setOtherValue(other)
+    .setHandleNull("keep")
+
+  test("manually constructed model retains learned values and lumps the rest deterministically") {
+    val out = persistedModel.transform(df)
+    assert(out.columns.toSeq == Seq("f1", "f2"))
+    assert(dump(out, Seq("f1", "f2")) == List(
+      s"$other|$other", s"$other|red", s"apple|$other", "apple|red", "apple|red"))
+  }
+
+  override def testObjects(): Seq[TestObject[LumpFeaturesModel]] =
+    Seq(new TestObject(persistedModel, df))
+
+  override def reader: MLReadable[_] = LumpFeaturesModel
 
 }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/stages/LumpFeaturesSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/stages/LumpFeaturesSuite.scala
@@ -88,7 +88,7 @@ class LumpFeaturesSuite extends EstimatorFuzzing[LumpFeatures] with LumpFeatures
   test("empty learned levels via manually constructed model maps all non-null to otherValue") {
     val model = new LumpFeaturesModel()
       .setLumpRules(Map("f1" -> 2))
-      .setKeptValuesJson(Map("f1" -> "[]"))
+      .setKeptValuesJson(Map("f1" -> "{\"topK\":2,\"values\":[]}"))
       .setHandleNull("keep")
     assert(dump(model.transform(df), Seq("f1")) == List(other, other, other, other, other))
   }
@@ -137,11 +137,11 @@ class LumpFeaturesSuite extends EstimatorFuzzing[LumpFeatures] with LumpFeatures
   test("model validates state and rule consistency") {
     val mismatch = new LumpFeaturesModel()
       .setLumpRules(Map("f1" -> 1))
-      .setKeptValuesJson(Map("f2" -> "[\"red\"]"))
+      .setKeptValuesJson(Map("f2" -> "{\"topK\":1,\"values\":[\"red\"]}"))
     intercept[IllegalArgumentException] { mismatch.transform(df).collect() }
     val tooMany = new LumpFeaturesModel()
       .setLumpRules(Map("f1" -> 1))
-      .setKeptValuesJson(Map("f1" -> "[\"apple\",\"banana\"]"))
+      .setKeptValuesJson(Map("f1" -> "{\"topK\":1,\"values\":[\"apple\",\"banana\"]}"))
     intercept[IllegalArgumentException] { tooMany.transform(df).collect() }
   }
 
@@ -245,6 +245,66 @@ class LumpFeaturesSuite extends EstimatorFuzzing[LumpFeatures] with LumpFeatures
     }
     assert(ex.getMessage.toLowerCase.contains("othervalue"))
   }
+
+  test("fitted model rejects increasing or decreasing K even when distinct values are fewer than K") {
+    val twoDistinct = Seq(("apple", "x"), ("apple", "x"), ("banana", "x")).toDF("f1", "f2")
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 3)).fit(twoDistinct)
+    assert(model.getKeptValues("f1") == Seq("apple", "banana"))
+    intercept[IllegalArgumentException] { model.setLumpRules(Map("f1" -> 5)) }
+    intercept[IllegalArgumentException] { model.setLumpRules(Map("f1" -> 2)) }
+    assert(model.getLumpRules == Map("f1" -> 3))
+    assert(model.getKeptValues("f1") == Seq("apple", "banana"))
+  }
+
+  test("setting the exact fitted lumpRules map on a fitted model is an allowed no-op") {
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 1, "f2" -> 1)).fit(df)
+    val before = dump(model.transform(df), Seq("f1", "f2"))
+    val returned = model.setLumpRules(Map("f1" -> 1, "f2" -> 1))
+    assert(returned.getLumpRules == Map("f1" -> 1, "f2" -> 1))
+    assert(dump(model.transform(df), Seq("f1", "f2")) == before)
+  }
+
+  test("loaded model and its copy retain immutable fitted rules and reject incompatible changes") {
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 1, "f2" -> 1)).fit(df)
+    val path = new File(tmpDir.toFile, "lump-immutable").toString
+    model.write.overwrite().save(path)
+    val loaded = LumpFeaturesModel.load(path)
+    assert(loaded.getLumpRules == Map("f1" -> 1, "f2" -> 1))
+    assert(loaded.getKeptValues == model.getKeptValues)
+    assertDFEq(loaded.transform(df), model.transform(df))
+    intercept[IllegalArgumentException] { loaded.setLumpRules(Map("f1" -> 2, "f2" -> 1)) }
+    val copied = loaded.copy(new ParamMap())
+    assert(copied.getKeptValues == model.getKeptValues)
+    assert(copied.getLumpRules == Map("f1" -> 1, "f2" -> 1))
+    intercept[IllegalArgumentException] { copied.setLumpRules(Map("f1" -> 3, "f2" -> 1)) }
+  }
+
+  test("copy with an incompatible lumpRules ParamMap override is rejected") {
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 1)).fit(df)
+    val incompatible = new ParamMap().put(model.lumpRules, Map("f1" -> 5))
+    intercept[IllegalArgumentException] { model.copy(incompatible) }
+    val same = new ParamMap().put(model.lumpRules, Map("f1" -> 1))
+    val copied = model.copy(same)
+    assert(copied.getLumpRules == Map("f1" -> 1))
+    assert(copied.getKeptValues == model.getKeptValues)
+  }
+
+  test("model-state validation rejects lumpRules mutated through the generic Param path") {
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 1)).fit(df)
+    model.set(model.lumpRules, Map("f1" -> 5))
+    val ex = intercept[IllegalArgumentException] { model.transform(df).collect() }
+    assert(ex.getMessage.toLowerCase.contains("lumprules") || ex.getMessage.toLowerCase.contains("top-k"))
+  }
+
+  test("fitted model setLumpRules overloads (Scala Map, Java HashMap, JSON string) all reject changes") {
+    def fitted(): LumpFeaturesModel = new LumpFeatures().setLumpRules(Map("f1" -> 1)).fit(df)
+    intercept[IllegalArgumentException] { fitted().setLumpRules(Map("f1" -> 2)) }
+    val jmap = new java.util.HashMap[String, Int]()
+    jmap.put("f1", 2)
+    intercept[IllegalArgumentException] { fitted().setLumpRules(jmap) }
+    intercept[IllegalArgumentException] { fitted().setLumpRules("{\"f1\":2}") }
+  }
+
   override def testObjects(): Seq[TestObject[LumpFeatures]] = Seq(
     new TestObject(new LumpFeatures().setLumpRules(Map("f1" -> 1, "f2" -> 1)), df))
 
@@ -264,7 +324,7 @@ class LumpFeaturesModelSuite extends TransformerFuzzing[LumpFeaturesModel] with 
 
   private def persistedModel: LumpFeaturesModel = new LumpFeaturesModel()
     .setLumpRules(Map("f1" -> 1, "f2" -> 1))
-    .setKeptValuesJson(Map("f1" -> "[\"apple\"]", "f2" -> "[\"red\"]"))
+    .setKeptValuesJson(Map("f1" -> "{\"topK\":1,\"values\":[\"apple\"]}", "f2" -> "{\"topK\":1,\"values\":[\"red\"]}"))
     .setOtherValue(other)
     .setHandleNull("keep")
 

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/stages/LumpFeaturesSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/stages/LumpFeaturesSuite.scala
@@ -1,0 +1,246 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.stages
+
+import com.microsoft.azure.synapse.ml.core.test.fuzzing.{EstimatorFuzzing, TestObject}
+import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.ml.util.MLReadable
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{Column, DataFrame, Row}
+
+import java.io.File
+import scala.collection.JavaConverters._
+
+//scalastyle:off null
+class LumpFeaturesSuite extends EstimatorFuzzing[LumpFeatures] {
+
+  import spark.implicits._
+
+  private lazy val df: DataFrame = Seq(
+    ("apple", "red"),
+    ("apple", "red"),
+    ("apple", "blue"),
+    ("banana", "red"),
+    ("cherry", "green")
+  ).toDF("f1", "f2")
+
+  private val other = "__other__"
+
+  private def dump(data: DataFrame, cols: Seq[String]): List[String] = {
+    val projected = data.select(cols.map(col): _*)
+    projected.collect().map { r =>
+      cols.indices.map(i => if (r.isNullAt(i)) "<null>" else r.get(i).toString).mkString("|")
+    }.sorted.toList
+  }
+
+  test("multi-column top-K retains learned values and lumps the rest") {
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 1, "f2" -> 1)).fit(df)
+    assert(model.getKeptValues("f1") == Seq("apple"))
+    assert(model.getKeptValues("f2") == Seq("red"))
+    val out = model.transform(df)
+    assert(out.columns.toSeq == Seq("f1", "f2"))
+    assert(dump(out, Seq("f1", "f2")) == List(
+      s"$other|$other", s"$other|red", s"apple|$other", "apple|red", "apple|red"))
+  }
+
+  test("stable ranking is count desc then value asc for ties") {
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 2)).fit(df)
+    assert(model.getKeptValues("f1") == Seq("apple", "banana"))
+    assert(dump(model.transform(df), Seq("f1")) == List(other, "apple", "apple", "apple", "banana"))
+  }
+
+  test("rare and unseen non-null values map to the other bucket") {
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 1)).fit(df)
+    val scoring = Seq(("banana", "red"), ("durian", "red"), ("apple", "red")).toDF("f1", "f2")
+    assert(dump(model.transform(scoring), Seq("f1")) == List(other, other, "apple"))
+  }
+
+  test("handleNull keep preserves null; handleNull other maps null to otherValue") {
+    val dfN = Seq(("apple", "red"), ("apple", "red"), (null, "red"), ("banana", "red"))
+      .toDF("f1", "f2")
+    val keepModel = new LumpFeatures().setLumpRules(Map("f1" -> 1)).setHandleNull("keep").fit(dfN)
+    assert(dump(keepModel.transform(dfN), Seq("f1")) == List("<null>", other, "apple", "apple"))
+    val otherModel = new LumpFeatures().setLumpRules(Map("f1" -> 1)).setHandleNull("other").fit(dfN)
+    assert(dump(otherModel.transform(dfN), Seq("f1")) == List(other, other, "apple", "apple"))
+  }
+
+  test("all-null column yields empty learned levels and maps values accordingly") {
+    val dfAllNull = Seq((null.asInstanceOf[String], "red"), (null.asInstanceOf[String], "blue"))
+      .toDF("f1", "f2")
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 2)).setHandleNull("keep").fit(dfAllNull)
+    assert(model.getKeptValues("f1").isEmpty)
+    assert(dump(model.transform(dfAllNull), Seq("f1")) == List("<null>", "<null>"))
+    val scoring = Seq(("zebra", "red")).toDF("f1", "f2")
+    assert(dump(model.transform(scoring), Seq("f1")) == List(other))
+  }
+
+  test("empty learned levels via manually constructed model maps all non-null to otherValue") {
+    val model = new LumpFeaturesModel()
+      .setLumpRules(Map("f1" -> 2))
+      .setKeptValuesJson(Map("f1" -> "[]"))
+      .setHandleNull("keep")
+    assert(dump(model.transform(df), Seq("f1")) == List(other, other, other, other, other))
+  }
+
+  test("fit rejects otherValue collision even when the value is rare") {
+    val dfCollide = Seq(("apple", "red"), ("apple", "red"), (other, "blue")).toDF("f1", "f2")
+    val ex = intercept[IllegalArgumentException] {
+      new LumpFeatures().setLumpRules(Map("f1" -> 1)).fit(dfCollide)
+    }
+    assert(ex.getMessage.toLowerCase.contains("othervalue"))
+  }
+
+  test("model transform rejects changed otherValue that collides with a retained value") {
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 1)).fit(df)
+    model.setOtherValue("apple")
+    intercept[IllegalArgumentException] {
+      model.transform(df).collect()
+    }
+  }
+
+  test("fit validates rules, K, column names, presence and string type") {
+    intercept[IllegalArgumentException] {
+      new LumpFeatures().setLumpRules(Map.empty[String, Int]).fit(df)
+    }
+    intercept[IllegalArgumentException] {
+      new LumpFeatures().fit(df)
+    }
+    intercept[IllegalArgumentException] {
+      new LumpFeatures().setLumpRules(Map("f1" -> 0)).fit(df)
+    }
+    intercept[IllegalArgumentException] {
+      new LumpFeatures().setLumpRules(Map("f1" -> -3)).fit(df)
+    }
+    intercept[IllegalArgumentException] {
+      new LumpFeatures().setLumpRules(Map("" -> 1)).fit(df)
+    }
+    intercept[IllegalArgumentException] {
+      new LumpFeatures().setLumpRules(Map("missing" -> 1)).fit(df)
+    }
+    val dfInt = Seq(("apple", 1), ("banana", 2)).toDF("f1", "n")
+    intercept[IllegalArgumentException] {
+      new LumpFeatures().setLumpRules(Map("n" -> 1)).fit(dfInt)
+    }
+  }
+
+  test("model validates state and rule consistency") {
+    val mismatch = new LumpFeaturesModel()
+      .setLumpRules(Map("f1" -> 1))
+      .setKeptValuesJson(Map("f2" -> "[\"red\"]"))
+    intercept[IllegalArgumentException] { mismatch.transform(df).collect() }
+    val tooMany = new LumpFeaturesModel()
+      .setLumpRules(Map("f1" -> 1))
+      .setKeptValuesJson(Map("f1" -> "[\"apple\",\"banana\"]"))
+    intercept[IllegalArgumentException] { tooMany.transform(df).collect() }
+  }
+
+  test("schema matches transform exactly with cleared metadata and correct nullability") {
+    val schema = StructType(Seq(
+      StructField("f1", StringType, nullable = true),
+      StructField("f2", StringType, nullable = true),
+      StructField("keep_me", IntegerType, nullable = false)))
+    val rows = Seq(Row("apple", "red", 1), Row("banana", "red", 2), Row(null, "blue", 3))
+    val md = new MetadataBuilder().putString("foo", "bar").build()
+    val base = spark.createDataFrame(rows.asJava, schema)
+    val dfMeta = base.withColumn("f1", col("f1").as("f1", md))
+
+    val keepModel = new LumpFeatures().setLumpRules(Map("f1" -> 1)).setHandleNull("keep").fit(dfMeta)
+    val declaredKeep = keepModel.transformSchema(dfMeta.schema)
+    assert(declaredKeep == keepModel.transform(dfMeta).schema)
+    assert(declaredKeep.fieldNames.toSeq == Seq("f1", "f2", "keep_me"))
+    assert(declaredKeep("f1").dataType == StringType)
+    assert(declaredKeep("f1").nullable)
+    assert(declaredKeep("f1").metadata == Metadata.empty)
+    assert(declaredKeep("f2") == dfMeta.schema("f2"))
+    assert(declaredKeep("keep_me") == dfMeta.schema("keep_me"))
+    assert(keepModel.transform(dfMeta).schema("f1").metadata == Metadata.empty)
+
+    val otherModel = new LumpFeatures().setLumpRules(Map("f1" -> 1)).setHandleNull("other").fit(dfMeta)
+    val declaredOther = otherModel.transformSchema(dfMeta.schema)
+    assert(declaredOther == otherModel.transform(dfMeta).schema)
+    assert(!declaredOther("f1").nullable)
+  }
+
+  test("estimator and model copy preserve parameters and learned state") {
+    val est = new LumpFeatures().setLumpRules(Map("f1" -> 1)).setOtherValue("X").setHandleNull("other")
+    val estCopy = est.copy(new ParamMap())
+    assert(estCopy.getLumpRules == Map("f1" -> 1))
+    assert(estCopy.getOtherValue == "X")
+    assert(estCopy.getHandleNull == "other")
+    val model = est.fit(df)
+    val modelCopy = model.copy(new ParamMap())
+    assert(modelCopy.getKeptValues == model.getKeptValues)
+    assert(modelCopy.getOtherValue == "X")
+    assert(modelCopy.getHandleNull == "other")
+    assert(modelCopy.getLumpRules == Map("f1" -> 1))
+  }
+
+  test("legacy JSON-string and Java HashMap setters populate lumpRules") {
+    val fromJson = new LumpFeatures().setLumpRules("{\"f1\":2,\"f2\":1}")
+    assert(fromJson.getLumpRules == Map("f1" -> 2, "f2" -> 1))
+    val jmap = new java.util.HashMap[String, Int]()
+    jmap.put("f1", 3)
+    val fromJava = new LumpFeatures().setLumpRules(jmap)
+    assert(fromJava.getLumpRules == Map("f1" -> 3))
+  }
+
+  test("persisted learned values survive arbitrary strings round-trip") {
+    val weird = Seq(
+      ("a\"b", "x"),
+      ("[bracket]", "x"),
+      ("\u00fcn\u00eecod\u00e9", "x"),
+      ("with,comma", "x"),
+      ("back\\slash", "x"),
+      ("a\"b", "y")
+    ).toDF("f1", "f2")
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 10)).fit(weird)
+    val path = new File(tmpDir.toFile, "lump-weird").toString
+    model.write.overwrite().save(path)
+    val loaded = LumpFeaturesModel.load(path)
+    assert(loaded.getKeptValues("f1").toSet ==
+      Set("a\"b", "[bracket]", "\u00fcn\u00eecod\u00e9", "with,comma", "back\\slash"))
+    assertDFEq(model.transform(weird), loaded.transform(weird))
+  }
+
+  private def bq(name: String): Column = col("`" + name.replace("`", "``") + "`")
+
+  private def dumpQ(data: DataFrame, cols: Seq[String]): List[String] = {
+    val projected = data.select(cols.map(bq): _*)
+    projected.collect().map { r =>
+      cols.indices.map(i => if (r.isNullAt(i)) "<null>" else r.get(i).toString).mkString("|")
+    }.sorted.toList
+  }
+
+  test("rule columns named count, dotted, and embedded-backtick fit and transform correctly") {
+    val specialDf = Seq(
+      ("apple", "red", "x"),
+      ("apple", "red", "x"),
+      ("apple", "blue", "y"),
+      ("banana", "red", "x")
+    ).toDF("count", "a.b", "a`b")
+    val rules = Map("count" -> 1, "a.b" -> 1, "a`b" -> 1)
+    val model = new LumpFeatures().setLumpRules(rules).fit(specialDf)
+    assert(model.getKeptValues("count") == Seq("apple"))
+    assert(model.getKeptValues("a.b") == Seq("red"))
+    assert(model.getKeptValues("a`b") == Seq("x"))
+    val out = model.transform(specialDf)
+    assert(out.columns.toSeq == Seq("count", "a.b", "a`b"))
+    assert(dumpQ(out, Seq("count")) == List(other, "apple", "apple", "apple"))
+    assert(dumpQ(out, Seq("a.b")) == List(other, "red", "red", "red"))
+    assert(dumpQ(out, Seq("a`b")) == List(other, "x", "x", "x"))
+    val collideDf = Seq(("apple", "red", "x"), (other, "blue", "y")).toDF("count", "a.b", "a`b")
+    val ex = intercept[IllegalArgumentException] {
+      new LumpFeatures().setLumpRules(Map("count" -> 1)).fit(collideDf)
+    }
+    assert(ex.getMessage.toLowerCase.contains("othervalue"))
+  }
+  override def testObjects(): Seq[TestObject[LumpFeatures]] = Seq(
+    new TestObject(new LumpFeatures().setLumpRules(Map("f1" -> 1, "f2" -> 1)), df))
+
+  override def reader: MLReadable[_] = LumpFeatures
+
+  override def modelReader: MLReadable[_] = LumpFeaturesModel
+
+}

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/stages/LumpFeaturesSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/stages/LumpFeaturesSuite.scala
@@ -102,12 +102,41 @@ class LumpFeaturesSuite extends EstimatorFuzzing[LumpFeatures] with LumpFeatures
     assert(ex.getMessage.toLowerCase.contains("othervalue"))
   }
 
-  test("model transform rejects changed otherValue that collides with a retained value") {
+  test("fitted model rejects direct otherValue mutation to an observed non-retained category") {
     val model = new LumpFeatures().setLumpRules(Map("f1" -> 1)).fit(df)
-    model.setOtherValue("apple")
-    intercept[IllegalArgumentException] {
-      model.transform(df).collect()
+    assert(model.getKeptValues("f1") == Seq("apple"))
+    val ex = intercept[IllegalArgumentException] { model.setOtherValue("banana") }
+    assert(ex.getMessage.toLowerCase.contains("othervalue"))
+    assert(model.getOtherValue == other)
+    assert(dump(model.transform(df), Seq("f1")) == List(other, other, "apple", "apple", "apple"))
+  }
+
+  test("generic otherValue Param mutation is rejected and leaves the fitted model unchanged") {
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 1)).fit(df)
+    val ex = intercept[IllegalArgumentException] {
+      model.set(model.otherValue, "banana")
     }
+    assert(ex.getMessage.toLowerCase.contains("othervalue"))
+    assert(model.getOtherValue == other)
+    assert(dump(model.transform(df), Seq("f1")) == List(other, other, "apple", "apple", "apple"))
+  }
+
+  test("generic clear and mutation cannot remove or corrupt fitted learned state") {
+    val model = new LumpFeatures()
+      .setLumpRules(Map("f1" -> 1))
+      .setOtherValue("fallback")
+      .fit(df)
+    val learned = model.getKeptValuesJson
+
+    intercept[IllegalArgumentException] { model.clear(model.getParam("keptValuesJson")) }
+    assert(model.getKeptValuesJson == learned)
+
+    intercept[IllegalArgumentException] { model.set(model.keptValuesJson, Map.empty[String, String]) }
+    assert(model.getKeptValuesJson == learned)
+
+    intercept[IllegalArgumentException] { model.clear(model.otherValue) }
+    assert(model.getOtherValue == "fallback")
+    intercept[IllegalArgumentException] { model.setOtherValue("banana") }
   }
 
   test("fit validates rules, K, column names, presence and string type") {
@@ -290,6 +319,35 @@ class LumpFeaturesSuite extends EstimatorFuzzing[LumpFeatures] with LumpFeatures
     assert(copied.getKeptValues == model.getKeptValues)
   }
 
+  test("copy rejects forged learned state, otherValue, and rules atomically but accepts identical state") {
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 1)).fit(df)
+    val learned = model.getKeptValuesJson
+    val before = dump(model.transform(df), Seq("f1"))
+
+    val incompatibleOther = new ParamMap().put(model.otherValue, "banana")
+    intercept[IllegalArgumentException] { model.copy(incompatibleOther) }
+
+    val incompatibleRules = new ParamMap().put(model.lumpRules, Map("f1" -> 2))
+    intercept[IllegalArgumentException] { model.copy(incompatibleRules) }
+
+    val forged = learned.updated("f1", LumpFeaturesModel.encodeKept(1, Seq("banana"), other))
+    val forgedState = new ParamMap().put(model.keptValuesJson, forged)
+    intercept[IllegalArgumentException] { model.copy(forgedState) }
+
+    val missingState = new ParamMap().put(model.keptValuesJson, Map.empty[String, String])
+    intercept[IllegalArgumentException] { model.copy(missingState) }
+
+    val identicalState = new ParamMap().put(model.keptValuesJson, learned)
+    val copied = model.copy(identicalState)
+    assert(copied.getKeptValuesJson == learned)
+    assertDFEq(copied.transform(df), model.transform(df))
+
+    assert(model.getOtherValue == other)
+    assert(model.getLumpRules == Map("f1" -> 1))
+    assert(model.getKeptValuesJson == learned)
+    assert(dump(model.transform(df), Seq("f1")) == before)
+  }
+
   test("model-state validation rejects lumpRules mutated through the generic Param path") {
     val model = new LumpFeatures().setLumpRules(Map("f1" -> 1)).fit(df)
     model.set(model.lumpRules, Map("f1" -> 5))
@@ -415,23 +473,59 @@ class LumpFeaturesSuite extends EstimatorFuzzing[LumpFeatures] with LumpFeatures
     assert(fromJson.getOutputCols == Map("f1" -> "f1_lumped"))
   }
 
-  test("declared nullability follows handleNull alone even for a non-nullable input column") {
+  test("estimator and model nullability follow handleNull even for a non-nullable input column") {
     val schema = StructType(Seq(StructField("f1", StringType, nullable = false)))
     val rows = Seq(Row("apple"), Row("apple"), Row("banana"))
     val dfNN = spark.createDataFrame(rows.asJava, schema)
     assert(!dfNN.schema("f1").nullable)
 
-    val keepModel = new LumpFeatures().setLumpRules(Map("f1" -> 1)).setHandleNull("keep").fit(dfNN)
+    val keepEstimator = new LumpFeatures().setLumpRules(Map("f1" -> 1)).setHandleNull("keep")
+    assert(keepEstimator.transformSchema(dfNN.schema)("f1").nullable)
+    val keepModel = keepEstimator.fit(dfNN)
     val declaredKeep = keepModel.transformSchema(dfNN.schema)
     assert(declaredKeep == keepModel.transform(dfNN).schema)
     assert(declaredKeep("f1").nullable)
     assert(dump(keepModel.transform(dfNN), Seq("f1")) == List(other, "apple", "apple"))
 
-    val otherModel = new LumpFeatures().setLumpRules(Map("f1" -> 1)).setHandleNull("other").fit(dfNN)
+    val otherEstimator = new LumpFeatures().setLumpRules(Map("f1" -> 1)).setHandleNull("other")
+    assert(!otherEstimator.transformSchema(dfNN.schema)("f1").nullable)
+    val otherModel = otherEstimator.fit(dfNN)
     val declaredOther = otherModel.transformSchema(dfNN.schema)
     assert(declaredOther == otherModel.transform(dfNN).schema)
     assert(!declaredOther("f1").nullable)
     assert(dump(otherModel.transform(dfNN), Seq("f1")) == List(other, "apple", "apple"))
+  }
+
+  test("fit-time otherValue survives save-load and protects observed non-retained categories") {
+    val fallback = "fallback"
+    val model = new LumpFeatures().setLumpRules(Map("f1" -> 1)).setOtherValue(fallback).fit(df)
+    val path = new File(tmpDir.toFile, "lump-fitted-other").toString
+    model.write.overwrite().save(path)
+    val loaded = LumpFeaturesModel.load(path)
+    val state = loaded.getKeptValuesJson("f1").parseJson.asJsObject.fields
+    assert(state("otherValue") == JsString(fallback))
+    assert(!loaded.hasParam("fittedOtherValue"))
+    assert(loaded.getKeptValues("f1") == Seq("apple"))
+    intercept[IllegalArgumentException] { loaded.setOtherValue("banana") }
+    intercept[IllegalArgumentException] { loaded.set(loaded.otherValue, "banana") }
+    assert(loaded.getOtherValue == fallback)
+    assertDFEq(loaded.transform(df), model.transform(df))
+  }
+
+  test("loading legacy model state initializes and enforces the fitted otherValue") {
+    val legacy = new LumpFeaturesModel()
+      .setLumpRules(Map("f1" -> 1))
+      .setOtherValue("fallback")
+      .setKeptValuesJson(Map("f1" -> "{\"topK\":1,\"values\":[\"apple\"]}"))
+    assert(!legacy.getKeptValuesJson("f1").parseJson.asJsObject.fields.contains("otherValue"))
+    val path = new File(tmpDir.toFile, "lump-legacy-other").toString
+    legacy.write.overwrite().save(path)
+    val loaded = LumpFeaturesModel.load(path)
+    val upgraded = loaded.getKeptValuesJson("f1").parseJson.asJsObject.fields
+    assert(upgraded("otherValue") == JsString("fallback"))
+    intercept[IllegalArgumentException] { loaded.setOtherValue("banana") }
+    intercept[IllegalArgumentException] { loaded.clear(loaded.getParam("keptValuesJson")) }
+    assert(loaded.getOtherValue == "fallback")
   }
 
   test("getKeptValuesAsJson gives language wrappers one document with the learned values") {
@@ -462,8 +556,10 @@ class LumpFeaturesModelSuite extends TransformerFuzzing[LumpFeaturesModel] with 
 
   private def persistedModel: LumpFeaturesModel = new LumpFeaturesModel()
     .setLumpRules(Map("f1" -> 1, "f2" -> 1))
-    .setKeptValuesJson(Map("f1" -> "{\"topK\":1,\"values\":[\"apple\"]}", "f2" -> "{\"topK\":1,\"values\":[\"red\"]}"))
     .setOtherValue(other)
+    .setKeptValuesJson(Map(
+      "f1" -> LumpFeaturesModel.encodeKept(1, Seq("apple"), other),
+      "f2" -> LumpFeaturesModel.encodeKept(1, Seq("red"), other)))
     .setHandleNull("keep")
 
   test("manually constructed model retains learned values and lumps the rest deterministically") {

--- a/docs/Quick Examples/estimators/core/_Stages.md
+++ b/docs/Quick Examples/estimators/core/_Stages.md
@@ -73,6 +73,80 @@ csharp="classSynapse_1_1ML_1_1Stages_1_1ClassBalancer.html"
 sourceLink="https://github.com/microsoft/SynapseML/blob/master/core/src/main/scala/com/microsoft/azure/synapse/ml/stages/ClassBalancer.scala" />
 
 
+### LumpFeatures
+
+<Tabs
+defaultValue="py"
+values={[
+{label: `Python`, value: `py`},
+{label: `Scala`, value: `scala`},
+]}>
+<TabItem value="py">
+
+<!--pytest-codeblocks:cont-->
+
+```python
+from synapse.ml.stages import *
+
+df = (spark.createDataFrame([
+      ("apple", "red"),
+      ("apple", "red"),
+      ("apple", "blue"),
+      ("banana", "red"),
+      ("banana", "green"),
+      ("cherry", "green")
+      ], ["fruit", "color"]))
+
+lumper = (LumpFeatures()
+        .setLumpRules({"fruit": 3, "color": 3})
+        .setMinCount(2)
+        .setOutputCols({"fruit": "fruit_lumped", "color": "color_lumped"}))
+
+model = lumper.fit(df)
+
+# cherry and blue occur once, so minCount drops them before the top-K cap is reached
+print(model.getKeptValues())
+
+model.transform(df).show()
+```
+
+</TabItem>
+<TabItem value="scala">
+
+```scala
+import com.microsoft.azure.synapse.ml.stages._
+
+val df = Seq(
+      ("apple", "red"),
+      ("apple", "red"),
+      ("apple", "blue"),
+      ("banana", "red"),
+      ("banana", "green"),
+      ("cherry", "green")).toDF("fruit", "color")
+
+val lumper = (new LumpFeatures()
+        .setLumpRules(Map("fruit" -> 3, "color" -> 3))
+        .setMinCount(2)
+        .setOutputCols(Map("fruit" -> "fruit_lumped", "color" -> "color_lumped")))
+
+val model = lumper.fit(df)
+
+// cherry and blue occur once, so minCount drops them before the top-K cap is reached
+println(model.getKeptValues)
+
+model.transform(df).show()
+```
+
+</TabItem>
+</Tabs>
+
+<DocTable className="LumpFeatures"
+py="synapse.ml.stages.html#module-synapse.ml.stages.LumpFeatures"
+scala="com/microsoft/azure/synapse/ml/stages/LumpFeatures.html"
+csharp="classSynapse_1_1ML_1_1Stages_1_1LumpFeatures.html"
+sourceLink="https://github.com/microsoft/SynapseML/blob/master/core/src/main/scala/com/microsoft/azure/synapse/ml/stages/LumpFeatures.scala" />
+
+
 ### MultiColumnAdapter
 
 <Tabs


### PR DESCRIPTION
## Summary

Recreates the valuable categorical-lumping proposal from #1941 for the current SynapseML codebase and addresses #1891.

- implements `LumpFeatures` as a Spark ML `Estimator` plus persisted `LumpFeaturesModel`
- preserves the multi-column `lumpRules` API, including Scala map, Java map, legacy JSON, and generated Python `dict` bindings
- learns top-K values once during `fit`; `transform` never refits
- ranks deterministically by count descending and value ascending
- retains learned values, maps rare and unseen non-null values to an explicit `otherValue`, and makes null handling configurable
- rejects real-data collisions with the other bucket
- validates StringType-only v1 schemas and handles literal dotted, backtick, and `count` column names safely
- persists learned state and supports estimator/model/pipeline serialization and copy behavior

This is a new implementation; it does not alter the ancient PR branch.

## Validation

- `core/compile`
- `core/testOnly com.microsoft.azure.synapse.ml.stages.LumpFeaturesSuite` — 18 tests passed
- `core/scalastyle; core/Test/scalastyle`
- `codegen`
- generated `LumpFeatures.py` and `LumpFeaturesModel.py` syntax-compiled with `py_compile`
- final SynapseML code review: no concrete issues

## Design notes

The initial API intentionally supports string columns only so the explicit other bucket cannot silently change numeric or boolean column types. Nulls are excluded from frequency counts and preserved by default; unseen non-null values always use the other bucket. Fitting fails if `otherValue` already occurs in any configured column, avoiding ambiguous category merges.

Related: #1941, #1891