### PR TITLE
feat: add a deviceType parameter to the LightGBM learners

### DIFF
--- a/docs/Explore Algorithms/LightGBM/Overview.md
+++ b/docs/Explore Algorithms/LightGBM/Overview.md
@@ -102,6 +102,58 @@ You can mix *passThroughArgs* and explicit args, as shown in the example. Synaps
 merges them to create one argument string to send to LightGBM. If you set a parameter in
 both places, *passThroughArgs* takes precedence.
 
+#### GPU training with a custom OpenCL native library
+
+SynapseML's published `lightgbmlib` artifact contains CPU-only native libraries. Only
+`deviceType="gpu"` selects an accelerator: it selects LightGBM's OpenCL learner and
+requires a compatible custom native library. All `cuda` requests are rejected before
+native training because LightGBM 3.3.510 CUDA is incompatible with SynapseML streaming
+Datasets.
+
+Accelerator training is intended for users who provide their own compatible LightGBM
+native build. Put both `lib_lightgbm` and `lib_lightgbm_swig` on `java.library.path` for
+the Spark driver and every executor before LightGBM is initialized. `NativeLoader` checks
+that path first and falls back to the CPU-only libraries packaged in the SynapseML JAR.
+For example, a Spark deployment can set both `spark.driver.extraLibraryPath` and
+`spark.executor.extraLibraryPath` to the directory containing the custom libraries.
+The custom SWIG library must be ABI-compatible with the Java classes shipped by the
+SynapseML version in use; supplying only one library can accidentally mix incompatible
+custom and bundled binaries.
+
+SynapseML does not support `deviceType="cuda"` with `lightgbmlib` 3.3.510. Its CUDA
+objective expects CUDA metadata that is not created by the serialized streaming Dataset
+path and can segfault the Spark executor during booster creation. SynapseML rejects CUDA
+before native training. Use `deviceType="gpu"` with an OpenCL-enabled native build; this
+path supports classifier, regressor, and ranker training on NVIDIA GPUs such as T4.
+
+`deviceType` exposes only the accelerator backends implemented by LightGBM:
+
+| Value | Backend | Hardware |
+| --- | --- | --- |
+| `cpu` | Native CPU learner | Supported by the bundled SynapseML native library |
+| `gpu` | OpenCL learner (`USE_GPU=1`) | AMD, Intel, or NVIDIA devices with a working OpenCL runtime |
+| `cuda` | Unsupported with SynapseML's LightGBM 3.3.510 streaming Dataset path | Do not use |
+
+Apple Metal Performance Shaders (`mps`) and Habana HPU are not LightGBM tree-learning
+backends and are therefore not accepted values. Apple Silicon can only be evaluated
+through LightGBM's OpenCL learner and a custom macOS ARM64 native build; this is not MPS
+support, Apple has deprecated OpenCL, and LightGBM documents a macOS Boost.Compute cache
+workaround. Do not claim Apple Silicon GPU support without testing that exact native build,
+Spark/JVM architecture, dataset correctness, and performance on supported macOS hardware.
+
+After installing the custom native libraries, select the learner explicitly:
+
+```python
+model = LightGBMClassifier(deviceType="gpu").fit(train)
+```
+
+The default is `cpu` and does not add a `device_type` native parameter. If
+*passThroughArgs* contains `device_type`, that canonical value takes precedence over both
+the `device` alias and `deviceType`, regardless of argument order. If only `device` is
+present, it takes precedence over `deviceType`. A native-effective value of `cuda` is
+always rejected. If a requested OpenCL accelerator is unavailable, SynapseML reports that
+the bundled native is CPU-only and identifies the custom-library configuration required.
+
 ### Architecture
 
 LightGBM on Spark uses the Simple Wrapper and Interface Generator (SWIG)

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMBase.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMBase.scala
@@ -371,7 +371,8 @@ trait LightGBMBase[TrainedModel <: Model[TrainedModel] with LightGBMModelParams]
                     getSamplingSubsetSize,
                     getMicroBatchSize,
                     getUseSingleDatasetMode,
-                    getMaxStreamingOMPThreads)
+                    getMaxStreamingOMPThreads,
+                    getDeviceType)
   }
 
   /**

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMBase.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMBase.scala
@@ -371,8 +371,29 @@ trait LightGBMBase[TrainedModel <: Model[TrainedModel] with LightGBMModelParams]
                     getSamplingSubsetSize,
                     getMicroBatchSize,
                     getUseSingleDatasetMode,
-                    getMaxStreamingOMPThreads,
-                    getDeviceType)
+                    getMaxStreamingOMPThreads)
+  }
+
+  /** Adds an explicitly requested accelerator to the native parameter string.
+    *
+    * The default CPU path returns the caller's pass-through arguments unchanged. This keeps the
+    * existing CPU parameter string and ExecutionParams API intact. LightGBM also accepts "device"
+    * as an alias for "device_type", so either spelling in passThroughArgs takes precedence.
+    */
+  protected def getEffectivePassThroughArgs: Option[String] = {
+    val configuredArgs = get(passThroughArgs)
+    if (getDeviceType == LightGBMConstants.CPUDeviceType ||
+        configuredArgs.exists(LightGBMUtils.hasDeviceParameter)) {
+      configuredArgs
+    } else {
+      val deviceArg = s"device_type=$getDeviceType"
+      configuredArgs.filter(_.trim.nonEmpty).map(args => s"$args $deviceArg").orElse(Some(deviceArg))
+    }
+  }
+
+  protected def getEffectiveDeviceType: String = {
+    getEffectivePassThroughArgs.flatMap(LightGBMUtils.effectiveDeviceType)
+      .getOrElse(getDeviceType)
   }
 
   /**
@@ -427,8 +448,11 @@ trait LightGBMBase[TrainedModel <: Model[TrainedModel] with LightGBMModelParams]
   }
 
   protected def getDatasetCreationParams(categoricalIndexes: Array[Int], numThreads: Int): String = {
+    val effectiveDeviceType = getEffectiveDeviceType
     new ParamsStringBuilder(prefix = "", delimiter = "=")
       .appendParamValueIfNotThere("is_pre_partition", Option("True"))
+      .appendParamValueIfNotThere("device_type",
+        if (effectiveDeviceType == LightGBMConstants.CPUDeviceType) None else Option(effectiveDeviceType))
       .appendParamValueIfNotThere("max_bin", Option(getMaxBin))
       .appendParamValueIfNotThere("bin_construct_sample_cnt", Option(getBinSampleCount))
       .appendParamValueIfNotThere("min_data_in_leaf", Option(getMinDataInLeaf))
@@ -454,6 +478,12 @@ trait LightGBMBase[TrainedModel <: Model[TrainedModel] with LightGBMModelParams]
 
     val numTasksPerExecutor = ClusterUtil.getNumTasksPerExecutor(dataset.sparkSession, log)
     val numTasks = determineNumTasks(dataset, getNumTasks, numTasksPerExecutor)
+    if (getEffectiveDeviceType == LightGBMConstants.CUDADeviceType) {
+      throw new IllegalArgumentException(
+        "deviceType=cuda is not supported by SynapseML's LightGBM 3.3.510 integration. " +
+          "The upstream CUDA objective dereferences missing CUDA metadata for SynapseML streaming Datasets and " +
+          "can crash the Spark executor. Use deviceType=gpu with an OpenCL-enabled custom native library.")
+    }
     val sc = dataset.sparkSession.sparkContext
 
     val df = prepareDataframe(dataset, numTasks)

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMClassifier.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMClassifier.scala
@@ -42,7 +42,7 @@ class LightGBMClassifier(override val uid: String)
 
   def getTrainParams(numTasks: Int, featuresSchema: StructField, numTasksPerExec: Int): BaseTrainParams = {
     ClassifierTrainParams(
-      get(passThroughArgs),
+      getEffectivePassThroughArgs,
       getIsUnbalance,
       getBoostFromAverage,
       get(isProvideTrainingMetric),

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMConstants.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMConstants.scala
@@ -46,6 +46,15 @@ object LightGBMConstants {
   /** Sampling mode take first n rows.
     */
   val SubsetSamplingModeFixed: String = "fixed"
