### PR TITLE
ci: restore Spark release compatibility checks

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -914,6 +914,14 @@ jobs:
         jdkSourceOption: PreInstalled
 
     - bash: |
+        set -euo pipefail
+        git config --local user.name "SynapseML CI"
+        git config --local user.email "synapseml-ci@users.noreply.github.com"
+        test "$(git config --local user.name)" = "SynapseML CI"
+        test "$(git config --local user.email)" = "synapseml-ci@users.noreply.github.com"
+      displayName: 'Configure Git identity for compatibility rebase'
+
+    - bash: |
         set -e
         echo "=== Current HEAD (PR merge commit) ==="
         git log --oneline -1
@@ -955,14 +963,21 @@ jobs:
 
         echo "=== Attempting to apply PR changes onto $(RELEASE_BRANCH) ==="
         git checkout $SOURCE_HEAD
-        git rebase --onto $RELEASE_TIP $TARGET_HEAD $SOURCE_HEAD 2>&1 || {
-          echo "##vso[task.logissue type=warning]PR changes conflict with $(RELEASE_BRANCH)"
-          echo ""
-          echo "=== Conflicting files ==="
-          git diff --name-only --diff-filter=U 2>/dev/null || true
+        if ! REBASE_OUTPUT=$(git rebase --onto $RELEASE_TIP $TARGET_HEAD $SOURCE_HEAD 2>&1); then
+          printf '%s\n' "$REBASE_OUTPUT"
+          CONFLICTING_FILES=$(git diff --name-only --diff-filter=U 2>/dev/null || true)
+          if [ -n "$CONFLICTING_FILES" ]; then
+            echo "##vso[task.logissue type=warning]PR changes conflict with $(RELEASE_BRANCH)"
+            echo ""
+            echo "=== Conflicting files ==="
+            printf '%s\n' "$CONFLICTING_FILES"
+          else
+            echo "##vso[task.logissue type=error]Unable to replay PR changes onto $(RELEASE_BRANCH) before conflict detection"
+          fi
           git rebase --abort 2>/dev/null || true
           exit 1
-        }
+        fi
+        printf '%s\n' "$REBASE_OUTPUT"
         echo "PR changes apply cleanly onto $(RELEASE_BRANCH)"
       displayName: 'Apply PR changes onto $(RELEASE_BRANCH)'
 

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -190,6 +190,22 @@ def test_release_compat_accepts_github_target_and_uses_one_sbt_process():
     assert not any(step.get("task") == "AzureCLI@2" for step in steps)
     assert not any(step.get("template") == "templates/kv.yml" for step in steps)
 
+    identity_steps = [
+        step
+        for step in steps
+        if isinstance(step, dict)
+        and step.get("displayName") == "Configure Git identity for compatibility rebase"
+    ]
+    assert len(identity_steps) == 1
+    identity_script = identity_steps[0]["bash"]
+    assert 'git config --local user.name "SynapseML CI"' in identity_script
+    assert (
+        'git config --local user.email "synapseml-ci@users.noreply.github.com"'
+        in identity_script
+    )
+    assert 'test "$(git config --local user.name)"' in identity_script
+    assert 'test "$(git config --local user.email)"' in identity_script
+
     rebase_steps = [
         step
         for step in steps
@@ -197,6 +213,7 @@ def test_release_compat_accepts_github_target_and_uses_one_sbt_process():
         and step.get("displayName") == "Apply PR changes onto $(RELEASE_BRANCH)"
     ]
     assert len(rebase_steps) == 1
+    assert steps.index(identity_steps[0]) < steps.index(rebase_steps[0])
     rebase_script = rebase_steps[0]["bash"]
     assert "TARGET_HEAD=$(git rev-parse HEAD^1)" in rebase_script
     assert "SOURCE_HEAD=$(git rev-parse HEAD^2)" in rebase_script
@@ -207,6 +224,9 @@ def test_release_compat_accepts_github_target_and_uses_one_sbt_process():
     assert "templates/*|tools/acr/*|tools/ci/*" in rebase_script
     assert "variable=releaseCompatRequired]false" in rebase_script
     assert "variable=releaseCompatRequired]true" in rebase_script
+    assert "CONFLICTING_FILES=$(git diff --name-only --diff-filter=U" in rebase_script
+    assert "before conflict detection" in rebase_script
+    assert rebase_script.count("printf '%s\\n' \"$REBASE_OUTPUT\"") == 2
 
     validation_steps = [
         step


### PR DESCRIPTION
## Summary

Fix the Spark 3.5 and Spark 4.1 release compatibility jobs after multiple
otherwise-green PR builds failed before compilation with
`Committer identity unknown`.

- Configure a repository-local `SynapseML CI` Git name and email before
  `git rebase --onto`.
- Verify the identity values before replaying PR commits.
- Report actual conflicted files as source conflicts.
- Report rebase failures with no conflicted files as infrastructure errors
  instead of false conflicts.
- Preserve Git rebase output on both success and failure.

## Why PR #2581 did not catch this

PR #2581 changed only `pipeline.yaml`, templates, and CI/ACR tooling. The
compatibility path filter intentionally classified those as release-irrelevant,
so its successful build exited with `No release-relevant paths changed` before
reaching the rebase.

The first later PRs that changed Scala sources exercised the rebase and exposed
the missing identity.

## Evidence

The same infrastructure error occurred independently in:

- #2595: [build 229952123](https://msdata.visualstudio.com/b9b2accc-2d1c-45b3-9d24-0eb5d78cc47f/_build/results?buildId=229952123)
- #2596: [build 229952126](https://msdata.visualstudio.com/b9b2accc-2d1c-45b3-9d24-0eb5d78cc47f/_build/results?buildId=229952126)
- #2594: [build 229952827](https://msdata.visualstudio.com/b9b2accc-2d1c-45b3-9d24-0eb5d78cc47f/_build/results?buildId=229952827)

PR #2581's [build 229941477](https://msdata.visualstudio.com/b9b2accc-2d1c-45b3-9d24-0eb5d78cc47f/_build/results?buildId=229941477)
confirms the early path-filter exit.

## Validation

- 14 targeted pipeline regression tests
- Real temporary Git fixture reproducing the empty-identity failure and
  succeeding with the hotfix identity
- Black 22.3.0 repository check
- Scala and test scalastyle with JDK 11
- YAML parsing and `git diff --check`



## Azure validation

Azure build [229963758](https://msdata.visualstudio.com/b9b2accc-2d1c-45b3-9d24-0eb5d78cc47f/_build/results?buildId=229963758) passed all 67 Azure jobs. Both Spark 3.5 and Spark 4.1 matrix legs successfully ran the new Configure Git identity for compatibility rebase step, and all 77 reported PR checks passed.

