### PR TITLE
ci: annotate scalastyle violations and stop coverage upload failing the build

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -55,7 +55,34 @@ jobs:
           sbt sbtVersion
 
       - name: Scalastyle check
-        run: sbt scalastyle test:scalastyle
+        run: |
+          set -o pipefail
+          sbt scalastyle test:scalastyle 2>&1 | tee "$RUNNER_TEMP/scalastyle-output.log"
+
+      - name: Annotate scalastyle violations
+        if: failure()
+        run: |
+          set -uo pipefail
+          log="$RUNNER_TEMP/scalastyle-output.log"
+          [ -f "$log" ] || exit 0
+          workspace="${GITHUB_WORKSPACE%/}/"
+          violations="$(grep -aE '^\[(error|warn)\] .+\.scala:[0-9]+:[0-9]+: ' "$log" || true)"
+          if [ -z "$violations" ]; then
+            echo "No scalastyle violations found in the log; the failure is reported in the step above."
+            exit 0
+          fi
+          while IFS= read -r violation; do
+            case "$violation" in
+              '[warn]'*) severity="warning" ;;
+              *) severity="error" ;;
+            esac
+            body="${violation#*] }"
+            location="${body%%: *}"
+            message="${body#*: }"
+            file="${location%%:*}"
+            position="${location#*:}"
+            echo "::${severity} file=${file#"$workspace"},line=${position%%:*},col=${position#*:}::${message}"
+          done <<< "$violations"
 
       - name: Compile
         run: sbt compile test:compile

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -66,7 +66,10 @@ jobs:
           log="$RUNNER_TEMP/scalastyle-output.log"
           [ -f "$log" ] || exit 0
           workspace="${GITHUB_WORKSPACE%/}/"
-          violations="$(grep -aE '^\[(error|warn)\] .+\.scala:[0-9]+:[0-9]+: ' "$log" || true)"
+          # sbt colorizes its output, so strip ANSI escapes before matching
+          violations="$(sed -e 's/\x1B\[[0-9;]*[a-zA-Z]//g' "$log" \
+            | grep -aE '^\[(error|warn)\] .+\.scala:[0-9]+(:[0-9]+)?: ' \
+            | awk '!seen[$0]++' || true)"
           if [ -z "$violations" ]; then
             echo "No scalastyle violations found in the log; the failure is reported in the step above."
             exit 0
@@ -81,7 +84,14 @@ jobs:
             message="${body#*: }"
             file="${location%%:*}"
             position="${location#*:}"
-            echo "::${severity} file=${file#"$workspace"},line=${position%%:*},col=${position#*:}::${message}"
+            lineno="${position%%:*}"
+            # File-level checks (line length, tabs, EOF newline) report no column
+            if [ "$position" = "$lineno" ]; then
+              column=""
+            else
+              column=",col=${position#*:}"
+            fi
+            echo "::${severity} file=${file#"$workspace"},line=${lineno}${column}::${message}"
           done <<< "$violations"
 
       - name: Compile

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -74,6 +74,18 @@ jobs:
             echo "No scalastyle violations found in the log; the failure is reported in the step above."
             exit 0
           fi
+          # Workflow commands treat %, CR and LF specially; property values
+          # additionally need : and , encoded
+          encode() {
+            local value="${1//%/%25}"
+            value="${value//$'\r'/%0D}"
+            value="${value//$'\n'/%0A}"
+            if [ "${2:-}" = "property" ]; then
+              value="${value//:/%3A}"
+              value="${value//,/%2C}"
+            fi
+            printf '%s' "$value"
+          }
           while IFS= read -r violation; do
             case "$violation" in
               '[warn]'*) severity="warning" ;;
@@ -91,7 +103,7 @@ jobs:
             else
               column=",col=${position#*:}"
             fi
