### PR TITLE
fix: make Fabric artifact names unique across parallel runs

### DIFF
--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/fabric/FabricArtifactNamesSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/fabric/FabricArtifactNamesSuite.scala
@@ -22,7 +22,7 @@ class FabricArtifactNamesSuite extends AnyFunSuite {
   test("Add a unique suffix to store artifact names") {
     assert(
       FabricArtifactNames.store("Lakehouse", testTime, testId) ==
-        "Lakehouse20260809021835-0123456789abcdef0123456789abcdef")
+        "Lakehouse202608090218350123456789abcdef0123456789abcdef")
   }
 
   test("Distinguish artifacts created with the same timestamp") {

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/fabric/FabricArtifactNamesSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/fabric/FabricArtifactNamesSuite.scala
@@ -1,0 +1,36 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.fabric
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+class FabricArtifactNamesSuite extends AnyFunSuite {
+  private val testTime = LocalDateTime.of(2026, 8, 9, 2, 18, 35)
+  private val testId = UUID.fromString("01234567-89ab-cdef-0123-456789abcdef")
+  private val otherTestId = UUID.fromString("fedcba98-7654-3210-fedc-ba9876543210")
+
+  test("Add a unique suffix to Spark Job Definition names") {
+    assert(
+      FabricArtifactNames.sjd("TestNotebook", testTime, testId) ==
+        "TestNotebook-20260809-02-18-35-0123456789abcdef0123456789abcdef")
+  }
+
+  test("Add a unique suffix to store artifact names") {
+    assert(
+      FabricArtifactNames.store("Lakehouse", testTime, testId) ==
+        "Lakehouse20260809021835-0123456789abcdef0123456789abcdef")
+  }
+
+  test("Distinguish artifacts created with the same timestamp") {
+    assert(
+      FabricArtifactNames.sjd("TestNotebook", testTime, testId) !=
+        FabricArtifactNames.sjd("TestNotebook", testTime, otherTestId))
+    assert(
+      FabricArtifactNames.store("Lakehouse", testTime, testId) !=
+        FabricArtifactNames.store("Lakehouse", testTime, otherTestId))
+  }
+}

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/fabric/FabricOperations.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/fabric/FabricOperations.scala
@@ -25,10 +25,30 @@ import java.net.URLEncoder
 import java.nio.file.{Files, Path}
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.util.UUID
 import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future, TimeoutException, blocking}
 import scala.util.Try
 import scala.util.control.Breaks.{break, breakable}
