### PR TITLE
fix(search): accept index schemas whose analyzers and CORS options are objects

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchSchemas.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchSchemas.scala
@@ -13,17 +13,22 @@ case class ASResponses(value: Seq[ASResponse])
 
 case class ASResponse(key: String, status: Boolean, errorMessage: Option[String], statusCode: Int)
 
+// These six fields are pure pass-through: the writer round-trips them to the service and never
+// inspects their contents. The Search REST API returns objects for all of them (a custom analyzer
+// is {"@odata.type":"#Microsoft.Azure.Search.CustomAnalyzer",...}, corsOptions is a single object),
+// so typing them as strings made any index using these features fail to deserialize. Keeping them
+// as opaque JsValue also stops the library from breaking when the service adds a new analyzer kind.
 case class IndexInfo(
                     name: Option[String],
                     fields: Seq[IndexField],
-                    suggesters: Option[Seq[String]],
+                    suggesters: Option[Seq[JsValue]],
                     scoringProfiles: Option[Seq[ScoringProfile]],
-                    analyzers: Option[Seq[String]],
-                    charFilters: Option[Seq[String]],
-                    tokenizers: Option[Seq[String]],
-                    tokenFilters: Option[Seq[String]],
+                    analyzers: Option[Seq[JsValue]],
+                    charFilters: Option[Seq[JsValue]],
+                    tokenizers: Option[Seq[JsValue]],
+                    tokenFilters: Option[Seq[JsValue]],
                     defaultScoringProfile: Option[String],
-                    corsOptions: Option[Seq[String]],
+                    corsOptions: Option[JsValue],
                     vectorSearch: Option[VectorSearch]
                     )
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchSchemas.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchSchemas.scala
@@ -18,17 +18,19 @@ case class ASResponse(key: String, status: Boolean, errorMessage: Option[String]
 // is {"@odata.type":"#Microsoft.Azure.Search.CustomAnalyzer",...}, corsOptions is a single object),
 // so typing them as strings made any index using these features fail to deserialize. Keeping them
 // as opaque JsValue also stops the library from breaking when the service adds a new analyzer kind.
+// spray.json.JsValue is written out in full because the release branches this change is replayed
+// onto import spray.json explicitly rather than by wildcard.
 case class IndexInfo(
                     name: Option[String],
                     fields: Seq[IndexField],
-                    suggesters: Option[Seq[JsValue]],
+                    suggesters: Option[Seq[spray.json.JsValue]],
                     scoringProfiles: Option[Seq[ScoringProfile]],
-                    analyzers: Option[Seq[JsValue]],
-                    charFilters: Option[Seq[JsValue]],
-                    tokenizers: Option[Seq[JsValue]],
-                    tokenFilters: Option[Seq[JsValue]],
+                    analyzers: Option[Seq[spray.json.JsValue]],
+                    charFilters: Option[Seq[spray.json.JsValue]],
+                    tokenizers: Option[Seq[spray.json.JsValue]],
+                    tokenFilters: Option[Seq[spray.json.JsValue]],
                     defaultScoringProfile: Option[String],
-                    corsOptions: Option[JsValue],
+                    corsOptions: Option[spray.json.JsValue],
                     vectorSearch: Option[VectorSearch]
                     )
 

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/IndexSchemaLiveRoundTripSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/IndexSchemaLiveRoundTripSuite.scala
@@ -1,0 +1,96 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.services.search
+
+import com.microsoft.azure.synapse.ml.Secrets
+import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import com.microsoft.azure.synapse.ml.io.http.RESTHelpers._
+import org.apache.http.client.methods.HttpDelete
+import spray.json._
+
+import java.util.UUID
+
+/** End-to-end companion to [[IndexSchemaParsingSuite]].
+  *
+  * The offline suite proves the parser accepts the payload shapes reported in issue #2143, but it
+  * asserts against hand-written JSON. This suite creates a real index that exercises every schema
+  * feature the service returns as an object, reads it back through the same production code path
+  * the writer uses, and parses it. That closes the gap where a hand-written fixture could drift
+  * from what the Search service actually emits.
+  */
+class IndexSchemaLiveRoundTripSuite extends TestBase with IndexJsonGetter with IndexParser {
+
+  private lazy val azureSearchKey: String = sys.env.getOrElse("AZURE_SEARCH_KEY", Secrets.AzureSearchKey)
+  private val testServiceName = "mmlspark-azure-search"
+
+  private def indexDefinition(name: String): String =
+    s"""
+       |{
+       |  "name": "$name",
+       |  "fields": [
+       |    { "name": "id", "type": "Edm.String", "key": true, "searchable": true },
+       |    { "name": "text", "type": "Edm.String", "searchable": true, "analyzer": "sml_custom_analyzer" },
+       |    { "name": "title", "type": "Edm.String", "searchable": true }
+       |  ],
+       |  "corsOptions": { "allowedOrigins": ["*"], "maxAgeInSeconds": 300 },
+       |  "suggesters": [
+       |    { "name": "sml_suggester", "searchMode": "analyzingInfixMatching", "sourceFields": ["title"] }
+       |  ],
+       |  "analyzers": [
+       |    {
+       |      "@odata.type": "#Microsoft.Azure.Search.CustomAnalyzer",
+       |      "name": "sml_custom_analyzer",
+       |      "tokenizer": "sml_tokenizer",
+       |      "tokenFilters": ["sml_asciifolding"],
+       |      "charFilters": ["sml_mapping"]
+       |    }
+       |  ],
+       |  "tokenizers": [
+       |    { "@odata.type": "#Microsoft.Azure.Search.KeywordTokenizerV2", "name": "sml_tokenizer" }
+       |  ],
+       |  "tokenFilters": [
+       |    { "@odata.type": "#Microsoft.Azure.Search.AsciiFoldingTokenFilter",
+       |      "name": "sml_asciifolding", "preserveOriginal": true }
+       |  ],
+       |  "charFilters": [
+       |    { "@odata.type": "#Microsoft.Azure.Search.MappingCharFilter",
+       |      "name": "sml_mapping", "mappings": ["a=>b"] }
+       |  ]
+       |}
+       |""".stripMargin
+
+  private def deleteIndex(name: String): Unit = {
+    val apiVersion = AzureSearchAPIConstants.DefaultAPIVersion
+    val deleteRequest = new HttpDelete(
+      s"https://$testServiceName.search.windows.net/indexes/$name?api-version=$apiVersion")
+    deleteRequest.setHeader("api-key", azureSearchKey)
+    safeSend(deleteRequest)
+    ()
+  }
+
+  test("An index using object-valued schema features round-trips through the live service") {
+    val indexName = s"test-schema-${UUID.randomUUID().toString.take(8)}"
+    SearchIndex.createIfNoneExists(azureSearchKey, testServiceName, indexDefinition(indexName))
+    try {
+      // Read back through the same path AzureSearchWriter uses, so this fails if the service
+      // emits a shape the production parser rejects.
+      val liveJson = getIndexJsonFromExistingIndex(azureSearchKey, testServiceName, indexName)
+      val info = parseIndexJson(liveJson)
+
+      assert(info.name.contains(indexName))
+      // The service returns these as objects; typing them as strings is what broke issue #2143.
+      assert(info.analyzers.exists(_.length == 1))
+      assert(info.analyzers.get.head.asJsObject.fields("name") == JsString("sml_custom_analyzer"))
+      assert(info.tokenizers.exists(_.length == 1))
+      assert(info.tokenFilters.exists(_.length == 1))
+      assert(info.charFilters.exists(_.length == 1))
+      assert(info.suggesters.exists(_.length == 1))
+      // corsOptions is a single object rather than an array.
+      assert(info.corsOptions.exists(_.asJsObject.fields("maxAgeInSeconds") == JsNumber(300)))
+    } finally {
+      deleteIndex(indexName)
+    }
+  }
+
+}

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/IndexSchemaParsingSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/IndexSchemaParsingSuite.scala
@@ -1,0 +1,102 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.services.search
+
+import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import com.microsoft.azure.synapse.ml.services.search.AzureSearchProtocol._
+import spray.json._
+
+/** Regression coverage for index definitions that use the schema features the Search service
+  * returns as objects rather than strings. See issue #2143: any index carrying a custom analyzer
+  * failed to deserialize with "Expected String as JsString" before the writer ever sent a document.
+  */
+class IndexSchemaParsingSuite extends TestBase with IndexParser {
+
+  private val keyField =
+    """{"name": "Id", "type": "Edm.String", "key": true, "searchable": false}"""
+
+  private def indexJson(extraMembers: String): String =
+    s"""{"name": "test-index", "fields": [$keyField]${if (extraMembers.isEmpty) "" else ", " + extraMembers}}"""
+
+  // Verbatim from the issue #2143 report.
+  private val customAnalyzer =
+    """"analyzers": [{
+      |  "@odata.type": "#Microsoft.Azure.Search.CustomAnalyzer",
+      |  "name": "keyword_analyzer",
+      |  "tokenizer": "keyword_v2",
+      |  "charFilters": [],
+      |  "tokenFilters": ["lowercase"]
+      |}]""".stripMargin
+
+  test("parseIndexJson accepts an index with a custom analyzer") {
+    val info = parseIndexJson(indexJson(customAnalyzer))
+    assert(info.name.contains("test-index"))
+    assert(info.analyzers.exists(_.length == 1))
+    val analyzer = info.analyzers.get.head.asJsObject
+    assert(analyzer.fields("name") == JsString("keyword_analyzer"))
+    assert(analyzer.fields("@odata.type") == JsString("#Microsoft.Azure.Search.CustomAnalyzer"))
+    assert(analyzer.fields("tokenFilters") == JsArray(JsString("lowercase")))
+  }
+
+  test("a custom analyzer survives a parse and re-serialize round trip") {
+    val original = indexJson(customAnalyzer)
+    val roundTripped = parseIndexJson(original).toJson.asJsObject
+    // The service rejects an analyzer it cannot identify, so every member has to come back intact.
+    assert(roundTripped.fields("analyzers") == original.parseJson.asJsObject.fields("analyzers"))
+  }
+
+  test("parseIndexJson accepts object-valued charFilters, tokenizers and tokenFilters") {
+    val members =
+      """"charFilters": [{"@odata.type": "#Microsoft.Azure.Search.MappingCharFilter",
+        |  "name": "cf", "mappings": ["a=>b"]}],
+        |"tokenizers": [{"@odata.type": "#Microsoft.Azure.Search.KeywordTokenizerV2", "name": "kw"}],
+        |"tokenFilters": [{"@odata.type": "#Microsoft.Azure.Search.AsciiFoldingTokenFilter",
+        |  "name": "af", "preserveOriginal": true}]""".stripMargin
+    val info = parseIndexJson(indexJson(members))
+    assert(info.charFilters.exists(_.length == 1))
+    assert(info.tokenizers.exists(_.length == 1))
+    assert(info.tokenFilters.exists(_.length == 1))
+    assert(info.tokenFilters.get.head.asJsObject.fields("preserveOriginal") == JsTrue)
+  }
+
+  test("parseIndexJson accepts object-valued suggesters") {
+    val members =
+      """"suggesters": [{"name": "sg", "searchMode": "analyzingInfixMatching", "sourceFields": ["Id"]}]"""
+    val info = parseIndexJson(indexJson(members))
+    assert(info.suggesters.exists(_.length == 1))
+    assert(info.suggesters.get.head.asJsObject.fields("name") == JsString("sg"))
+  }
+
+  test("parseIndexJson accepts corsOptions, which the service returns as an object not an array") {
+    val members = """"corsOptions": {"allowedOrigins": ["*"], "maxAgeInSeconds": 300}"""
+    val info = parseIndexJson(indexJson(members))
+    assert(info.corsOptions.exists(_.asJsObject.fields("maxAgeInSeconds") == JsNumber(300)))
+  }
+
+  test("an index using every object-valued feature at once still parses") {
+    val members = Seq(
+      customAnalyzer,
+      """"charFilters": [{"@odata.type": "#Microsoft.Azure.Search.MappingCharFilter",
+        |  "name": "cf", "mappings": ["a=>b"]}]""".stripMargin,
+      """"tokenizers": [{"@odata.type": "#Microsoft.Azure.Search.KeywordTokenizerV2", "name": "kw"}]""",
+      """"tokenFilters": [{"@odata.type": "#Microsoft.Azure.Search.AsciiFoldingTokenFilter", "name": "af"}]""",
+      """"suggesters": [{"name": "sg", "searchMode": "analyzingInfixMatching", "sourceFields": ["Id"]}]""",
+      """"corsOptions": {"allowedOrigins": ["*"]}"""
+    ).mkString(", ")
+    val info = parseIndexJson(indexJson(members))
+    assert(info.fields.length == 1)
+    assert(info.analyzers.isDefined && info.charFilters.isDefined && info.tokenizers.isDefined)
+    assert(info.tokenFilters.isDefined && info.suggesters.isDefined && info.corsOptions.isDefined)
+  }
+
+  test("omitting the optional members leaves them empty rather than failing") {
+    val info = parseIndexJson(indexJson(""))
+    assert(info.analyzers.isEmpty)
+    assert(info.charFilters.isEmpty)
+    assert(info.tokenizers.isEmpty)
+    assert(info.tokenFilters.isEmpty)
+    assert(info.suggesters.isEmpty)
+    assert(info.corsOptions.isEmpty)
+  }
+}

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -844,6 +844,7 @@ jobs:
           com.microsoft.azure.synapse.ml.services.search.AddDocumentsHeaderPersistenceSuite
           com.microsoft.azure.synapse.ml.services.search.AzureSearchAuthSuite
           com.microsoft.azure.synapse.ml.services.search.AzureSearchGenericParamPersistenceSuite
+          com.microsoft.azure.synapse.ml.services.search.IndexSchemaLiveRoundTripSuite
           com.microsoft.azure.synapse.ml.services.search.IndexSchemaParsingSuite
           com.microsoft.azure.synapse.ml.services.speech.SpeechToTextSDKSecuritySuite
   steps:

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -844,6 +844,7 @@ jobs:
           com.microsoft.azure.synapse.ml.services.search.AddDocumentsHeaderPersistenceSuite
           com.microsoft.azure.synapse.ml.services.search.AzureSearchAuthSuite
           com.microsoft.azure.synapse.ml.services.search.AzureSearchGenericParamPersistenceSuite
+          com.microsoft.azure.synapse.ml.services.search.IndexSchemaParsingSuite
           com.microsoft.azure.synapse.ml.services.speech.SpeechToTextSDKSecuritySuite
   steps:
     - template: templates/sbt_cache.yml


### PR DESCRIPTION
## Why

Fixes #2143. An Azure AI Search index that uses a **custom analyzer** (or char filter, tokenizer, token filter, suggester, or CORS configuration) could not be written to *at all*:

```
spray.json.DeserializationException: Expected String as JsString, but got
{"@odata.type":"#Microsoft.Azure.Search.CustomAnalyzer","charFilters":[],
 "name":"keyword_analyzer","tokenFilters":["lowercase"],"tokenizer":"keyword_v2"}
```

Reported against 0.11.0 and still reproducible on `master`.

## Root cause

`IndexInfo` declared six members as `Option[Seq[String]]`, but the Search REST API returns **objects** for every one:

| Member | Declared | Actually returned |
|---|---|---|
| `suggesters` | `Option[Seq[String]]` | array of objects |
| `analyzers` | `Option[Seq[String]]` | array of objects |
| `charFilters` | `Option[Seq[String]]` | array of objects |
| `tokenizers` | `Option[Seq[String]]` | array of objects |
| `tokenFilters` | `Option[Seq[String]]` | array of objects |
| `corsOptions` | `Option[Seq[String]]` | a single object, not an array |

The right-hand column was confirmed against the live service, not inferred from the issue.

`IndexInfo` is deserialized twice from the caller's `indexJson`, both **before any document is sent** — `parseIndexJson(...).name.get` at the top of `createIfNoneExists`, and `validateIndexInfo`. So the write threw straight out of `AzureSearchWriter.write` regardless of `apiVersion` or whether the index already existed.

## The fix

Type the six members as opaque `JsValue`.

The writer never inspects them — it only round-trips them to the service — so `JsValue` is both sufficient and strictly more robust: it won't break again when the service adds a new analyzer or tokenizer kind. Same class of defect as the standing `TODO` about `synonymMaps`.

**In-repo compatibility:** nothing reads these fields (verified by grep), and the only construction site passes `None` for all six. Existing callers compile unchanged, and serialized output is byte-identical since `None` fields are omitted.

**⚠️ External breaking change (for release notes):** `IndexInfo` is a public case class returned by the public `IndexParser.parseIndexJson`, so retyping changes its `apply`/`copy`/accessor signatures. Real exposure is near zero — under the old typing *any* index carrying these features threw on read, so no working downstream code could have depended on the `Seq[String]` shape. There is no MiMa gate here, so CI won't flag it; noting it so it can be captured in the next release notes.

## Tests

**`IndexSchemaParsingSuite`** — 7 offline tests driven by the exact index definition from #2143: custom analyzer parses; custom analyzer survives parse → re-serialize **byte-identically** (the service rejects an analyzer it can't identify, so round-trip fidelity is the property that matters); object-valued `charFilters`/`tokenizers`/`tokenFilters` parse; object-valued `suggesters` parse; `corsOptions` parses as an object not an array; all six at once parse; omitting them yields empty rather than failure. **Every one fails on `master`** with `Expected String as JsString`.

**`IndexSchemaLiveRoundTripSuite`** — 1 end-to-end test. The offline suite asserts against hand-written JSON, so alone it proves the parser *accepts* these shapes, not that they're what the service *emits*. This creates a real index using all six features, reads it back through the same production `getIndexJsonFromExistingIndex` path the writer uses, parses it, and deletes the index in a `finally`. ~21s.

`pipeline.yaml` registers both in the `misc` leg — `PipelineTestCoverageSuite` fails the build otherwise, since nothing globs the `services.search` parent package.

## Proving it's a real fix, not a cosmetic retype

Reverting `AzureSearchSchemas.scala` fails at *compile* time (the tests use the new types), which shows type-safety but not the runtime bug. So a payload captured live from `mmlspark-azure-search` (API `2026-04-01`) was parsed through `parseIndexJson` alone under both schema versions:

| Schema | Result |
|---|---|
| `master`'s `Option[Seq[String]]` | `DeserializationException: Expected String as JsString, but got {"name":"sml_suggester",...}` — verbatim #2143 |
| this PR's `JsValue` | parses successfully |

Incidental finding worth recording: a suggester's `sourceFields` cannot reference a field using a **custom** analyzer — the service returns 400. The test points its suggester at a separate default-analyzer field.

## Validation

`IndexSchemaParsingSuite` 7/7 · `IndexSchemaLiveRoundTripSuite` passes live · `PipelineTestCoverageSuite` passes · `cognitive/scalastyle` + `Test/scalastyle` 0 errors · full ADO pipeline **77/77 green, 0 failures**, including the `UnitTests misc` leg that runs the live suite.

## Checklist

- [x] Tests added, including a live end-to-end test
- [x] No dependency changes
- [x] Bug fix, not a new feature — no website samples needed
