### PR TITLE
test: clean up Fabric E2E artifacts

### DIFF
--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricNotebookTests.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricNotebookTests.scala
@@ -17,25 +17,27 @@ trait HasFabricNotebookTestConnection extends HasFabricOperationsConnection {
   fabricClientId = Some(FabricTestConstants.INTEGRATION_APP_ID)
   fabricRedirectUri = Some(FabricTestConstants.INTEGRATION_REDIRECT_URI)
   fabricWorkspaceId = Some(FabricTestConstants.INTEGRATION_WORKSPACE_ID)
+
+  private val artifactTracker =
+    new FabricTestArtifactTracker(artifactId => fabric.deleteArtifact(artifactId))
+
+  protected def trackArtifact(artifactId: String): String = artifactTracker.track(artifactId)
+
+  protected def cleanupTrackedArtifacts(): Unit = artifactTracker.cleanup()
 }
 
 class FabricTestCleanup extends TestBase with HasFabricNotebookTestConnection {
   test("Clean up old artifacts") {
     fabric.listArtifacts()
+      .filter(artifact =>
+        FabricNotebookTests.isTestArtifactName(artifact.displayName) &&
+          artifact.lastUpdatedDate.isBefore(LocalDateTime.now().minusDays(3)))
       .foreach(artifact => {
-        if (artifact.lastUpdatedDate.isBefore(LocalDateTime.now().minusDays(3))) {
-          println(s"Artifact cleanup: deleting artifact ${artifact.displayName}.")
-          println(s"Last Update Date: ${artifact.lastUpdatedDate.toString()}")
-          try {
-            fabric.deleteArtifact(artifact.objectId)
-          } catch {
-            case e: RuntimeException if e.getMessage.contains("PowerBIEntityNotFound") =>
-              println(s"Artifact ${artifact.displayName} not found. It may have already been deleted.")
-            case t: Throwable =>
-              throw t
-          }
-        }
+        println(s"Artifact cleanup: scheduling artifact ${artifact.displayName} for deletion.")
+        println(s"Last Update Date: ${artifact.lastUpdatedDate.toString()}")
+        trackArtifact(artifact.objectId)
       })
+    cleanupTrackedArtifacts()
   }
 }
 
@@ -64,11 +66,11 @@ class FabricSmokeTests extends TestBase with HasFabricNotebookTestConnection {
     f
   }
 