-            echo "::${severity} file=${file#"$workspace"},line=${lineno}${column}::${message}"
+            echo "::${severity} file=$(encode "${file#"$workspace"}" property),line=${lineno}${column}::$(encode "$message")"
           done <<< "$violations"
 
       - name: Compile

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -872,6 +872,7 @@ jobs:
         displayName: Load Codecov token
         condition: succeededOrFailed()
         retryCountOnTaskFailure: 3
+        continueOnError: true
         inputs:
           azureSubscription: 'SynapseML Build'
           keyVaultName: mmlspark-keys

--- a/templates/codecov.yml
+++ b/templates/codecov.yml
@@ -21,3 +21,4 @@ steps:
     retryCountOnTaskFailure: 1
     displayName: Upload Coverage Report To Codecov.io
     condition: succeededOrFailed()
+    continueOnError: true


### PR DESCRIPTION
Two CI reliability fixes, both prompted by real failures on this repo in the last few days.

| File | Change |
| --- | --- |
| `.github/workflows/pr-validation.yml` | Re-emit scalastyle violations as GitHub annotations |
| `pipeline.yaml`, `templates/codecov.yml` | Stop coverage-upload infrastructure failures from failing the build |

---

## 1. Surface scalastyle violations as PR annotations

### Problem

The `Compile & Style Check` job runs `sbt scalastyle test:scalastyle`. sbt continues across every subproject and never restates the failure at the end, so a failing run ends with nothing but:

```
##[error]Process completed with exit code 1
```

The actual violation sits hundreds of lines earlier, surrounded by `Found 0 errors` lines from the other modules. Grepping the log for `[error]` surfaces only that generic exit line, so contributors have to scroll the raw log to find the cause.

This is not hypothetical: it cost real debugging time on a recent PR whose only failure was a single `Avoid using null` at line ~313 of a 375-line log.

### Change

Tee the scalastyle output to a log and, when the step fails, re-emit each violation as a GitHub annotation, so it appears inline on the diff in **Files changed** and in the run summary:

```
::error file=lightgbm/src/.../DriverSocketRetrySuite.scala,line=355,col=75::Avoid using null
```

### Validation

Rather than assume the parsing was right, a commit adding two deliberate over-long lines was pushed to this branch, the job was allowed to fail in real CI, and the annotations GitHub actually recorded were read back from the check-runs API.

**That caught two bugs local testing could not**, both fixed here:

1. **sbt colorizes its output.** A real error line is `ESC[0m[ESC[0mESC[31merrorESC[0m] ESC[0m/path/File.scala:6: ...`, so a `^\[error\]` anchor never matched and *zero* annotations were produced. ANSI escapes are now stripped before matching.
2. **File-level checks report no column.** Line length, tabs, EOF newline and header checks emit `path:LINE:`, while scalariform checks emit `path:LINE:COL:`. Requiring a column silently dropped every file-level violation. The column is now optional, and `col=` is emitted only when reported.

After the fix, the same deliberate failure produced real annotations:

```
failure | core/src/main/scala/.../SlicerFunctions.scala:6 | File line length exceeds 120 characters
failure | core/src/main/scala/.../SlicerFunctions.scala:7 | File line length exceeds 120 characters
```

The validation commit was then dropped by rebase, so no Scala source is touched by this PR.

Cases covered, replayed against the unmodified real CI log:

| Case | Result |
| --- | --- |
| Colorized file-level violation (no column) | `::error` with `line=`, no `col=` |
| Colorized scalariform violation (with column) | `::error` with `line=` and `col=` |
| Colorized `[warn]` line | emitted as `::warning` |
| `%`, CR, LF in message; `:`/`,` in path | percent-encoded per workflow-command rules |
| Message containing extra `: ` | preserved, path/line/col still correct |
| Duplicate violation lines | deduped, annotated once |
| Noise (`Total time: ...`, `Found 0 errors`) | ignored |
| Log with no violations | prints a note, exits 0 |
| Log missing (an earlier step failed) | exits 0 |
| Pipeline through `tee` with non-zero exit | exit code preserved, job still fails |

`set -o pipefail` keeps the pipe through `tee` from masking sbt's exit code, so the gate behaves exactly as before: the clean commit on this branch passes `Compile & Style Check`, and the violation commit failed it. The annotation step is purely additive diagnostics and is a no-op when there is nothing to report, so it cannot turn a passing build red.

---

## 2. Coverage upload no longer fails the build

The last master build ([230617908](https://msdata.visualstudio.com/_build/results?buildId=230617908)) failed with:

```
Error while trying to get OIDC token: Error [ERR_TLS_CERT_ALTNAME_INVALID]:
Hostname/IP does not match certificate's altnames:
Host: msdata.visualstudio.com. is not in the cert's altnames: DNS:*.azureedge.net
```

Reading the build timeline, a transient TLS fault on the agent broke **every** federated-credential handshake in the `UnitTests stages` job, which also logged `The SSL connection could not be established` telemetry warnings throughout:

| # | Task | Result |
| --- | --- | --- |
| 14 | `Unit Test` (AzureCLI@2) | **failed** — OIDC token; retried after 1000 ms, hit the same blip |
| 15 | `Publish Test Results` | succeeded |
| 16 | `Generate Codecov report` | succeeded |
| 17 | `Load Codecov token` (AzureKeyVault@2) | **failed** — OIDC token |
| 18 | `Upload Coverage Report To Codecov.io` | **failed** — no token |

Two separate things are visible here.

**The `Unit Test` failure was infrastructure, not the repo.** The agent could not complete a TLS handshake to the ADO OIDC endpoint — it was served an `*.azureedge.net` certificate. The task already retries, but the retry fired 1 s later and hit the same fault. There is no repo-side fix for that; it needs a re-run, and an infra report if it recurs. **This PR does not attempt to fix it.**

**Steps 17 and 18 are a real, independent weakness, and that is what this PR fixes.** Those steps only publish coverage telemetry, yet a failure in Key Vault, the OIDC endpoint or codecov.io fails the whole job and blocks the merge. They would have failed this job *even if every test had passed*. Both are now `continueOnError: true`, so they degrade to a warning.

This does not weaken the gate:

- `Unit Test` and `Publish Test Results` (`failTaskOnFailedTests: true`) still fail the job exactly as before.
- Both steps already carried `condition: succeededOrFailed()` and `retryCountOnTaskFailure`, so the only change is what happens once retries are exhausted.
- No test result, compilation or style outcome is affected.