+
+private[fabric] object FabricArtifactNames {
+  private val SjdTimestampFormat = DateTimeFormatter.ofPattern("yyyyMMdd-HH-mm-ss")
+  private val StoreTimestampFormat = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
+
+  def sjd(runName: String): String =
+    sjd(runName, LocalDateTime.now(), UUID.randomUUID())
+
+  def store(storeName: String): String =
+    store(storeName, LocalDateTime.now(), UUID.randomUUID())
+
+  private[fabric] def sjd(runName: String, now: LocalDateTime, uniqueId: UUID): String =
+    s"$runName-${SjdTimestampFormat.format(now)}-${compact(uniqueId)}"
+
+  private[fabric] def store(storeName: String, now: LocalDateTime, uniqueId: UUID): String =
+    s"$storeName${StoreTimestampFormat.format(now)}-${compact(uniqueId)}"
+
+  private def compact(uniqueId: UUID): String = uniqueId.toString.replace("-", "")
+}
 
 private[fabric] class FabricOperations(clientId: String, redirectUri: String, workspaceId: String)
   extends FabricInternalConnection(clientId, redirectUri, workspaceId) {
@@ -94,14 +114,12 @@ private[fabric] class FabricOperations(clientId: String, redirectUri: String, wo
 
   def createSJDArtifact(path: String, artifactType: String): String = {
     val runName = getBlobNameFromFilepath(path).replace(".py", "")
-
-    val dtf = DateTimeFormatter.ofPattern("yyyyMMdd-HH-mm-ss")
-    val now = dtf.format(LocalDateTime.now)
+    val displayName = FabricArtifactNames.sjd(runName)
 
     val reqBody: String =
       s"""
          |{
-         |  "displayName": "$runName-$now",
+         |  "displayName": "$displayName",
          |  "description": "Synapse Spark Job Definition $artifactType",
          |  "artifactType": "$artifactType"
          |}
@@ -113,13 +131,12 @@ private[fabric] class FabricOperations(clientId: String, redirectUri: String, wo
 
   def createStoreArtifact(): String = {
     val store = Secrets.ArtifactStore.capitalize
-    val dtf = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
-    val now = dtf.format(LocalDateTime.now)
+    val displayName = FabricArtifactNames.store(store)
 
     val reqBody: String =
       s"""
          |{
-         |  "displayName": "$store$now",
+         |  "displayName": "$displayName",
          |  "description": "SynapseML Test Infra $store",
          |  "artifactType": "$store"
          |}

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/fabric/FabricOperations.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/fabric/FabricOperations.scala
@@ -45,7 +45,7 @@ private[fabric] object FabricArtifactNames {
     s"$runName-${SjdTimestampFormat.format(now)}-${compact(uniqueId)}"
 
   private[fabric] def store(storeName: String, now: LocalDateTime, uniqueId: UUID): String =
-    s"$storeName${StoreTimestampFormat.format(now)}-${compact(uniqueId)}"
+    s"$storeName${StoreTimestampFormat.format(now)}${compact(uniqueId)}"
 
   private def compact(uniqueId: UUID): String = uniqueId.toString.replace("-", "")
 }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricNotebookTests.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricNotebookTests.scala
@@ -176,9 +176,10 @@ object FabricNotebookTests {
   )
 
   private val ExecutorShutdownTimeoutSeconds = 30L
-  private val UniqueArtifactSuffix = "(?:-[0-9a-fA-F]{32})?"
-  private val StoreArtifactName = s"^(Lakehouse|Warehouse)\\d{14}$UniqueArtifactSuffix$$".r
-  private val SJDArtifactName = s"^(.+)-\\d{8}-\\d{2}-\\d{2}-\\d{2}$UniqueArtifactSuffix$$".r
+  private val UniqueArtifactId = "[0-9a-fA-F]{32}"
+  private val StoreArtifactName = s"^(Lakehouse|Warehouse)\\d{14}(?:$UniqueArtifactId)?$$".r
+  private val SJDArtifactName =
+    s"^(.+)-\\d{8}-\\d{2}-\\d{2}-\\d{2}(?:-$UniqueArtifactId)?$$".r
   private val TestSJDNames = (IncludedNotebooks :+ "OnePlusOne").toSet
 
   private[nbtest] def shutdownExecutor(executorService: ExecutorService): Unit = {

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricNotebookTests.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricNotebookTests.scala
@@ -176,8 +176,9 @@ object FabricNotebookTests {
   )
 
   private val ExecutorShutdownTimeoutSeconds = 30L
-  private val StoreArtifactName = "^(Lakehouse|Warehouse)\\d{14}$".r
-  private val SJDArtifactName = "^(.+)-\\d{8}-\\d{2}-\\d{2}-\\d{2}$".r
+  private val UniqueArtifactSuffix = "(?:-[0-9a-fA-F]{32})?"
+  private val StoreArtifactName = s"^(Lakehouse|Warehouse)\\d{14}$UniqueArtifactSuffix$$".r
+  private val SJDArtifactName = s"^(.+)-\\d{8}-\\d{2}-\\d{2}-\\d{2}$UniqueArtifactSuffix$$".r
   private val TestSJDNames = (IncludedNotebooks :+ "OnePlusOne").toSet
 
   private[nbtest] def shutdownExecutor(executorService: ExecutorService): Unit = {

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricTestArtifactTrackerSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricTestArtifactTrackerSuite.scala
@@ -62,9 +62,16 @@ class FabricTestArtifactTrackerSuite extends AnyFunSuite {
   test("Recognize only SynapseML Fabric test artifact names") {
     assert(FabricNotebookTests.isTestArtifactName("Lakehouse20260808010917"))
     assert(FabricNotebookTests.isTestArtifactName(
+      "Lakehouse20260808010917-0123456789abcdef0123456789abcdef"))
+    assert(FabricNotebookTests.isTestArtifactName(
       "ExploreAlgorithmsRegressionQuickstartTrainRegressor-20260808-01-09-17"))
+    assert(FabricNotebookTests.isTestArtifactName(
+      "ExploreAlgorithmsRegressionQuickstartTrainRegressor-20260808-01-09-17-" +
+        "0123456789abcdef0123456789abcdef"))
     assert(FabricNotebookTests.isTestArtifactName("OnePlusOne-20260808-01-09-17"))
     assert(!FabricNotebookTests.isTestArtifactName("LakehouseForManualTesting"))
+    assert(!FabricNotebookTests.isTestArtifactName(
+      "Lakehouse20260808010917-not-a-unique-id"))
     assert(!FabricNotebookTests.isTestArtifactName(
       "ExploreAlgorithmsAdHocNotebook-20260808-01-09-17"))
     assert(!FabricNotebookTests.isTestArtifactName("CustomerNotebook-20260808-01-09-17"))

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricTestArtifactTrackerSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricTestArtifactTrackerSuite.scala
@@ -62,7 +62,7 @@ class FabricTestArtifactTrackerSuite extends AnyFunSuite {
   test("Recognize only SynapseML Fabric test artifact names") {
     assert(FabricNotebookTests.isTestArtifactName("Lakehouse20260808010917"))
     assert(FabricNotebookTests.isTestArtifactName(
-      "Lakehouse20260808010917-0123456789abcdef0123456789abcdef"))
+      "Lakehouse202608080109170123456789abcdef0123456789abcdef"))
     assert(FabricNotebookTests.isTestArtifactName(
       "ExploreAlgorithmsRegressionQuickstartTrainRegressor-20260808-01-09-17"))
     assert(FabricNotebookTests.isTestArtifactName(
@@ -72,6 +72,8 @@ class FabricTestArtifactTrackerSuite extends AnyFunSuite {
     assert(!FabricNotebookTests.isTestArtifactName("LakehouseForManualTesting"))
     assert(!FabricNotebookTests.isTestArtifactName(
       "Lakehouse20260808010917-not-a-unique-id"))
+    assert(!FabricNotebookTests.isTestArtifactName(
+      "Lakehouse20260808010917-0123456789abcdef0123456789abcdef"))
     assert(!FabricNotebookTests.isTestArtifactName(
       "ExploreAlgorithmsAdHocNotebook-20260808-01-09-17"))
     assert(!FabricNotebookTests.isTestArtifactName("CustomerNotebook-20260808-01-09-17"))


### PR DESCRIPTION
## Summary

- append a compact UUID to Fabric Spark Job Definition and Lakehouse/Warehouse display names
- preserve the timestamp for diagnostics and stale-artifact age handling
- recognize both legacy timestamp-only names and new UUID-suffixed names during stale cleanup
- keep normal teardown scoped to the object IDs created by each suite

## Root cause

Parallel PR validations can create the same notebook artifact in the same second. The existing second-resolution display name then causes Fabric to reject one creation with `PowerBIMetadataArtifactDisplayNameInUseException` before ID-based ownership tracking can begin.

This was observed in [ADO build 230394225](https://dev.azure.com/msdata/A365/_build/results?buildId=230394225) while validating the cleanup introduced by #2615. The failure was a creation-time name collision, not one pipeline deleting another pipeline's artifact.

## Why this approach

A random UUID avoids relying on synchronized clocks across agents. The cleanup suffix is optional only within the existing exact allowlist, so artifacts leaked by older runs remain eligible for stale cleanup without broadening deletion to unrelated workspace artifacts.

## Validation

- full Scala and test scalastyle
- `FabricArtifactNamesSuite` and `FabricTestArtifactTrackerSuite`: 9/9 tests
- Black 22.3.0: 185 files
- pipeline YAML tests: 15/15
- `git diff --check`