### PR TITLE
feat: add Spark-native univariate time series anomaly detection

### DIFF
--- a/cognitive/src/main/python/synapse/ml/cognitive/anomaly.py
+++ b/cognitive/src/main/python/synapse/ml/cognitive/anomaly.py
@@ -1,8 +1,11 @@
 import warnings
 
 warnings.warn(
-    "The 'synapse.ml.cognitive.anomaly' module has been removed. "
-    "The Azure AI Anomaly Detector service has been retired and its transformers "
-    "are no longer available. Use synapse.ml.isolationforest instead.",
+    "The 'synapse.ml.cognitive.anomaly' module has been removed because the Azure AI "
+    "Anomaly Detector service has been retired. For time series anomaly detection use "
+    "synapse.ml.timeseries.UnivariateAnomalyDetector, which runs the same algorithms "
+    "locally through the open source 'time-series-anomaly-detector' package and keeps "
+    "the original parameter and output field names. For point anomaly detection over "
+    "feature vectors use synapse.ml.isolationforest.",
     DeprecationWarning,
 )

--- a/core/src/main/python/synapse/ml/timeseries/UnivariateAnomalyDetector.py
+++ b/core/src/main/python/synapse/ml/timeseries/UnivariateAnomalyDetector.py
@@ -1,0 +1,469 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+"""Spark-native univariate time series anomaly detection.
+
+This module wraps the open source ``time-series-anomaly-detector`` package
+(imported as ``anomaly_detector``), which open sources the algorithms that used
+to back the retired Azure AI Anomaly Detector service.
+
+The library itself is single node pandas code, so this transformer supplies the
+distribution: series are partitioned with ``groupBy().applyInPandas()`` and each
+one is detected independently on an executor.
+"""
+
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from pyspark import keyword_only
+from pyspark.ml import Transformer
+from pyspark.ml.param import Param, Params, TypeConverters
+from pyspark.ml.util import DefaultParamsReadable, DefaultParamsWritable
+from pyspark.sql import DataFrame
+from pyspark.sql import functions as F
+from pyspark.sql import types as T
+
+__all__ = ["UnivariateAnomalyDetector"]
+
+MISSING_PACKAGE_MESSAGE = (
+    "UnivariateAnomalyDetector requires the 'time-series-anomaly-detector' package, "
+    "which is not installed. Install it with:\n"
+    "    pip install time-series-anomaly-detector\n"
+    "Note that the install name and the import name differ: the package installs as "
+    "'time-series-anomaly-detector' but imports as 'anomaly_detector'."
+)
+
+DETECT_MODE_ENTIRE = "entire"
+DETECT_MODE_LATEST = "latest"
+
+# Field names are deliberately the camelCase names the retired Azure AI Anomaly
+# Detector transformers emitted, so existing `col("anomalies.isAnomaly")` style
+# expressions keep working after migrating.
+#
+# `severity` is intentionally absent: the retired service returned it, but the
+# open source library does not compute it in either detect mode.
+_RESULT_FIELDS: List[Tuple[str, str, T.DataType]] = [
+    ("isAnomaly", "is_anomaly", T.BooleanType()),
+    ("isPositiveAnomaly", "is_positive_anomaly", T.BooleanType()),
+    ("isNegativeAnomaly", "is_negative_anomaly", T.BooleanType()),
+    ("expectedValue", "expected_value", T.DoubleType()),
+    ("upperMargin", "upper_margin", T.DoubleType()),
+    ("lowerMargin", "lower_margin", T.DoubleType()),
+    ("period", "period", T.IntegerType()),
+]
+
+_TEMP_PREFIX = "__synapseml_uvad_"
+_ERROR_FIELD = _TEMP_PREFIX + "error"
+
+# Parameters forwarded verbatim to the library. The names match the retired
+# service so migrating callers keep their existing tuning values.
+_PASSTHROUGH_PARAMS = [
+    "granularity",
+    "customInterval",
+    "period",
+    "maxAnomalyRatio",
+    "sensitivity",
+    "imputeMode",
+    "imputeFixedValue",
+]
+
+
+def result_schema() -> T.StructType:
+    """Return the struct schema emitted into ``outputCol``."""
+    return T.StructType(
+        [T.StructField(name, dtype, True) for name, _, dtype in _RESULT_FIELDS]
+    )
+
+
+def _default_detector_factory(detect_mode: str) -> Tuple[Any, Any]:
+    """Build a library detector. Imported lazily so the dependency stays optional."""
+    try:
+        from anomaly_detector.univariate.univariate_anomaly_detection import (
+            UnivariateAnomalyDetector as _LibraryDetector,
+        )
+        from anomaly_detector.univariate.util.fields import DetectType
+    except ImportError as exc:  # pragma: no cover - only hit without the dependency
+        raise ImportError(MISSING_PACKAGE_MESSAGE) from exc
+
+    detect_type = (
+        DetectType.LATEST if detect_mode == DETECT_MODE_LATEST else DetectType.ENTIRE
+    )
+    return _LibraryDetector(), detect_type
+
+
+def _coerce(value: Any, dtype: T.DataType) -> Any:
+    if value is None:
+        return None
+    if isinstance(dtype, T.BooleanType):
+        return bool(value)
+    if isinstance(dtype, T.IntegerType):
+        return int(value)
+    return float(value)
+
+
+def detect_series(
+    pdf,
+    options: Dict[str, Any],
+    detector_factory: Optional[Callable[[str], Tuple[Any, Any]]] = None,
+):
+    """Detect anomalies for a single, complete time series.
+
+    Pure pandas with no Spark dependency, which keeps it directly unit testable.
+    Any failure is captured per series so one bad group cannot fail the job.
+    """
+    import pandas as pd
+
+    timestamp_col = options["timestampCol"]
+    value_col = options["valueCol"]
+    detect_mode = options["detectMode"]
+
+    pdf = pdf.sort_values(timestamp_col, kind="mergesort").reset_index(drop=True)
+    row_count = len(pdf)
+    columns: Dict[str, List[Any]] = {
+        _TEMP_PREFIX + name: [None] * row_count for name, _, _ in _RESULT_FIELDS
+    }
+    error: Optional[str] = None
+
+    try:
+        if row_count == 0:
+            raise ValueError("the series is empty")
+
+        factory = detector_factory or _default_detector_factory
+        detector, detect_type = factory(detect_mode)
+
+        params = dict(options["params"])
+        params["detect_mode"] = detect_type
+        series = pd.DataFrame(
+            {
+                "timestamp": pdf[timestamp_col].astype(str).tolist(),
+                "value": pdf[value_col].astype(float).tolist(),
+            }
+        )
+        response = detector.predict(None, series, params)
+        results = [entry.get("result", entry) for entry in response]
+
+        if detect_mode == DETECT_MODE_LATEST:
+            # Only the most recent point is scored; earlier rows are the context
+            # window the model needed in order to score it.
+            results = [None] * (row_count - 1) + [results[-1]]
+        elif len(results) != row_count:
+            raise ValueError(
+                "detector returned {0} results for {1} rows".format(
+                    len(results), row_count
+                )
+            )
+
+        for index, result in enumerate(results):
+            if result is None:
+                continue
+            for name, source, dtype in _RESULT_FIELDS:
+                columns[_TEMP_PREFIX + name][index] = _coerce(result.get(source), dtype)
+    except Exception as exc:  # noqa: BLE001 - deliberately surfaced through errorCol
+        error = "{0}: {1}".format(type(exc).__name__, exc)
+        for name, _, _ in _RESULT_FIELDS:
+            columns[_TEMP_PREFIX + name] = [None] * row_count
+
+    for column, values in columns.items():
+        pdf[column] = values
+    pdf[_ERROR_FIELD] = [error] * row_count
+    return pdf
+
+
+class UnivariateAnomalyDetector(
+    Transformer, DefaultParamsReadable, DefaultParamsWritable
+):
+    """Detect anomalies in univariate time series, one series per group.
+
+    Replaces the retired ``DetectAnomalies``, ``DetectLastAnomaly`` and
+    ``SimpleDetectAnomalies`` transformers. Parameter names and output field
+    names are unchanged from those transformers, so migrating is normally just a
+    change of import and constructor.
+
+    Requires the optional ``time-series-anomaly-detector`` package.
+    """
+
+    timestampCol = Param(
+        Params._dummy(),
+        "timestampCol",
+        "Name of the column holding the timestamp of each point",
+        typeConverter=TypeConverters.toString,
+    )
+
+    valueCol = Param(
+        Params._dummy(),
+        "valueCol",
+        "Name of the column holding the measured value of each point",
+        typeConverter=TypeConverters.toString,
+    )
+
+    groupByCols = Param(
+        Params._dummy(),
+        "groupByCols",
+        "Columns identifying an individual series. Each group is detected "
+        "independently and in parallel. When empty the whole DataFrame is "
+        "treated as a single series",
+        typeConverter=TypeConverters.toListString,
+    )
+
+    outputCol = Param(
+        Params._dummy(),
+        "outputCol",
+        "Name of the output struct column holding the detection result",
+        typeConverter=TypeConverters.toString,
+    )
+
+    errorCol = Param(
+        Params._dummy(),
+        "errorCol",
+        "Name of the output column holding the error message for series that "
+        "could not be scored. Null when detection succeeded",
+        typeConverter=TypeConverters.toString,
+    )
+
+    detectMode = Param(
+        Params._dummy(),
+        "detectMode",
+        "Either 'entire' to score every point, or 'latest' to score only the "
+        "most recent point of each series",
+        typeConverter=TypeConverters.toString,
+    )
+
+    granularity = Param(
+        Params._dummy(),
+        "granularity",
+        "Sampling rate of the series: yearly, monthly, weekly, daily, hourly, "
+        "minutely, secondly, microsecond or none",
+        typeConverter=TypeConverters.toString,
+    )
+
+    customInterval = Param(
+        Params._dummy(),
+        "customInterval",
+        "Custom interval used together with granularity, for example 5 with a "
+        "granularity of minutely for a five minute series",
+        typeConverter=TypeConverters.toInt,
+    )
+
+    period = Param(
+        Params._dummy(),
+        "period",
+        "Known period of the series. Omit to have it inferred",
+        typeConverter=TypeConverters.toInt,
+    )
+
+    maxAnomalyRatio = Param(
+        Params._dummy(),
+        "maxAnomalyRatio",
+        "Maximum proportion of points that may be flagged, in (0, 0.49]",
+        typeConverter=TypeConverters.toFloat,
+    )
+
+    sensitivity = Param(
+        Params._dummy(),
+        "sensitivity",
+        "Detection sensitivity from 0 to 99. Lower values widen the margins "
+        "and flag fewer points",
+        typeConverter=TypeConverters.toInt,
+    )
+
+    imputeMode = Param(
+        Params._dummy(),
+        "imputeMode",
+        "How to fill missing points: auto, previous, linear, fixed, zero or notFill",
+        typeConverter=TypeConverters.toString,
+    )
+
+    imputeFixedValue = Param(
+        Params._dummy(),
+        "imputeFixedValue",
+        "Value used to fill gaps when imputeMode is 'fixed'",
+        typeConverter=TypeConverters.toFloat,
+    )
+
+    @keyword_only
+    def __init__(
+        self,
+        timestampCol="timestamp",
+        valueCol="value",
+        groupByCols=None,
+        outputCol="anomalies",
+        errorCol="error",
+        detectMode=DETECT_MODE_ENTIRE,
+        granularity=None,
+        customInterval=None,
+        period=None,
+        maxAnomalyRatio=None,
+        sensitivity=None,
+        imputeMode=None,
+        imputeFixedValue=None,
+    ):
+        super(UnivariateAnomalyDetector, self).__init__()
+        self._setDefault(
+            timestampCol="timestamp",
+            valueCol="value",
+            groupByCols=[],
+            outputCol="anomalies",
+            errorCol="error",
+            detectMode=DETECT_MODE_ENTIRE,
+        )
+        kwargs = self._input_kwargs
+        self.setParams(**{k: v for k, v in kwargs.items() if v is not None})
+
+    @keyword_only
+    def setParams(self, **kwargs):
+        return self._set(**kwargs)
+
+    def setTimestampCol(self, value):
+        return self._set(timestampCol=value)
+
+    def getTimestampCol(self):
+        return self.getOrDefault(self.timestampCol)
+
+    def setValueCol(self, value):
+        return self._set(valueCol=value)
+
+    def getValueCol(self):
+        return self.getOrDefault(self.valueCol)
+
+    def setGroupByCols(self, value):
+        return self._set(groupByCols=value)
+
+    def getGroupByCols(self):
+        return self.getOrDefault(self.groupByCols)
+
+    def setOutputCol(self, value):
+        return self._set(outputCol=value)
+
+    def getOutputCol(self):
+        return self.getOrDefault(self.outputCol)
+
+    def setErrorCol(self, value):
+        return self._set(errorCol=value)
+
+    def getErrorCol(self):
+        return self.getOrDefault(self.errorCol)
+
+    def setDetectMode(self, value):
+        return self._set(detectMode=value)
+
+    def getDetectMode(self):
+        return self.getOrDefault(self.detectMode)
+
+    def setGranularity(self, value):
+        return self._set(granularity=value)
+
+    def getGranularity(self):
+        return self.getOrDefault(self.granularity)
+
+    def setCustomInterval(self, value):
+        return self._set(customInterval=value)
+
+    def setPeriod(self, value):
+        return self._set(period=value)
+
+    def setMaxAnomalyRatio(self, value):
+        return self._set(maxAnomalyRatio=value)
+
+    def setSensitivity(self, value):
+        return self._set(sensitivity=value)
+
+    def setImputeMode(self, value):
+        return self._set(imputeMode=value)
+
+    def setImputeFixedValue(self, value):
+        return self._set(imputeFixedValue=value)
+
+    def _detector_params(self) -> Dict[str, Any]:
+        params: Dict[str, Any] = {}
+        for name in _PASSTHROUGH_PARAMS:
+            param = getattr(self, name)
+            if self.isSet(param) or self.hasDefault(param):
+                value = self.getOrDefault(param)
+                if value is not None:
+                    params[name] = value
+        return params
+
+    def _options(self) -> Dict[str, Any]:
+        return {
+            "timestampCol": self.getTimestampCol(),
+            "valueCol": self.getValueCol(),
+            "detectMode": self.getDetectMode(),
+            "params": self._detector_params(),
+        }
+
+    def _validate(self, schema: T.StructType) -> None:
+        detect_mode = self.getDetectMode()
+        if detect_mode not in (DETECT_MODE_ENTIRE, DETECT_MODE_LATEST):
+            raise ValueError(
+                "detectMode must be '{0}' or '{1}', got '{2}'".format(
+                    DETECT_MODE_ENTIRE, DETECT_MODE_LATEST, detect_mode
+                )
+            )
+        known = set(schema.fieldNames())
+        for column in [self.getTimestampCol(), self.getValueCol()] + list(
+            self.getGroupByCols()
+        ):
+            if column not in known:
+                raise ValueError(
+                    "column '{0}' is not present in the input DataFrame".format(column)
+                )
+
+    def transformSchema(self, schema: T.StructType) -> T.StructType:
+        self._validate(schema)
+        return T.StructType(
+            list(schema.fields)
+            + [
+                T.StructField(self.getOutputCol(), result_schema(), True),
+                T.StructField(self.getErrorCol(), T.StringType(), True),
+            ]
+        )
+
+    def _transform(self, dataset: DataFrame) -> DataFrame:
+        self._validate(dataset.schema)
+
+        options = self._options()
+        output_col = self.getOutputCol()
+        error_col = self.getErrorCol()
+        group_by_cols = list(self.getGroupByCols())
+
+        working = dataset
+        # applyInPandas always needs a grouping key. With no user supplied key the
+        # whole DataFrame is a single series, which cannot be parallelized.
+        synthetic_key = None
+        if not group_by_cols:
+            synthetic_key = _TEMP_PREFIX + "group"
+            working = working.withColumn(synthetic_key, F.lit(0))
+            group_by_cols = [synthetic_key]
+
+        udf_schema = T.StructType(
+            list(working.schema.fields)
+            + [
+                T.StructField(_TEMP_PREFIX + name, dtype, True)
+                for name, _, dtype in _RESULT_FIELDS
+            ]
+            + [T.StructField(_ERROR_FIELD, T.StringType(), True)]
+        )
+        ordered = [field.name for field in udf_schema.fields]
+
+        def _apply(pdf):
+            return detect_series(pdf, options)[ordered]
+
+        detected = working.groupBy(*group_by_cols).applyInPandas(
+            _apply, schema=udf_schema
+        )
+
+        error_column = F.col(_ERROR_FIELD)
+        struct_column = F.struct(
+            *[F.col(_TEMP_PREFIX + name).alias(name) for name, _, _ in _RESULT_FIELDS]
+        )
+        detected = detected.withColumn(
+            output_col,
+            F.when(error_column.isNull(), struct_column).otherwise(
+                F.lit(None).cast(result_schema())
+            ),
+        ).withColumn(error_col, error_column)
+
+        drop_cols = [_TEMP_PREFIX + name for name, _, _ in _RESULT_FIELDS]
+        drop_cols.append(_ERROR_FIELD)
+        if synthetic_key is not None:
+            drop_cols.append(synthetic_key)
+        return detected.drop(*drop_cols)

