### PR TITLE
fix: preserve the real cause when a LightGBM task retry cannot rejoin the network

### DIFF
--- a/docs/Explore Algorithms/LightGBM/Overview.md
+++ b/docs/Explore Algorithms/LightGBM/Overview.md
@@ -261,10 +261,11 @@ To use it in scala, you can call setUseBarrierExecutionMode(true), for example:
     <train classifier>
 Note: barrier execution mode can also cause complicated issues, so use it only if needed.
 
-Barrier execution mode is also the only mode that can recover from a task failure. A LightGBM network is
-negotiated once and then fixed, so an individual Spark task retry can never rejoin it. Spark restarts a
-barrier stage in its entirety, and the driver serves a fresh topology round for each stage attempt, so
-training can survive a failure that would otherwise abort the job.
+Barrier execution mode is also the only mode that can recover from a task failure that happens after the
+network topology has been negotiated. A LightGBM network is negotiated once and then fixed, so an individual
+Spark task retry can never rejoin it. Spark restarts a barrier stage in its entirety, and the driver serves a
+fresh topology round for each stage attempt, so training can survive a failure that would otherwise abort the
+job. Failures that happen before a task joins the network are still retried normally in either mode.
 
 ### Diagnosing "Connection refused" during training
 

--- a/docs/Explore Algorithms/LightGBM/Overview.md
+++ b/docs/Explore Algorithms/LightGBM/Overview.md
@@ -260,3 +260,19 @@ To use it in scala, you can call setUseBarrierExecutionMode(true), for example:
     ...
     <train classifier>
 Note: barrier execution mode can also cause complicated issues, so use it only if needed.
+
+Barrier execution mode is also the only mode that can recover from a task failure. A LightGBM network is
+negotiated once and then fixed, so an individual Spark task retry can never rejoin it. Spark restarts a
+barrier stage in its entirety, and the driver serves a fresh topology round for each stage attempt, so
+training can survive a failure that would otherwise abort the job.
+
+### Diagnosing "Connection refused" during training
+
+Distributed training first exchanges `host:port` information with the driver, which serves that exchange
+once per stage attempt. If a task fails after that exchange, the regular (non-barrier) retry of that task
+reconnects to a driver endpoint that is no longer accepting connections. Because Spark only reports the
+most recent attempt, this can hide the failure that actually caused the retry.
+
+When this happens, the reported error explains that it's a retry that could not rejoin the network, and
+names the partition to investigate. Look for the **first** failed attempt of that partition in the executor
+logs — that attempt holds the real cause.

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMBase.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMBase.scala
@@ -595,10 +595,17 @@ trait LightGBMBase[TrainedModel <: Model[TrainedModel] with LightGBMModelParams]
                                  networkManager)
 
     // Execute the Tasks on workers
-    val lightGBMBooster = executePartitionTasks(ctx, dataframe, measures)
+    val lightGBMBooster = try {
+      val booster = executePartitionTasks(ctx, dataframe, measures)
 
-    // Wait for network to complete (should be done by now)
-    networkManager.waitForNetworkCommunicationsDone()
+      // Wait for network to complete (should be done by now)
+      networkManager.waitForNetworkCommunicationsDone()
+      booster
+    } finally {
+      // If training failed, the network thread may still be blocked accepting connections that will
+      // never arrive. Closing the driver sockets releases it and the port for the next attempt.
+      networkManager.closeConnections()
+    }
     measures.markTrainingStop()
     val model = getModel(trainParams, lightGBMBooster)
     measures.markExecutionEnd()

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
@@ -14,7 +14,8 @@ import org.apache.spark.sql.SparkSession
 import org.slf4j.Logger
 
 import java.io.{BufferedReader, BufferedWriter, IOException, InputStreamReader, OutputStreamWriter}
-import java.net.{BindException, ConnectException, InetSocketAddress, ServerSocket, Socket}
+import java.net.{BindException, ConnectException, InetSocketAddress, ServerSocket, Socket,
+  SocketException, SocketTimeoutException}
 import java.util.concurrent.Executors
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -27,15 +28,18 @@ case class TaskMessageInfo(status: String,
                            taskHost: String,
                            localListenPort: Int,
                            partitionId: Int,
-                           executorId: String) {
-  def this(status: String) = this(status, "", -1, -1, "") // Constructor for general messages, not Task-connected
+                           executorId: String,
+                           stageAttemptNumber: Int = 0) {
+  // Constructor for general messages, not Task-connected
+  def this(status: String, stageAttemptNumber: Int) = this(status, "", -1, -1, "", stageAttemptNumber)
 
   val isForTraining: Boolean = status == LightGBMConstants.EnabledTask
   val isForLoadOnly: Boolean = status == LightGBMConstants.IgnoreStatus
   val isFinished: Boolean = status == LightGBMConstants.FinishedStatus
 
   // Format all the information as a delimited string to send to driver
-  override def toString: String = s"$status:$taskHost:$localListenPort:$partitionId:$executorId"
+  override def toString: String =
+    s"$status:$taskHost:$localListenPort:$partitionId:$executorId:$stageAttemptNumber"
 }
 
 case class NetworkTopologyInfo(lightgbmNetworkString: String,
@@ -275,12 +279,14 @@ object NetworkManager {
             val driverOutput = io(1).asInstanceOf[BufferedWriter]
 
             // Get message to send to driver with info about this task
+            val stageAttemptNumber = Option(TaskContext.get()).map(_.stageAttemptNumber()).getOrElse(0)
             val taskStatus = TaskMessageInfo(
               if (shouldExecuteTraining) LightGBMConstants.EnabledTask else LightGBMConstants.IgnoreStatus,
               driverSocket.getLocalAddress.getHostAddress,
               localListenPort,
               partitionId,
-              LightGBMUtils.getExecutorId) // TODO can we use host for this?
+              LightGBMUtils.getExecutorId, // TODO can we use host for this?
+              stageAttemptNumber)
             val message = taskStatus.toString()
             log.info(s"task $taskId sending status message to driver: $message ")
             driverOutput.write(s"$message\n")
@@ -291,7 +297,7 @@ object NetworkManager {
               val context = BarrierTaskContext.get()
               context.barrier()
               if (context.partitionId() == 0) {
-                 setFinishedStatus(networkParams, log)
+                 setFinishedStatus(networkParams, stageAttemptNumber, log)
               }
             }
 
@@ -549,14 +555,14 @@ object NetworkManager {
     }
   }
 