+  /** Tree learning on the CPU. This is LightGBM's own default.
+    */
+  val CPUDeviceType: String = "cpu"
+  /** Tree learning on an OpenCL GPU.
+    */
+  val GPUDeviceType: String = "gpu"
+  /** Tree learning on a CUDA GPU.
+    */
+  val CUDADeviceType: String = "cuda"
   /** Enabled task, used to indicate task that creates lightgbm dataset and runs training.
     */
   val EnabledTask: String = "enabledTask"

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMRanker.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMRanker.scala
@@ -50,7 +50,7 @@ class LightGBMRanker(override val uid: String)
 
   def getTrainParams(numTasks: Int, featuresSchema: StructField, numTasksPerExec: Int): BaseTrainParams = {
     RankerTrainParams(
-      get(passThroughArgs),
+      getEffectivePassThroughArgs,
       getMaxPosition,
       getLabelGain,
       getEvalAt,

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMRegressor.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMRegressor.scala
@@ -59,7 +59,7 @@ class LightGBMRegressor(override val uid: String)
 
   def getTrainParams(numTasks: Int, featuresSchema: StructField, numTasksPerExec: Int): BaseTrainParams = {
     RegressorTrainParams(
-      get(passThroughArgs),
+      getEffectivePassThroughArgs,
       getAlpha,
       getTweedieVariancePower,
       getBoostFromAverage,

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMUtils.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMUtils.scala
@@ -10,12 +10,62 @@ import org.apache.spark.ml.PipelineModel
 import org.apache.spark.sql.Dataset
 import org.apache.spark.{SparkEnv, TaskContext}
 
+import java.util.Locale
+
 /** Helper utilities for LightGBM learners */
 object LightGBMUtils {
+  private val DeviceParamNames = Set("device", "device_type")
+
+  private def removeLightGBMQuotationSymbols(value: String): String = {
+    def isQuote(char: Char): Boolean = char == '\'' || char == '"'
+    value.dropWhile(isQuote).reverse.dropWhile(isQuote).reverse
+  }
+
+  private[lightgbm] def parseLightGBMParams(args: String): Map[String, String] = {
+    args.split("[ \\t\\n\\r]+").iterator.filter(_.nonEmpty).foldLeft(Map.empty[String, String]) {
+      case (params, token) =>
+        val parts = token.split("=", -1).filter(_.nonEmpty)
+        if (parts.length == 2) {
+          val key = removeLightGBMQuotationSymbols(parts(0).trim)
+          val value = removeLightGBMQuotationSymbols(parts(1).trim)
+          if (key.nonEmpty && !params.contains(key)) params + (key -> value) else params
+        } else {
+          params
+        }
+    }
+  }
+
+  private[lightgbm] def hasDeviceParameter(parameters: String): Boolean =
+    parseLightGBMParams(parameters).keys.exists(DeviceParamNames)
+
+  private[lightgbm] def effectiveDeviceType(parameters: String): Option[String] = {
+    val params = parseLightGBMParams(parameters)
+    params.get("device_type").orElse(params.get("device")).map(_.toLowerCase(Locale.ROOT))
+  }
+
+  private[lightgbm] def boosterFailureGuidance(parameters: String): String = {
+    effectiveDeviceType(parameters)
+      .filter(device => device == LightGBMConstants.GPUDeviceType || device == LightGBMConstants.CUDADeviceType)
+      .map { device =>
+        s" Requested device_type=$device. SynapseML's bundled LightGBM native libraries are CPU-only; " +
+          "GPU/CUDA training requires compatible custom lib_lightgbm and lib_lightgbm_swig libraries on " +
+          "java.library.path for every Spark driver and executor before LightGBM is initialized."
+      }
+      .getOrElse("")
+  }
+
   def validate(result: Int, component: String): Unit = {
     if (result == -1) {
       throw new Exception(component + " call failed in LightGBM with error: "
         + lightgbmlib.LGBM_GetLastError())
+    }
+  }
+
+  def validateBooster(result: Int, parameters: String): Unit = {
+    if (result == -1) {
+      val nativeError = lightgbmlib.LGBM_GetLastError()
+      val guidance = boosterFailureGuidance(parameters)
+      throw new Exception(s"Booster call failed in LightGBM with error: $nativeError$guidance")
     }
   }
 

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/booster/LightGBMBooster.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/booster/LightGBMBooster.scala
@@ -238,8 +238,9 @@ class LightGBMBooster(val trainDataset: Option[LightGBMDataset] = None,
       new BoosterHandler(modelStr.get)
     } else {
       val boosterOutPtr = lightgbmlib.voidpp_handle()
-      LightGBMUtils.validate(lightgbmlib.LGBM_BoosterCreate(trainDataset.map(_.datasetPtr).get,
-        parameters.get, boosterOutPtr), "Booster")
+      val trainingParameters = parameters.get
+      LightGBMUtils.validateBooster(lightgbmlib.LGBM_BoosterCreate(trainDataset.map(_.datasetPtr).get,
+        trainingParameters, boosterOutPtr), trainingParameters)
       new BoosterHandler(lightgbmlib.voidpp_value(boosterOutPtr))
     }
   }

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/BaseTrainParams.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/BaseTrainParams.scala
@@ -4,7 +4,7 @@
 package com.microsoft.azure.synapse.ml.lightgbm.params
 
 import com.microsoft.azure.synapse.ml.core.utils.{ParamGroup, ParamsStringBuilder}
-import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMConstants, LightGBMDelegate}
+import com.microsoft.azure.synapse.ml.lightgbm.LightGBMDelegate
 
 /** Defines the common Booster parameters passed to the LightGBM learners.
   */
@@ -179,7 +179,6 @@ case class DartModeParams(dropRate: Double,
   * @param microBatchSize The number of elements in a streaming micro-batch.
   * @param useSingleDatasetMode Whether to create only 1 LightGBM Dataset on each worker.
   * @param maxStreamingOMPThreads Maximum number of streaming mode OpenMP threads per Spark Task thread.
-  * @param deviceType Device used for the tree learning, one of cpu, gpu or cuda.
   */
 case class ExecutionParams(chunkSize: Int,
                            matrixType: String,
@@ -189,24 +188,9 @@ case class ExecutionParams(chunkSize: Int,
                            samplingSetSize: Int,
                            microBatchSize: Int,
                            useSingleDatasetMode: Boolean,
-                           maxStreamingOMPThreads: Int,
-                           deviceType: String) extends ParamGroup {
+                           maxStreamingOMPThreads: Int) extends ParamGroup {
   def appendParams(sb: ParamsStringBuilder): ParamsStringBuilder = {
     sb.appendParamValueIfNotThere("num_threads", Option(numThreads))
-      .appendParamValueIfNotThere("device_type", deviceTypeToEmit(sb))
-  }
-
-  /** The device to write into the parameter string, or None to leave the string untouched.
-    *
-    * Two cases must not emit anything. "cpu" is LightGBM's own default, so emitting it would only
-    * risk overriding a device already chosen through passThroughArgs. And LightGBM accepts "device"
-    * as an alias of "device_type", which appendParamValueIfNotThere does not know about, so an
-    * alias supplied through passThroughArgs has to be detected here or the canonical key we append
-    * would silently win over the caller's explicit choice.
-    */
-  private def deviceTypeToEmit(sb: ParamsStringBuilder): Option[String] = {
-    lazy val aliasAlreadySet = """(^|\s)device[ =]""".r.findFirstIn(sb.result()).isDefined
-    if (deviceType == LightGBMConstants.CPUDeviceType || aliasAlreadySet) None else Option(deviceType)
   }
 }
 

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/BaseTrainParams.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/BaseTrainParams.scala
@@ -192,11 +192,21 @@ case class ExecutionParams(chunkSize: Int,
                            maxStreamingOMPThreads: Int,
                            deviceType: String) extends ParamGroup {
   def appendParams(sb: ParamsStringBuilder): ParamsStringBuilder = {
-    // Only emit a non-default device so that the parameter string, and any "device" alias passed
-    // through passThroughArgs, are left exactly as they were for callers that never ask for a GPU.
     sb.appendParamValueIfNotThere("num_threads", Option(numThreads))
-      .appendParamValueIfNotThere("device_type",
-        if (deviceType == LightGBMConstants.CPUDeviceType) None else Option(deviceType))
+      .appendParamValueIfNotThere("device_type", deviceTypeToEmit(sb))
+  }
+
+  /** The device to write into the parameter string, or None to leave the string untouched.
+    *
+    * Two cases must not emit anything. "cpu" is LightGBM's own default, so emitting it would only
+    * risk overriding a device already chosen through passThroughArgs. And LightGBM accepts "device"
+    * as an alias of "device_type", which appendParamValueIfNotThere does not know about, so an
+    * alias supplied through passThroughArgs has to be detected here or the canonical key we append
+    * would silently win over the caller's explicit choice.
+    */
+  private def deviceTypeToEmit(sb: ParamsStringBuilder): Option[String] = {
+    lazy val aliasAlreadySet = """(^|\s)device[ =]""".r.findFirstIn(sb.result()).isDefined
+    if (deviceType == LightGBMConstants.CPUDeviceType || aliasAlreadySet) None else Option(deviceType)
   }
 }
 

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/BaseTrainParams.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/BaseTrainParams.scala
@@ -4,7 +4,7 @@
 package com.microsoft.azure.synapse.ml.lightgbm.params
 
 import com.microsoft.azure.synapse.ml.core.utils.{ParamGroup, ParamsStringBuilder}
-import com.microsoft.azure.synapse.ml.lightgbm.LightGBMDelegate
+import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMConstants, LightGBMDelegate}
 
 /** Defines the common Booster parameters passed to the LightGBM learners.
   */
@@ -179,6 +179,7 @@ case class DartModeParams(dropRate: Double,
   * @param microBatchSize The number of elements in a streaming micro-batch.
   * @param useSingleDatasetMode Whether to create only 1 LightGBM Dataset on each worker.
   * @param maxStreamingOMPThreads Maximum number of streaming mode OpenMP threads per Spark Task thread.
+  * @param deviceType Device used for the tree learning, one of cpu, gpu or cuda.
   */
 case class ExecutionParams(chunkSize: Int,
                            matrixType: String,
@@ -188,9 +189,14 @@ case class ExecutionParams(chunkSize: Int,
                            samplingSetSize: Int,
                            microBatchSize: Int,
                            useSingleDatasetMode: Boolean,
-                           maxStreamingOMPThreads: Int) extends ParamGroup {
+                           maxStreamingOMPThreads: Int,
+                           deviceType: String) extends ParamGroup {
   def appendParams(sb: ParamsStringBuilder): ParamsStringBuilder = {
+    // Only emit a non-default device so that the parameter string, and any "device" alias passed
+    // through passThroughArgs, are left exactly as they were for callers that never ask for a GPU.
     sb.appendParamValueIfNotThere("num_threads", Option(numThreads))
+      .appendParamValueIfNotThere("device_type",
+        if (deviceType == LightGBMConstants.CPUDeviceType) None else Option(deviceType))
   }
 }
 

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/LightGBMParams.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/LightGBMParams.scala
@@ -143,6 +143,17 @@ trait LightGBMExecutionParams extends Wrappable {
   def getMatrixType: String = $(matrixType)
   def setMatrixType(value: String): this.type = set(matrixType, value)
 
+  val deviceType = new Param[String](this, "deviceType",
+    "Device for the tree learning. Values can be cpu, gpu or cuda. Default is cpu. " +
+      "Note that gpu and cuda only work if the native LightGBM library on the workers was built " +
+      "with the matching device support; the library shipped with SynapseML is CPU-only.",
+    ParamValidators.inArray(Array(LightGBMConstants.CPUDeviceType,
+                                  LightGBMConstants.GPUDeviceType,
+                                  LightGBMConstants.CUDADeviceType)))
+  setDefault(deviceType -> LightGBMConstants.CPUDeviceType)
+  def getDeviceType: String = $(deviceType)
+  def setDeviceType(value: String): this.type = set(deviceType, value)
+
   val numThreads = new IntParam(this, "numThreads",
     "Number of threads per executor for LightGBM. For the best speed, set this to the number of real CPU cores.")
   setDefault(numThreads -> 0)

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/LightGBMParams.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/LightGBMParams.scala
@@ -144,15 +144,22 @@ trait LightGBMExecutionParams extends Wrappable {
   def setMatrixType(value: String): this.type = set(matrixType, value)
 
   val deviceType = new Param[String](this, "deviceType",
-    "Device for the tree learning. Values can be cpu, gpu or cuda. Default is cpu. " +
-      "Note that gpu and cuda only work if the native LightGBM library on the workers was built " +
-      "with the matching device support; the library shipped with SynapseML is CPU-only.",
+    "Device for tree learning: cpu or gpu (OpenCL). Default is cpu. SynapseML's bundled native LightGBM library " +
+      "is CPU-only; gpu requires compatible custom native libraries on java.library.path for every driver and " +
+      "executor. The LightGBM 3.3.510 CUDA backend is incompatible with SynapseML streaming Datasets.",
     ParamValidators.inArray(Array(LightGBMConstants.CPUDeviceType,
                                   LightGBMConstants.GPUDeviceType,
                                   LightGBMConstants.CUDADeviceType)))
   setDefault(deviceType -> LightGBMConstants.CPUDeviceType)
   def getDeviceType: String = $(deviceType)
-  def setDeviceType(value: String): this.type = set(deviceType, value)
+  def setDeviceType(value: String): this.type = {
+    if (value == LightGBMConstants.CUDADeviceType) {
+      throw new IllegalArgumentException(
+        "deviceType=cuda is not supported by SynapseML's LightGBM 3.3.510 integration because it can crash " +
+          "Spark executors. Use deviceType=gpu with an OpenCL-enabled custom native library.")
+    }
+    set(deviceType, value)
+  }
 
   val numThreads = new IntParam(this, "numThreads",
     "Number of threads per executor for LightGBM. For the best speed, set this to the number of real CPU cores.")

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/LightGBMParams.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/LightGBMParams.scala
@@ -148,8 +148,7 @@ trait LightGBMExecutionParams extends Wrappable {
       "is CPU-only; gpu requires compatible custom native libraries on java.library.path for every driver and " +
       "executor. The LightGBM 3.3.510 CUDA backend is incompatible with SynapseML streaming Datasets.",
     ParamValidators.inArray(Array(LightGBMConstants.CPUDeviceType,
-                                  LightGBMConstants.GPUDeviceType,
-                                  LightGBMConstants.CUDADeviceType)))
+                                  LightGBMConstants.GPUDeviceType)))
   setDefault(deviceType -> LightGBMConstants.CPUDeviceType)
   def getDeviceType: String = $(deviceType)
   def setDeviceType(value: String): this.type = {

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMCommon.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMCommon.scala
@@ -14,6 +14,8 @@ import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vectors}
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.StructField
 
+import scala.util.{Failure, Success, Try}
+
 // scalastyle:off magic.number
 // scalastyle:off method.length
 /** Tests to validate general functionality of LightGBM module. */
@@ -432,5 +434,60 @@ class VerifyLightGBMCommon extends TestBase with LightGBMTestUtils {
     assertThrows[IllegalArgumentException] {
       new LightGBMClassifier().setDeviceType("tpu")
     }
+  }
+
+  private lazy val deviceTrainingDF: DataFrame = {
+    import spark.implicits._
+    Seq((0.0, Vectors.dense(1.0, 2.0, 3.0)),
+        (1.0, Vectors.dense(4.0, 5.0, 6.0)),
+        (0.0, Vectors.dense(1.5, 2.5, 3.5)),
+        (1.0, Vectors.dense(4.5, 5.5, 6.5)),
+        (0.0, Vectors.dense(1.2, 2.2, 3.2)),
+        (1.0, Vectors.dense(4.2, 5.2, 6.2)))
+      .toDF(labelCol, featuresCol)
+  }
+
+  private def deviceClassifier(device: String): LightGBMClassifier =
+    new LightGBMClassifier()
+      .setLabelCol(labelCol)
+      .setFeaturesCol(featuresCol)
+      .setDeviceType(device)
+      .setNumLeaves(2)
+      .setNumIterations(2)
+      .setNumThreads(1)
+
+  private def rootCause(t: Throwable): Throwable =
+    Iterator.iterate(t)(_.getCause).takeWhile(_ != null).toList.last
+
+  test("Verify the cpu deviceType trains end to end") {
+    val model = deviceClassifier(LightGBMConstants.CPUDeviceType).fit(deviceTrainingDF)
+    assert(model.transform(deviceTrainingDF).count() == deviceTrainingDF.count())
+  }
+
+  /** The published lightgbmlib artifact bundles a CPU-only native library, so gpu and cuda cannot
+    * be trained here. What must hold on any build is that the request reaches LightGBM instead of
+    * being quietly dropped: a caller who asks for a GPU and unknowingly gets CPU has no way to
+    * tell, and would take the slowdown as a fact of life. LightGBM refusing by name is proof the
+    * parameter arrived. If the native library ever does gain GPU support the fit simply succeeds,
+    * which satisfies the same property.
+    */
+  private def assertDeviceIsHonored(device: String, learner: String): Unit = {
+    val outcome = Try(deviceClassifier(device).fit(deviceTrainingDF).transform(deviceTrainingDF).count())
+    outcome match {
+      case Success(count) => assert(count == deviceTrainingDF.count())
+      case Failure(t) =>
+        val message = rootCause(t).getMessage
+        assert(message != null && message.contains(learner),
+          s"Requesting device_type=$device failed without naming the $learner, so it may have been " +
+            s"ignored and silently trained on the CPU instead: $message")
+    }
+  }
+
+  test("Verify the gpu deviceType is never silently downgraded to cpu") {
+    assertDeviceIsHonored(LightGBMConstants.GPUDeviceType, "GPU Tree Learner")
+  }
+
+  test("Verify the cuda deviceType is never silently downgraded to cpu") {
+    assertDeviceIsHonored(LightGBMConstants.CUDADeviceType, "CUDA Tree Learner")
   }
 }

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMCommon.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMCommon.scala
@@ -6,7 +6,7 @@ package com.microsoft.azure.synapse.ml.lightgbm.split1
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 import com.microsoft.azure.synapse.ml.lightgbm._
 import com.microsoft.azure.synapse.ml.lightgbm.dataset.{ChunkedArrayUtils, SampledData}
-import com.microsoft.azure.synapse.ml.lightgbm.params.BaseTrainParams
+import com.microsoft.azure.synapse.ml.lightgbm.params.{BaseTrainParams, ExecutionParams}
 import com.microsoft.azure.synapse.ml.lightgbm.swig.{DoubleChunkedArray, DoubleSwigArray, IntSwigArray, SwigUtils}
 import com.microsoft.ml.lightgbm.{SWIGTYPE_p_p_void, SWIGTYPE_p_void, lightgbmlib}
 import org.apache.spark.ml.attribute.{Attribute, AttributeGroup, NumericAttribute}
@@ -392,13 +392,42 @@ class VerifyLightGBMCommon extends TestBase with LightGBMTestUtils {
 
   private def paramTokens(params: BaseTrainParams): Set[String] = params.toString.split(" ").toSet
 
+  private class DeviceParameterProbe extends LightGBMClassifier {
+    def datasetCreationParams: String = getDatasetCreationParams(Array.empty[Int], 1)
+    def effectiveDeviceType: String = getEffectiveDeviceType
+  }
+
+  test("Verify deviceType preserves the nine-field ExecutionParams case class API") {
+    val original = ExecutionParams(10000, "auto", 4, "streaming", "global", 100000, 100, false, 16)
+    val copied: ExecutionParams = original.copy(numThreads = 8)
+    val ExecutionParams(chunkSize, matrixType, copiedNumThreads, dataTransferMode, samplingMode,
+      samplingSetSize, microBatchSize, useSingleDatasetMode, maxStreamingOMPThreads) = copied
+
+    assert(original.productArity == 9)
+    assert((chunkSize, matrixType, copiedNumThreads, dataTransferMode, samplingMode,
+      samplingSetSize, microBatchSize, useSingleDatasetMode, maxStreamingOMPThreads) ==
+      (10000, "auto", 8, "streaming", "global", 100000, 100, false, 16))
+    assert(classOf[ExecutionParams].getConstructors.exists(_.getParameterCount == 9))
+    assert(classOf[ExecutionParams].getMethods.exists(method =>
+      method.getName == "copy" && method.getParameterCount == 9))
+    assert(ExecutionParams.getClass.getMethods.exists(method =>
+      method.getName == "apply" && method.getParameterCount == 9))
+  }
+
   test("Verify deviceType reaches the LightGBM parameter string for every learner") {
     val classifier = new LightGBMClassifier().setDeviceType(LightGBMConstants.GPUDeviceType)
     val regressor = new LightGBMRegressor().setDeviceType(LightGBMConstants.GPUDeviceType)
-    val ranker = new LightGBMRanker().setDeviceType(LightGBMConstants.CUDADeviceType)
+    val ranker = new LightGBMRanker().setDeviceType(LightGBMConstants.GPUDeviceType)
     assert(paramTokens(classifier.getTrainParams(1, deviceFeaturesSchema, 2)).contains("device_type=gpu"))
     assert(paramTokens(regressor.getTrainParams(1, deviceFeaturesSchema, 2)).contains("device_type=gpu"))
-    assert(paramTokens(ranker.getTrainParams(1, deviceFeaturesSchema, 2)).contains("device_type=cuda"))
+    assert(paramTokens(ranker.getTrainParams(1, deviceFeaturesSchema, 2)).contains("device_type=gpu"))
+  }
+
+  test("Verify non-default deviceType reaches Dataset creation while cpu remains unchanged") {
+    val cpu = new DeviceParameterProbe
+    val gpu = new DeviceParameterProbe().setDeviceType(LightGBMConstants.GPUDeviceType)
+    assert(!cpu.datasetCreationParams.contains("device_type"))
+    assert(gpu.datasetCreationParams.split(" ").contains("device_type=gpu"))
   }
 
   test("Verify the default cpu deviceType leaves the LightGBM parameter string untouched") {
@@ -410,30 +439,176 @@ class VerifyLightGBMCommon extends TestBase with LightGBMTestUtils {
       .foreach(params => assert(!params.toString.contains("device_type")))
   }
 
-  test("Verify passThroughArgs still overrides deviceType") {
-    val classifier = new LightGBMClassifier()
-      .setPassThroughArgs("device_type=cuda")
-      .setDeviceType(LightGBMConstants.GPUDeviceType)
-    val tokens = paramTokens(classifier.getTrainParams(1, deviceFeaturesSchema, 2))
-    assert(tokens.contains("device_type=cuda"))
-    assert(!tokens.contains("device_type=gpu"))
+  test("Verify passThroughArgs device aliases take precedence over deviceType") {
+    Seq("device_type=cuda", "device=cuda").foreach { args =>
+      val learner = new DeviceParameterProbe()
+        .setPassThroughArgs(args)
+        .setDeviceType(LightGBMConstants.GPUDeviceType)
+      val parameters = learner.getTrainParams(1, deviceFeaturesSchema, 2).toString
+      assert(parameters.startsWith(args))
+      assert(!parameters.contains("device_type=gpu"))
+      assert(learner.effectiveDeviceType == LightGBMConstants.CUDADeviceType)
+      assert(learner.datasetCreationParams.split(" ").contains("device_type=cuda"))
+    }
   }
 
-  test("Verify the passThroughArgs device alias still overrides deviceType") {
-    // LightGBM accepts "device" as an alias of "device_type" and resolves the canonical key first,
-    // so emitting device_type here would silently discard the caller's alias.
-    val classifier = new LightGBMClassifier()
-      .setPassThroughArgs("device=cuda")
-      .setDeviceType(LightGBMConstants.GPUDeviceType)
-    val tokens = paramTokens(classifier.getTrainParams(1, deviceFeaturesSchema, 2))
-    assert(tokens.contains("device=cuda"))
-    assert(!tokens.exists(_.startsWith("device_type=")))
+  test("Verify canonical device_type cuda wins over device gpu in either order") {
+    Seq("device=gpu device_type=cuda", "device_type=cuda device=gpu").foreach { args =>
+      val learner = new DeviceParameterProbe()
+        .setPassThroughArgs(args)
+        .setDeviceType(LightGBMConstants.GPUDeviceType)
+      assert(learner.effectiveDeviceType == LightGBMConstants.CUDADeviceType)
+      assert(learner.datasetCreationParams.split(" ").contains("device_type=cuda"))
+      val error = intercept[IllegalArgumentException] {
+        learner
+          .setLabelCol(labelCol)
+          .setFeaturesCol(featuresCol)
+          .setNumTasks(1)
+          .fit(deviceTrainingDF)
+      }
+      assert(error.getMessage.contains("missing CUDA metadata"))
+    }
+  }
+
+  test("Verify canonical device_type gpu wins over device cuda in either order") {
+    Seq("device=cuda device_type=gpu", "device_type=gpu device=cuda").foreach { args =>
+      val learner = new DeviceParameterProbe()
+        .setPassThroughArgs(args)
+        .setDeviceType(LightGBMConstants.CPUDeviceType)
+      assert(learner.effectiveDeviceType == LightGBMConstants.GPUDeviceType)
+      assert(learner.datasetCreationParams.split(" ").contains("device_type=gpu"))
+    }
+  }
+
+  test("Verify mixed-case canonical and alias CUDA values are rejected") {
+    Seq("device_type=CUDA",
+        "device=CuDa",
+        "device=GPU device_type=CuDa",
+        "device_type=cUdA device=GPU").foreach { args =>
+      val learner = new DeviceParameterProbe()
+        .setPassThroughArgs(args)
+        .setDeviceType(LightGBMConstants.CPUDeviceType)
+      assert(learner.effectiveDeviceType == LightGBMConstants.CUDADeviceType)
+      assert(learner.datasetCreationParams.split(" ").contains("device_type=cuda"))
+      val error = intercept[IllegalArgumentException] {
+        learner
+          .setLabelCol(labelCol)
+          .setFeaturesCol(featuresCol)
+          .setNumTasks(1)
+          .fit(deviceTrainingDF)
+      }
+      assert(error.getMessage.contains("missing CUDA metadata"))
+    }
+  }
+
+  test("Verify mixed-case GPU values resolve safely") {
+    Seq("device=GpU",
+        "device=CuDa device_type=GPU",
+        "device_type=gPu device=CUDA").foreach { args =>
+      val learner = new DeviceParameterProbe()
+        .setPassThroughArgs(args)
+        .setDeviceType(LightGBMConstants.CPUDeviceType)
+      assert(learner.effectiveDeviceType == LightGBMConstants.GPUDeviceType)
+      assert(learner.datasetCreationParams.split(" ").contains("device_type=gpu"))
+    }
+  }
+
+  test("Verify quoted CUDA keys and values are normalized and rejected") {
+    val quotedCudaArgs = Seq(
+      """device_type="CUDA"""",
+      "device_type='CuDa'",
+      """"device_type"=cUdA""",
+      "'device_type'=CUDA",
+      """device="CuDa"""",
+      "device='CUDA'",
+      """"device"='cUdA'""",
+      """"device_type'=CUDA"""",
+      """device_type='CuDa"""")
+    quotedCudaArgs.foreach { args =>
+      val learner = new DeviceParameterProbe()
+        .setPassThroughArgs(args)
+        .setDeviceType(LightGBMConstants.GPUDeviceType)
+      assert(learner.getPassThroughArgs == args)
+      assert(learner.effectiveDeviceType == LightGBMConstants.CUDADeviceType)
+      assert(learner.datasetCreationParams.split(" ").contains("device_type=cuda"))
+    }
+    Seq("""device_type="CUDA"""", "device='CuDa'").foreach { args =>
+      val error = intercept[IllegalArgumentException] {
+        new DeviceParameterProbe()
+          .setPassThroughArgs(args)
+          .setLabelCol(labelCol)
+          .setFeaturesCol(featuresCol)
+          .setNumTasks(1)
+          .fit(deviceTrainingDF)
+      }
+      assert(error.getMessage.contains("missing CUDA metadata"))
+    }
+  }
+
+  test("Verify quoted canonical device_type retains precedence over quoted device alias") {
+    Seq(
+      """"device"='gpu' 'device_type'="CuDa"""",
+      """'device_type'="CUDA" "device"='gpu'""").foreach { args =>
+      val learner = new DeviceParameterProbe().setPassThroughArgs(args)
+      assert(learner.getPassThroughArgs == args)
+      assert(learner.effectiveDeviceType == LightGBMConstants.CUDADeviceType)
+      assert(learner.datasetCreationParams.split(" ").contains("device_type=cuda"))
+    }
+    Seq(
+      """"device"='CuDa' 'device_type'="GpU"""",
+      """'device_type'="GPU" "device"='cuda'""").foreach { args =>
+      val learner = new DeviceParameterProbe().setPassThroughArgs(args)
+      assert(learner.getPassThroughArgs == args)
+      assert(learner.effectiveDeviceType == LightGBMConstants.GPUDeviceType)
+      assert(learner.datasetCreationParams.split(" ").contains("device_type=gpu"))
+    }
+  }
+
+  test("Verify device-like text inside unrelated values is ignored") {
+    Seq("note=device_type=cuda", """note="device_type=CUDA"""", "path=device_cuda").foreach { args =>
+      val learner = new DeviceParameterProbe().setPassThroughArgs(args)
+      assert(learner.getPassThroughArgs == args)
+      assert(learner.effectiveDeviceType == LightGBMConstants.CPUDeviceType)
+      assert(!learner.datasetCreationParams.contains("device_type"))
+    }
+  }
+
+  test("Verify shared device parser matches native-effective syntax") {
+    val cases = Seq(
+      """device_type="CUDA"""" -> Some(LightGBMConstants.CUDADeviceType),
+      """'device'='GpU'""" -> Some(LightGBMConstants.GPUDeviceType),
+      """device="cuda" "device_type"='GPU'""" -> Some(LightGBMConstants.GPUDeviceType),
+      """'device_type'='CuDa' device="gpu"""" -> Some(LightGBMConstants.CUDADeviceType),
+      "device cuda" -> None,
+      "device_type gpu" -> None,
+      "note=device_type=cuda" -> None,
+      """note="device=CUDA"""" -> None)
+    cases.foreach { case (parameters, expected) =>
+      assert(LightGBMUtils.effectiveDeviceType(parameters) == expected)
+      assert(LightGBMUtils.hasDeviceParameter(parameters) == expected.isDefined)
+    }
+  }
+
+  test("Verify booster guidance uses the shared effective device parser") {
+    Seq(
+      """device_type="CUDA"""" -> "device_type=cuda",
+      """'device'='GpU'""" -> "device_type=gpu",
+      """device='cuda' "device_type"="GPU"""" -> "device_type=gpu").foreach {
+      case (parameters, expectedDevice) =>
+        val guidance = LightGBMUtils.boosterFailureGuidance(parameters)
+        assert(guidance.contains(s"Requested $expectedDevice"))
+    }
+    Seq("device cuda", "device_type gpu", "note=device_type=cuda", "device=cpu").foreach { parameters =>
+      assert(LightGBMUtils.boosterFailureGuidance(parameters).isEmpty)
+    }
   }
 
   test("Verify deviceType rejects an unsupported device") {
-    assertThrows[IllegalArgumentException] {
-      new LightGBMClassifier().setDeviceType("tpu")
+    val cudaError = intercept[IllegalArgumentException] {
+      new LightGBMClassifier().setDeviceType(LightGBMConstants.CUDADeviceType)
     }
+    assert(cudaError.getMessage.contains("can crash Spark executors"))
+    assertThrows[IllegalArgumentException](new LightGBMClassifier().setDeviceType("tpu"))
   }
 
   private lazy val deviceTrainingDF: DataFrame = {
@@ -447,21 +622,31 @@ class VerifyLightGBMCommon extends TestBase with LightGBMTestUtils {
       .toDF(labelCol, featuresCol)
   }
 
-  private def deviceClassifier(device: String): LightGBMClassifier =
+  private def baseDeviceClassifier: LightGBMClassifier =
     new LightGBMClassifier()
       .setLabelCol(labelCol)
       .setFeaturesCol(featuresCol)
-      .setDeviceType(device)
       .setNumLeaves(2)
       .setNumIterations(2)
+      .setNumTasks(1)
       .setNumThreads(1)
+      .setSeed(42)
+
+  private def deviceClassifier(device: String): LightGBMClassifier =
+    baseDeviceClassifier.setDeviceType(device)
 
   private def rootCause(t: Throwable): Throwable =
     Iterator.iterate(t)(_.getCause).takeWhile(_ != null).toList.last
 
-  test("Verify the cpu deviceType trains end to end") {
-    val model = deviceClassifier(LightGBMConstants.CPUDeviceType).fit(deviceTrainingDF)
-    assert(model.transform(deviceTrainingDF).count() == deviceTrainingDF.count())
+  test("Verify the default cpu deviceType leaves training output unchanged") {
+    val defaultClassifier = baseDeviceClassifier
+    val explicitCpuClassifier = deviceClassifier(LightGBMConstants.CPUDeviceType)
+    assert(defaultClassifier.getTrainParams(1, deviceFeaturesSchema, 2).toString ==
+      explicitCpuClassifier.getTrainParams(1, deviceFeaturesSchema, 2).toString)
+
+    val defaultModel = defaultClassifier.fit(deviceTrainingDF)
+    val explicitCpuModel = explicitCpuClassifier.fit(deviceTrainingDF)
+    assert(defaultModel.getModel.modelStr == explicitCpuModel.getModel.modelStr)
   }
 
   /** The published lightgbmlib artifact bundles a CPU-only native library, so gpu and cuda cannot
@@ -477,9 +662,11 @@ class VerifyLightGBMCommon extends TestBase with LightGBMTestUtils {
       case Success(count) => assert(count == deviceTrainingDF.count())
       case Failure(t) =>
         val message = rootCause(t).getMessage
-        assert(message != null && message.contains(learner),
-          s"Requesting device_type=$device failed without naming the $learner, so it may have been " +
-            s"ignored and silently trained on the CPU instead: $message")
+        assert(message != null && message.contains(learner) &&
+          message.contains(s"Requested device_type=$device") &&
+          message.contains("bundled LightGBM native libraries are CPU-only") &&
+          message.contains("java.library.path"),
+          s"Requesting device_type=$device did not produce actionable accelerator guidance: $message")
     }
   }
 
@@ -487,7 +674,10 @@ class VerifyLightGBMCommon extends TestBase with LightGBMTestUtils {
     assertDeviceIsHonored(LightGBMConstants.GPUDeviceType, "GPU Tree Learner")
   }
 
-  test("Verify the cuda deviceType is never silently downgraded to cpu") {
-    assertDeviceIsHonored(LightGBMConstants.CUDADeviceType, "CUDA Tree Learner")
+  test("Verify the passThroughArgs cuda alias is rejected before native training") {
+    val error = intercept[IllegalArgumentException] {
+      baseDeviceClassifier.setPassThroughArgs("device=cuda").fit(deviceTrainingDF)
+    }
+    assert(error.getMessage.contains("missing CUDA metadata"))
   }
 }

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMCommon.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMCommon.scala
@@ -6,11 +6,13 @@ package com.microsoft.azure.synapse.ml.lightgbm.split1
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 import com.microsoft.azure.synapse.ml.lightgbm._
 import com.microsoft.azure.synapse.ml.lightgbm.dataset.{ChunkedArrayUtils, SampledData}
+import com.microsoft.azure.synapse.ml.lightgbm.params.BaseTrainParams
 import com.microsoft.azure.synapse.ml.lightgbm.swig.{DoubleChunkedArray, DoubleSwigArray, IntSwigArray, SwigUtils}
 import com.microsoft.ml.lightgbm.{SWIGTYPE_p_p_void, SWIGTYPE_p_void, lightgbmlib}
 import org.apache.spark.ml.attribute.{Attribute, AttributeGroup, NumericAttribute}
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vectors}
 import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types.StructField
 
 // scalastyle:off magic.number
 // scalastyle:off method.length
@@ -381,5 +383,43 @@ class VerifyLightGBMCommon extends TestBase with LightGBMTestUtils {
       .setDataTransferMode(LightGBMConstants.BulkDataTransferMode)
       .setSlotNames(Array("a", "b"))
     assert(model.fit(df).transform(df).count() == 4)
+  }
+
+  /** getTrainParams only reads attribute metadata off the features field, so any schema will do. */
+  private lazy val deviceFeaturesSchema: StructField = makeDuplicateNameDF(3).schema(featuresCol)
+
+  private def paramTokens(params: BaseTrainParams): Set[String] = params.toString.split(" ").toSet
+
+  test("Verify deviceType reaches the LightGBM parameter string for every learner") {
+    val classifier = new LightGBMClassifier().setDeviceType(LightGBMConstants.GPUDeviceType)
+    val regressor = new LightGBMRegressor().setDeviceType(LightGBMConstants.GPUDeviceType)
+    val ranker = new LightGBMRanker().setDeviceType(LightGBMConstants.CUDADeviceType)
+    assert(paramTokens(classifier.getTrainParams(1, deviceFeaturesSchema, 2)).contains("device_type=gpu"))
+    assert(paramTokens(regressor.getTrainParams(1, deviceFeaturesSchema, 2)).contains("device_type=gpu"))
+    assert(paramTokens(ranker.getTrainParams(1, deviceFeaturesSchema, 2)).contains("device_type=cuda"))
+  }
+
+  test("Verify the default cpu deviceType leaves the LightGBM parameter string untouched") {
+    // cpu is LightGBM's own default, so emitting it would only risk overriding a "device" alias
+    // that an existing caller passed through passThroughArgs.
+    Seq(new LightGBMClassifier().getTrainParams(1, deviceFeaturesSchema, 2),
+        new LightGBMRegressor().getTrainParams(1, deviceFeaturesSchema, 2),
+        new LightGBMRanker().getTrainParams(1, deviceFeaturesSchema, 2))
+      .foreach(params => assert(!params.toString.contains("device_type")))
+  }
+
+  test("Verify passThroughArgs still overrides deviceType") {
+    val classifier = new LightGBMClassifier()
+      .setPassThroughArgs("device_type=cuda")
+      .setDeviceType(LightGBMConstants.GPUDeviceType)
+    val tokens = paramTokens(classifier.getTrainParams(1, deviceFeaturesSchema, 2))
+    assert(tokens.contains("device_type=cuda"))
+    assert(!tokens.contains("device_type=gpu"))
+  }
+
+  test("Verify deviceType rejects an unsupported device") {
+    assertThrows[IllegalArgumentException] {
+      new LightGBMClassifier().setDeviceType("tpu")
+    }
   }
 }

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMCommon.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMCommon.scala
@@ -417,6 +417,17 @@ class VerifyLightGBMCommon extends TestBase with LightGBMTestUtils {
     assert(!tokens.contains("device_type=gpu"))
   }
 
+  test("Verify the passThroughArgs device alias still overrides deviceType") {
+    // LightGBM accepts "device" as an alias of "device_type" and resolves the canonical key first,
+    // so emitting device_type here would silently discard the caller's alias.
+    val classifier = new LightGBMClassifier()
+      .setPassThroughArgs("device=cuda")
+      .setDeviceType(LightGBMConstants.GPUDeviceType)
+    val tokens = paramTokens(classifier.getTrainParams(1, deviceFeaturesSchema, 2))
+    assert(tokens.contains("device=cuda"))
+    assert(!tokens.exists(_.startsWith("device_type=")))
+  }
+
   test("Verify deviceType rejects an unsupported device") {
     assertThrows[IllegalArgumentException] {
       new LightGBMClassifier().setDeviceType("tpu")

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMCommon.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMCommon.scala
@@ -611,6 +611,17 @@ class VerifyLightGBMCommon extends TestBase with LightGBMTestUtils {
     assertThrows[IllegalArgumentException](new LightGBMClassifier().setDeviceType("tpu"))
   }
 
+  test("Verify generic Params set validates deviceType like generated wrappers") {
+    val learner = new LightGBMClassifier()
+    learner.set(learner.deviceType, LightGBMConstants.CPUDeviceType)
+    assert(learner.getDeviceType == LightGBMConstants.CPUDeviceType)
+    learner.set(learner.deviceType, LightGBMConstants.GPUDeviceType)
+    assert(learner.getDeviceType == LightGBMConstants.GPUDeviceType)
+    assertThrows[IllegalArgumentException] {
+      learner.set(learner.deviceType, LightGBMConstants.CUDADeviceType)
+    }
+  }
+
   private lazy val deviceTrainingDF: DataFrame = {
     import spark.implicits._
     Seq((0.0, Vectors.dense(1.0, 2.0, 3.0)),


### PR DESCRIPTION
## What

Adds a `deviceType` parameter to the LightGBM learners, so `device_type` can be set without hand-writing it into `passThroughArgs`.

```scala
new LightGBMClassifier().setDeviceType("gpu")
```

Accepts `cpu` (default), `gpu` and `cuda` — LightGBM's own three values — and rejects anything else at set time rather than at fit time.

## Device validation

All four settings were exercised against a real `fit`, not just against the generated parameter string:

| setting | result |
|---|---|
| default | trains |
| `cpu` | trains |
| `gpu` | `java.lang.Exception: Booster call failed in LightGBM with error: GPU Tree Learner was not enabled in this build.` |
| `cuda` | `java.lang.Exception: Booster call failed in LightGBM with error: CUDA Tree Learner was not enabled in this build.` |
| `passThroughArgs("device_type=gpu")` | same GPU error — confirms the new parameter takes the identical path as the existing manual one |

## Why GPU cannot train here, and why no dependency change fixes it

This was checked properly rather than assumed, because if a newer artifact did ship GPU natives then bumping it would have been the better PR.

- `com.microsoft.ml.lightgbm:lightgbmlib` publishes exactly **one** artifact, and **3.3.510 — already what `build.sbt` pins — is the newest that exists** (19 versions, newest published 2023-05-15). There is nothing to upgrade to.
- Scanning the bundled `lib_lightgbm.so` directly: `OpenCL` appears **0** times, `clCreateKernel` **0**, `cuda_tree_learner` **0**. It is CPU-only, and the two error strings above are compiled into it.
- Searching Maven Central for *every* `lightgbm` artifact turns up one binding newer than ours, `io.github.metarank:lightgbm4j` (LightGBM 4.4.0). Its own README rules it out: its bundled natives are CPU-only as well, and GPU requires you to *"rebuild the LightGBM with GPU support: use `-DUSE_CUDA=1 -DUSE_SWIG=ON`"* and point `LIGHTGBM_NATIVE_LIB_PATH` at the result.

So **no published Maven artifact ships a GPU-enabled LightGBM native.** GPU needs a self-compiled `lib_lightgbm.so`, which is a build-infrastructure project (#2642), not a dependency bump — and it is orthogonal to this PR, because a GPU-capable native still needs a way to be told to use the GPU. That switch is what this PR adds.

The question worth asking is therefore not *"does GPU training work in CI"* — it cannot — but **"is the request honored, or silently ignored?"** A caller who asks for a GPU and unknowingly gets CPU has no way to tell and would take the slowdown as a fact of life. LightGBM refusing *by name* is proof the parameter reached the native layer. That is what the tests pin.

## Tests

Eight tests in `VerifyLightGBMCommon`:

```
- Verify deviceType reaches the LightGBM parameter string for every learner
- Verify the default cpu deviceType leaves the LightGBM parameter string untouched
- Verify passThroughArgs still overrides deviceType
- Verify the passThroughArgs device alias still overrides deviceType
- Verify deviceType rejects an unsupported device
- Verify the cpu deviceType trains end to end
- Verify the gpu deviceType is never silently downgraded to cpu
- Verify the cuda deviceType is never silently downgraded to cpu
```

The last two accept either outcome — a successful fit, or a failure whose message names the tree learner. Written that way they assert the safety property itself rather than today's dependency, so on a GPU-capable native (per #2642) they keep passing unchanged instead of turning into a false alarm.

## Backward compatibility

Two deliberate choices keep this from disturbing anything that works today.

**The default emits nothing.** `cpu` is LightGBM's own default, so writing `device_type=cpu` would add a token that changes nothing on its own but *would* start overriding callers who had set the device through `passThroughArgs`. `deviceTypeToEmit` suppresses it.

**The `device` alias is respected.** LightGBM accepts `device` as an alias of `device_type` and resolves the canonical key first, so emitting `device_type=cpu` alongside a caller's `device=gpu` would silently discard their setting. The parameter builder detects the alias and stands down. Both cases are covered by tests.

`passThroughArgs` continues to win over `deviceType`, matching how it already relates to every other typed parameter.

## Related

Supersedes #1062, which proposed the same capability but has an unsignable CLA. Follow-up #2642 tracks shipping a GPU-enabled native, the missing half of actually running on a GPU.
