### PR TITLE
chore: remove inactive code owners and refresh maintainer listings

### DIFF
--- a/.github/workflows/ado-integration.yml
+++ b/.github/workflows/ado-integration.yml
@@ -9,7 +9,7 @@ jobs:
   alert:
     runs-on: ubuntu-latest
     steps:
-      - uses: mhamilton723/github-actions-issue-to-work-item@master
+      - uses: danhellem/github-actions-issue-to-work-item@8d0ead9b49a65aa66dac6949b1ff149d7ef8b4de # v2.5
         env:
           ado_token: "${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}"
           github_token: "${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,35 +1,10 @@
 # For general updates to the library
-*                @mhamilton723 @drdarshan
-
-# Ilya's Areas
-lightgbm/        @imatiach-msft
-automl/          @imatiach-msft
-featurize/       @imatiach-msft
-featurize/text/  @mhamilton723
-train/           @imatiach-msft
-
-# Dan's Areas
-recommendation/  @dciborow
-recommendation/  @miguelgfierro
-recommendation/  @gramhagen
-
-# Dalitso's Areas
-tools/helm/      @dbanda
+*                @ranadeepsingh @BrendanWalsh
 
 # Markus' Areas
 vw/              @eisber
 isolationforest/ @eisber
 recommendation/  @eisber
-
-#Roy's Areas
-cyber/           @rolevin
-
-#Jason's Areas
-explainers/      @memoryz
-
-#Serena's Areas
-website/         @serena-ruan
-core/src/main/scala/com/microsoft/azure/synapse/ml/codegen @serena-ruan
 
 # Scott's Areas
 lightgbm/        @svotaw

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -10,16 +10,14 @@ ThisBuild / scmInfo := Some(
   )
 )
 ThisBuild / developers := List(
-  Developer("mhamilton723", "Mark Hamilton",
-    "synapseml-support@microsoft.com", url("https://github.com/mhamilton723")),
-  Developer("imatiach-msft", "Ilya Matiach",
-    "synapseml-support@microsoft.com", url("https://github.com/imatiach-msft")),
-  Developer("drdarshan", "Sudarshan Raghunathan",
-    "synapseml-support@microsoft.com", url("https://github.com/drdarshan")),
-  Developer("svotaw", "Scott Votaw",
-    "synapseml-support@microsoft.com", url("https://github.com/svotaw")),
+  Developer("ranadeepsingh", "Rana Singh",
+    "synapseml-support@microsoft.com", url("https://github.com/ranadeepsingh")),
   Developer("BrendanWalsh", "Brendan Walsh",
     "synapseml-support@microsoft.com", url("https://github.com/BrendanWalsh")),
+  Developer("svotaw", "Scott Votaw",
+    "synapseml-support@microsoft.com", url("https://github.com/svotaw")),
+  Developer("eisber", "Markus Cozowicz",
+    "synapseml-support@microsoft.com", url("https://github.com/eisber")),
   Developer("JessicaXYWang", "Jessica Wang",
     "synapseml-support@microsoft.com", url("https://github.com/JessicaXYWang"))
 )


### PR DESCRIPTION
## Related Issues/PRs

N/A — maintenance cleanup.

## What changes are proposed in this pull request?

Updates `CODEOWNERS` and the other places in the repo that carry a maintainer roster, so they reflect the people actually maintaining SynapseML today. Several listed owners are no longer with Microsoft or no longer active on the project, which means review requests are currently routed to people who cannot action them.

### `CODEOWNERS`

- `*` is now owned by @ranadeepsingh and @BrendanWalsh (previously @mhamilton723 and @drdarshan).
- Retained @eisber for `vw/`, `isolationforest/`, and `recommendation/`.
- Retained @svotaw for `lightgbm/`.
- Removed the remaining stale owners — @mhamilton723, @drdarshan, @imatiach-msft, @dciborow, @miguelgfierro, @gramhagen, @dbanda, @rolevin, @memoryz, @serena-ruan — along with the rules that existed only to point at them (`automl/`, `featurize/`, `featurize/text/`, `train/`, `tools/helm/`, `cyber/`, `explainers/`, `website/`, and the `codegen` path). Those paths now fall through to the `*` owners.

### `sonatype.sbt`

The `developers` list is baked into the Maven POM published with every release, so it was shipping the same stale roster to Maven Central.

- Removed: Mark Hamilton (@mhamilton723), Ilya Matiach (@imatiach-msft), Sudarshan Raghunathan (@drdarshan)
- Added: Rana Singh (@ranadeepsingh), Markus Cozowicz (@eisber) — so the published roster lines up with `CODEOWNERS`
- Kept: Brendan Walsh (@BrendanWalsh), Scott Votaw (@svotaw), Jessica Wang (@JessicaXYWang)

### `.github/workflows/ado-integration.yml`