-  val storeArtifactId: String = fabric.createStoreArtifact()
+  val storeArtifactId: String = trackArtifact(fabric.createStoreArtifact())
 
   test("OnePlusOne") {
     val notebookName = fabric.getBlobNameFromFilepath(notebookFile.getPath)
-    val artifactId = fabric.createSJDArtifact(notebookFile.getPath)
+    val artifactId = trackArtifact(fabric.createSJDArtifact(notebookFile.getPath))
     val notebookBlobPath = fabric.uploadNotebookToAzure(notebookFile)
     fabric.updateSJDArtifact(notebookBlobPath, artifactId, storeArtifactId, includePackages = false)
     blocking {
@@ -88,6 +90,14 @@ class FabricSmokeTests extends TestBase with HasFabricNotebookTestConnection {
         throw new RuntimeException(s"Job failed for $notebookName", t)
     }
   }
+
+  override def afterAll(): Unit = {
+    try {
+      cleanupTrackedArtifacts()
+    } finally {
+      super.afterAll()
+    }
+  }
 }
 
 class FabricNotebookTests extends TestBase with HasFabricNotebookTestConnection {
@@ -102,7 +112,7 @@ class FabricNotebookTests extends TestBase with HasFabricNotebookTestConnection 
   selectedPythonFiles.foreach(x => println(s"Fabric notebook to be tested: $x"))
   assert(selectedPythonFiles.nonEmpty, "No notebooks found to test")
 
-  val storeArtifactId: String = fabric.createStoreArtifact()
+  val storeArtifactId: String = trackArtifact(fabric.createStoreArtifact())
 
   val executorService = Executors.newFixedThreadPool(FabricNotebookTests.MaxConcurrency)
   implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutor(executorService)
@@ -111,7 +121,7 @@ class FabricNotebookTests extends TestBase with HasFabricNotebookTestConnection 
   val futures: Array[(Future[String], String)] = selectedPythonFiles.map { notebookFile =>
     val notebookName = fabric.getBlobNameFromFilepath(notebookFile.getPath)
     val future = Future {
-      val artifactId = fabric.createSJDArtifact(notebookFile.getPath)
+      val artifactId = trackArtifact(fabric.createSJDArtifact(notebookFile.getPath))
       val notebookBlobPath = fabric.uploadNotebookToAzure(notebookFile)
       fabric.updateSJDArtifact(notebookBlobPath, artifactId, storeArtifactId)
       blocking { Thread.sleep(3000) } //scalastyle:ignore
@@ -137,12 +147,23 @@ class FabricNotebookTests extends TestBase with HasFabricNotebookTestConnection 
 
   override def afterAll(): Unit = {
     executorService.shutdown()
-    super.afterAll()
+    try {
+      cleanupTrackedArtifacts()
+    } finally {
+      super.afterAll()
+    }
   }
 }
 
 object FabricNotebookTests {
   val MaxConcurrency: Int = 3
+  private val StoreArtifactName = "^(Lakehouse|Warehouse)\\d{14}$".r
+  private val SJDArtifactName = "^(OnePlusOne|ExploreAlgorithms.+)-\\d{8}-\\d{2}-\\d{2}-\\d{2}$".r
+
+  private[nbtest] def isTestArtifactName(displayName: String): Boolean = {
+    StoreArtifactName.pattern.matcher(displayName).matches() ||
+      SJDArtifactName.pattern.matcher(displayName).matches()
+  }
 
   // Include-based filtering: start with a small core set of self-contained notebooks
   // that don't require API keys (no Cognitive Services, OpenAI, etc.).

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricNotebookTests.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricNotebookTests.scala
@@ -158,31 +158,6 @@ class FabricNotebookTests extends TestBase with HasFabricNotebookTestConnection 
 
 object FabricNotebookTests {
   val MaxConcurrency: Int = 3
-  private val ExecutorShutdownTimeoutSeconds = 30L
-  private val StoreArtifactName = "^(Lakehouse|Warehouse)\\d{14}$".r
-  private val SJDArtifactName = "^(OnePlusOne|ExploreAlgorithms.+)-\\d{8}-\\d{2}-\\d{2}-\\d{2}$".r
-
-  private[nbtest] def shutdownExecutor(executorService: ExecutorService): Unit = {
-    try {
-      executorService.shutdown()
-      if (!executorService.awaitTermination(ExecutorShutdownTimeoutSeconds, TimeUnit.SECONDS)) {
-        executorService.shutdownNow()
-        if (!executorService.awaitTermination(ExecutorShutdownTimeoutSeconds, TimeUnit.SECONDS)) {
-          throw new IllegalStateException("Fabric notebook tasks did not stop before artifact cleanup")
-        }
-      }
-    } catch {
-      case e: InterruptedException =>
-        executorService.shutdownNow()
-        Thread.currentThread().interrupt()
-        throw e
-    }
-  }
-
-  private[nbtest] def isTestArtifactName(displayName: String): Boolean = {
-    StoreArtifactName.pattern.matcher(displayName).matches() ||
-      SJDArtifactName.pattern.matcher(displayName).matches()
-  }
 
   // Include-based filtering: start with a small core set of self-contained notebooks
   // that don't require API keys (no Cognitive Services, OpenAI, etc.).
@@ -199,4 +174,40 @@ object FabricNotebookTests {
     // "ExploreAlgorithmsVowpalWabbitQuickstartClassificationQuantileRegressionandRegression",
     // "ExploreAlgorithmsVowpalWabbitQuickstartClassificationusingSparkMLVectors",
   )
+
+  private val ExecutorShutdownTimeoutSeconds = 30L
+  private val StoreArtifactName = "^(Lakehouse|Warehouse)\\d{14}$".r
+  private val SJDArtifactName = "^(.+)-\\d{8}-\\d{2}-\\d{2}-\\d{2}$".r
+  private val TestSJDNames = (IncludedNotebooks :+ "OnePlusOne").toSet
+
+  private[nbtest] def shutdownExecutor(executorService: ExecutorService): Unit = {
+    shutdownExecutor(executorService, ExecutorShutdownTimeoutSeconds, TimeUnit.SECONDS)
+  }
+
+  private[nbtest] def shutdownExecutor(executorService: ExecutorService,
+                                       timeout: Long,
+                                       timeUnit: TimeUnit): Unit = {
+    try {
+      executorService.shutdown()
+      if (!executorService.awaitTermination(timeout, timeUnit)) {
+        executorService.shutdownNow()
+        if (!executorService.awaitTermination(timeout, timeUnit)) {
+          throw new IllegalStateException("Fabric notebook tasks did not stop before artifact cleanup")
+        }
+      }
+    } catch {
+      case e: InterruptedException =>
+        executorService.shutdownNow()
+        Thread.currentThread().interrupt()
+        throw e
+    }
+  }
+
+  private[nbtest] def isTestArtifactName(displayName: String): Boolean = {
+    displayName match {
+      case StoreArtifactName(_) => true
+      case SJDArtifactName(name) => TestSJDNames(name)
+      case _ => false
+    }
+  }
 }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricNotebookTests.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricNotebookTests.scala
@@ -9,7 +9,7 @@ import com.microsoft.azure.synapse.ml.fabric.{FabricTestConstants, HasFabricOper
 
 import java.io.{File, PrintWriter}
 import java.time.LocalDateTime
-import java.util.concurrent.{Executors, TimeUnit}
+import java.util.concurrent.{ExecutorService, Executors, TimeUnit}
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future, blocking}
 
@@ -28,10 +28,11 @@ trait HasFabricNotebookTestConnection extends HasFabricOperationsConnection {
 
 class FabricTestCleanup extends TestBase with HasFabricNotebookTestConnection {
   test("Clean up old artifacts") {
+    val cutoff = LocalDateTime.now().minusDays(3)
     fabric.listArtifacts()
       .filter(artifact =>
         FabricNotebookTests.isTestArtifactName(artifact.displayName) &&
-          artifact.lastUpdatedDate.isBefore(LocalDateTime.now().minusDays(3)))
+          artifact.lastUpdatedDate.isBefore(cutoff))
       .foreach(artifact => {
         println(s"Artifact cleanup: scheduling artifact ${artifact.displayName} for deletion.")
         println(s"Last Update Date: ${artifact.lastUpdatedDate.toString()}")
@@ -146,8 +147,8 @@ class FabricNotebookTests extends TestBase with HasFabricNotebookTestConnection 
   }
 
   override def afterAll(): Unit = {
-    executorService.shutdown()
     try {
+      FabricNotebookTests.shutdownExecutor(executorService)
       cleanupTrackedArtifacts()
     } finally {
       super.afterAll()
@@ -157,8 +158,26 @@ class FabricNotebookTests extends TestBase with HasFabricNotebookTestConnection 
 
 object FabricNotebookTests {
   val MaxConcurrency: Int = 3
+  private val ExecutorShutdownTimeoutSeconds = 30L
   private val StoreArtifactName = "^(Lakehouse|Warehouse)\\d{14}$".r
   private val SJDArtifactName = "^(OnePlusOne|ExploreAlgorithms.+)-\\d{8}-\\d{2}-\\d{2}-\\d{2}$".r
+
+  private[nbtest] def shutdownExecutor(executorService: ExecutorService): Unit = {
+    try {
+      executorService.shutdown()
+      if (!executorService.awaitTermination(ExecutorShutdownTimeoutSeconds, TimeUnit.SECONDS)) {
+        executorService.shutdownNow()
+        if (!executorService.awaitTermination(ExecutorShutdownTimeoutSeconds, TimeUnit.SECONDS)) {
+          throw new IllegalStateException("Fabric notebook tasks did not stop before artifact cleanup")
+        }
+      }
+    } catch {
+      case e: InterruptedException =>
+        executorService.shutdownNow()
+        Thread.currentThread().interrupt()
+        throw e
+    }
+  }
 
   private[nbtest] def isTestArtifactName(displayName: String): Boolean = {
     StoreArtifactName.pattern.matcher(displayName).matches() ||

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricTestArtifactTracker.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricTestArtifactTracker.scala
@@ -1,0 +1,37 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.nbtest
+
+import java.util.concurrent.ConcurrentLinkedDeque
+import scala.collection.mutable.ArrayBuffer
+import scala.util.control.NonFatal
+
+private[nbtest] final class FabricTestArtifactTracker(deleteArtifact: String => Unit) {
+  private val artifactIds = new ConcurrentLinkedDeque[String]()
+
+  def track(artifactId: String): String = {
+    artifactIds.push(artifactId)
+    artifactId
+  }
+
+  def cleanup(): Unit = {
+    val failures = ArrayBuffer.empty[Throwable]
+    Iterator.continually(artifactIds.poll()).takeWhile(_ != null).foreach { artifactId =>
+      try {
+        deleteArtifact(artifactId)
+        println(s"Artifact cleanup: deleted artifact $artifactId.")
+      } catch {
+        case e: RuntimeException if Option(e.getMessage).exists(_.contains("PowerBIEntityNotFound")) =>
+          println(s"Artifact $artifactId was already deleted.")
+        case NonFatal(e) =>
+          failures += e
+      }
+    }
+
+    failures.headOption.foreach { failure =>
+      failures.tail.foreach(failure.addSuppressed)
+      throw failure
+    }
+  }
+}

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricTestArtifactTracker.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricTestArtifactTracker.scala
@@ -25,6 +25,7 @@ private[nbtest] final class FabricTestArtifactTracker(deleteArtifact: String => 
         case e: RuntimeException if Option(e.getMessage).exists(_.contains("PowerBIEntityNotFound")) =>
           println(s"Artifact $artifactId was already deleted.")
         case NonFatal(e) =>
+          println(s"Artifact cleanup failed for artifact $artifactId: $e")
           failures += e
       }
     }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricTestArtifactTrackerSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricTestArtifactTrackerSuite.scala
@@ -65,19 +65,51 @@ class FabricTestArtifactTrackerSuite extends AnyFunSuite {
       "ExploreAlgorithmsRegressionQuickstartTrainRegressor-20260808-01-09-17"))
     assert(FabricNotebookTests.isTestArtifactName("OnePlusOne-20260808-01-09-17"))
     assert(!FabricNotebookTests.isTestArtifactName("LakehouseForManualTesting"))
+    assert(!FabricNotebookTests.isTestArtifactName(
+      "ExploreAlgorithmsAdHocNotebook-20260808-01-09-17"))
     assert(!FabricNotebookTests.isTestArtifactName("CustomerNotebook-20260808-01-09-17"))
   }
 
   test("Wait for notebook tasks before artifact cleanup") {
     val executor = Executors.newSingleThreadExecutor()
     val completed = new CountDownLatch(1)
-    executor.submit(new Runnable {
-      override def run(): Unit = completed.countDown()
-    })
+    try {
+      executor.submit(new Runnable {
+        override def run(): Unit = completed.countDown()
+      })
 
-    FabricNotebookTests.shutdownExecutor(executor)
+      FabricNotebookTests.shutdownExecutor(executor)
 
-    assert(completed.await(0, TimeUnit.SECONDS))
-    assert(executor.isTerminated)
+      assert(completed.await(0, TimeUnit.SECONDS))
+      assert(executor.isTerminated)
+    } finally {
+      executor.shutdownNow()
+    }
+  }
+
+  test("Interrupt notebook tasks that do not stop gracefully") {
+    val executor = Executors.newSingleThreadExecutor()
+    val started = new CountDownLatch(1)
+    val interrupted = new CountDownLatch(1)
+    try {
+      executor.submit(new Runnable {
+        override def run(): Unit = {
+          started.countDown()
+          try {
+            new CountDownLatch(1).await()
+          } catch {
+            case _: InterruptedException => interrupted.countDown()
+          }
+        }
+      })
+
+      assert(started.await(5, TimeUnit.SECONDS))
+      FabricNotebookTests.shutdownExecutor(executor, 1, TimeUnit.SECONDS)
+
+      assert(interrupted.await(0, TimeUnit.SECONDS))
+      assert(executor.isTerminated)
+    } finally {
+      executor.shutdownNow()
+    }
   }
 }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricTestArtifactTrackerSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricTestArtifactTrackerSuite.scala
@@ -1,0 +1,69 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.nbtest
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.collection.mutable.ArrayBuffer
+
+class FabricTestArtifactTrackerSuite extends AnyFunSuite {
+
+  test("Delete tracked artifacts in reverse creation order") {
+    val deleted = ArrayBuffer.empty[String]
+    val tracker = new FabricTestArtifactTracker(artifactId => {
+      deleted += artifactId
+      ()
+    })
+
+    tracker.track("store")
+    tracker.track("job-1")
+    tracker.track("job-2")
+    tracker.cleanup()
+
+    assert(deleted == Seq("job-2", "job-1", "store"))
+  }
+
+  test("Ignore artifacts that were already deleted") {
+    val attempted = ArrayBuffer.empty[String]
+    val tracker = new FabricTestArtifactTracker(artifactId => {
+      attempted += artifactId
+      if (artifactId == "missing") {
+        throw new RuntimeException("PowerBIEntityNotFound")
+      }
+    })
+
+    tracker.track("remaining")
+    tracker.track("missing")
+    tracker.cleanup()
+
+    assert(attempted == Seq("missing", "remaining"))
+  }
+
+  test("Attempt all deletions and preserve cleanup failures") {
+    val attempted = ArrayBuffer.empty[String]
+    val firstFailure = new RuntimeException("first failure")
+    val secondFailure = new RuntimeException("second failure")
+    val tracker = new FabricTestArtifactTracker(artifactId => {
+      attempted += artifactId
+      throw Map("first" -> firstFailure, "second" -> secondFailure)(artifactId)
+    })
+
+    tracker.track("first")
+    tracker.track("second")
+
+    val thrown = intercept[RuntimeException](tracker.cleanup())
+    assert(thrown eq secondFailure)
+    assert(thrown.getSuppressed.toSeq == Seq(firstFailure))
+    assert(attempted == Seq("second", "first"))
+  }
+
+  test("Recognize only SynapseML Fabric test artifact names") {
+    assert(FabricNotebookTests.isTestArtifactName("Lakehouse20260808010917"))
+    assert(FabricNotebookTests.isTestArtifactName(
+      "ExploreAlgorithmsRegressionQuickstartTrainRegressor-20260808-01-09-17"))
+    assert(FabricNotebookTests.isTestArtifactName("OnePlusOne-20260808-01-09-17"))
+    assert(!FabricNotebookTests.isTestArtifactName("LakehouseForManualTesting"))
+    assert(!FabricNotebookTests.isTestArtifactName("CustomerNotebook-20260808-01-09-17"))
+  }
+}

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricTestArtifactTrackerSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricTestArtifactTrackerSuite.scala
@@ -3,6 +3,7 @@
 
 package com.microsoft.azure.synapse.ml.nbtest
 
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
 import org.scalatest.funsuite.AnyFunSuite
 
 import scala.collection.mutable.ArrayBuffer
@@ -65,5 +66,18 @@ class FabricTestArtifactTrackerSuite extends AnyFunSuite {
     assert(FabricNotebookTests.isTestArtifactName("OnePlusOne-20260808-01-09-17"))
     assert(!FabricNotebookTests.isTestArtifactName("LakehouseForManualTesting"))
     assert(!FabricNotebookTests.isTestArtifactName("CustomerNotebook-20260808-01-09-17"))
+  }
+
+  test("Wait for notebook tasks before artifact cleanup") {
+    val executor = Executors.newSingleThreadExecutor()
+    val completed = new CountDownLatch(1)
+    executor.submit(new Runnable {
+      override def run(): Unit = completed.countDown()
+    })
+
+    FabricNotebookTests.shutdownExecutor(executor)
+
+    assert(completed.await(0, TimeUnit.SECONDS))
+    assert(executor.isTerminated)
   }
 }

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -323,6 +323,7 @@ jobs:
         inlineScript: |
           set -e
           source activate synapseml
+          sbt "testOnly com.microsoft.azure.synapse.ml.nbtest.FabricTestCleanup"
           sbt "testOnly com.microsoft.azure.synapse.ml.nbtest.FabricSmokeTests com.microsoft.azure.synapse.ml.nbtest.FabricNotebookTests"
       env:
         INTEGRATION_ENV: $(sempy-integration-region)

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -323,8 +323,9 @@ jobs:
         inlineScript: |
           set -e
           source activate synapseml
-          sbt "testOnly com.microsoft.azure.synapse.ml.nbtest.FabricTestCleanup"
-          sbt "testOnly com.microsoft.azure.synapse.ml.nbtest.FabricSmokeTests com.microsoft.azure.synapse.ml.nbtest.FabricNotebookTests"
+          sbt \
+            "testOnly com.microsoft.azure.synapse.ml.nbtest.FabricTestCleanup" \
+            "testOnly com.microsoft.azure.synapse.ml.nbtest.FabricSmokeTests com.microsoft.azure.synapse.ml.nbtest.FabricNotebookTests"
       env:
         INTEGRATION_ENV: $(sempy-integration-region)
         INTEGRATION_ACCOUNT: $(sempy-integration-account)

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -196,12 +196,13 @@ def test_fabric_e2e_cleans_stale_artifacts_before_running_tests():
 
     script = e2e_steps[0]["inputs"]["inlineScript"]
     cleanup_command = (
-        'sbt "testOnly com.microsoft.azure.synapse.ml.nbtest.FabricTestCleanup"'
+        '"testOnly com.microsoft.azure.synapse.ml.nbtest.FabricTestCleanup"'
     )
     test_command = (
-        'sbt "testOnly com.microsoft.azure.synapse.ml.nbtest.FabricSmokeTests '
+        '"testOnly com.microsoft.azure.synapse.ml.nbtest.FabricSmokeTests '
         'com.microsoft.azure.synapse.ml.nbtest.FabricNotebookTests"'
     )
+    assert script.count("sbt ") == 1
     assert cleanup_command in script
     assert test_command in script
     assert script.index(cleanup_command) < script.index(test_command)

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -183,6 +183,30 @@ def test_databricks_e2e_uses_fail_open_pr_impact_detection():
     assert any(step.get("displayName") == "Publish Test Results" for step in steps)
 
 
+def test_fabric_e2e_cleans_stale_artifacts_before_running_tests():
+    data = yaml.safe_load(_pipeline_text())
+    jobs = {j.get("job"): j for j in _jobs(data["jobs"])}
+    fabric_e2e = jobs["FabricE2E"]
+    e2e_steps = [
+        step
+        for step in fabric_e2e["steps"]
+        if isinstance(step, dict) and step.get("displayName") == "E2E"
+    ]
+    assert len(e2e_steps) == 1
+
+    script = e2e_steps[0]["inputs"]["inlineScript"]
+    cleanup_command = (
+        'sbt "testOnly com.microsoft.azure.synapse.ml.nbtest.FabricTestCleanup"'
+    )
+    test_command = (
+        'sbt "testOnly com.microsoft.azure.synapse.ml.nbtest.FabricSmokeTests '
+        'com.microsoft.azure.synapse.ml.nbtest.FabricNotebookTests"'
+    )
+    assert cleanup_command in script
+    assert test_command in script
+    assert script.index(cleanup_command) < script.index(test_command)
+
+
 def test_release_compat_accepts_github_target_and_uses_one_sbt_process():
     data = yaml.safe_load(_pipeline_text())
     jobs = {j.get("job"): j for j in _jobs(data["jobs"])}


### PR DESCRIPTION
## Related Issues/PRs

Unblocks the Fabric E2E checks currently failing on #2604 and #2612 with `PowerBIMetadataWorkspaceArtifactsQuotaExceededException`.

## What changes are proposed in this pull request?

- Run the existing `FabricTestCleanup` suite before Fabric smoke/notebook tests.
- Restrict stale cleanup to SynapseML-generated Lakehouse, Warehouse, and Spark Job Definition names.
- Track every artifact created by each suite and delete it in reverse creation order from `afterAll`.
- Continue cleanup after individual deletion failures, tolerate already-deleted artifacts, and preserve real failures.
- Add unit tests for lifecycle ordering/error handling and a pipeline-wiring regression test.

## Why is this separate from #2604?

The quota failure is shared Fabric test infrastructure debt introduced with #2495, not a release-compatibility regression. Keeping the repair separate preserves #2604's original scope and prevents every successful PR build from leaking more workspace artifacts.

## How is this patch tested?

- `FabricTestArtifactTrackerSuite`: 4 tests passed.
- Core main and test scalastyle: zero findings.
- `tools/ci/tests/test_pipeline_yaml.py`: 15 tests passed.
- Fabric E2E is intentionally validated in Azure Pipelines because it uses the shared integration workspace and credentials.