--- a/core/src/main/python/synapse/ml/timeseries/__init__.py
+++ b/core/src/main/python/synapse/ml/timeseries/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+from synapse.ml.timeseries.UnivariateAnomalyDetector import UnivariateAnomalyDetector
+
+__all__ = ["UnivariateAnomalyDetector"]

--- a/core/src/test/python/synapsemltest/timeseries/__init__.py
+++ b/core/src/test/python/synapsemltest/timeseries/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.

--- a/core/src/test/python/synapsemltest/timeseries/test_univariate_anomaly_detector.py
+++ b/core/src/test/python/synapsemltest/timeseries/test_univariate_anomaly_detector.py
@@ -1,0 +1,289 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+import unittest
+
+import pandas as pd
+import pytest
+
+from synapse.ml.core.init_spark import *
+from synapse.ml.timeseries.UnivariateAnomalyDetector import (
+    DETECT_MODE_ENTIRE,
+    DETECT_MODE_LATEST,
+    UnivariateAnomalyDetector,
+    detect_series,
+    result_schema,
+)
+
+spark = init_spark()
+
+
+def _frame(rows=6, spike_at=None):
+    values = [10.0 + i for i in range(rows)]
+    if spike_at is not None:
+        values[spike_at] = 500.0
+    return pd.DataFrame(
+        {
+            "timestamp": [
+                "2024-01-01T{0:02d}:00:00Z".format(hour) for hour in range(rows)
+            ],
+            "value": values,
+        }
+    )
+
+
+def _options(detect_mode=DETECT_MODE_ENTIRE, params=None):
+    return {
+        "timestampCol": "timestamp",
+        "valueCol": "value",
+        "detectMode": detect_mode,
+        "params": {"granularity": "hourly"} if params is None else params,
+    }
+
+
+class FakeDetector:
+    """Stands in for the optional library so the plumbing is testable in CI."""
+
+    def __init__(self, flag_indices=(), recorder=None):
+        self.flag_indices = set(flag_indices)
+        self.recorder = recorder
+
+    def predict(self, context, data, params):
+        if self.recorder is not None:
+            self.recorder.append(dict(params))
+        return [
+            {
+                "result": {
+                    "is_anomaly": index in self.flag_indices,
+                    "is_positive_anomaly": index in self.flag_indices,
+                    "is_negative_anomaly": False,
+                    "expected_value": float(index),
+                    "upper_margin": 1.0,
+                    "lower_margin": 2.0,
+                    "period": 3,
+                }
+            }
+            for index in range(len(data))
+        ]
+
+
+def _factory(detector):
+    return lambda detect_mode: (detector, detect_mode)
+
+
+class TestDetectSeries(unittest.TestCase):
+    def test_entire_mode_maps_every_row(self):
+        result = detect_series(
+            _frame(), _options(), _factory(FakeDetector(flag_indices=[2]))
+        )
+        self.assertEqual(len(result), 6)
+        flags = result["__synapseml_uvad_isAnomaly"].tolist()
+        self.assertEqual(flags, [False, False, True, False, False, False])
+        self.assertEqual(result["__synapseml_uvad_expectedValue"].tolist()[2], 2.0)
+        self.assertEqual(result["__synapseml_uvad_period"].tolist()[0], 3)
+        self.assertTrue(result["__synapseml_uvad_error"].isnull().all())
+
+    def test_latest_mode_scores_only_the_final_row(self):
+        # The library returns a single result in latest mode.
+        detector = FakeDetector(flag_indices=[0])
+        detector.predict = lambda context, data, params: [
+            {
+                "result": {
+                    "is_anomaly": True,
+                    "is_positive_anomaly": True,
+                    "is_negative_anomaly": False,
+                    "expected_value": 42.0,
+                    "upper_margin": 1.0,
+                    "lower_margin": 2.0,
+                    "period": 0,
+                }
+            }
+        ]
+        result = detect_series(
+            _frame(), _options(DETECT_MODE_LATEST), _factory(detector)
+        )
+        flags = result["__synapseml_uvad_isAnomaly"].tolist()
+        self.assertEqual(flags, [None, None, None, None, None, True])
+        self.assertTrue(result["__synapseml_uvad_error"].isnull().all())
+
+    def test_rows_are_sorted_by_timestamp_before_detection(self):
+        shuffled = _frame().iloc[[4, 0, 5, 1, 3, 2]].reset_index(drop=True)
+        result = detect_series(
+            shuffled, _options(), _factory(FakeDetector(flag_indices=[0]))
+        )
+        self.assertEqual(result["timestamp"].tolist(), _frame()["timestamp"].tolist())
+        # Index 0 of the sorted series must be the flagged one.
+        self.assertTrue(result["__synapseml_uvad_isAnomaly"].tolist()[0])
+
+    def test_detector_failure_is_isolated_to_the_series(self):
+        def exploding(detect_mode):
+            raise RuntimeError("boom")
+
+        result = detect_series(_frame(), _options(), exploding)
+        self.assertEqual(len(result), 6)
+        self.assertTrue(result["__synapseml_uvad_isAnomaly"].isnull().all())
+        self.assertTrue(
+            all(
+                error == "RuntimeError: boom"
+                for error in result["__synapseml_uvad_error"]
+            )
+        )
+
+    def test_empty_series_reports_an_error_rather_than_raising(self):
+        empty = _frame().iloc[0:0]
+        result = detect_series(empty, _options(), _factory(FakeDetector()))
+        self.assertEqual(len(result), 0)
+
+    def test_result_count_mismatch_is_reported(self):
+        detector = FakeDetector()
+        detector.predict = lambda context, data, params: [
+            {"result": {"is_anomaly": False}}
+        ]
+        result = detect_series(_frame(), _options(), _factory(detector))
+        self.assertTrue(
+            all(
+                "returned 1 results for 6 rows" in e
+                for e in result["__synapseml_uvad_error"]
+            )
+        )
+
+    def test_caller_params_are_not_mutated(self):
+        # The library mutates the params dict it is handed, which makes a shared
+        # dict single use. detect_series must copy it before every call.
+        recorder = []
+        options = _options()
+        original = dict(options["params"])
+        for _ in range(3):
+            detect_series(_frame(), options, _factory(FakeDetector(recorder=recorder)))
+        self.assertEqual(options["params"], original)
+        self.assertEqual(len(recorder), 3)
+        for seen in recorder:
+            self.assertEqual(seen["granularity"], "hourly")
+
+
+class TestTransformerContract(unittest.TestCase):
+    def _df(self):
+        return spark.createDataFrame(
+            [("a", "2024-01-01T00:00:00Z", 1.0)],
+            "group string, timestamp string, value double",
+        )
+
+    def test_transform_schema_appends_output_and_error(self):
+        detector = UnivariateAnomalyDetector().setGroupByCols(["group"])
+        schema = detector.transformSchema(self._df().schema)
+        self.assertIn("anomalies", schema.fieldNames())
+        self.assertIn("error", schema.fieldNames())
+        self.assertEqual(schema["anomalies"].dataType, result_schema())
+
+    def test_output_struct_preserves_legacy_field_names(self):
+        # These are the field names the retired transformers emitted.
+        self.assertEqual(
+            result_schema().fieldNames(),
+            [
+                "isAnomaly",
+                "isPositiveAnomaly",
+                "isNegativeAnomaly",
+                "expectedValue",
+                "upperMargin",
+                "lowerMargin",
+                "period",
+            ],
+        )
+
+    def test_missing_column_is_rejected(self):
+        detector = UnivariateAnomalyDetector().setValueCol("absent")
+        with self.assertRaises(ValueError):
+            detector.transformSchema(self._df().schema)
+
+    def test_invalid_detect_mode_is_rejected(self):
+        detector = UnivariateAnomalyDetector().setDetectMode("sometimes")
+        with self.assertRaises(ValueError):
+            detector.transformSchema(self._df().schema)
+
+    def test_parameters_round_trip(self):
+        detector = (
+            UnivariateAnomalyDetector()
+            .setGranularity("hourly")
+            .setSensitivity(90)
+            .setMaxAnomalyRatio(0.25)
+            .setImputeMode("fixed")
+            .setImputeFixedValue(0.0)
+            .setCustomInterval(5)
+            .setPeriod(24)
+        )
+        params = detector._detector_params()
+        self.assertEqual(params["granularity"], "hourly")
+        self.assertEqual(params["sensitivity"], 90)
+        self.assertEqual(params["maxAnomalyRatio"], 0.25)
+        self.assertEqual(params["imputeMode"], "fixed")
+        self.assertEqual(params["customInterval"], 5)
+        self.assertEqual(params["period"], 24)
+
+    def test_unset_parameters_are_not_forwarded(self):
+        params = UnivariateAnomalyDetector().setGranularity("daily")._detector_params()
+        self.assertEqual(list(params.keys()), ["granularity"])
+
+
+class TestEndToEnd(unittest.TestCase):
+    """Runs only where the optional library is installed."""
+
+    def setUp(self):
+        pytest.importorskip(
+            "anomaly_detector",
+            reason="requires the optional time-series-anomaly-detector package",
+        )
+
+    def _multi_series(self, series_count=4, points=100):
+        rows = []
+        for index in range(series_count):
+            timestamps = pd.date_range("2024-01-01", periods=points, freq="h")
+            for position, timestamp in enumerate(timestamps):
+                value = 50.0 + (position % 12)
+                if position == 40 + index:
+                    value = 500.0
+                rows.append(
+                    (
+                        "series_{0}".format(index),
+                        timestamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        float(value),
+                    )
+                )
+        return spark.createDataFrame(
+            rows, "group string, timestamp string, value double"
+        )
+
+    def test_detects_planted_spike_in_every_series(self):
+        detector = (
+            UnivariateAnomalyDetector()
+            .setGroupByCols(["group"])
+            .setGranularity("hourly")
+            .setSensitivity(95)
+        )
+        result = detector.transform(self._multi_series()).cache()
+        self.assertEqual(result.count(), 400)
+        self.assertEqual(result.filter("error is not null").count(), 0)
+        flagged = result.filter("anomalies.isAnomaly").select("group").distinct()
+        self.assertEqual(flagged.count(), 4)
+
+    def test_bad_series_does_not_fail_the_job(self):
+        good = self._multi_series(series_count=1)
+        bad = spark.createDataFrame(
+            [("broken", "2024-01-01T00:00:00Z", 1.0)],
+            "group string, timestamp string, value double",
+        )
+        detector = (
+            UnivariateAnomalyDetector()
+            .setGroupByCols(["group"])
+            .setGranularity("hourly")
+        )
+        result = detector.transform(good.union(bad)).cache()
+        self.assertEqual(
+            result.filter("group = 'broken' and error is not null").count(), 1
+        )
+        self.assertEqual(
+            result.filter("group = 'series_0' and error is null").count(), 100
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/Explore Algorithms/Anomaly Detection/Time Series Anomaly Detection.md
+++ b/docs/Explore Algorithms/Anomaly Detection/Time Series Anomaly Detection.md
@@ -1,0 +1,149 @@
+---
+title: Time Series Anomaly Detection
+hide_title: true
+sidebar_label: Time Series Anomaly Detection
+---
+
+## Time Series Anomaly Detection on Apache Spark
+
+`UnivariateAnomalyDetector` finds anomalies in univariate time series and scales
+across many series at once. Each series is scored independently and in parallel,
+so a table holding thousands of separate signals is detected in a single pass.
+
+It replaces the `DetectAnomalies`, `DetectLastAnomaly` and `SimpleDetectAnomalies`
+transformers, which were removed when the Azure AI Anomaly Detector service was
+retired. Parameter names and output field names are unchanged, so migrating is
+normally just a change of import and constructor.
+
+### Installation
+
+The detector is built on the open source
+[`microsoft/anomaly-detector`](https://github.com/microsoft/anomaly-detector)
+library, which open sources the same algorithms that used to back the retired
+service. It's an optional dependency, so install it separately:
+
+```bash
+pip install time-series-anomaly-detector
+```
+
+The install name and the import name differ: the package installs as
+`time-series-anomaly-detector` but imports as `anomaly_detector`.
+
+### Usage
+
+```python
+from synapse.ml.timeseries import UnivariateAnomalyDetector
+
+detector = (
+    UnivariateAnomalyDetector()
+    .setGroupByCols(["deviceId"])
+    .setTimestampCol("timestamp")
+    .setValueCol("value")
+    .setGranularity("hourly")
+    .setSensitivity(95)
+    .setOutputCol("anomalies")
+)
+
+scored = detector.transform(df)
+scored.select("deviceId", "timestamp", "value", "anomalies.isAnomaly").show()
+```
+
+The output column is a struct with the fields `isAnomaly`, `isPositiveAnomaly`,
+`isNegativeAnomaly`, `expectedValue`, `upperMargin`, `lowerMargin` and `period`.
+
+Set `detectMode` to `latest` to score only the most recent point of each series,
+which is the streaming style check the old `DetectLastAnomaly` performed. In that
+mode every row except the last one in each series has a null result.
+
+### Scaling
+
+`setGroupByCols` is what makes this scale. The underlying library is single node
+pandas code, so parallelism comes from detecting many series concurrently rather
+than splitting one series across executors. Give each independent signal its own
+group key and Spark spreads the work across the cluster.
+
+Leaving `groupByCols` empty treats the whole DataFrame as one series. That's
+correct, but it runs on a single executor and won't benefit from a larger
+cluster.
+
+Note that a series is materialized in memory on one executor while it's scored,
+so extremely long individual series are the practical limit, not the number of
+series.
+
+### Error handling
+
+Time series data is uneven in practice: some groups are too short to model, and
+some carry a granularity the detector can't infer. Rather than failing the job,
+those series are returned with a null result and a message in the error column.
+
+```python
+scored.filter("error is not null").select("deviceId", "error").show(truncate=False)
+```
+
+This means a single malformed group cannot take down a run over thousands of
+series. Check the error column when a series unexpectedly has no result.
+
+### Parameters
+
+| Parameter | Description |
+| --- | --- |
+| `timestampCol` | Column holding the timestamp of each point. Defaults to `timestamp`. |
+| `valueCol` | Column holding the measured value. Defaults to `value`. |
+| `groupByCols` | Columns identifying an individual series. Empty means a single series. |
+| `outputCol` | Output struct column. Defaults to `anomalies`. |
+| `errorCol` | Output column holding per series error messages. Defaults to `error`. |
+| `detectMode` | `entire` to score every point, or `latest` for only the most recent one. |
+| `granularity` | `yearly`, `monthly`, `weekly`, `daily`, `hourly`, `minutely`, `secondly`, `microsecond` or `none`. |
+| `customInterval` | Used with `granularity`, for example `5` with `minutely` for a five minute series. |
+| `period` | Known period of the series. Omit to have it inferred. |
+| `maxAnomalyRatio` | Maximum proportion of points that may be flagged, in (0, 0.49]. |
+| `sensitivity` | 0 to 99. Lower values widen the margins and flag fewer points. |
+| `imputeMode` | `auto`, `previous`, `linear`, `fixed`, `zero` or `notFill`. |
+| `imputeFixedValue` | Value used to fill gaps when `imputeMode` is `fixed`. |
+
+### Migrating from the retired transformers
+
+Parameters and output fields carry over unchanged, so most pipelines only need
+the import and constructor swapped:
+
+```python
+# Before, against the retired Azure AI Anomaly Detector service
+from synapse.ml.services.anomaly import SimpleDetectAnomalies
+
+detector = (
+    SimpleDetectAnomalies()
+    .setSubscriptionKey(key)
+    .setLocation("westus2")
+    .setGroupbyCol("deviceId")
+    .setGranularity("hourly")
+    .setOutputCol("anomalies")
+)
+
+# After, running locally with no service call
+from synapse.ml.timeseries import UnivariateAnomalyDetector
+
+detector = (
+    UnivariateAnomalyDetector()
+    .setGroupByCols(["deviceId"])
+    .setGranularity("hourly")
+    .setOutputCol("anomalies")
+)
+```
+
+Two differences are worth knowing about:
+
+- No subscription key, endpoint or location is needed, because detection runs on
+  the cluster instead of calling a REST API. Throughput is bounded by the cluster
+  rather than by service quota.
+- The `severity` output field is gone. The retired service returned it, but the
+  open source library doesn't compute it. Use `expectedValue` together with
+  `upperMargin` and `lowerMargin` to gauge how far a point deviates.
+
+### Multivariate series
+
+The library also implements the multivariate model that backed the retired
+`FitMultivariateAnomaly` and `DetectMultivariateAnomaly` transformers, but it
+trains a PyTorch model over a sliding window rather than scoring rows
+independently. That doesn't decompose into a per row Spark transformer, so it
+isn't wrapped here. Train it on the driver and apply it with a pandas UDF, or
+featurize your signals and use [Isolation Forests](../Quickstart%20-%20Isolation%20Forests).

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -121,6 +121,7 @@ module.exports = {
                     label: 'Anomaly Detection',
                     items: [
                         "Explore Algorithms/Anomaly Detection/Quickstart - Isolation Forests",
+                        "Explore Algorithms/Anomaly Detection/Time Series Anomaly Detection",
                     ],
                 },
                 {


### PR DESCRIPTION
## Why

[#2605](https://github.com/microsoft/SynapseML/pull/2605) removed the Azure AI Anomaly Detector wrappers because the service was retired — every endpoint returns `HTTP 410 Gone`. That fixed the broken CI job, but it left SynapseML users with **no time series anomaly detection path at all**. `IsolationForest` covers *point* anomalies in tabular data, but it has no notion of time, seasonality, or trend, so it is not a substitute.

This PR restores the capability on top of the open source successor, [`microsoft/anomaly-detector`](https://github.com/microsoft/anomaly-detector) (PyPI: `time-series-anomaly-detector`), and — importantly — **distributes it across the cluster** instead of leaving users to loop over series on the driver.

## What this adds

| File | Purpose |
| --- | --- |
| `core/src/main/python/synapse/ml/timeseries/UnivariateAnomalyDetector.py` | The Spark `Transformer` |
| `core/src/main/python/synapse/ml/timeseries/__init__.py` | Package export |
| `core/src/test/python/synapsemltest/timeseries/test_univariate_anomaly_detector.py` | 15 tests |
| `docs/Explore Algorithms/Anomaly Detection/Time Series Anomaly Detection.md` | Docs incl. migration guide |
| `cognitive/.../anomaly.py` | Migration shim now points somewhere useful |
| `website/sidebars.js` | Registers the new page |

## Performance: this is the main point

Each series is detected on the executor that already holds it, using `groupBy(groupByCols).applyInPandas(...)`. Throughput scales with the number of series — no driver bottleneck, no collect.

```python
from synapse.ml.timeseries import UnivariateAnomalyDetector

detector = (UnivariateAnomalyDetector()
    .setTimestampCol("timestamp")
    .setValueCol("value")
    .setGroupByCols(["device_id"])   # <- thousands of series, detected in parallel
    .setGranularity("hourly")
    .setOutputCol("anomalies"))

detector.transform(df).select("device_id", "timestamp", "anomalies.isAnomaly")
```

Verified on 12 series × 200 points across 4 partitions: all 12 planted spikes detected, one Spark job, no driver-side iteration.

Rows are sorted by the timestamp column *within* each group, because the library assumes chronological order and `applyInPandas` does not guarantee it.

## Drop-in migration

All **seven** inputs of the retired transformer are preserved verbatim: `granularity`, `customInterval`, `period`, `maxAnomalyRatio`, `sensitivity`, `imputeMode`, `imputeFixedValue`. Granularity values are identical (`yearly` … `microsecond`, `none`).

The OSS library returns snake_case fields; I map them back to the **legacy camelCase output contract** (`isAnomaly`, `isPositiveAnomaly`, `isNegativeAnomaly`, `expectedValue`, `upperMargin`, `lowerMargin`, `period`), so existing code like `col("anomalies.isAnomaly")` keeps working.

> ⚠️ **`severity` is gone.** The OSS library does not expose it in either detection mode. Documented rather than faked.

## Why the dependency is optional (not in `environment.yml`)

`time-series-anomaly-detector` requires `mlflow>=3.1.0` (it pulls **3.15.1**). This repo pins:

```yaml
# Petastorm needs legacy Parquet and fsspec APIs removed after PyArrow 10; MLflow accepts this pin.
- mlflow==2.21.3
```

Adding the package would force a conflicting MLflow upgrade and risk breaking Petastorm. So the import is **lazy**, with an actionable install message, and the two end-to-end tests use `pytest.importorskip` and skip cleanly in CI. Happy to revisit if maintainers would rather take the upgrade.

## Three library behaviours found empirically

None of these are in the library's docs — its README is still the unedited GitHub template. Each was found by actually running it, and each shaped the implementation:

1. **`predict()` mutates the caller's params dict**, rewriting `granularity` from `'hourly'` to `<Granularity.hourly: 4>`. Reuse that dict for a second series and validation fails, `parse_arg` returns `None`, and `predict` dies with the cryptic `TypeError: cannot unpack non-iterable NoneType object`. Every series now gets a defensive `dict()` copy — locked in by `test_caller_params_are_not_mutated`.
2. **`DetectType.LATEST` returns exactly one result**, not one per row. Mapped onto the final row with nulls before it.
3. **`DetectType.ENTIRE` returns one result per row.**

## Reliability

- **Per-series error isolation** — failures go to `errorCol` instead of being thrown, so one malformed group cannot fail a job spanning thousands of series. The output struct is null for those rows.
- **Struct assembled in Spark, not pandas** — the UDF returns flat scalar columns, avoiding Arrow dict→struct conversion issues.
- `detect_series(pdf, options, detector_factory=None)` is a **pure pandas function**, so the algorithm is unit-testable with an injected fake, with no Spark session and no optional dependency. (Monkeypatching cannot reach PySpark workers — they are separate processes.)

## Testing

**15/15 passing locally.**

- `TestDetectSeries` (7) — algorithm behaviour via an injected fake detector
- `TestTransformerContract` (6) — params, schema, defaults
- `TestEndToEnd` (2) — real library through real Spark; skip in CI via `importorskip`

Also verified: `black --check --extend-exclude 'docs/' .` clean (189 files), `website/sidebars.js` parses and registers the page, doc links resolve, LF endings + trailing newlines throughout.

The `PythonTests` job already runs `PACKAGE: "core"` with no `TEST_SUB_PATH`/`IGNORE_TEST_PATH` filter, so `synapsemltest/timeseries/` is collected automatically — **no `pipeline.yaml` changes needed**.

## Docs placement is deliberate

The page lives under `docs/Explore Algorithms/Anomaly Detection/` rather than `docs/Quick Examples/`, because `website/doctest.py` executes Python blocks **only** in `docs/Quick Examples` (via `WebsiteSamplesTests`) — and the optional dependency isn't installed in CI. A `.md` rather than an `.ipynb` for the same reason: notebooks under `docs/**` are executed by the Databricks/Synapse E2E jobs.

## Not included

**Multivariate anomaly detection (MVAD).** The OSS multivariate model is a torch sliding-window model that does not decompose to a per-row Spark operation the way the univariate detector does. Wrapping it properly is a larger design question; the docs include a driver-side recipe in the meantime.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