The issue-to-ADO sync was pinned to `mhamilton723/github-actions-issue-to-work-item@master` — a personal fork whose last commit was in April 2022 — while being passed `ADO_PERSONAL_ACCESS_TOKEN` and `GH_PERSONAL_ACCESS_TOKEN`. Since that account is no longer maintaining the project, this repoints to the canonical upstream it was forked from:

```
danhellem/github-actions-issue-to-work-item@8d0ead9b49a65aa66dac6949b1ff149d7ef8b4de # v2.5
```

**On the choice of `danhellem`.** It is a personal account rather than an org, so it's worth stating the provenance explicitly: it belongs to Dan Hellem, a Product Manager at Microsoft on Azure DevOps / Azure Boards. It is the canonical upstream that the `mhamilton723` copy was forked from, it's the most-used action for this purpose (87 stars / 70 forks), it's actively maintained, and the sibling workflow `ado-pr-to-workitem.yml` in this repo already consumes `danhellem/github-actions-pr-to-work-item`. There is no Microsoft-org-owned equivalent — none of the `microsoft/azure-boards-*` repos do GitHub-issue→work-item sync, and the only org-owned alternative (`MicrosoftEdge/action-issue-to-workitem`, 3 stars) is Edge-team-specific with a different input contract. If maintainers would still prefer to vendor this action under a Microsoft org, that's a reasonable follow-up and this PR doesn't block it.

**Why a commit SHA and not `@master`.** Two reasons:

1. **`@master` would have been broken.** The upstream renamed its default branch to `main` and has no `master` branch at all — `GET /repos/danhellem/github-actions-issue-to-work-item/commits/heads/master` returns HTTP 422. The old fork still had `master` only because it was forked in 2022, before the rename. Carrying `@master` over would have silently broken the issue→ADO sync on the next issue event.
2. **Supply-chain hygiene.** This job is handed two PATs, so it should not track a moving ref. The pin is the `v2.5` release commit (published 2025-06-09, the latest release; `main` is only 1 commit ahead), which runs on `node20`. This matches how every other action in this repo is pinned (e.g. `actions/checkout@3d3c42e5... # v7.0.1`), and `.github/dependabot.yml` already tracks the `github-actions` ecosystem daily so the pin stays current.

The env-var contract is unchanged: the action accepts exactly the set this workflow sets — `ado_token`, `github_token`, `ado_organization`, `ado_project`, `ado_area_path`, `ado_wit`, `ado_new_state`, `ado_active_state`, `ado_close_state`, `ado_bypassrules`.

## Notes for reviewers

**`CODEOWNERS` uses last-match-wins.** GitHub applies only the last rule that matches a path, so the per-area rules still take precedence over `*`. In practice that means `lightgbm/` requests only @svotaw, and `vw/` / `isolationforest/` / `recommendation/` request only @eisber — @ranadeepsingh and @BrendanWalsh are not added on top. This preserves the semantics the file already had. If the preference is for the `*` owners to also be requested on those paths, they need to be appended to each area line; happy to fold that in.

**Deliberately left unchanged:**

- `__author__ = "rolevin"` in `core/src/main/python/synapse/ml/cyber/**` — historical source authorship credit, not review ownership.
- The ESRP `owners:` / `approvers:` lists in `pipeline.yaml` — these are release-approval identities tied to the ESRP process and should be rotated in coordination with it, not as part of a `CODEOWNERS` cleanup.
- `hub.verifyRepoRef("mhamilton723/models")` in `ONNXHubSuite.scala` — a test fixture asserting that an ONNX hub repo ref is rejected; unrelated to ownership.

## How is this patch tested?

- [x] No test changes required — this PR touches only ownership/maintainer metadata and one workflow action reference; there is no product code change.

Verification performed:
- `.github/workflows/ado-integration.yml` was confirmed to still parse as valid YAML after the edit, and its `env` keys were diffed against the action's documented inputs.
- Confirmed the pinned SHA `8d0ead9b` is the `v2.5` release commit and that the action at that SHA runs on `node20`.
- Confirmed the upstream has no `master` branch (HTTP 422), which is why the ref is pinned to a SHA rather than a branch.
- Confirmed via the GitHub API that every retained/added handle resolves: `ranadeepsingh`, `BrendanWalsh`, `eisber`, `svotaw`, `JessicaXYWang`.
- Ran GitHub's CODEOWNERS validator against this PR head on `microsoft/SynapseML` — returns zero errors, confirming all four owners exist and hold write access.
- Re-scanned all tracked files to confirm no other references to the removed owners remain beyond the intentional exclusions noted above.
- `sonatype.sbt` change is a like-for-like edit to the existing `Developer(...)` list; structure and arity are unchanged, and `Compile & Style Check` passes.

## Does this PR change any dependencies?

- [x] Yes. `.github/workflows/ado-integration.yml` now consumes `danhellem/github-actions-issue-to-work-item` pinned to `8d0ead9b` (`v2.5`), replacing the stale, unpinned fork `mhamilton723/github-actions-issue-to-work-item@master`. This is the canonical upstream of that fork and takes the same inputs. No other dependency changes.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No. You can skip this section.