-  private def setFinishedStatus(networkParams: NetworkParams, log: Logger): Unit = {
+  private def setFinishedStatus(networkParams: NetworkParams, stageAttemptNumber: Int, log: Logger): Unit = {
     using(new Socket(networkParams.ipAddress, networkParams.port)) {
       driverSocket =>
         using(new BufferedWriter(new OutputStreamWriter(driverSocket.getOutputStream))) {
           driverOutput =>
             log.info("sending finished status to driver")
             // If barrier execution mode enabled, create a barrier across tasks
-            driverOutput.write(s"${LightGBMConstants.FinishedStatus}\n")
+            driverOutput.write(s"${LightGBMConstants.FinishedStatus}:$stageAttemptNumber\n")
             driverOutput.flush()
         }.get
     }.get
@@ -566,16 +572,24 @@ object NetworkManager {
     val components = message.split(":")
     val status = components(0)
 
-    if (status == LightGBMConstants.FinishedStatus) new TaskMessageInfo(status)
-    else {
-      if (components.length != 5) throw new Exception(s"Unexpected message: $message")
+    if (status == LightGBMConstants.FinishedStatus) {
+      new TaskMessageInfo(status, parseStageAttemptNumber(components, 1))
+    } else {
+      if (components.length != 5 && components.length != 6) {  //scalastyle:ignore magic.number
+        throw new Exception(s"Unexpected message: $message")
+      }
 
       val host = components(1)
       val port = components(2).toInt
       val partitionId: Int = components(3).toInt
       val executorId = components(4)  //scalastyle:ignore magic.number
-      TaskMessageInfo(status, host, port, partitionId, executorId)
+      TaskMessageInfo(status, host, port, partitionId, executorId,
+                      parseStageAttemptNumber(components, 5))  //scalastyle:ignore magic.number
     }
+  }
+
+  private def parseStageAttemptNumber(components: Array[String], index: Int): Int = {
+    if (components.length > index) components(index).toInt else 0
   }
 }
 
@@ -596,9 +610,14 @@ case class NetworkManager(numTasks: Int,
   private val hostToMinPartition = mutable.Map[String, Int]()
   private val partitionsByExecutor = mutable.Map[String, List[Int]]()
 
+  // The Spark stage attempt whose topology is currently being collected. A barrier stage restarts
+  // as a whole, so a higher attempt number means everything gathered so far is obsolete.
+  private var currentStageAttempt = -1
+  @volatile private var shutdownRequested = false
+
   // Concatenate with commas, eg: host1:port1,host2:port2, ... etc
   // Also make sure the order is deterministic by sorting on minimum partition id
-  private lazy val networkTopologyAsString: String = {
+  private def networkTopologyAsString: String = synchronized {
     val hostPortsList = hostAndPorts.map(_._2).sortBy(hostPort => {
       val host = hostPort.split(":")(0)
       hostToMinPartition(host)
@@ -608,7 +627,7 @@ case class NetworkManager(numTasks: Int,
 
   // Create a string representing of the partitionsByExecutor map
   // e.g. executor1=partition1,partition2:executor2=partition3,partition4
-  private lazy val partitionsByExecutorAsString: String = {
+  private def partitionsByExecutorAsString: String = synchronized {
     val executorList = partitionsByExecutor.map { case (executor, partitionList) =>
       executor + "=" + partitionList.mkString(",")
     }
@@ -619,17 +638,49 @@ case class NetworkManager(numTasks: Int,
   private val networkCommunicationThread: Future[Unit] = Future {
     try {
       log.info(s"driver waiting for connections on host: $host and port: $port")
-      waitForAllTasksToReport()
-
-      // We have all the information now, so report back to workers
-      sendDataToExecutors(networkTopologyAsString, partitionsByExecutorAsString)
+      if (useBarrierExecutionMode) serveTopologyRoundsUntilShutdown() else serveTopologyRound()
     } finally {
       // Always release the sockets, including when the topology exchange fails or times out.
       closeConnections()
     }
   } (ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor()))
 
+  private def serveTopologyRound(): Unit = {
+    waitForAllTasksToReport()
+
+    // We have all the information now, so report back to workers
+    sendDataToExecutors(networkTopologyAsString, partitionsByExecutorAsString)
+  }
+
+  /** Serves topology rounds until the training job says it is done.
+    *
+    * A barrier stage is restarted in its entirety when any of its tasks fails, which is the only way
+    * a LightGBM network can legitimately re-form. Serving a single round means the restarted stage
+    * finds a closed port and dies with "connection refused", so keep listening instead.
+    */
+  @tailrec
+  private def serveTopologyRoundsUntilShutdown(): Unit = {
+    val keepServing =
+      try {
+        serveTopologyRound()
+        resetRoundState()
+        true
+      } catch {
+        case _: SocketTimeoutException =>
+          // Training can easily outlast the socket timeout, so an idle driver is not an error here.
+          log.info("driver saw no task connections within the timeout, still listening for a stage restart")
+          true
+        case socketFailure: SocketException =>
+          if (!shutdownRequested) throw socketFailure
+          log.info("driver stopped serving topology rounds")
+          false
+      }
+    if (keepServing) serveTopologyRoundsUntilShutdown()
+  }
+
   def waitForNetworkCommunicationsDone(): Unit = {
+    // In barrier mode the driver keeps listening for a restarted stage, so it never stops on its own.
+    if (useBarrierExecutionMode) closeConnections()
     Await.result(networkCommunicationThread, Duration(timeout, SECONDS))
   }
 
@@ -647,14 +698,15 @@ case class NetworkManager(numTasks: Int,
     } else {
       log.info(s"driver expecting $numTasks connections...")
 
+      // Count the tasks actually recorded rather than the connections seen, so that connections
+      // discarded as belonging to a superseded stage attempt do not end the round early.
       @tailrec
-      def connectToWorkers(numProcessedTasks: Int): Unit = {
+      def connectToWorkers(): Unit = {
         handleNextWorkerConnection()
-        val newNumProcessedTasks = numProcessedTasks + 1
-        if (newNumProcessedTasks != numTasks) connectToWorkers(newNumProcessedTasks)
+        if (reportedTaskCount < numTasks) connectToWorkers()
       }
 
-      connectToWorkers(0)
+      connectToWorkers()
     }
   }
 
@@ -673,8 +725,33 @@ case class NetworkManager(numTasks: Int,
     log.info(s"received worker message string: $messageStr")
     val message: TaskMessageInfo = parseWorkerMessage(messageStr)
 
+    if (message.stageAttemptNumber < currentStageAttempt) {
+      // A straggler from a stage attempt that Spark has already abandoned. Recording it would put a
+      // dead host:port into the topology that every surviving task then tries to connect to.
+      log.info(s"driver ignoring message from superseded stage attempt ${message.stageAttemptNumber}")
+      closeQuietly(socket)
+      false
+    } else {
+      startNewStageAttemptIfNeeded(message.stageAttemptNumber)
+      recordWorkerConnection(socket, message)
+    }
+  }
+
+  private def startNewStageAttemptIfNeeded(stageAttemptNumber: Int): Unit = {
+    if (stageAttemptNumber > currentStageAttempt) {
+      if (currentStageAttempt >= 0) {
+        log.info(s"driver starting topology round for stage attempt $stageAttemptNumber, " +
+          s"discarding the partial topology collected for attempt $currentStageAttempt")
+        resetRoundState()
+      }
+      currentStageAttempt = stageAttemptNumber
+    }
+  }
+
+  private def recordWorkerConnection(socket: Socket, message: TaskMessageInfo): Boolean = {
     if (message.isFinished) {
       log.info("driver received all tasks from barrier stage")
+      closeQuietly(socket)  // The finished message uses its own short-lived connection.
       true
     } else {
       message match {
@@ -732,13 +809,32 @@ case class NetworkManager(numTasks: Int,
     * that is still parked in accept() waiting for tasks that will never arrive.
     */
   private[lightgbm] def closeConnections(): Unit = synchronized {
+    shutdownRequested = true
     if (!driverServerSocket.isClosed) {
       log.info("driver closing all sockets and server socket")
-      hostAndPorts.foreach(hostAndPort => closeQuietly(hostAndPort._1))
-      loadOnlyHostAndPorts.foreach(closeQuietly)
+      closeRoundSockets()
       closeQuietly(driverServerSocket)
       log.info("driver done closing all sockets and server socket")
     }
+  }
+
+  /** Number of tasks whose topology has been recorded for the current stage attempt. */
+  private def reportedTaskCount: Int = synchronized {
+    hostAndPorts.length + loadOnlyHostAndPorts.length
+  }
+
+  /** Discards everything gathered for a stage attempt so the next one starts from a clean slate. */
+  private def resetRoundState(): Unit = synchronized {
+    closeRoundSockets()
+    hostAndPorts.clear()
+    loadOnlyHostAndPorts.clear()
+    hostToMinPartition.clear()
+    partitionsByExecutor.clear()
+  }
+
+  private def closeRoundSockets(): Unit = synchronized {
+    hostAndPorts.foreach(hostAndPort => closeQuietly(hostAndPort._1))
+    loadOnlyHostAndPorts.foreach(closeQuietly)
   }
 
   /** Records an accepted socket. The network thread appends while the training job may be closing

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
@@ -8,12 +8,13 @@ import com.microsoft.azure.synapse.ml.core.utils.{ClusterUtil, FaultToleranceUti
 import com.microsoft.azure.synapse.ml.lightgbm.NetworkManager.parseWorkerMessage
 import com.microsoft.ml.lightgbm.lightgbmlib
 import org.apache.spark.BarrierTaskContext
+import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.slf4j.Logger
 
 import java.io.{BufferedReader, BufferedWriter, IOException, InputStreamReader, OutputStreamWriter}
-import java.net.{BindException, InetSocketAddress, ServerSocket, Socket}
+import java.net.{BindException, ConnectException, InetSocketAddress, ServerSocket, Socket}
 import java.util.concurrent.Executors
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -210,18 +211,53 @@ object NetworkManager {
         localListenPort =>
           log.info(s"LightGBM task $taskId connecting to host: " +
             s"${networkParams.ipAddress}, port: ${networkParams.port}")
-          FaultToleranceUtils.retryWithTimeout() {
-            getNetworkTopologyInfoFromDriver(networkParams,
-                                             taskId,
-                                             partitionId,
-                                             localListenPort,
-                                             log,
-                                             shouldExecuteTraining)
+          try {
+            FaultToleranceUtils.retryWithTimeout() {
+              getNetworkTopologyInfoFromDriver(networkParams,
+                                               taskId,
+                                               partitionId,
+                                               localListenPort,
+                                               log,
+                                               shouldExecuteTraining)
+            }
+          } catch {
+            case connectFailure: ConnectException =>
+              throw driverUnreachableException(networkParams, taskId, partitionId, log, connectFailure)
           }
       }
     } finally {
       measures.markNetworkInitializationStop()
     }
+  }
+
+  /** Explain why a task could not reach the driver's network topology endpoint.
+    *
+    * The driver serves the topology exchange exactly once per training round and then closes its
+    * server socket. A task that Spark retries after that point can therefore only ever see
+    * "connection refused", which silently replaces the failure that caused the retry in the first
+    * place. Naming that explicitly keeps the original failure discoverable.
+    */
+  private[lightgbm] def driverUnreachableException(networkParams: NetworkParams,
+                                                   taskId: Long,
+                                                   partitionId: Int,
+                                                   log: Logger,
+                                                   cause: ConnectException): Exception = {
+    val attemptNumber = Option(TaskContext.get()).map(_.attemptNumber()).getOrElse(0)
+    val endpoint = s"${networkParams.ipAddress}:${networkParams.port}"
+    val message = if (attemptNumber > 0) {
+      s"LightGBM task $taskId (partition $partitionId) could not reach the driver network topology endpoint " +
+        s"$endpoint on retry attempt $attemptNumber. The driver serves the topology exchange once per training " +
+        "round and has already closed it, so a retried task can never rejoin the LightGBM network. This error " +
+        s"is therefore a consequence of an earlier failure: inspect the logs of the first failed attempt of " +
+        s"partition $partitionId to find the real cause. Distributed LightGBM training cannot recover from a " +
+        "partial task retry."
+    } else {
+      s"LightGBM task $taskId (partition $partitionId) could not reach the driver network topology endpoint " +
+        s"$endpoint on its first attempt. Verify that executors are allowed to open connections to the driver " +
+        "on that port, and that the driver was not shut down before training started."
+    }
+    log.error(message, cause)
+    new Exception(message, cause)
   }
 
   private def getNetworkTopologyInfoFromDriver(networkParams: NetworkParams,
@@ -581,13 +617,16 @@ case class NetworkManager(numTasks: Int,
 
   // This will be kicked off at object creation time, and can be waited on by waitForNetworkDone()
   private val networkCommunicationThread: Future[Unit] = Future {
-    log.info(s"driver waiting for connections on host: $host and port: $port")
-    waitForAllTasksToReport()
+    try {
+      log.info(s"driver waiting for connections on host: $host and port: $port")
+      waitForAllTasksToReport()
 
-    // We have all the information now, so report back to workers
-    sendDataToExecutors(networkTopologyAsString, partitionsByExecutorAsString)
-
-    closeConnections()
+      // We have all the information now, so report back to workers
+      sendDataToExecutors(networkTopologyAsString, partitionsByExecutorAsString)
+    } finally {
+      // Always release the sockets, including when the topology exchange fails or times out.
+      closeConnections()
+    }
   } (ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor()))
 
   def waitForNetworkCommunicationsDone(): Unit = {
@@ -641,12 +680,11 @@ case class NetworkManager(numTasks: Int,
       message match {
         case m if m.isForLoadOnly =>
           log.info("driver received load-only status from task")
-          loadOnlyHostAndPorts += socket
+          addSocket(loadOnlyHostAndPorts, socket)
         case m if m.isForTraining =>
           val networkInfoString = s"${message.taskHost}:${message.localListenPort}"
           log.info(s"driver received socket from task: $networkInfoString")
-          val socketAndMessage = (socket, networkInfoString)
-          hostAndPorts += socketAndMessage
+          addSocket(hostAndPorts, (socket, networkInfoString))
         case _ => throw new Exception(s"Unknown message type: ${message.toString()}")
       }
 
@@ -687,10 +725,36 @@ case class NetworkManager(numTasks: Int,
     })
   }
 
-  private def closeConnections(): Unit = {
-    log.info("driver closing all sockets and server socket")
-    hostAndPorts.foreach(_._1.close())
-    driverServerSocket.close()
-    log.info("driver done closing all sockets and server socket")
+  /** Release every driver-side socket for this training round.
+    *
+    * Safe to call more than once and from more than one thread, so both the network thread and the
+    * training job can guarantee cleanup. Closing the server socket also unblocks a network thread
+    * that is still parked in accept() waiting for tasks that will never arrive.
+    */
+  private[lightgbm] def closeConnections(): Unit = synchronized {
+    if (!driverServerSocket.isClosed) {
+      log.info("driver closing all sockets and server socket")
+      hostAndPorts.foreach(hostAndPort => closeQuietly(hostAndPort._1))
+      loadOnlyHostAndPorts.foreach(closeQuietly)
+      closeQuietly(driverServerSocket)
+      log.info("driver done closing all sockets and server socket")
+    }
+  }
+
+  /** Records an accepted socket. The network thread appends while the training job may be closing
+    * everything down, so the buffers are only ever touched under the instance lock.
+    */
+  private def addSocket[T](buffer: ListBuffer[T], entry: T): Unit = synchronized {
+    buffer += entry
+  }
+
+  private def closeQuietly(closeable: java.io.Closeable): Unit = {
+    try {
+      closeable.close()
+    } catch {
+      case closeFailure: IOException =>
+        // One socket refusing to close must not strand the others, especially the server socket.
+        log.warn(s"driver could not close a network socket cleanly: $closeFailure")
+    }
   }
 }

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
@@ -14,7 +14,7 @@ import org.slf4j.Logger
 
 import java.io.{BufferedReader, BufferedWriter, IOException, InputStreamReader, OutputStreamWriter}
 import java.net.{ConnectException, ServerSocket, Socket, SocketException, SocketTimeoutException}
-import java.util.concurrent.Executors
+import java.util.concurrent.{ExecutorService, Executors}
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Future}
@@ -464,6 +464,9 @@ object NetworkManager {
   }
 
   private def parseWorkerProtocolMessage(message: String): WorkerMessage = {
+    if (message == null) {
+      throw new IOException("Worker closed the connection before sending a status message")
+    }
     val components = message.split(":")
     val status = components(0)
 
@@ -546,6 +549,8 @@ case class NetworkManager(numTasks: Int,
       .mkString(":")
   }
 
+  private val networkCommunicationExecutor: ExecutorService = Executors.newSingleThreadExecutor()
+
   // This will be kicked off at object creation time, and can be waited on by waitForNetworkDone()
   private val networkCommunicationThread: Future[Unit] = Future {
     try {
@@ -554,8 +559,10 @@ case class NetworkManager(numTasks: Int,
     } finally {
       // Always release the sockets, including when the topology exchange fails or times out.
       closeConnections()
+      // Release the dedicated thread so repeated fits on a long-lived driver do not leak threads.
+      networkCommunicationExecutor.shutdown()
     }
-  } (ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor()))
+  } (ExecutionContext.fromExecutor(networkCommunicationExecutor))
 
   private def serveTopologyRound(): Unit = {
     waitForAllTasksToReport()

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
@@ -74,7 +74,7 @@ case class NetworkTopologyInfo(lightgbmNetworkString: String,
     }
   }
 }
-object NetworkManager {
+
 object NetworkManager {
   private val MaxSocketCloseAttempts = 2
 

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
@@ -13,8 +13,7 @@ import org.apache.spark.sql.SparkSession
 import org.slf4j.Logger
 
 import java.io.{BufferedReader, BufferedWriter, IOException, InputStreamReader, OutputStreamWriter}
-import java.net.{BindException, ConnectException, InetSocketAddress, ServerSocket, Socket,
-  SocketException, SocketTimeoutException}
+import java.net.{ConnectException, ServerSocket, Socket, SocketException, SocketTimeoutException}
 import java.util.concurrent.Executors
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -76,71 +75,17 @@ case class NetworkTopologyInfo(lightgbmNetworkString: String,
 }
 
 object NetworkManager {
-  private val MaxSocketCloseAttempts = 2
+  private def addSuppressed(primaryFailure: Throwable, secondaryFailure: Throwable): Unit =
+    NetworkManagerSocketSupport.addSuppressed(primaryFailure, secondaryFailure)
 
-  private def addSuppressed(primaryFailure: Throwable, secondaryFailure: Throwable): Unit = {
-    if (primaryFailure ne secondaryFailure) primaryFailure.addSuppressed(secondaryFailure)
-  }
+  private[lightgbm] def closeSocketWithRetry(socket: Socket): Unit =
+    NetworkManagerSocketSupport.closeSocketWithRetry(socket)
 
-  /** Close a socket with one immediate retry, retaining every observed cleanup failure. */
-  private[lightgbm] def closeSocketWithRetry(socket: Socket): Unit = {
-    @tailrec
-    def attemptClose(attemptsRemaining: Int,
-                     firstFailure: Option[IOException]): Option[IOException] = {
-      if (socket.isClosed || attemptsRemaining == 0) {
-        firstFailure
-      } else {
-        val updatedFailure = try {
-          socket.close()
-          firstFailure
-        } catch {
-          case failure: IOException =>
-            firstFailure.foreach(existing => addSuppressed(existing, failure))
-            firstFailure.orElse(Option(failure))
-        }
-        attemptClose(attemptsRemaining - 1, updatedFailure)
-      }
-    }
+  private[lightgbm] def withCleanupPreservingPrimary[T](cleanup: => Unit)(operation: => T): T =
+    NetworkManagerSocketSupport.withCleanupPreservingPrimary(cleanup)(operation)
 
-    val closeFailure = attemptClose(MaxSocketCloseAttempts, None).orElse {
-      if (socket.isClosed) None else Option(new IOException("Socket remained open after cleanup attempts"))
-    }
-    closeFailure.foreach(throw _)
-  }
-
-  /** Run cleanup without allowing it to replace a failure from the protected operation.
-    *
-    * The Throwable catch is deliberately limited to recording and immediately rethrowing the original
-    * failure; it is not a fallback or recovery boundary.
-    */
-  private[lightgbm] def withCleanupPreservingPrimary[T](cleanup: => Unit)(operation: => T): T = {
-    var primaryFailure: Option[Throwable] = None
-    try {
-      operation
-    } catch {
-      case failure: Throwable =>
-        primaryFailure = Option(failure)
-        throw failure
-    } finally {
-      try {
-        cleanup
-      } catch {
-        case cleanupFailure: Throwable if primaryFailure.isDefined =>
-          addSuppressed(primaryFailure.get, cleanupFailure)
-      }
-    }
-  }
-
-  /** Run cleanup only when the protected operation fails, preserving that primary failure. */
-  private[lightgbm] def withCleanupOnFailurePreservingPrimary[T]
-      (cleanup: => Unit)(operation: => T): T = {
-    var completed = false
-    withCleanupPreservingPrimary(if (!completed) cleanup) {
-      val result = operation
-      completed = true
-      result
-    }
-  }
+  private[lightgbm] def withCleanupOnFailurePreservingPrimary[T](cleanup: => Unit)(operation: => T): T =
+    NetworkManagerSocketSupport.withCleanupOnFailurePreservingPrimary(cleanup)(operation)
 
   private final case class WorkerMessage(status: String,
                                          taskHost: String,
@@ -485,85 +430,21 @@ object NetworkManager {
     reserveOpenPort(basePort, log)
   }
 
-  /** Reserve the first available port at or above basePort.
-    *
-    * Only address-in-use failures advance to another port. Other failures propagate after the candidate
-    * socket is closed, rather than silently falling back to a different port.
-    */
-  private[lightgbm] def reserveOpenPort(basePort: Int, log: Logger): Socket = {
-    reserveOpenPort(basePort, log, () => new Socket())
-  }
+  private[lightgbm] def reserveOpenPort(basePort: Int, log: Logger): Socket =
+    NetworkManagerSocketSupport.reserveOpenPort(basePort, log)
 
   private[lightgbm] def reserveOpenPort(basePort: Int,
                                         log: Logger,
-                                        createSocket: () => Socket): Socket = {
-    validatePort(basePort)
+                                        createSocket: () => Socket): Socket =
+    NetworkManagerSocketSupport.reserveOpenPort(basePort, log, createSocket)
 
-    @tailrec
-    def reservePort(localListenPort: Int): Socket = {
-      val bindResult: Either[BindException, Socket] = try {
-        Right(reserveExactPort(localListenPort, log, createSocket))
-      } catch {
-        // A suppressed exception means candidate cleanup failed, so proceeding would leak a socket.
-        case contention: BindException if contention.getSuppressed.isEmpty => Left(contention)
-      }
+  private[lightgbm] def reserveExactPort(localListenPort: Int, log: Logger): Socket =
+    NetworkManagerSocketSupport.reserveExactPort(localListenPort, log)
 
-      bindResult match {
-        case Right(reservation) => reservation
-        case Left(_) =>
-          log.warn(s"Could not bind to port $localListenPort...")
-          val nextPort = localListenPort + 1
-          if (nextPort > LightGBMConstants.MaxPort) {
-            throw new Exception(s"Error: port $basePort out of range, " +
-              "possibly due to networking or firewall issues")
-          }
-          if (nextPort - basePort > 1000) {
-            throw new Exception("Error: Could not find open port after 1k tries")
-          }
-          reservePort(nextPort)
-      }
-    }
-
-    reservePort(basePort)
-  }
-
-  /** Reserve one exact port. Native-init retries cannot change the previously advertised port. */
-  private[lightgbm] def reserveExactPort(localListenPort: Int, log: Logger): Socket = {
-    reserveExactPort(localListenPort, log, () => new Socket())
-  }
-
-  private def reserveExactPort(localListenPort: Int,
-                               log: Logger,
-                               createSocket: () => Socket): Socket = {
-    validatePort(localListenPort)
-    val candidate = createSocket()
-    withCleanupOnFailurePreservingPrimary(closeSocketWithRetry(candidate)) {
-      candidate.bind(new InetSocketAddress(localListenPort))
-      log.info(s"Successfully bound to port $localListenPort")
-      candidate
-    }
-  }
-
-  private def validatePort(port: Int): Unit = {
-    if (port < 0 || port > LightGBMConstants.MaxPort) {
-      throw new Exception(s"Error: port $port out of range, possibly due to too many executors or unknown error")
-    }
-  }
-
-  /** Keep a training task's port reserved, while releasing helper and failed-task reservations immediately. */
   private[lightgbm] def withPortReservation(reservation: Socket,
                                             shouldExecuteTraining: Boolean)
-                                           (getTopology: Int => NetworkTopologyInfo): NetworkTopologyInfo = {
-    var retained = false
-    withCleanupPreservingPrimary(if (!retained) closeSocketWithRetry(reservation)) {
-      val topology = getTopology(reservation.getLocalPort)
-      if (shouldExecuteTraining) {
-        topology.retainPortReservation(reservation)
-        retained = true
-      }
-      topology
-    }
-  }
+                                           (getTopology: Int => NetworkTopologyInfo): NetworkTopologyInfo =
+    NetworkManagerSocketSupport.withPortReservation(reservation, shouldExecuteTraining)(getTopology)
 
   private def setFinishedStatus(networkParams: NetworkParams, stageAttemptNumber: Int, log: Logger): Unit = {
     using(new Socket(networkParams.ipAddress, networkParams.port)) {

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
@@ -5,7 +5,6 @@ package com.microsoft.azure.synapse.ml.lightgbm
 
 import com.microsoft.azure.synapse.ml.core.env.StreamUtilities.{using, usingMany}
 import com.microsoft.azure.synapse.ml.core.utils.{ClusterUtil, FaultToleranceUtils}
-import com.microsoft.azure.synapse.ml.lightgbm.NetworkManager.parseWorkerMessage
 import com.microsoft.ml.lightgbm.lightgbmlib
 import org.apache.spark.BarrierTaskContext
 import org.apache.spark.TaskContext
@@ -19,27 +18,24 @@ import java.net.{BindException, ConnectException, InetSocketAddress, ServerSocke
 import java.util.concurrent.Executors
 import scala.annotation.tailrec
 import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Future}
 import scala.concurrent.duration.{Duration, SECONDS}
 import scala.language.existentials
+import scala.util.control.NonFatal
 
 case class TaskMessageInfo(status: String,
                            taskHost: String,
                            localListenPort: Int,
                            partitionId: Int,
-                           executorId: String,
-                           stageAttemptNumber: Int = 0) {
-  // Constructor for general messages, not Task-connected
-  def this(status: String, stageAttemptNumber: Int) = this(status, "", -1, -1, "", stageAttemptNumber)
+                           executorId: String) {
+  def this(status: String) = this(status, "", -1, -1, "") // Constructor for general messages, not Task-connected
 
   val isForTraining: Boolean = status == LightGBMConstants.EnabledTask
   val isForLoadOnly: Boolean = status == LightGBMConstants.IgnoreStatus
   val isFinished: Boolean = status == LightGBMConstants.FinishedStatus
 
   // Format all the information as a delimited string to send to driver
-  override def toString: String =
-    s"$status:$taskHost:$localListenPort:$partitionId:$executorId:$stageAttemptNumber"
+  override def toString: String = s"$status:$taskHost:$localListenPort:$partitionId:$executorId"
 }
 
 case class NetworkTopologyInfo(lightgbmNetworkString: String,
@@ -78,7 +74,7 @@ case class NetworkTopologyInfo(lightgbmNetworkString: String,
     }
   }
 }
-
+object NetworkManager {
 object NetworkManager {
   private val MaxSocketCloseAttempts = 2
 
@@ -145,6 +141,21 @@ object NetworkManager {
       result
     }
   }
+
+  private final case class WorkerMessage(status: String,
+                                         taskHost: String,
+                                         localListenPort: Int,
+                                         partitionId: Int,
+                                         executorId: String,
+                                         stageAttemptNumber: Int) {
+    val isForTraining: Boolean = status == LightGBMConstants.EnabledTask
+    val isForLoadOnly: Boolean = status == LightGBMConstants.IgnoreStatus
+    val isFinished: Boolean = status == LightGBMConstants.FinishedStatus
+
+    def toTaskMessage: TaskMessageInfo =
+      TaskMessageInfo(status, taskHost, localListenPort, partitionId, executorId)
+  }
+
   /**
     * Create a NetworkManager, which will encapsulate all network operations.
     * This method will opens a socket communications channel on the driver, and then initialize
@@ -285,9 +296,8 @@ object NetworkManager {
               driverSocket.getLocalAddress.getHostAddress,
               localListenPort,
               partitionId,
-              LightGBMUtils.getExecutorId, // TODO can we use host for this?
-              stageAttemptNumber)
-            val message = taskStatus.toString()
+              LightGBMUtils.getExecutorId) // TODO can we use host for this?
+            val message = workerMessageToString(taskStatus, stageAttemptNumber)
             log.info(s"task $taskId sending status message to driver: $message ")
             driverOutput.write(s"$message\n")
             driverOutput.flush()
@@ -569,11 +579,15 @@ object NetworkManager {
   }
 
   def parseWorkerMessage(message: String): TaskMessageInfo = {
+    parseWorkerProtocolMessage(message).toTaskMessage
+  }
+
+  private def parseWorkerProtocolMessage(message: String): WorkerMessage = {
     val components = message.split(":")
     val status = components(0)
 
     if (status == LightGBMConstants.FinishedStatus) {
-      new TaskMessageInfo(status, parseStageAttemptNumber(components, 1))
+      WorkerMessage(status, "", -1, -1, "", parseStageAttemptNumber(components, 1))
     } else {
       if (components.length != 5 && components.length != 6) {  //scalastyle:ignore magic.number
         throw new Exception(s"Unexpected message: $message")
@@ -583,9 +597,13 @@ object NetworkManager {
       val port = components(2).toInt
       val partitionId: Int = components(3).toInt
       val executorId = components(4)  //scalastyle:ignore magic.number
-      TaskMessageInfo(status, host, port, partitionId, executorId,
-                      parseStageAttemptNumber(components, 5))  //scalastyle:ignore magic.number
+      WorkerMessage(status, host, port, partitionId, executorId,
+                    parseStageAttemptNumber(components, 5))  //scalastyle:ignore magic.number
     }
+  }
+
+  private def workerMessageToString(message: TaskMessageInfo, stageAttemptNumber: Int): String = {
+    s"${message.toString}:$stageAttemptNumber"
   }
 
   private def parseStageAttemptNumber(components: Array[String], index: Int): Int = {
@@ -604,34 +622,47 @@ case class NetworkManager(numTasks: Int,
                           timeout: Double,
                           useBarrierExecutionMode: Boolean) extends Logging {
 
-  // Arrays to store network topology in as it arrives
-  private val hostAndPorts = ListBuffer[(Socket, String)]()
-  private val loadOnlyHostAndPorts = ListBuffer[Socket]() // TODO we know this count right?
-  private val hostToMinPartition = mutable.Map[String, Int]()
-  private val partitionsByExecutor = mutable.Map[String, List[Int]]()
+  private final class TaskConnection(val socket: Socket, val message: NetworkManager.WorkerMessage) {
+    def networkInfoString: String = s"${message.taskHost}:${message.localListenPort}"
+  }
+
+  // Spark can retry a task report within the same stage attempt. Keeping one connection per
+  // partition prevents duplicates from satisfying or permanently overshooting the round count.
+  private val taskConnectionsByPartition = mutable.Map[Int, TaskConnection]()
 
   // The Spark stage attempt whose topology is currently being collected. A barrier stage restarts
   // as a whole, so a higher attempt number means everything gathered so far is obsolete.
   private var currentStageAttempt = -1
+  private var finishedForCurrentStageAttempt = false
+  private var acceptedSocket: Option[Socket] = None
   @volatile private var shutdownRequested = false
 
   // Concatenate with commas, eg: host1:port1,host2:port2, ... etc
   // Also make sure the order is deterministic by sorting on minimum partition id
   private def networkTopologyAsString: String = synchronized {
-    val hostPortsList = hostAndPorts.map(_._2).sortBy(hostPort => {
-      val host = hostPort.split(":")(0)
-      hostToMinPartition(host)
-    })
-    hostPortsList.mkString(",")
+    val connections = taskConnectionsByPartition.values.toSeq
+    val minPartitionByHost = connections.groupBy(_.message.taskHost).map { case (taskHost, hostConnections) =>
+      taskHost -> hostConnections.map(_.message.partitionId).min
+    }
+    connections
+      .filter(_.message.isForTraining)
+      .sortBy(connection =>
+        (minPartitionByHost(connection.message.taskHost), connection.message.partitionId))
+      .map(_.networkInfoString)
+      .mkString(",")
   }
 
   // Create a string representing of the partitionsByExecutor map
   // e.g. executor1=partition1,partition2:executor2=partition3,partition4
   private def partitionsByExecutorAsString: String = synchronized {
-    val executorList = partitionsByExecutor.map { case (executor, partitionList) =>
-      executor + "=" + partitionList.mkString(",")
-    }
-    executorList.mkString(":")
+    taskConnectionsByPartition.values
+      .groupBy(_.message.executorId)
+      .toSeq
+      .sortBy(_._1)
+      .map { case (executorId, connections) =>
+        s"$executorId=${connections.map(_.message.partitionId).toSeq.sorted.mkString(",")}"
+      }
+      .mkString(":")
   }
 
   // This will be kicked off at object creation time, and can be waited on by waitForNetworkDone()
@@ -712,24 +743,39 @@ case class NetworkManager(numTasks: Int,
 
   /** Handles the connection to a task from the driver.
     *
-    * @return Whether the response was a "Finished" response for barrier mode.
+    * @return Whether the current barrier round has both its Finished marker and every task report.
     *         Always false for non-barrier mode.
     */
   private def handleNextWorkerConnection(): Boolean = {
     log.info("driver accepting a new connection...")
 
     val socket = driverServerSocket.accept()  // block until connection is made
+    if (!registerAcceptedSocket(socket)) {
+      closeQuietly(socket)
+      false
+    } else {
+      try {
+        val reader = new BufferedReader(new InputStreamReader(socket.getInputStream))
+        val messageStr = reader.readLine()
+        log.info(s"received worker message string: $messageStr")
+        processWorkerConnection(socket, NetworkManager.parseWorkerProtocolMessage(messageStr))
+      } catch {
+        case failure: Throwable =>
+          closeAcceptedSocket(socket)
+          throw failure
+      }
+    }
+  }
 
-    val reader = new BufferedReader(new InputStreamReader(socket.getInputStream))
-    val messageStr = reader.readLine()
-    log.info(s"received worker message string: $messageStr")
-    val message: TaskMessageInfo = parseWorkerMessage(messageStr)
-
-    if (message.stageAttemptNumber < currentStageAttempt) {
+  private def processWorkerConnection(socket: Socket, message: NetworkManager.WorkerMessage): Boolean = synchronized {
+    if (shutdownRequested) {
+      closeAcceptedSocket(socket)
+      false
+    } else if (message.stageAttemptNumber < currentStageAttempt) {
       // A straggler from a stage attempt that Spark has already abandoned. Recording it would put a
       // dead host:port into the topology that every surviving task then tries to connect to.
       log.info(s"driver ignoring message from superseded stage attempt ${message.stageAttemptNumber}")
-      closeQuietly(socket)
+      closeAcceptedSocket(socket)
       false
     } else {
       startNewStageAttemptIfNeeded(message.stageAttemptNumber)
@@ -748,54 +794,54 @@ case class NetworkManager(numTasks: Int,
     }
   }
 
-  private def recordWorkerConnection(socket: Socket, message: TaskMessageInfo): Boolean = {
+  private def recordWorkerConnection(socket: Socket, message: NetworkManager.WorkerMessage): Boolean = {
     if (message.isFinished) {
-      log.info("driver received all tasks from barrier stage")
-      closeQuietly(socket)  // The finished message uses its own short-lived connection.
-      true
+      log.info("driver received finished marker from barrier stage")
+      finishedForCurrentStageAttempt = true
+      closeAcceptedSocket(socket)  // The finished message uses its own short-lived connection.
     } else {
-      message match {
-        case m if m.isForLoadOnly =>
-          log.info("driver received load-only status from task")
-          addSocket(loadOnlyHostAndPorts, socket)
-        case m if m.isForTraining =>
-          val networkInfoString = s"${message.taskHost}:${message.localListenPort}"
-          log.info(s"driver received socket from task: $networkInfoString")
-          addSocket(hostAndPorts, (socket, networkInfoString))
-        case _ => throw new Exception(s"Unknown message type: ${message.toString()}")
-      }
+      recordTaskConnection(socket, message)
+    }
 
-      // Update the min partition/executor tracking
-      if (!hostToMinPartition.contains(message.taskHost)
-        || hostToMinPartition(message.taskHost) > message.partitionId) {
-        hostToMinPartition(message.taskHost) = message.partitionId
-      }
+    val roundComplete =
+      useBarrierExecutionMode && finishedForCurrentStageAttempt && reportedTaskCount == numTasks
+    if (roundComplete) log.info("driver received all task reports and the finished marker from barrier stage")
+    roundComplete
+  }
 
-      // Update the tracking of which partitions are on which executor
-      if (!partitionsByExecutor.contains(message.executorId)) {
-        partitionsByExecutor(message.executorId) = List { message.partitionId }
-      } else {
-        val currentPartitionList = partitionsByExecutor(message.executorId)
-        partitionsByExecutor(message.executorId) = currentPartitionList :+ message.partitionId
-      }
-      false
+  private def recordTaskConnection(socket: Socket, message: NetworkManager.WorkerMessage): Unit = {
+    if (message.partitionId < 0 || message.partitionId >= numTasks) {
+      throw new Exception(s"Unexpected partition id ${message.partitionId}; expected a value in [0, $numTasks)")
+    }
+
+    val connection = new TaskConnection(socket, message)
+    message match {
+      case m if m.isForLoadOnly =>
+        log.info("driver received load-only status from task")
+      case m if m.isForTraining =>
+        log.info(s"driver received socket from task: ${connection.networkInfoString}")
+      case _ => throw new Exception(s"Unknown message type: ${message.status}")
+    }
+
+    val previousConnection = taskConnectionsByPartition.put(message.partitionId, connection)
+    acceptedSocket = None
+    previousConnection.foreach { previous =>
+      log.info(s"driver replacing duplicate report for partition ${message.partitionId}")
+      if (previous.socket ne socket) closeQuietly(previous.socket)
     }
   }
 
   private def sendDataToExecutors(lightGBMNetworkTopology: String, partitionsByExecutor: String): Unit = {
     // TODO optimize and not send for bulk mode helpers
     // Send aggregated network information back to all tasks and helper tasks on executors
-    val count = hostAndPorts.length + loadOnlyHostAndPorts.length
+    val sockets = synchronized {
+      taskConnectionsByPartition.values.map(_.socket).toSeq
+    }
+    val count = sockets.length
     log.info(s"driver writing back network topology to $count connections: $lightGBMNetworkTopology")
     log.info(s"driver writing back partition topology to $count connections: $partitionsByExecutor")
-    hostAndPorts.foreach(hostAndPort => {
-      val writer = new BufferedWriter(new OutputStreamWriter(hostAndPort._1.getOutputStream))
-      writer.write(lightGBMNetworkTopology + "\n")
-      writer.write(partitionsByExecutor + "\n")
-      writer.flush()
-    })
-    loadOnlyHostAndPorts.foreach(hostAndPort => {
-      val writer = new BufferedWriter(new OutputStreamWriter(hostAndPort.getOutputStream))
+    sockets.foreach(socket => {
+      val writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream))
       writer.write(lightGBMNetworkTopology + "\n")
       writer.write(partitionsByExecutor + "\n")
       writer.flush()
@@ -810,47 +856,54 @@ case class NetworkManager(numTasks: Int,
     */
   private[lightgbm] def closeConnections(): Unit = synchronized {
     shutdownRequested = true
-    if (!driverServerSocket.isClosed) {
-      log.info("driver closing all sockets and server socket")
-      closeRoundSockets()
-      closeQuietly(driverServerSocket)
-      log.info("driver done closing all sockets and server socket")
-    }
+    log.info("driver closing all sockets and server socket")
+    acceptedSocket.foreach(closeQuietly)
+    acceptedSocket = None
+    closeRoundSockets()
+    closeQuietly(driverServerSocket)
+    log.info("driver done closing all sockets and server socket")
   }
 
   /** Number of tasks whose topology has been recorded for the current stage attempt. */
   private def reportedTaskCount: Int = synchronized {
-    hostAndPorts.length + loadOnlyHostAndPorts.length
+    taskConnectionsByPartition.size
   }
 
   /** Discards everything gathered for a stage attempt so the next one starts from a clean slate. */
   private def resetRoundState(): Unit = synchronized {
     closeRoundSockets()
-    hostAndPorts.clear()
-    loadOnlyHostAndPorts.clear()
-    hostToMinPartition.clear()
-    partitionsByExecutor.clear()
+    taskConnectionsByPartition.clear()
+    finishedForCurrentStageAttempt = false
   }
 
   private def closeRoundSockets(): Unit = synchronized {
-    hostAndPorts.foreach(hostAndPort => closeQuietly(hostAndPort._1))
-    loadOnlyHostAndPorts.foreach(closeQuietly)
+    taskConnectionsByPartition.values.foreach(connection => closeQuietly(connection.socket))
   }
 
-  /** Records an accepted socket. The network thread appends while the training job may be closing
-    * everything down, so the buffers are only ever touched under the instance lock.
-    */
-  private def addSocket[T](buffer: ListBuffer[T], entry: T): Unit = synchronized {
-    buffer += entry
+  /** Tracks the socket between accept() and its transfer into the current round's socket buffers. */
+  private def registerAcceptedSocket(socket: Socket): Boolean = synchronized {
+    if (shutdownRequested) {
+      false
+    } else {
+      acceptedSocket = Some(socket)
+      true
+    }
+  }
+
+  private def closeAcceptedSocket(socket: Socket): Unit = synchronized {
+    if (acceptedSocket.contains(socket)) {
+      acceptedSocket = None
+      closeQuietly(socket)
+    }
   }
 
   private def closeQuietly(closeable: java.io.Closeable): Unit = {
     try {
       closeable.close()
     } catch {
-      case closeFailure: IOException =>
+      case NonFatal(closeFailure) =>
         // One socket refusing to close must not strand the others, especially the server socket.
-        log.warn(s"driver could not close a network socket cleanly: $closeFailure")
+        log.warn("driver could not close a network socket cleanly", closeFailure)
     }
   }
 }

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
@@ -87,20 +87,6 @@ object NetworkManager {
   private[lightgbm] def withCleanupOnFailurePreservingPrimary[T](cleanup: => Unit)(operation: => T): T =
     NetworkManagerSocketSupport.withCleanupOnFailurePreservingPrimary(cleanup)(operation)
 
-  private final case class WorkerMessage(status: String,
-                                         taskHost: String,
-                                         localListenPort: Int,
-                                         partitionId: Int,
-                                         executorId: String,
-                                         stageAttemptNumber: Int) {
-    val isForTraining: Boolean = status == LightGBMConstants.EnabledTask
-    val isForLoadOnly: Boolean = status == LightGBMConstants.IgnoreStatus
-    val isFinished: Boolean = status == LightGBMConstants.FinishedStatus
-
-    def toTaskMessage: TaskMessageInfo =
-      TaskMessageInfo(status, taskHost, localListenPort, partitionId, executorId)
-  }
-
   /**
     * Create a NetworkManager, which will encapsulate all network operations.
     * This method will opens a socket communications channel on the driver, and then initialize
@@ -242,7 +228,7 @@ object NetworkManager {
               localListenPort,
               partitionId,
               LightGBMUtils.getExecutorId) // TODO can we use host for this?
-            val message = workerMessageToString(taskStatus, stageAttemptNumber)
+            val message = WorkerMessage.format(taskStatus, stageAttemptNumber)
             log.info(s"task $taskId sending status message to driver: $message ")
             driverOutput.write(s"$message\n")
             driverOutput.flush()
@@ -252,7 +238,7 @@ object NetworkManager {
               val context = BarrierTaskContext.get()
               context.barrier()
               if (context.partitionId() == 0) {
-                 setFinishedStatus(networkParams, stageAttemptNumber, log)
+                 setFinishedStatus(networkParams, stageAttemptNumber, context.getTaskInfos().length, log)
               }
             }
 
@@ -446,52 +432,26 @@ object NetworkManager {
                                            (getTopology: Int => NetworkTopologyInfo): NetworkTopologyInfo =
     NetworkManagerSocketSupport.withPortReservation(reservation, shouldExecuteTraining)(getTopology)
 
-  private def setFinishedStatus(networkParams: NetworkParams, stageAttemptNumber: Int, log: Logger): Unit = {
+  private def setFinishedStatus(networkParams: NetworkParams,
+                                stageAttemptNumber: Int,
+                                barrierTaskCount: Int,
+                                log: Logger): Unit = {
     using(new Socket(networkParams.ipAddress, networkParams.port)) {
       driverSocket =>
         using(new BufferedWriter(new OutputStreamWriter(driverSocket.getOutputStream))) {
           driverOutput =>
-            log.info("sending finished status to driver")
-            // If barrier execution mode enabled, create a barrier across tasks
-            driverOutput.write(s"${LightGBMConstants.FinishedStatus}:$stageAttemptNumber\n")
+            log.info(s"sending finished status to driver for $barrierTaskCount barrier tasks")
+            // The barrier task count tells the driver how many topology reports to expect. It can be
+            // smaller than numTasks, because barrier mode never repartitions upwards when the input
+            // has fewer partitions than numTasks.
+            driverOutput.write(s"${WorkerMessage.formatFinished(stageAttemptNumber, barrierTaskCount)}\n")
             driverOutput.flush()
         }.get
     }.get
   }
 
   def parseWorkerMessage(message: String): TaskMessageInfo = {
-    parseWorkerProtocolMessage(message).toTaskMessage
-  }
-
-  private def parseWorkerProtocolMessage(message: String): WorkerMessage = {
-    if (message == null) {
-      throw new IOException("Worker closed the connection before sending a status message")
-    }
-    val components = message.split(":")
-    val status = components(0)
-
-    if (status == LightGBMConstants.FinishedStatus) {
-      WorkerMessage(status, "", -1, -1, "", parseStageAttemptNumber(components, 1))
-    } else {
-      if (components.length != 5 && components.length != 6) {  //scalastyle:ignore magic.number
-        throw new Exception(s"Unexpected message: $message")
-      }
-
-      val host = components(1)
-      val port = components(2).toInt
-      val partitionId: Int = components(3).toInt
-      val executorId = components(4)  //scalastyle:ignore magic.number
-      WorkerMessage(status, host, port, partitionId, executorId,
-                    parseStageAttemptNumber(components, 5))  //scalastyle:ignore magic.number
-    }
-  }
-
-  private def workerMessageToString(message: TaskMessageInfo, stageAttemptNumber: Int): String = {
-    s"${message.toString}:$stageAttemptNumber"
-  }
-
-  private def parseStageAttemptNumber(components: Array[String], index: Int): Int = {
-    if (components.length > index) components(index).toInt else 0
+    WorkerMessage.parse(message).toTaskMessage
   }
 }
 
@@ -506,7 +466,7 @@ case class NetworkManager(numTasks: Int,
                           timeout: Double,
                           useBarrierExecutionMode: Boolean) extends Logging {
 
-  private final class TaskConnection(val socket: Socket, val message: NetworkManager.WorkerMessage) {
+  private final class TaskConnection(val socket: Socket, val message: WorkerMessage) {
     def networkInfoString: String = s"${message.taskHost}:${message.localListenPort}"
   }
 
@@ -518,6 +478,7 @@ case class NetworkManager(numTasks: Int,
   // as a whole, so a higher attempt number means everything gathered so far is obsolete.
   private var currentStageAttempt = -1
   private var finishedForCurrentStageAttempt = false
+  private var expectedTaskCountForCurrentStageAttempt: Option[Int] = None
   private var acceptedSocket: Option[Socket] = None
   @volatile private var shutdownRequested = false
 
@@ -646,7 +607,7 @@ case class NetworkManager(numTasks: Int,
         val reader = new BufferedReader(new InputStreamReader(socket.getInputStream))
         val messageStr = reader.readLine()
         log.info(s"received worker message string: $messageStr")
-        processWorkerConnection(socket, NetworkManager.parseWorkerProtocolMessage(messageStr))
+        processWorkerConnection(socket, WorkerMessage.parse(messageStr))
       } catch {
         case failure: Throwable =>
           closeAcceptedSocket(socket)
@@ -655,7 +616,7 @@ case class NetworkManager(numTasks: Int,
     }
   }
 
-  private def processWorkerConnection(socket: Socket, message: NetworkManager.WorkerMessage): Boolean = synchronized {
+  private def processWorkerConnection(socket: Socket, message: WorkerMessage): Boolean = synchronized {
     if (shutdownRequested) {
       closeAcceptedSocket(socket)
       false
@@ -682,22 +643,42 @@ case class NetworkManager(numTasks: Int,
     }
   }
 
-  private def recordWorkerConnection(socket: Socket, message: NetworkManager.WorkerMessage): Boolean = {
+  private def recordWorkerConnection(socket: Socket, message: WorkerMessage): Boolean = {
     if (message.isFinished) {
-      log.info("driver received finished marker from barrier stage")
+      log.info(s"driver received finished marker from barrier stage for ${message.barrierTaskCount} tasks")
       finishedForCurrentStageAttempt = true
+      message.barrierTaskCount.filter(_ > 0).foreach(count => expectedTaskCountForCurrentStageAttempt = Some(count))
       closeAcceptedSocket(socket)  // The finished message uses its own short-lived connection.
     } else {
       recordTaskConnection(socket, message)
     }
 
-    val roundComplete =
-      useBarrierExecutionMode && finishedForCurrentStageAttempt && reportedTaskCount == numTasks
+    val roundComplete = barrierRoundComplete
     if (roundComplete) log.info("driver received all task reports and the finished marker from barrier stage")
     roundComplete
   }
 
-  private def recordTaskConnection(socket: Socket, message: NetworkManager.WorkerMessage): Unit = {
+  /**
+    * The finished marker only tells the driver that the barrier stage synchronized; the task reports
+    * can still be sitting in the accept backlog, so completing on the marker alone risks broadcasting
+    * a partial topology. Wait for as many reports as the barrier stage actually ran, which the marker
+    * carries. That count is not always numTasks: barrier mode never repartitions upwards, so a user
+    * who sets numTasks above the input's partition count runs fewer tasks, and waiting for numTasks
+    * reports would hang until Spark's barrier timeout.
+    */
+  private def barrierRoundComplete: Boolean = {
+    if (!useBarrierExecutionMode || !finishedForCurrentStageAttempt) {
+      false
+    } else {
+      expectedTaskCountForCurrentStageAttempt match {
+        case Some(expected) => reportedTaskCount >= math.min(expected, numTasks)
+        // A sender that did not report a count leaves the marker as the only signal available.
+        case None => true
+      }
+    }
+  }
+
+  private def recordTaskConnection(socket: Socket, message: WorkerMessage): Unit = {
     if (message.partitionId < 0 || message.partitionId >= numTasks) {
       throw new Exception(s"Unexpected partition id ${message.partitionId}; expected a value in [0, $numTasks)")
     }
@@ -762,6 +743,7 @@ case class NetworkManager(numTasks: Int,
     closeRoundSockets()
     taskConnectionsByPartition.clear()
     finishedForCurrentStageAttempt = false
+    expectedTaskCountForCurrentStageAttempt = None
   }
 
   private def closeRoundSockets(): Unit = synchronized {

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManagerSocketSupport.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManagerSocketSupport.scala
@@ -1,0 +1,157 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm
+
+import org.slf4j.Logger
+
+import java.io.IOException
+import java.net.{BindException, InetSocketAddress, Socket}
+import scala.annotation.tailrec
+
+private[lightgbm] object NetworkManagerSocketSupport {
+  private val MaxSocketCloseAttempts = 2
+
+  def addSuppressed(primaryFailure: Throwable, secondaryFailure: Throwable): Unit = {
+    if (primaryFailure ne secondaryFailure) primaryFailure.addSuppressed(secondaryFailure)
+  }
+
+  /** Close a socket with one immediate retry, retaining every observed cleanup failure. */
+  def closeSocketWithRetry(socket: Socket): Unit = {
+    @tailrec
+    def attemptClose(attemptsRemaining: Int,
+                     firstFailure: Option[IOException]): Option[IOException] = {
+      if (socket.isClosed || attemptsRemaining == 0) {
+        firstFailure
+      } else {
+        val updatedFailure = try {
+          socket.close()
+          firstFailure
+        } catch {
+          case failure: IOException =>
+            firstFailure.foreach(existing => addSuppressed(existing, failure))
+            firstFailure.orElse(Option(failure))
+        }
+        attemptClose(attemptsRemaining - 1, updatedFailure)
+      }
+    }
+
+    val closeFailure = attemptClose(MaxSocketCloseAttempts, None).orElse {
+      if (socket.isClosed) None else Option(new IOException("Socket remained open after cleanup attempts"))
+    }
+    closeFailure.foreach(throw _)
+  }
+
+  /** Run cleanup without allowing it to replace a failure from the protected operation.
+    *
+    * The Throwable catch is deliberately limited to recording and immediately rethrowing the original
+    * failure; it is not a fallback or recovery boundary.
+    */
+  def withCleanupPreservingPrimary[T](cleanup: => Unit)(operation: => T): T = {
+    var primaryFailure: Option[Throwable] = None
+    try {
+      operation
+    } catch {
+      case failure: Throwable =>
+        primaryFailure = Option(failure)
+        throw failure
+    } finally {
+      try {
+        cleanup
+      } catch {
+        case cleanupFailure: Throwable if primaryFailure.isDefined =>
+          addSuppressed(primaryFailure.get, cleanupFailure)
+      }
+    }
+  }
+
+  /** Run cleanup only when the protected operation fails, preserving that primary failure. */
+  def withCleanupOnFailurePreservingPrimary[T](cleanup: => Unit)(operation: => T): T = {
+    var completed = false
+    withCleanupPreservingPrimary(if (!completed) cleanup) {
+      val result = operation
+      completed = true
+      result
+    }
+  }
+
+  /** Reserve the first available port at or above basePort.
+    *
+    * Only address-in-use failures advance to another port. Other failures propagate after the candidate
+    * socket is closed, rather than silently falling back to a different port.
+    */
+  def reserveOpenPort(basePort: Int, log: Logger): Socket = {
+    reserveOpenPort(basePort, log, () => new Socket())
+  }
+
+  def reserveOpenPort(basePort: Int,
+                      log: Logger,
+                      createSocket: () => Socket): Socket = {
+    validatePort(basePort)
+
+    @tailrec
+    def reservePort(localListenPort: Int): Socket = {
+      val bindResult: Either[BindException, Socket] = try {
+        Right(reserveExactPort(localListenPort, log, createSocket))
+      } catch {
+        // A suppressed exception means candidate cleanup failed, so proceeding would leak a socket.
+        case contention: BindException if contention.getSuppressed.isEmpty => Left(contention)
+      }
+
+      bindResult match {
+        case Right(reservation) => reservation
+        case Left(_) =>
+          log.warn(s"Could not bind to port $localListenPort...")
+          val nextPort = localListenPort + 1
+          if (nextPort > LightGBMConstants.MaxPort) {
+            throw new Exception(s"Error: port $basePort out of range, " +
+              "possibly due to networking or firewall issues")
+          }
+          if (nextPort - basePort > 1000) {
+            throw new Exception("Error: Could not find open port after 1k tries")
+          }
+          reservePort(nextPort)
+      }
+    }
+
+    reservePort(basePort)
+  }
+
+  /** Reserve one exact port. Native-init retries cannot change the previously advertised port. */
+  def reserveExactPort(localListenPort: Int, log: Logger): Socket = {
+    reserveExactPort(localListenPort, log, () => new Socket())
+  }
+
+  private def reserveExactPort(localListenPort: Int,
+                               log: Logger,
+                               createSocket: () => Socket): Socket = {
+    validatePort(localListenPort)
+    val candidate = createSocket()
+    withCleanupOnFailurePreservingPrimary(closeSocketWithRetry(candidate)) {
+      candidate.bind(new InetSocketAddress(localListenPort))
+      log.info(s"Successfully bound to port $localListenPort")
+      candidate
+    }
+  }
+
+  private def validatePort(port: Int): Unit = {
+    if (port < 0 || port > LightGBMConstants.MaxPort) {
+      throw new Exception(s"Error: port $port out of range, possibly due to too many executors or unknown error")
+    }
+  }
+
+  /** Keep a training task's port reserved, while releasing helper and failed-task reservations immediately. */
+  def withPortReservation(reservation: Socket,
+                          shouldExecuteTraining: Boolean)
+                         (getTopology: Int => NetworkTopologyInfo): NetworkTopologyInfo = {
+    var retained = false
+    withCleanupPreservingPrimary(if (!retained) closeSocketWithRetry(reservation)) {
+      val topology = getTopology(reservation.getLocalPort)
+      if (shouldExecuteTraining) {
+        topology.retainPortReservation(reservation)
+        retained = true
+      }
+      topology
+    }
+  }
+}

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/WorkerMessage.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/WorkerMessage.scala
@@ -1,0 +1,66 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm
+
+import java.io.IOException
+
+/**
+  * The line protocol tasks use to report themselves to the driver while the LightGBM network
+  * topology is being assembled.
+  *
+  * A task report is `status:host:port:partitionId:executorId[:stageAttemptNumber]`, and the
+  * barrier-stage marker is `finished:stageAttemptNumber[:barrierTaskCount]`. The trailing
+  * fields are parsed defensively so a message written without them is still understood.
+  */
+private[lightgbm] final case class WorkerMessage(status: String,
+                                                 taskHost: String,
+                                                 localListenPort: Int,
+                                                 partitionId: Int,
+                                                 executorId: String,
+                                                 stageAttemptNumber: Int,
+                                                 barrierTaskCount: Option[Int] = None) {
+  val isForTraining: Boolean = status == LightGBMConstants.EnabledTask
+  val isForLoadOnly: Boolean = status == LightGBMConstants.IgnoreStatus
+  val isFinished: Boolean = status == LightGBMConstants.FinishedStatus
+
+  def toTaskMessage: TaskMessageInfo =
+    TaskMessageInfo(status, taskHost, localListenPort, partitionId, executorId)
+}
+
+private[lightgbm] object WorkerMessage {
+  private val TaskMessageFieldCount = 5
+  private val TaskMessageFieldCountWithStageAttempt = 6
+
+  def parse(message: String): WorkerMessage = {
+    if (message == null) {
+      throw new IOException("Worker closed the connection before sending a status message")
+    }
+    val components = message.split(":")
+    val status = components(0)
+
+    if (status == LightGBMConstants.FinishedStatus) {
+      WorkerMessage(status, "", -1, -1, "", parseIntOrDefault(components, 1, 0),
+        parseOptionalInt(components, 2))
+    } else {
+      if (components.length != TaskMessageFieldCount && components.length != TaskMessageFieldCountWithStageAttempt) {
+        throw new Exception(s"Unexpected message: $message")
+      }
+
+      WorkerMessage(status, components(1), components(2).toInt, components(3).toInt, components(4),
+        parseIntOrDefault(components, TaskMessageFieldCount, 0))
+    }
+  }
+
+  def format(message: TaskMessageInfo, stageAttemptNumber: Int): String =
+    s"${message.toString}:$stageAttemptNumber"
+
+  def formatFinished(stageAttemptNumber: Int, barrierTaskCount: Int): String =
+    s"${LightGBMConstants.FinishedStatus}:$stageAttemptNumber:$barrierTaskCount"
+
+  private def parseIntOrDefault(components: Array[String], index: Int, default: Int): Int =
+    if (components.length > index) components(index).toInt else default
+
+  private def parseOptionalInt(components: Array[String], index: Int): Option[Int] =
+    if (components.length > index) Some(components(index).toInt) else None
+}

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/BarrierNetworkRecoverySuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/BarrierNetworkRecoverySuite.scala
@@ -83,13 +83,14 @@ class BarrierNetworkRecoverySuite extends AnyFunSuite {
   }
 
   /** Partition 0 signals the end of a barrier round over its own short-lived connection. */
-  private def sendFinished(port: Int, stageAttempt: Int): Unit = {
+  private def sendFinished(port: Int, stageAttempt: Int, barrierTaskCount: Option[Int] = Some(2)): Unit = {
     val socket = new Socket()
     try {
       socket.connect(new InetSocketAddress(host, port), socketTimeoutMillis)
       socket.setSoTimeout(socketTimeoutMillis)
       val writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream))
-      writer.write(s"${LightGBMConstants.FinishedStatus}:$stageAttempt\n")
+      val countSuffix = barrierTaskCount.map(count => s":$count").getOrElse("")
+      writer.write(s"${LightGBMConstants.FinishedStatus}:$stageAttempt$countSuffix\n")
       writer.flush()
       socket.shutdownOutput()
       val reader = new BufferedReader(new InputStreamReader(socket.getInputStream))
@@ -231,6 +232,51 @@ class BarrierNetworkRecoverySuite extends AnyFunSuite {
       current.head.assertNoTopologyYet()
 
       sendFinished(port, stageAttempt = 0)
+
+      val expected = current.map(_.address).toSet
+      current.foreach(task => assert(task.readTopology().split(",").toSet == expected))
+    } finally {
+      closeAll(manager, tasks)
+    }
+  }
+
+  test("A barrier stage smaller than numTasks completes instead of hanging") {
+    // Barrier mode never repartitions upwards, so setNumTasks above the input's partition
+    // count leaves the stage running fewer tasks than numTasks. Waiting for numTasks reports
+    // would block until Spark's barrier timeout (365 days by default).
+    val (manager, port) = newBarrierManager(numTasks = 4)
+    var tasks = Seq.empty[FakeBarrierTask]
+    try {
+      val current = (0 until 2).map { partitionId =>
+        val task = new FakeBarrierTask(port, partitionId, stageAttempt = 0)
+        tasks :+= task
+        task
+      }
+      current.foreach(_.report())
+      current.head.assertNoTopologyYet()
+
+      sendFinished(port, stageAttempt = 0, barrierTaskCount = Some(2))
+
+      val expected = current.map(_.address).toSet
+      current.foreach(task => assert(task.readTopology().split(",").toSet == expected))
+    } finally {
+      closeAll(manager, tasks)
+    }
+  }
+
+  test("A Finished marker without a task count still completes the round") {
+    // Defensive: the marker is the only completion signal available when no count is reported.
+    val (manager, port) = newBarrierManager(numTasks = 2)
+    var tasks = Seq.empty[FakeBarrierTask]
+    try {
+      val current = (0 until 2).map { partitionId =>
+        val task = new FakeBarrierTask(port, partitionId, stageAttempt = 0)
+        tasks :+= task
+        task
+      }
+      current.foreach(_.report())
+
+      sendFinished(port, stageAttempt = 0, barrierTaskCount = None)
 
       val expected = current.map(_.address).toSet
       current.foreach(task => assert(task.readTopology().split(",").toSet == expected))

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/BarrierNetworkRecoverySuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/BarrierNetworkRecoverySuite.scala
@@ -6,8 +6,8 @@ package com.microsoft.azure.synapse.ml.lightgbm.split1
 import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMConstants, NetworkManager}
 import org.scalatest.funsuite.AnyFunSuite
 
-import java.io.{BufferedReader, BufferedWriter, InputStreamReader, OutputStreamWriter}
-import java.net.{ServerSocket, Socket}
+import java.io.{BufferedReader, BufferedWriter, IOException, InputStreamReader, OutputStreamWriter}
+import java.net.{InetSocketAddress, ServerSocket, Socket, SocketException, SocketTimeoutException}
 
 /** Covers recovery of the driver topology exchange when Spark restarts a barrier stage.
   *
@@ -18,109 +18,309 @@ import java.net.{ServerSocket, Socket}
 class BarrierNetworkRecoverySuite extends AnyFunSuite {
 
   private val timeout = 30.0
+  private val socketTimeoutMillis = 30000
+  private val noResponseTimeoutMillis = 250
   private val host = "127.0.0.1"
 
-  private class FakeBarrierTask(port: Int, partitionId: Int, stageAttempt: Int) {
-    private val socket = new Socket(host, port)
+  private class FakeBarrierTask(port: Int,
+                                partitionId: Int,
+                                stageAttempt: Int,
+                                loadOnly: Boolean = false,
+                                listenPortOffset: Int = 0,
+                                executorId: String = "") extends AutoCloseable {
+    private val socket = {
+      val result = new Socket()
+      try {
+        result.connect(new InetSocketAddress(host, port), socketTimeoutMillis)
+        result.setSoTimeout(socketTimeoutMillis)
+        result
+      } catch {
+        case failure: Throwable =>
+          try result.close()
+          catch {
+            case closeFailure: IOException => failure.addSuppressed(closeFailure)
+          }
+          throw failure
+      }
+    }
     private val reader = new BufferedReader(new InputStreamReader(socket.getInputStream))
     private val writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream))
 
-    val listenPort: Int = LightGBMConstants.DefaultLocalListenPort + stageAttempt * 100 + partitionId
+    val listenPort: Int =
+      LightGBMConstants.DefaultLocalListenPort + stageAttempt * 100 + partitionId + listenPortOffset
     def address: String = s"$host:$listenPort"
 
     def report(): Unit = {
+      val status = if (loadOnly) LightGBMConstants.IgnoreStatus else LightGBMConstants.EnabledTask
+      val reportedExecutorId = if (executorId.isEmpty) s"executor$partitionId" else executorId
       writer.write(
-        s"${LightGBMConstants.EnabledTask}:$host:$listenPort:$partitionId:executor$partitionId:$stageAttempt\n")
+        s"$status:$host:$listenPort:$partitionId:$reportedExecutorId:$stageAttempt\n")
       writer.flush()
     }
 
     def readTopology(): String = reader.readLine()
 
-    def isClosedByDriver: Boolean = reader.readLine() == null
+    def readExecutorTopology(): String = reader.readLine()
 
-    def close(): Unit = socket.close()
+    def assertNoTopologyYet(): Unit = {
+      socket.setSoTimeout(noResponseTimeoutMillis)
+      try {
+        intercept[SocketTimeoutException](reader.readLine())
+      } finally {
+        socket.setSoTimeout(socketTimeoutMillis)
+      }
+    }
+
+    def isClosedByDriver: Boolean = {
+      try {
+        reader.readLine() == null
+      } catch {
+        case _: SocketException => true
+      }
+    }
+
+    override def close(): Unit = socket.close()
   }
 
   /** Partition 0 signals the end of a barrier round over its own short-lived connection. */
   private def sendFinished(port: Int, stageAttempt: Int): Unit = {
-    val socket = new Socket(host, port)
-    val writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream))
-    writer.write(s"${LightGBMConstants.FinishedStatus}:$stageAttempt\n")
-    writer.flush()
-    socket.close()
+    val socket = new Socket()
+    try {
+      socket.connect(new InetSocketAddress(host, port), socketTimeoutMillis)
+      socket.setSoTimeout(socketTimeoutMillis)
+      val writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream))
+      writer.write(s"${LightGBMConstants.FinishedStatus}:$stageAttempt\n")
+      writer.flush()
+      socket.shutdownOutput()
+      val reader = new BufferedReader(new InputStreamReader(socket.getInputStream))
+      try {
+        assert(reader.readLine() == null, "The driver unexpectedly replied to a Finished marker")
+      } catch {
+        case _: SocketException => () // A reset also proves that the driver processed and rejected the marker socket.
+      }
+    } finally {
+      socket.close()
+    }
   }
 
   private def newBarrierManager(numTasks: Int): (NetworkManager, Int) = {
     val serverSocket = new ServerSocket(0)
+    serverSocket.setSoTimeout(socketTimeoutMillis)
     val port = serverSocket.getLocalPort
     (NetworkManager(numTasks, serverSocket, host, port, timeout, useBarrierExecutionMode = true), port)
   }
 
+  private def closeAll(manager: NetworkManager, tasks: Seq[FakeBarrierTask]): Unit = {
+    manager.closeConnections()
+    try {
+      tasks.foreach { task =>
+        try task.close()
+        catch {
+          case _: IOException => ()
+        }
+      }
+    } finally {
+      manager.waitForNetworkCommunicationsDone()
+    }
+  }
+
+  private def partitionIds(executorTopology: String): Seq[Int] = {
+    executorTopology.split(":").flatMap { executorEntry =>
+      executorEntry.split("=")(1).split(",").map(_.toInt)
+    }.toSeq
+  }
+
   test("A restarted barrier stage gets a fresh topology round instead of a closed port") {
     val (manager, port) = newBarrierManager(numTasks = 2)
+    var tasks = Seq.empty[FakeBarrierTask]
+    try {
+      // First stage attempt reports but never reaches the barrier, so the round never completes.
+      val abandoned = (0 until 2).map { partitionId =>
+        val task = new FakeBarrierTask(port, partitionId, stageAttempt = 0)
+        tasks :+= task
+        task
+      }
+      abandoned.foreach(_.report())
 
-    // First stage attempt reports but never reaches the barrier, so the round never completes.
-    val abandoned = (0 until 2).map(new FakeBarrierTask(port, _, stageAttempt = 0))
-    abandoned.foreach(_.report())
+      // Spark restarts the whole stage. Every task reconnects to the same driver endpoint.
+      val restarted = (0 until 2).map { partitionId =>
+        val task = new FakeBarrierTask(port, partitionId, stageAttempt = 1)
+        tasks :+= task
+        task
+      }
+      restarted.foreach(_.report())
+      sendFinished(port, stageAttempt = 1)
 
-    // Spark restarts the whole stage. Every task reconnects to the same driver endpoint.
-    val restarted = (0 until 2).map(new FakeBarrierTask(port, _, stageAttempt = 1))
-    restarted.foreach(_.report())
-    sendFinished(port, stageAttempt = 1)
+      val topologies = restarted.map(_.readTopology())
+      assert(topologies.forall(_ != null), "The restarted stage attempt never received a topology")
 
-    val topologies = restarted.map(_.readTopology())
-    assert(topologies.forall(_ != null), "The restarted stage attempt never received a topology")
+      val expected = restarted.map(_.address).toSet
+      topologies.foreach { topology =>
+        assert(topology.split(",").toSet == expected,
+          s"Topology '$topology' should contain only the restarted stage attempt, expected $expected")
+      }
 
-    val expected = restarted.map(_.address).toSet
-    topologies.foreach { topology =>
-      assert(topology.split(",").toSet == expected,
-        s"Topology '$topology' should contain only the restarted stage attempt, expected $expected")
+    } finally {
+      closeAll(manager, tasks)
     }
-
-    abandoned.foreach(task =>
-      assert(task.isClosedByDriver, "The abandoned stage attempt should have had its sockets released"))
-
-    (abandoned ++ restarted).foreach(_.close())
-    manager.waitForNetworkCommunicationsDone()
   }
 
   test("A straggler from a superseded stage attempt is kept out of the topology") {
     val (manager, port) = newBarrierManager(numTasks = 2)
+    var tasks = Seq.empty[FakeBarrierTask]
+    try {
+      val abandoned = new FakeBarrierTask(port, 0, stageAttempt = 0)
+      tasks :+= abandoned
+      abandoned.report()
 
-    val abandoned = new FakeBarrierTask(port, 0, stageAttempt = 0)
-    abandoned.report()
+      val restarted = (0 until 2).map { partitionId =>
+        val task = new FakeBarrierTask(port, partitionId, stageAttempt = 1)
+        tasks :+= task
+        task
+      }
+      restarted.foreach(_.report())
 
-    val restarted = (0 until 2).map(new FakeBarrierTask(port, _, stageAttempt = 1))
-    restarted.foreach(_.report())
+      // A task from the abandoned attempt reports late. Its host:port is already dead.
+      val straggler = new FakeBarrierTask(port, 1, stageAttempt = 0)
+      tasks :+= straggler
+      straggler.report()
+      assert(straggler.isClosedByDriver, "The straggler should have been rejected by the driver")
 
-    // A task from the abandoned attempt reports late. Its host:port is already dead.
-    val straggler = new FakeBarrierTask(port, 1, stageAttempt = 0)
-    straggler.report()
-    assert(straggler.isClosedByDriver, "The straggler should have been rejected by the driver")
+      sendFinished(port, stageAttempt = 1)
 
-    sendFinished(port, stageAttempt = 1)
-
-    val expected = restarted.map(_.address).toSet
-    restarted.foreach { task =>
-      assert(task.readTopology().split(",").toSet == expected,
-        s"The straggler at ${straggler.address} should not appear in the topology")
+      val expected = restarted.map(_.address).toSet
+      restarted.foreach { task =>
+        assert(task.readTopology().split(",").toSet == expected,
+          s"The straggler at ${straggler.address} should not appear in the topology")
+      }
+    } finally {
+      closeAll(manager, tasks)
     }
-
-    (abandoned +: straggler +: restarted).foreach(_.close())
-    manager.waitForNetworkCommunicationsDone()
   }
 
-  test("A barrier round that completes normally still returns the full topology") {
+  test("A Finished marker before task reports waits for every report in that stage attempt") {
     val (manager, port) = newBarrierManager(numTasks = 2)
+    var tasks = Seq.empty[FakeBarrierTask]
+    try {
+      sendFinished(port, stageAttempt = 0)
 
-    val tasks = (0 until 2).map(new FakeBarrierTask(port, _, stageAttempt = 0))
-    tasks.foreach(_.report())
-    sendFinished(port, stageAttempt = 0)
+      val current = (0 until 2).map { partitionId =>
+        val task = new FakeBarrierTask(port, partitionId, stageAttempt = 0)
+        tasks :+= task
+        task
+      }
+      current.foreach(_.report())
 
-    val expected = tasks.map(_.address).toSet
-    tasks.foreach(task => assert(task.readTopology().split(",").toSet == expected))
+      val expected = current.map(_.address).toSet
+      current.foreach(task => assert(task.readTopology().split(",").toSet == expected))
+    } finally {
+      closeAll(manager, tasks)
+    }
+  }
 
-    tasks.foreach(_.close())
-    manager.waitForNetworkCommunicationsDone()
+  test("Task reports before the Finished marker do not complete a barrier round early") {
+    val (manager, port) = newBarrierManager(numTasks = 2)
+    var tasks = Seq.empty[FakeBarrierTask]
+    try {
+      val current = (0 until 2).map { partitionId =>
+        val task = new FakeBarrierTask(port, partitionId, stageAttempt = 0)
+        tasks :+= task
+        task
+      }
+      current.foreach(_.report())
+      current.head.assertNoTopologyYet()
+
+      sendFinished(port, stageAttempt = 0)
+
+      val expected = current.map(_.address).toSet
+      current.foreach(task => assert(task.readTopology().split(",").toSet == expected))
+    } finally {
+      closeAll(manager, tasks)
+    }
+  }
+
+  test("A duplicate partition report before Finished replaces the old socket without changing the count") {
+    val (manager, port) = newBarrierManager(numTasks = 2)
+    var tasks = Seq.empty[FakeBarrierTask]
+    try {
+      val original = new FakeBarrierTask(
+        port, partitionId = 0, stageAttempt = 0, loadOnly = true, executorId = "old-executor")
+      val replacement = new FakeBarrierTask(
+        port, partitionId = 0, stageAttempt = 0, listenPortOffset = 1000, executorId = "new-executor")
+      val secondPartition = new FakeBarrierTask(port, partitionId = 1, stageAttempt = 0)
+      tasks = Seq(original, replacement, secondPartition)
+
+      original.report()
+      replacement.report()
+      assert(original.isClosedByDriver, "The superseded partition report socket was not closed")
+      secondPartition.report()
+      sendFinished(port, stageAttempt = 0)
+
+      val expectedNetwork = Set(replacement.address, secondPartition.address)
+      Seq(replacement, secondPartition).foreach { task =>
+        val networkNodes = task.readTopology().split(",").toSeq
+        assert(networkNodes.size == expectedNetwork.size)
+        assert(networkNodes.toSet == expectedNetwork)
+        val executorTopology = task.readExecutorTopology()
+        assert(partitionIds(executorTopology).sorted == Seq(0, 1))
+        assert(!executorTopology.contains("old-executor"))
+        assert(executorTopology.contains("new-executor=0"))
+      }
+    } finally {
+      closeAll(manager, tasks)
+    }
+  }
+
+  test("A duplicate partition report after Finished still waits for every unique partition") {
+    val (manager, port) = newBarrierManager(numTasks = 2)
+    var tasks = Seq.empty[FakeBarrierTask]
+    try {
+      sendFinished(port, stageAttempt = 0)
+
+      val original = new FakeBarrierTask(
+        port, partitionId = 0, stageAttempt = 0, executorId = "old-executor")
+      val replacement = new FakeBarrierTask(
+        port, partitionId = 0, stageAttempt = 0, loadOnly = true,
+        listenPortOffset = 1000, executorId = "new-executor")
+      val secondPartition = new FakeBarrierTask(port, partitionId = 1, stageAttempt = 0)
+      tasks = Seq(original, replacement, secondPartition)
+
+      original.report()
+      replacement.report()
+      assert(original.isClosedByDriver, "The superseded partition report socket was not closed")
+      secondPartition.report()
+
+      Seq(replacement, secondPartition).foreach { task =>
+        assert(task.readTopology() == secondPartition.address)
+        val executorTopology = task.readExecutorTopology()
+        assert(partitionIds(executorTopology).sorted == Seq(0, 1))
+        assert(!executorTopology.contains("old-executor"))
+        assert(executorTopology.contains("new-executor=0"))
+      }
+    } finally {
+      closeAll(manager, tasks)
+    }
+  }
+
+  test("A stale Finished marker cannot complete the current stage attempt") {
+    val (manager, port) = newBarrierManager(numTasks = 2)
+    var tasks = Seq.empty[FakeBarrierTask]
+    try {
+      val current = (0 until 2).map { partitionId =>
+        val task = new FakeBarrierTask(port, partitionId, stageAttempt = 1)
+        tasks :+= task
+        task
+      }
+      current.foreach(_.report())
+
+      sendFinished(port, stageAttempt = 0)
+      current.head.assertNoTopologyYet()
+
+      sendFinished(port, stageAttempt = 1)
+      val expected = current.map(_.address).toSet
+      current.foreach(task => assert(task.readTopology().split(",").toSet == expected))
+    } finally {
+      closeAll(manager, tasks)
+    }
   }
 }

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/BarrierNetworkRecoverySuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/BarrierNetworkRecoverySuite.scala
@@ -1,0 +1,126 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm.split1
+
+import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMConstants, NetworkManager}
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.io.{BufferedReader, BufferedWriter, InputStreamReader, OutputStreamWriter}
+import java.net.{ServerSocket, Socket}
+
+/** Covers recovery of the driver topology exchange when Spark restarts a barrier stage.
+  *
+  * A barrier stage is restarted in its entirety when any of its tasks fails, so it is the only case
+  * where a LightGBM network can legitimately be re-formed. The driver has to serve a second topology
+  * round for the new stage attempt, and must not mix it with the topology of the abandoned one.
+  */
+class BarrierNetworkRecoverySuite extends AnyFunSuite {
+
+  private val timeout = 30.0
+  private val host = "127.0.0.1"
+
+  private class FakeBarrierTask(port: Int, partitionId: Int, stageAttempt: Int) {
+    private val socket = new Socket(host, port)
+    private val reader = new BufferedReader(new InputStreamReader(socket.getInputStream))
+    private val writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream))
+
+    val listenPort: Int = LightGBMConstants.DefaultLocalListenPort + stageAttempt * 100 + partitionId
+    def address: String = s"$host:$listenPort"
+
+    def report(): Unit = {
+      writer.write(
+        s"${LightGBMConstants.EnabledTask}:$host:$listenPort:$partitionId:executor$partitionId:$stageAttempt\n")
+      writer.flush()
+    }
+
+    def readTopology(): String = reader.readLine()
+
+    def isClosedByDriver: Boolean = reader.readLine() == null
+
+    def close(): Unit = socket.close()
+  }
+
+  /** Partition 0 signals the end of a barrier round over its own short-lived connection. */
+  private def sendFinished(port: Int, stageAttempt: Int): Unit = {
+    val socket = new Socket(host, port)
+    val writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream))
+    writer.write(s"${LightGBMConstants.FinishedStatus}:$stageAttempt\n")
+    writer.flush()
+    socket.close()
+  }
+
+  private def newBarrierManager(numTasks: Int): (NetworkManager, Int) = {
+    val serverSocket = new ServerSocket(0)
+    val port = serverSocket.getLocalPort
+    (NetworkManager(numTasks, serverSocket, host, port, timeout, useBarrierExecutionMode = true), port)
+  }
+
+  test("A restarted barrier stage gets a fresh topology round instead of a closed port") {
+    val (manager, port) = newBarrierManager(numTasks = 2)
+
+    // First stage attempt reports but never reaches the barrier, so the round never completes.
+    val abandoned = (0 until 2).map(new FakeBarrierTask(port, _, stageAttempt = 0))
+    abandoned.foreach(_.report())
+
+    // Spark restarts the whole stage. Every task reconnects to the same driver endpoint.
+    val restarted = (0 until 2).map(new FakeBarrierTask(port, _, stageAttempt = 1))
+    restarted.foreach(_.report())
+    sendFinished(port, stageAttempt = 1)
+
+    val topologies = restarted.map(_.readTopology())
+    assert(topologies.forall(_ != null), "The restarted stage attempt never received a topology")
+
+    val expected = restarted.map(_.address).toSet
+    topologies.foreach { topology =>
+      assert(topology.split(",").toSet == expected,
+        s"Topology '$topology' should contain only the restarted stage attempt, expected $expected")
+    }
+
+    abandoned.foreach(task =>
+      assert(task.isClosedByDriver, "The abandoned stage attempt should have had its sockets released"))
+
+    (abandoned ++ restarted).foreach(_.close())
+    manager.waitForNetworkCommunicationsDone()
+  }
+
+  test("A straggler from a superseded stage attempt is kept out of the topology") {
+    val (manager, port) = newBarrierManager(numTasks = 2)
+
+    val abandoned = new FakeBarrierTask(port, 0, stageAttempt = 0)
+    abandoned.report()
+
+    val restarted = (0 until 2).map(new FakeBarrierTask(port, _, stageAttempt = 1))
+    restarted.foreach(_.report())
+
+    // A task from the abandoned attempt reports late. Its host:port is already dead.
+    val straggler = new FakeBarrierTask(port, 1, stageAttempt = 0)
+    straggler.report()
+    assert(straggler.isClosedByDriver, "The straggler should have been rejected by the driver")
+
+    sendFinished(port, stageAttempt = 1)
+
+    val expected = restarted.map(_.address).toSet
+    restarted.foreach { task =>
+      assert(task.readTopology().split(",").toSet == expected,
+        s"The straggler at ${straggler.address} should not appear in the topology")
+    }
+
+    (abandoned +: straggler +: restarted).foreach(_.close())
+    manager.waitForNetworkCommunicationsDone()
+  }
+
+  test("A barrier round that completes normally still returns the full topology") {
+    val (manager, port) = newBarrierManager(numTasks = 2)
+
+    val tasks = (0 until 2).map(new FakeBarrierTask(port, _, stageAttempt = 0))
+    tasks.foreach(_.report())
+    sendFinished(port, stageAttempt = 0)
+
+    val expected = tasks.map(_.address).toSet
+    tasks.foreach(task => assert(task.readTopology().split(",").toSet == expected))
+
+    tasks.foreach(_.close())
+    manager.waitForNetworkCommunicationsDone()
+  }
+}

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/DriverSocketRetryE2ESuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/DriverSocketRetryE2ESuite.scala
@@ -1,0 +1,89 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm.split1
+
+import com.microsoft.azure.synapse.ml.lightgbm.params.BaseTrainParams
+import com.microsoft.azure.synapse.ml.lightgbm.{ColumnParams, LightGBMClassifier, LightGBMDelegate}
+import org.apache.spark.SparkException
+import org.apache.spark.TaskContext
+import org.apache.spark.ml.linalg.{SQLDataTypes, Vectors}
+import org.apache.spark.sql.types.{DoubleType, StructField, StructType}
+import org.apache.spark.sql.{DataFrame, Row}
+import org.slf4j.Logger
+
+import java.io.{PrintWriter, StringWriter}
+
+object FailFirstAttemptDelegate {
+  val Sentinel: String = "INJECTED_TASK_FAILURE_AFTER_TOPOLOGY_HANDSHAKE"
+}
+
+/** Fails the first attempt of a training task, after it has already completed the driver
+  * topology handshake. Later attempts do nothing, so the job could succeed on retry.
+  */
+class FailFirstAttemptDelegate extends LightGBMDelegate {
+  override def beforeGenerateTrainDataset(batchIndex: Int,
+                                          partitionId: Int,
+                                          columnParams: ColumnParams,
+                                          schema: StructType,
+                                          log: Logger,
+                                          trainParams: BaseTrainParams): Unit = {
+    val context = TaskContext.get()
+    if (context != null && context.attemptNumber() == 0) {
+      throw new RuntimeException(FailFirstAttemptDelegate.Sentinel)
+    }
+  }
+}
+
+/** End-to-end coverage for distributed LightGBM training when a task fails after it has joined the
+  * LightGBM network. Every Spark retry of that task is refused by the driver, which used to replace
+  * the real failure with a bare "java.net.ConnectException: Connection refused".
+  */
+class DriverSocketRetryE2ESuite extends LightGBMTestUtils {
+
+  private def makeDataframe: DataFrame = {
+    val schema = StructType(Seq(
+      StructField(labelCol, DoubleType),
+      StructField(featuresCol, SQLDataTypes.VectorType)))
+    val rows = (0 until 400).map(i =>
+      Row(if (i % 2 == 0) 0.0 else 1.0, Vectors.dense((i % 13).toDouble, (i % 7).toDouble)))
+    spark.createDataFrame(spark.sparkContext.parallelize(rows, 2), schema)
+  }
+
+  private def stackTraceOf(throwable: Throwable): String = {
+    val writer = new StringWriter()
+    throwable.printStackTrace(new PrintWriter(writer))
+    writer.toString
+  }
+
+  test("A task retry that cannot rejoin the LightGBM network reports why instead of Connection refused") {
+    // Spark must be allowed to retry tasks for the failure cascade to appear.
+    sparkProvider.resetSparkSession(numRetries = 4, numCores = Some(2))
+    try {
+      val classifier = new LightGBMClassifier()
+        .setLabelCol(labelCol)
+        .setFeaturesCol(featuresCol)
+        .setNumLeaves(5)
+        .setNumIterations(5)
+        .setDefaultListenPort(getAndIncrementPort())
+        .setDelegate(new FailFirstAttemptDelegate())
+
+      val thrown = intercept[SparkException] {
+        classifier.fit(makeDataframe)
+      }
+      val trace = stackTraceOf(thrown)
+
+      // Spark only surfaces the last attempt, and that attempt can never reach the driver again.
+      assert(trace.contains("ConnectException"),
+        s"Expected the retries to fail against the closed driver endpoint, got:\n${trace.take(4000)}")
+
+      // The reported message must explain the cascade and point at the attempt that really failed.
+      assert(thrown.getMessage.contains("retry attempt"),
+        s"Expected the failure to identify itself as a retry, got:\n${thrown.getMessage.take(2000)}")
+      assert(thrown.getMessage.contains("consequence of an earlier failure"),
+        s"Expected the failure to point at the original error, got:\n${thrown.getMessage.take(2000)}")
+    } finally {
+      sparkProvider.resetSparkSession()
+    }
+  }
+}

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/DriverSocketRetrySuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/DriverSocketRetrySuite.scala
@@ -352,7 +352,7 @@ class DriverSocketRetrySuite extends AnyFunSuite {
   }
 
   test("A worker that disconnects before sending a message reports the disconnect, not a NullPointerException") {
-    val failure = intercept[IOException](NetworkManager.parseWorkerMessage(null))
+    val failure = intercept[IOException](NetworkManager.parseWorkerMessage(null))  //scalastyle:ignore null
     assert(failure.getMessage.contains("closed the connection before sending a status message"))
   }
 

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/DriverSocketRetrySuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/DriverSocketRetrySuite.scala
@@ -3,11 +3,14 @@
 
 package com.microsoft.azure.synapse.ml.lightgbm.split1
 
-import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMConstants, NetworkManager}
+import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMConstants, NetworkManager, TaskMessageInfo}
 import org.scalatest.funsuite.AnyFunSuite
 
-import java.io.{BufferedReader, BufferedWriter, InputStreamReader, OutputStreamWriter}
-import java.net.{ConnectException, ServerSocket, Socket}
+import java.io.{BufferedReader, BufferedWriter, IOException, InputStreamReader, OutputStreamWriter}
+import java.net.{ConnectException, InetSocketAddress, ServerSocket, Socket, SocketException, SocketTimeoutException}
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicInteger
+import scala.collection.mutable.ListBuffer
 
 /** Covers the driver topology socket lifecycle behind repeated
   * "java.net.ConnectException: Connection refused" failures in distributed LightGBM training.
@@ -15,97 +18,362 @@ import java.net.{ConnectException, ServerSocket, Socket}
 class DriverSocketRetrySuite extends AnyFunSuite {
 
   private val timeout = 30.0
+  private val socketTimeoutMillis = 30000
+  private val host = "127.0.0.1"
 
-  private class FakeTask(host: String, port: Int, partitionId: Int, loadOnly: Boolean = false) {
-    private val socket = new Socket(host, port)
+  private class FakeTask(host: String,
+                         port: Int,
+                         partitionId: Int,
+                         loadOnly: Boolean = false,
+                         listenPortOffset: Int = 0,
+                         executorId: String = "")
+    extends AutoCloseable {
+    private val socket = {
+      val result = new Socket()
+      try {
+        result.connect(new InetSocketAddress(host, port), socketTimeoutMillis)
+        result.setSoTimeout(socketTimeoutMillis)
+        result
+      } catch {
+        case failure: Throwable =>
+          try result.close()
+          catch {
+            case closeFailure: IOException => failure.addSuppressed(closeFailure)
+          }
+          throw failure
+      }
+    }
     private val reader = new BufferedReader(new InputStreamReader(socket.getInputStream))
     private val writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream))
 
     def report(): Unit = {
       val status = if (loadOnly) LightGBMConstants.IgnoreStatus else LightGBMConstants.EnabledTask
-      val listenPort = LightGBMConstants.DefaultLocalListenPort + partitionId
-      writer.write(s"$status:127.0.0.1:$listenPort:$partitionId:$partitionId\n")
+      val reportedExecutorId = if (executorId.isEmpty) partitionId.toString else executorId
+      writer.write(s"$status:127.0.0.1:$listenPort:$partitionId:$reportedExecutorId\n")
       writer.flush()
     }
+
+    val listenPort: Int = LightGBMConstants.DefaultLocalListenPort + partitionId + listenPortOffset
+    def address: String = s"127.0.0.1:$listenPort"
 
     def readTopology(): (String, String) = (reader.readLine(), reader.readLine())
 
     /** The driver closing its end is observed here as end-of-stream. */
-    def isClosedByDriver: Boolean = reader.readLine() == null
+    def isClosedByDriver: Boolean = {
+      try {
+        reader.readLine() == null
+      } catch {
+        case _: SocketException => true
+      }
+    }
 
-    def close(): Unit = socket.close()
+    override def close(): Unit = socket.close()
   }
 
-  private def newManager(numTasks: Int): (NetworkManager, String, Int) = {
-    val serverSocket = new ServerSocket(0)
-    val host = "127.0.0.1"
+  private class SignalSecondAcceptServerSocket extends ServerSocket(0) {
+    private val acceptCount = new AtomicInteger()
+    private val secondAcceptStarted = new CountDownLatch(1)
+    setSoTimeout(socketTimeoutMillis)
+
+    override def accept(): Socket = {
+      if (acceptCount.incrementAndGet() == 2) secondAcceptStarted.countDown()
+      super.accept()
+    }
+
+    def awaitSecondAccept(): Unit = {
+      assert(secondAcceptStarted.await(socketTimeoutMillis, TimeUnit.MILLISECONDS),
+        "The driver never registered the first task socket")
+    }
+  }
+
+  private class GateAfterAcceptServerSocket extends ServerSocket(0) {
+    private val socketAccepted = new CountDownLatch(1)
+    private val releaseAcceptedSocket = new CountDownLatch(1)
+    @volatile private var socket: Socket = _
+    setSoTimeout(socketTimeoutMillis)
+
+    override def accept(): Socket = {
+      val result = super.accept()
+      socket = result
+      socketAccepted.countDown()
+      if (!releaseAcceptedSocket.await(socketTimeoutMillis, TimeUnit.MILLISECONDS)) {
+        result.close()
+        throw new SocketTimeoutException("Timed out waiting to release the accepted socket")
+      }
+      result
+    }
+
+    def awaitAccepted(): Unit = {
+      assert(socketAccepted.await(socketTimeoutMillis, TimeUnit.MILLISECONDS),
+        "The driver never accepted the task socket")
+    }
+
+    def release(): Unit = releaseAcceptedSocket.countDown()
+
+    def acceptedSocketIsClosed: Boolean = socket != null && socket.isClosed
+  }
+
+  private class GateUnexpectedAcceptFailureServerSocket extends SignalSecondAcceptServerSocket {
+    private val acceptFailureObserved = new CountDownLatch(1)
+    private val releaseAcceptFailure = new CountDownLatch(1)
+
+    override def accept(): Socket = {
+      try {
+        super.accept()
+      } catch {
+        case failure: SocketException =>
+          acceptFailureObserved.countDown()
+          if (!releaseAcceptFailure.await(socketTimeoutMillis, TimeUnit.MILLISECONDS)) {
+            failure.addSuppressed(new SocketTimeoutException("Timed out waiting to release accept failure"))
+          }
+          throw failure
+      }
+    }
+
+    def awaitAcceptFailure(): Unit = {
+      assert(acceptFailureObserved.await(socketTimeoutMillis, TimeUnit.MILLISECONDS),
+        "The driver's blocked accept did not observe the unexpected server close")
+    }
+
+    def releaseFailure(): Unit = releaseAcceptFailure.countDown()
+  }
+
+  private def newManager(numTasks: Int,
+                         useBarrierExecutionMode: Boolean = false,
+                         serverSocket: ServerSocket = new ServerSocket(0)): (NetworkManager, String, Int) = {
+    serverSocket.setSoTimeout(socketTimeoutMillis)
     val port = serverSocket.getLocalPort
-    (NetworkManager(numTasks, serverSocket, host, port, timeout, useBarrierExecutionMode = false), host, port)
+    (NetworkManager(numTasks, serverSocket, host, port, timeout, useBarrierExecutionMode), host, port)
+  }
+
+  private def closeTasks(tasks: Iterable[FakeTask]): Unit = {
+    tasks.foreach { task =>
+      try task.close()
+      catch {
+        case _: IOException => ()
+      }
+    }
+  }
+
+  private def partitionIds(executorTopology: String): Seq[Int] = {
+    executorTopology.split(":").flatMap { executorEntry =>
+      executorEntry.split("=")(1).split(",").map(_.toInt)
+    }.toSeq
   }
 
   private def runTopologyRound(numTasks: Int,
                                numLoadOnlyTasks: Int = 0): (NetworkManager, String, Int, Seq[FakeTask]) = {
     val (manager, host, port) = newManager(numTasks + numLoadOnlyTasks)
-    val trainingTasks = (0 until numTasks).map(new FakeTask(host, port, _))
-    val loadOnlyTasks = (0 until numLoadOnlyTasks).map(i => new FakeTask(host, port, numTasks + i, loadOnly = true))
-    val tasks = trainingTasks ++ loadOnlyTasks
-
-    tasks.foreach(_.report())
-    tasks.foreach { task =>
-      val (machineList, partitionList) = task.readTopology()
-      assert(machineList != null && machineList.nonEmpty)
-      assert(partitionList != null && partitionList.nonEmpty)
+    val tasks = ListBuffer.empty[FakeTask]
+    try {
+      (0 until numTasks).foreach(partitionId => tasks += new FakeTask(host, port, partitionId))
+      (0 until numLoadOnlyTasks).foreach { index =>
+        tasks += new FakeTask(host, port, numTasks + index, loadOnly = true)
+      }
+      tasks.foreach(_.report())
+      tasks.foreach { task =>
+        val (machineList, partitionList) = task.readTopology()
+        assert(machineList != null && machineList.nonEmpty)
+        assert(partitionList != null && partitionList.nonEmpty)
+      }
+      manager.waitForNetworkCommunicationsDone()
+      (manager, host, port, tasks.toList)
+    } catch {
+      case failure: Throwable =>
+        manager.closeConnections()
+        closeTasks(tasks)
+        throw failure
     }
-    manager.waitForNetworkCommunicationsDone()
-    (manager, host, port, tasks)
   }
 
   test("A retried task is refused by the driver once the topology round has completed") {
-    val (_, host, port, tasks) = runTopologyRound(numTasks = 2)
-    tasks.foreach(_.close())
+    val (manager, host, port, tasks) = runTopologyRound(numTasks = 2)
+    try {
+      // A Spark task retry re-enters getGlobalNetworkInfo and reconnects to the same driver endpoint.
+      val retriedSocket = new Socket()
+      val thrown = try {
+        intercept[ConnectException] {
+          retriedSocket.connect(new InetSocketAddress(host, port), socketTimeoutMillis)
+        }
+      } finally {
+        retriedSocket.close()
+      }
 
-    // A Spark task retry re-enters getGlobalNetworkInfo and reconnects to the same driver endpoint.
-    val thrown = intercept[ConnectException] {
-      new Socket(host, port).close()
+      assert(thrown.getMessage.toLowerCase.contains("refused"),
+        s"Expected a connection-refused failure but got: ${thrown.getMessage}")
+    } finally {
+      manager.closeConnections()
+      closeTasks(tasks)
     }
-
-    assert(thrown.getMessage.toLowerCase.contains("refused"),
-      s"Expected a connection-refused failure but got: ${thrown.getMessage}")
   }
 
   test("Helper task sockets are released along with training task sockets") {
-    val (_, _, _, tasks) = runTopologyRound(numTasks = 2, numLoadOnlyTasks = 2)
-
-    tasks.zipWithIndex.foreach { case (task, index) =>
-      assert(task.isClosedByDriver, s"Driver leaked the socket for task $index")
-      task.close()
+    val (manager, _, _, tasks) = runTopologyRound(numTasks = 2, numLoadOnlyTasks = 2)
+    try {
+      tasks.zipWithIndex.foreach { case (task, index) =>
+        assert(task.isClosedByDriver, s"Driver leaked the socket for task $index")
+      }
+    } finally {
+      manager.closeConnections()
+      closeTasks(tasks)
     }
   }
 
-  test("closeConnections is idempotent so both the network thread and the training job can call it") {
-    val (manager, host, port, tasks) = runTopologyRound(numTasks = 2)
-    tasks.foreach(_.close())
+  test("Non-barrier topology waits for every unique partition when a report is retried") {
+    val (manager, _, port) = newManager(numTasks = 2)
+    var tasks = Seq.empty[FakeTask]
+    try {
+      val original = new FakeTask(
+        host, port, partitionId = 0, loadOnly = true, executorId = "old-executor")
+      tasks :+= original
+      val replacement = new FakeTask(
+        host, port, partitionId = 0, listenPortOffset = 1000, executorId = "new-executor")
+      tasks :+= replacement
 
-    manager.closeConnections()
-    manager.closeConnections()
+      original.report()
+      replacement.report()
+      assert(original.isClosedByDriver, "The superseded partition report socket was not closed")
 
-    intercept[ConnectException] {
-      new Socket(host, port).close()
+      val secondPartition = new FakeTask(host, port, partitionId = 1)
+      tasks :+= secondPartition
+      secondPartition.report()
+
+      val expectedNetwork = Set(replacement.address, secondPartition.address)
+      Seq(replacement, secondPartition).foreach { task =>
+        val (networkTopology, executorTopology) = task.readTopology()
+        val networkNodes = networkTopology.split(",").toSeq
+        assert(networkNodes.size == expectedNetwork.size)
+        assert(networkNodes.toSet == expectedNetwork)
+        assert(partitionIds(executorTopology).sorted == Seq(0, 1))
+        assert(!executorTopology.contains("old-executor"))
+        assert(executorTopology.contains("new-executor=0"))
+      }
+      manager.waitForNetworkCommunicationsDone()
+    } finally {
+      manager.closeConnections()
+      closeTasks(tasks)
     }
+  }
+
+  test("closeConnections remains idempotent while a topology round owns task sockets") {
+    val serverSocket = new SignalSecondAcceptServerSocket()
+    val (manager, _, port) =
+      newManager(numTasks = 2, useBarrierExecutionMode = true, serverSocket = serverSocket)
+    var task = Option.empty[FakeTask]
+    try {
+      task = Some(new FakeTask(host, port, partitionId = 0))
+      task.get.report()
+      serverSocket.awaitSecondAccept()
+
+      manager.closeConnections()
+      manager.closeConnections()
+
+      assert(task.get.isClosedByDriver, "The driver leaked a task socket during repeated cleanup")
+      manager.waitForNetworkCommunicationsDone()
+    } finally {
+      manager.closeConnections()
+      closeTasks(task)
+    }
+  }
+
+  test("An unexpected server close preserves the accept failure and still closes task sockets") {
+    val serverSocket = new GateUnexpectedAcceptFailureServerSocket()
+    val (manager, _, port) =
+      newManager(numTasks = 2, useBarrierExecutionMode = true, serverSocket = serverSocket)
+    var task = Option.empty[FakeTask]
+    try {
+      task = Some(new FakeTask(host, port, partitionId = 0))
+      task.get.report()
+      serverSocket.awaitSecondAccept()
+
+      serverSocket.close()
+      serverSocket.awaitAcceptFailure()
+      serverSocket.releaseFailure()
+
+      assert(task.get.isClosedByDriver, "The unexpected server close leaked a task socket")
+      intercept[SocketException] {
+        manager.waitForNetworkCommunicationsDone()
+      }
+    } finally {
+      serverSocket.releaseFailure()
+      manager.closeConnections()
+      closeTasks(task)
+    }
+  }
+
+  test("A socket accepted during shutdown is rejected before round registration") {
+    val serverSocket = new GateAfterAcceptServerSocket()
+    val (manager, _, port) =
+      newManager(numTasks = 1, useBarrierExecutionMode = true, serverSocket = serverSocket)
+    var task = Option.empty[FakeTask]
+    try {
+      task = Some(new FakeTask(host, port, partitionId = 0))
+      task.get.report()
+      serverSocket.awaitAccepted()
+
+      manager.closeConnections()
+      serverSocket.release()
+
+      assert(task.get.isClosedByDriver, "The socket accepted during shutdown was retained")
+      manager.waitForNetworkCommunicationsDone()
+      assert(serverSocket.acceptedSocketIsClosed, "The driver did not close the accepted socket")
+    } finally {
+      serverSocket.release()
+      manager.closeConnections()
+      closeTasks(task)
+    }
+  }
+
+  test("The legacy TaskMessageInfo constructors, extractor, and product shape remain unchanged") {
+    val message = TaskMessageInfo(
+      LightGBMConstants.EnabledTask,
+      "127.0.0.1",
+      LightGBMConstants.DefaultLocalListenPort,
+      3,
+      "executor-1")
+    val generalMessage = new TaskMessageInfo(LightGBMConstants.FinishedStatus)
+
+    val TaskMessageInfo(status, taskHost, listenPort, partitionId, executorId) = message
+    assert(status == LightGBMConstants.EnabledTask)
+    assert(taskHost == "127.0.0.1")
+    assert(listenPort == LightGBMConstants.DefaultLocalListenPort)
+    assert(partitionId == 3)
+    assert(executorId == "executor-1")
+    assert(message.productArity == 5)
+    assert(message.toString ==
+      s"${LightGBMConstants.EnabledTask}:127.0.0.1:${LightGBMConstants.DefaultLocalListenPort}:3:executor-1")
+    assert(NetworkManager.parseWorkerMessage(s"${message.toString}:7") == message)
+    assert(generalMessage.isFinished)
+    assert(generalMessage.productArity == 5)
+    val constructorArities = classOf[TaskMessageInfo].getConstructors.map(_.getParameterCount).toSet
+    assert(constructorArities.contains(1))
+    assert(constructorArities.contains(5))
+    assert(!constructorArities.contains(6))
   }
 
   test("The driver server socket is released when a training job fails before the round completes") {
     // Only one of the two expected tasks reports, so the network thread stays blocked in accept().
-    val (manager, host, port) = newManager(numTasks = 2)
-    val task = new FakeTask(host, port, 0)
-    task.report()
+    val (manager, _, port) = newManager(numTasks = 2, useBarrierExecutionMode = true)
+    var task = Option.empty[FakeTask]
+    try {
+      task = Some(new FakeTask(host, port, 0))
+      task.get.report()
 
-    // This is what executeTraining now does in its finally block when partition tasks fail.
-    manager.closeConnections()
-    task.close()
+      // This is what executeTraining now does in its finally block when partition tasks fail.
+      manager.closeConnections()
 
-    intercept[ConnectException] {
-      new Socket(host, port).close()
+      val retriedSocket = new Socket()
+      try {
+        intercept[ConnectException] {
+          retriedSocket.connect(new InetSocketAddress(host, port), socketTimeoutMillis)
+        }
+      } finally {
+        retriedSocket.close()
+      }
+      manager.waitForNetworkCommunicationsDone()
+    } finally {
+      manager.closeConnections()
+      closeTasks(task)
     }
   }
 }

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/DriverSocketRetrySuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/DriverSocketRetrySuite.scala
@@ -1,0 +1,111 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm.split1
+
+import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMConstants, NetworkManager}
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.io.{BufferedReader, BufferedWriter, InputStreamReader, OutputStreamWriter}
+import java.net.{ConnectException, ServerSocket, Socket}
+
+/** Covers the driver topology socket lifecycle behind repeated
+  * "java.net.ConnectException: Connection refused" failures in distributed LightGBM training.
+  */
+class DriverSocketRetrySuite extends AnyFunSuite {
+
+  private val timeout = 30.0
+
+  private class FakeTask(host: String, port: Int, partitionId: Int, loadOnly: Boolean = false) {
+    private val socket = new Socket(host, port)
+    private val reader = new BufferedReader(new InputStreamReader(socket.getInputStream))
+    private val writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream))
+
+    def report(): Unit = {
+      val status = if (loadOnly) LightGBMConstants.IgnoreStatus else LightGBMConstants.EnabledTask
+      val listenPort = LightGBMConstants.DefaultLocalListenPort + partitionId
+      writer.write(s"$status:127.0.0.1:$listenPort:$partitionId:$partitionId\n")
+      writer.flush()
+    }
+
+    def readTopology(): (String, String) = (reader.readLine(), reader.readLine())
+
+    /** The driver closing its end is observed here as end-of-stream. */
+    def isClosedByDriver: Boolean = reader.readLine() == null
+
+    def close(): Unit = socket.close()
+  }
+
+  private def newManager(numTasks: Int): (NetworkManager, String, Int) = {
+    val serverSocket = new ServerSocket(0)
+    val host = "127.0.0.1"
+    val port = serverSocket.getLocalPort
+    (NetworkManager(numTasks, serverSocket, host, port, timeout, useBarrierExecutionMode = false), host, port)
+  }
+
+  private def runTopologyRound(numTasks: Int,
+                               numLoadOnlyTasks: Int = 0): (NetworkManager, String, Int, Seq[FakeTask]) = {
+    val (manager, host, port) = newManager(numTasks + numLoadOnlyTasks)
+    val trainingTasks = (0 until numTasks).map(new FakeTask(host, port, _))
+    val loadOnlyTasks = (0 until numLoadOnlyTasks).map(i => new FakeTask(host, port, numTasks + i, loadOnly = true))
+    val tasks = trainingTasks ++ loadOnlyTasks
+
+    tasks.foreach(_.report())
+    tasks.foreach { task =>
+      val (machineList, partitionList) = task.readTopology()
+      assert(machineList != null && machineList.nonEmpty)
+      assert(partitionList != null && partitionList.nonEmpty)
+    }
+    manager.waitForNetworkCommunicationsDone()
+    (manager, host, port, tasks)
+  }
+
+  test("A retried task is refused by the driver once the topology round has completed") {
+    val (_, host, port, tasks) = runTopologyRound(numTasks = 2)
+    tasks.foreach(_.close())
+
+    // A Spark task retry re-enters getGlobalNetworkInfo and reconnects to the same driver endpoint.
+    val thrown = intercept[ConnectException] {
+      new Socket(host, port).close()
+    }
+
+    assert(thrown.getMessage.toLowerCase.contains("refused"),
+      s"Expected a connection-refused failure but got: ${thrown.getMessage}")
+  }
+
+  test("Helper task sockets are released along with training task sockets") {
+    val (_, _, _, tasks) = runTopologyRound(numTasks = 2, numLoadOnlyTasks = 2)
+
+    tasks.zipWithIndex.foreach { case (task, index) =>
+      assert(task.isClosedByDriver, s"Driver leaked the socket for task $index")
+      task.close()
+    }
+  }
+
+  test("closeConnections is idempotent so both the network thread and the training job can call it") {
+    val (manager, host, port, tasks) = runTopologyRound(numTasks = 2)
+    tasks.foreach(_.close())
+
+    manager.closeConnections()
+    manager.closeConnections()
+
+    intercept[ConnectException] {
+      new Socket(host, port).close()
+    }
+  }
+
+  test("The driver server socket is released when a training job fails before the round completes") {
+    // Only one of the two expected tasks reports, so the network thread stays blocked in accept().
+    val (manager, host, port) = newManager(numTasks = 2)
+    val task = new FakeTask(host, port, 0)
+    task.report()
+
+    // This is what executeTraining now does in its finally block when partition tasks fail.
+    manager.closeConnections()
+    task.close()
+
+    intercept[ConnectException] {
+      new Socket(host, port).close()
+    }
+  }
+}

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/DriverSocketRetrySuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/DriverSocketRetrySuite.scala
@@ -351,6 +351,11 @@ class DriverSocketRetrySuite extends AnyFunSuite {
     assert(!constructorArities.contains(6))
   }
 
+  test("A worker that disconnects before sending a message reports the disconnect, not a NullPointerException") {
+    val failure = intercept[IOException](NetworkManager.parseWorkerMessage(null))
+    assert(failure.getMessage.contains("closed the connection before sending a status message"))
+  }
+
   test("The driver server socket is released when a training job fails before the round completes") {
     // Only one of the two expected tasks reports, so the network thread stays blocked in accept().
     val (manager, _, port) = newManager(numTasks = 2, useBarrierExecutionMode = true)


### PR DESCRIPTION
## Problem

Distributed LightGBM training exchanges network topology with the driver exactly once per training round, then closes `driverServerSocket`. Any Spark task retried after that point reconnects to an endpoint that is no longer listening, so **every retry fails with a bare `java.net.ConnectException: Connection refused`**.

Because Spark only reports the most recent attempt, the failure that actually caused the retry is never surfaced:

```
org.apache.spark.SparkException: Job aborted due to stage failure: Task 4 in stage 103.0 failed 4 times,
most recent failure: Lost task 4.3 in stage 103.0 (TID 1954) (vm-... executor 2):
java.net.ConnectException: Connection refused
```

This makes such failures undiagnosable from the job output alone. It is reproduced end to end in `DriverSocketRetryE2ESuite`, which fails one task *after* it completes the driver handshake and produces exactly the signature above on unpatched code.

Barrier execution mode is affected too, and more seriously: a barrier stage restarts in its entirety, which is the *only* recovery a fixed LightGBM network can support — but the restarted stage also found the port closed, so barrier mode could not actually recover from anything.

## Changes

**Stop masking the real cause** — a terminal `ConnectException` in `getGlobalNetworkInfo` is translated into an actionable error. On a retry it states that the topology exchange is already closed, that a partial task retry can never rejoin the network, and that the real cause is in the logs of the first failed attempt of that partition. On a first attempt it points at driver reachability instead.

**Make barrier stage restarts work** — the driver now keeps serving topology rounds in barrier mode until training is done. Task messages carry the Spark stage attempt number so the driver can tell attempts apart: a newer attempt discards the previous attempt's partial topology, and a straggler from a superseded attempt is rejected. This matters because a topology containing a dead `host:port` makes every surviving task hang trying to connect to it. Message parsing accepts both the old and new formats. A barrier round completes only after the current attempt has both its finished marker and every unique partition report; retried reports replace the prior socket instead of inflating the count.

**Preserve the public message API** — stage-attempt metadata is carried by a private wire message while `TaskMessageInfo` keeps its public five-field constructor, extractor, product shape, and string representation.

**Fix the socket and thread lifecycle**

- The driver network thread closes its sockets in a `finally`, so the server socket is no longer leaked when a round throws or times out.
- `closeConnections` is idempotent and synchronized, closes each socket independently, and closes the accepted-but-not-yet-registered socket plus the **load-only helper sockets** that were leaked on every `fit()`.
- `LightGBMBase.executeTraining` closes the network manager in a `finally`. Previously a failure in the partition tasks left the network thread parked in `accept()` holding the driver port for up to the configured timeout (20 minutes by default).
- The barrier finished-marker connection is closed rather than leaked.
- Cleanup warnings retain the throwable and stack trace.

## Algorithm and performance

No change to the training algorithm, the LightGBM parameters, or the data path. The new error handling only runs on a path that was already failing. Per-report work is a constant-time partition-map update; topology strings are built once per completed round. `getGlobalNetworkInfo` runs in `initialize`, before `preparePartitionData`, so a failing retry costs ~800ms and does not redo data preparation.

## Tests

| Suite | Covers |
| --- | --- |
| `DriverSocketRetryE2ESuite` | Full Spark job: a task fails after the handshake; asserts the reported error explains the cascade instead of `Connection refused` |
| `DriverSocketRetrySuite` | Refused retry, duplicate partition replacement, public message compatibility, helper socket release, idempotent close, unexpected close, and accept/shutdown races |
| `BarrierNetworkRecoverySuite` | Restarted stage isolation, stale markers, both marker/report orderings, and duplicate reports before or after completion signaling |

Validated locally: 68 tests across 8 suites pass, including `VerifyLightGBMClassifierStreamBasic` (barrier mode), `VerifyLightGBMRegressorBulk`, `VerifyLightGBMRegressorStream` and `VerifyLightGBMRankerBulk`. Latest focused validation: 19/19 socket lifecycle and barrier recovery tests. `scalastyle` and `Test/scalastyle` are clean.

## Related

Distinct from #2595, which fixes a native executor-to-executor listen port race. That failure surfaces via `LightGBMUtils.validate` as a generic `Exception`, not `ConnectException`, so the two are complementary rather than overlapping.

## Update: barrier round completion fix

Review of this branch found a **hang** introduced by the earlier round-completion change, now fixed in this PR.

`roundComplete` required `reportedTaskCount == numTasks`. `numTasks` is the *requested* task count, not the number of tasks a stage actually runs: `determineNumTasks` never clamps a user-set `numTasks`, and barrier-mode `prepareDataframe` only repartitions *downwards*. So `setNumTasks(16)` on an 8-partition DataFrame ran 8 tasks, the equality never held, and the driver waited on Spark's barrier timeout (365 days by default) while every executor blocked on a read with no timeout.

Partition 0 now reports the stage's real task count (`BarrierTaskContext.getTaskInfos().length`) in the finished marker, and the driver completes the round once that many unique partitions have reported. Completing on the marker alone -- the pre-PR behavior -- has its own race: reports still sitting in the accept backlog get dropped from the topology.

**Compatibility:** the count is appended to the existing marker, so a sender that omits it still parses and the marker alone completes the round (previous behavior, never a hang).

The wire protocol moved to `WorkerMessage.scala`; `NetworkManager.scala` was at 797 of the 800-line scalastyle limit.

**Validation:** 19 tests across 3 lightgbm suites pass on Java 11; the new `A barrier stage smaller than numTasks completes instead of hanging` test was confirmed to **fail** against the unfixed condition.
