### PR TITLE
fix: handle empty featurized text features

### DIFF
--- a/.pipelines/release-compat-prerequisites.txt
+++ b/.pipelines/release-compat-prerequisites.txt
@@ -13,3 +13,6 @@ f7a1dc50d09d400d279d08bf69a1fac322896748
 # PR #2632 then added deterministic scored-model metadata resolution used by this change.
 # Remove this prerequisite once every validated release branch contains that backport.
 704fb34a51072af56157bf4dade33f4b82dcf129
+# PR #2638 added the missing-numeric Featurize API and test imports used by this change.
+# Remove this prerequisite once every validated release branch contains that backport.
+816804baa722f4154886a528303e81b8f0a7e86a

--- a/.pipelines/release-compat-prerequisites.txt
+++ b/.pipelines/release-compat-prerequisites.txt
@@ -1,18 +1,3 @@
-# PR #2591 adds Azure AI Search AAD auth required by this change.
-# Remove this prerequisite once every validated release branch contains that backport.
-04897bae9baa08f0d67855566f7bad235791d508
-# PR #2612 introduces the WorkerMessage protocol used by the IPv6 endpoint parsing fix.
-# Remove this prerequisite once every validated release branch contains that backport.
-4a52d9ae4184d3ce00394cd9cb4209c35990fc47
-# PR #2507 introduced tests modified by PR #2635 but absent from Spark 4.1.
-# Remove this scoped prerequisite once every validated release branch contains these tests.
-6938c472175ed1592ec24e7d8c65d9174f17c4e5	core/src/test/scala/com/microsoft/azure/synapse/ml/automl/VerifyEvaluationUtils.scala	core/src/test/scala/com/microsoft/azure/synapse/ml/core/metrics/VerifyMetricConstants.scala
-# PR #2635 changed ComputeModelStatistics and its tests before this metadata fix.
-# Remove this prerequisite once every validated release branch contains that backport.
-f7a1dc50d09d400d279d08bf69a1fac322896748
-# PR #2632 then added deterministic scored-model metadata resolution used by this change.
-# Remove this prerequisite once every validated release branch contains that backport.
-704fb34a51072af56157bf4dade33f4b82dcf129
 # PR #2638 added the missing-numeric Featurize API and test imports used by this change.
 # Remove this prerequisite once every validated release branch contains that backport.
 816804baa722f4154886a528303e81b8f0a7e86a

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/featurize/CountSelector.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/featurize/CountSelector.scala
@@ -6,20 +6,26 @@ package com.microsoft.azure.synapse.ml.featurize
 import com.microsoft.azure.synapse.ml.codegen.Wrappable
 import com.microsoft.azure.synapse.ml.core.contracts.{HasInputCol, HasOutputCol}
 import com.microsoft.azure.synapse.ml.logging.{FeatureNames, SynapseMLLogging}
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.feature._
 import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
-import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.util._
 import org.apache.spark.ml.{Estimator, Model}
 import org.apache.spark.sql._
+import org.apache.spark.sql.functions.udf
 import org.apache.spark.sql.types._
 
 import scala.collection.immutable.BitSet
 
 object CountSelector extends DefaultParamsReadable[CountSelector]
 
-/** Drops vector indicies with no nonzero data. */
+/** Drops vector indices with no nonzero data.
+  *
+  * If no indices remain, the fitted model emits a zero-width sparse vector with size-0 metadata
+  * for non-null inputs and preserves nulls.
+  */
 class CountSelector(override val uid: String) extends Estimator[CountSelectorModel]
   with Wrappable with DefaultParamsWritable with HasInputCol with HasOutputCol with SynapseMLLogging {
   logClass(FeatureNames.Featurize)
@@ -75,15 +81,39 @@ class CountSelectorModel(val uid: String) extends Model[CountSelectorModel]
     new VectorSlicer().setInputCol(getInputCol).setOutputCol(getOutputCol).setIndices(getIndices)
   }
 
+  private def hasEmptySelection: Boolean = getIndices.isEmpty
+
+  private def emptyOutputMetadata: Metadata = new AttributeGroup(getOutputCol, 0).toMetadata()
+
+  private def emptyOutputField: StructField =
+    StructField(getOutputCol, VectorType, nullable = true, emptyOutputMetadata)
+
   override def transform(dataset: Dataset[_]): DataFrame = {
     logTransform[DataFrame](
-      getModel.transform(dataset),
+      if (hasEmptySelection) {
+        transformSchema(dataset.schema)
+        val emptySelectionVector = Vectors.sparse(0, Array.empty[Int], Array.empty[Double])
+        val emptyVector = udf { vector: Vector =>
+          if (vector eq null) null else emptySelectionVector  // scalastyle:ignore null
+        }
+        dataset.withColumn(getOutputCol, emptyVector(dataset(getInputCol)).as(getOutputCol, emptyOutputMetadata))
+      } else {
+        getModel.transform(dataset)
+      },
       dataset.columns.length
     )
   }
 
   override def transformSchema(schema: StructType): StructType = {
-    getModel.transformSchema(schema)
+    if (hasEmptySelection) {
+      require(schema(getInputCol).dataType == VectorType,
+        s"Input column ${getInputCol} must be of type vector.")
+      require(!schema.fieldNames.contains(getOutputCol),
+        s"Output column ${getOutputCol} already exists.")
+      schema.add(emptyOutputField)
+    } else {
+      getModel.transformSchema(schema)
+    }
   }
 
 }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/featurize/Featurize.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/featurize/Featurize.scala
@@ -31,7 +31,11 @@ private[ml] object FeaturizeUtilities {
 
 object Featurize extends DefaultParamsReadable[Featurize]
 
-/** Featurizes a dataset. Converts the specified columns to feature columns. */
+/** Featurizes a dataset. Converts the specified columns to feature columns.
+  *
+  * Text inputs whose fitted text features are all zero contribute no output slots. Fitting fails
+  * with a column-specific error when every requested input collapses this way.
+  */
 class Featurize(override val uid: String) extends Estimator[PipelineModel]
   with Wrappable with DefaultParamsWritable with HasOutputCol with HasInputCols with SynapseMLLogging {
   logClass(FeatureNames.Featurize)
@@ -150,6 +154,31 @@ class Featurize(override val uid: String) extends Estimator[PipelineModel]
 
   }
 
+  private def emptyCountSelectorModels(stage: PipelineStage): Seq[CountSelectorModel] = {
+    stage match {
+      case model: CountSelectorModel if model.getIndices.isEmpty =>
+        Seq(model)
+      case model: PipelineModel =>
+        model.stages.flatMap(emptyCountSelectorModels)
+      case _ =>
+        Seq.empty
+    }
+  }
+
+  private def validateUsableFeatures(featureColumns: Seq[String],
+                                     emptyTextColumns: Seq[String]): Unit = {
+    val distinctEmptyTextColumns = emptyTextColumns.distinct
+    val emptyTextColumnSet = distinctEmptyTextColumns.toSet
+    if (featureColumns.nonEmpty && featureColumns.forall(emptyTextColumnSet.contains)) {
+      val columnLabel = if (distinctEmptyTextColumns.length == 1) "column" else "columns"
+      val formattedColumns = distinctEmptyTextColumns.sorted.map(col => s"'$col'").mkString(", ")
+      throw new IllegalArgumentException(
+        s"No usable featurized features were produced. Text $columnLabel $formattedColumns " +
+          "produced zero-width feature vectors after text featurization. This usually means " +
+          "the input values were constant, empty, or otherwise contained no information.")
+    }
+  }
+
   /** Featurizes the dataset.
     *
     * @param dataset The input dataset to train.
@@ -160,6 +189,7 @@ class Featurize(override val uid: String) extends Estimator[PipelineModel]
   override def fit(dataset: Dataset[_]): PipelineModel = {
     logFit({
       val columnState = new ColumnState(dataset)
+      val textSelectorOutputs = mutable.Map[String, String]()
 
       val (oldEncoderCols, newEncoderCols) = getInputCols.flatMap {
         baseCol =>
@@ -222,6 +252,7 @@ class Featurize(override val uid: String) extends Estimator[PipelineModel]
               })
               val m1 = new TextFeaturizer().setNumFeatures(getNumFeatures).setInputCol(oldCol).setOutputCol(newCol)
               val newCol2 = columnState.makeNewCol(baseCol, VectorType)
+              textSelectorOutputs.update(newCol2, baseCol)
               val m2 = new CountSelector().setInputCol(newCol).setOutputCol(newCol2)
               Some(new Pipeline().setStages(Array(m0, m1, m2)))
             case _: TimestampType =>
@@ -263,7 +294,13 @@ class Featurize(override val uid: String) extends Estimator[PipelineModel]
         new DropColumns().setCols(columnState.getColsToDrop.toArray)
       )
 
-      new Pipeline().setStages(Seq(encoders, casters, imputers, featurizers, va).flatten.toArray).fit(dataset)
+      val featurizedModel =
+        new Pipeline().setStages(Seq(encoders, casters, imputers, featurizers, va).flatten.toArray).fit(dataset)
+      val emptyTextColumns = featurizedModel.stages
+        .flatMap(emptyCountSelectorModels)
+        .flatMap(model => textSelectorOutputs.get(model.getOutputCol))
+      validateUsableFeatures(getInputCols.toSeq, emptyTextColumns)
+      featurizedModel
     }, dataset.columns.length)
   }
   //scalastyle:on cyclomatic.complexity

--- a/core/src/test/python/synapsemltest/core/test_empty_featurized_text.py
+++ b/core/src/test/python/synapsemltest/core/test_empty_featurized_text.py
@@ -1,0 +1,77 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+import unittest
+
+from pyspark.ml.linalg import VectorUDT, Vectors
+from pyspark.sql import types as t
+
+from synapse.ml.core.init_spark import init_spark
+from synapse.ml.featurize import CountSelectorModel, Featurize
+
+spark = init_spark()
+
+
+class EmptyFeaturizedTextSpec(unittest.TestCase):
+    def test_empty_count_selector_model_preserves_schema_and_nulls(self):
+        schema = t.StructType(
+            [
+                t.StructField("id", t.IntegerType(), nullable=False),
+                t.StructField("features", VectorUDT(), nullable=True),
+            ],
+        )
+        dataset = spark.createDataFrame(
+            [(0, Vectors.sparse(4, [], [])), (1, None)],
+            schema,
+        )
+        model = CountSelectorModel(
+            indices=[],
+            inputCol="features",
+            outputCol="selected",
+        )
+
+        transformed = model.transform(dataset)
+        by_id = {
+            row.id: row.selected
+            for row in transformed.select("id", "selected").collect()
+        }
+
+        self.assertEqual(by_id[0].size, 0)
+        self.assertIsNone(by_id[1])
+        self.assertTrue(transformed.schema["selected"].nullable)
+        self.assertEqual(
+            transformed.schema["selected"].metadata["ml_attr"]["num_attrs"],
+            0,
+        )
+
+    def test_featurize_ignores_collapsed_text_when_numeric_features_remain(self):
+        dataset = spark.createDataFrame(
+            [(0.0, "2", 1.0), (1.0, "2", 2.0), (2.0, "2", 3.0)],
+            ["label", "text", "numeric"],
+        )
+        model = Featurize(
+            inputCols=["text", "numeric"],
+            outputCol="features",
+            numFeatures=1024,
+        ).fit(dataset)
+
+        features = [
+            row.features.toArray().tolist()
+            for row in model.transform(dataset).select("features").collect()
+        ]
+
+        self.assertEqual(features, [[1.0], [2.0], [3.0]])
+
+    def test_featurize_rejects_an_all_collapsed_text_feature_set(self):
+        dataset = spark.createDataFrame([("2",), ("2",), ("2",)], ["text"])
+
+        with self.assertRaisesRegex(Exception, "No usable featurized features"):
+            Featurize(
+                inputCols=["text"],
+                outputCol="features",
+                numFeatures=1024,
+            ).fit(dataset)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/featurize/VerifyCountSelector.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/featurize/VerifyCountSelector.scala
@@ -5,9 +5,14 @@ package com.microsoft.azure.synapse.ml.featurize
 
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 import com.microsoft.azure.synapse.ml.core.test.fuzzing.{EstimatorFuzzing, TestObject, TransformerFuzzing}
-import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vectors}
+import org.apache.commons.io.FileUtils
+import org.apache.spark.ml.attribute.AttributeGroup
+import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
+import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.util.MLReadable
 import org.apache.spark.sql._
+import org.apache.spark.sql.functions.{col, lit, when}
+
 
 trait VerifyCountSelectorShared extends TestBase {
   import spark.implicits._
@@ -16,6 +21,14 @@ trait VerifyCountSelectorShared extends TestBase {
     (Vectors.sparse(3, Seq((0, 1.0), (2, 2.0))), Vectors.dense(1.0, 0.1, 0)),
     (Vectors.sparse(3, Seq((0, 1.0), (2, 2.0))), Vectors.dense(1.0, 0.1, 0))
   ).toDF("col1", "col2")
+
+  lazy val emptyVectorDf: DataFrame = Seq(
+    Tuple1(Vectors.sparse(4, Array.empty[Int], Array.empty[Double])),
+    Tuple1(Vectors.dense(0.0, 0.0, 0.0, 0.0))
+  ).toDF("features")
+
+  lazy val emptyVectorDfWithNull: DataFrame = emptyVectorDf.unionByName(
+    emptyVectorDf.limit(1).select(when(lit(false), col("features")).as("features")))
 
 }
 
@@ -29,6 +42,16 @@ class VerifyCountSelector extends EstimatorFuzzing[CountSelector] with VerifyCou
     assert(result2.head().getAs[DenseVector]("col4").size === 2)
   }
 
+  test("issue 1667 - CountSelector produces an empty model without throwing") {
+    val model = new CountSelector().setInputCol("features").setOutputCol("selected").fit(emptyVectorDf)
+    assert(model.getIndices.isEmpty)
+
+    val transformed = model.transform(emptyVectorDf)
+    val selectedVectors = transformed.select("selected").collect().map(_.getAs[Vector](0))
+    assert(selectedVectors.forall(_.size == 0))
+    assert(AttributeGroup.fromStructField(transformed.schema("selected")).numAttributes.contains(0))
+  }
+
   override def testObjects(): List[TestObject[CountSelector]] = List(new TestObject(
     new CountSelector().setInputCol("col1").setOutputCol("col3"), df))
 
@@ -39,6 +62,77 @@ class VerifyCountSelector extends EstimatorFuzzing[CountSelector] with VerifyCou
 }
 
 class VerifyCountSelectorModel extends TransformerFuzzing[CountSelectorModel] with VerifyCountSelectorShared {
+
+  test("issue 1667 - CountSelectorModel supports empty indices, copy, and persistence") {
+    val model = new CountSelectorModel()
+      .setIndices(Array.empty[Int])
+      .setInputCol("features")
+      .setOutputCol("selected")
+
+    val copiedModel = model.copy(ParamMap.empty)
+    assert(copiedModel.getIndices.isEmpty)
+    assert(copiedModel.uid == model.uid)
+    assert(copiedModel.getInputCol == model.getInputCol)
+    assert(copiedModel.getOutputCol == model.getOutputCol)
+
+    val modelDir = tmpDir.resolve("count-selector-empty-model").toFile
+    if (modelDir.exists()) {
+      FileUtils.deleteDirectory(modelDir)
+    }
+
+    try {
+      model.write.overwrite().save(modelDir.getAbsolutePath)
+      val loadedModel = CountSelectorModel.load(modelDir.getAbsolutePath)
+      assert(loadedModel.getIndices.isEmpty)
+
+      val expected = model.transform(emptyVectorDfWithNull).select("selected")
+      val actual = loadedModel.transform(emptyVectorDfWithNull).select("selected")
+      assert(AttributeGroup.fromStructField(actual.schema("selected")).numAttributes.contains(0))
+      assert(verifyResult(expected, actual))
+    } finally {
+      if (modelDir.exists()) {
+        FileUtils.deleteDirectory(modelDir)
+      }
+    }
+  }
+
+  test("issue 1667 - empty CountSelectorModel preserves nulls and matches transformSchema") {
+    val model = new CountSelectorModel()
+      .setIndices(Array.empty[Int])
+      .setInputCol("features")
+      .setOutputCol("selected")
+
+    val expectedSchema = model.transformSchema(emptyVectorDfWithNull.schema)
+    val transformed = model.transform(emptyVectorDfWithNull)
+    val selected = transformed.select("selected").collect().map(row => Option(row.getAs[Vector](0)))
+
+    assert(transformed.schema == expectedSchema)
+    assert(transformed.schema("selected").nullable)
+    assert(selected.count(_.isEmpty) == 1)
+    assert(selected.flatten.forall(_.size == 0))
+    assert(AttributeGroup.fromStructField(transformed.schema("selected")).numAttributes.contains(0))
+  }
+
+  test("issue 1667 - empty CountSelectorModel validates input and output columns") {
+    val model = new CountSelectorModel()
+      .setIndices(Array.empty[Int])
+      .setInputCol("features")
+      .setOutputCol("selected")
+
+    val wrongType = emptyVectorDf.select(lit(1.0).as("features"))
+    val wrongTypeError = intercept[IllegalArgumentException] {
+      model.transform(wrongType)
+    }
+    assert(wrongTypeError.getMessage.contains("features"))
+    assert(wrongTypeError.getMessage.contains("vector"))
+
+    val existingOutput = emptyVectorDf.withColumn("selected", lit(1.0))
+    val existingOutputError = intercept[IllegalArgumentException] {
+      model.transform(existingOutput)
+    }
+    assert(existingOutputError.getMessage.contains("selected"))
+    assert(existingOutputError.getMessage.contains("already exists"))
+  }
 
   override def testObjects(): List[TestObject[CountSelectorModel]] = List(new TestObject(
     new CountSelectorModel().setIndices(Array(0)).setInputCol("col1").setOutputCol("col3"), df))

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/featurize/VerifyFeaturize.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/featurize/VerifyFeaturize.scala
@@ -238,6 +238,155 @@ class VerifyFeaturize extends TestBase with EstimatorFuzzing[Featurize] {
     assert(resultStringIndexer.first().getAs[DenseVector](featuresColumn).size == 7)
   }
 
+  test("issue 1667 - ordinary text featurization is unchanged when constant text columns are present") {
+    val trainingDataset = spark.createDataFrame(Seq(
+      (0, 1.0, "always the same", "red fox"),
+      (1, 2.0, "always the same", "blue fox"),
+      (0, 3.0, "always the same", "red dog"),
+      (1, 4.0, "always the same", "blue dog")))
+      .toDF(mockLabelColumn, "numeric", "constantText", "informativeText")
+    val featurizeUid = "issue1667Featurize"
+
+    val baseModel = new Featurize(featurizeUid)
+      .setNumFeatures(1024)
+      .setOutputCol(featuresColumn)
+      .setInputCols(Array("informativeText", "numeric"))
+      .fit(trainingDataset)
+
+    val modelWithConstantText = new Featurize(featurizeUid)
+      .setNumFeatures(1024)
+      .setOutputCol(featuresColumn)
+      .setInputCols(Array("constantText", "informativeText", "numeric"))
+      .fit(trainingDataset)
+
+    val scoringDataset = spark.createDataFrame(Seq(
+      (4, 5.0, null, "yellow bird"),
+      (5, 6.0, "", "red fox"),
+      (6, 7.0, "novel scoring text", "blue dog")))
+      .toDF(mockLabelColumn, "numeric", "constantText", "informativeText")
+
+    val baseResult = baseModel.transform(scoringDataset).select(featuresColumn)
+    val resultWithConstantText = modelWithConstantText.transform(scoringDataset).select(featuresColumn)
+
+    assert(baseResult.collect().map(_.getAs[Vector](0)).toSeq ===
+      resultWithConstantText.collect().map(_.getAs[Vector](0)).toSeq)
+    assert(baseResult.schema(featuresColumn).metadata === resultWithConstantText.schema(featuresColumn).metadata)
+    assert(AttributeGroup.fromStructField(baseResult.schema(featuresColumn)).numAttributes ===
+      AttributeGroup.fromStructField(resultWithConstantText.schema(featuresColumn)).numAttributes)
+
+    val modelDir = new File(tmpDir.toFile, "issue1667-featurize-model")
+    modelWithConstantText.write.overwrite().save(modelDir.toString)
+    val loadedModel = PipelineModel.load(modelDir.toString)
+    val loadedResult = loadedModel.transform(scoringDataset).select(featuresColumn)
+    assert(verifyResult(resultWithConstantText, loadedResult))
+  }
+
+  test("issue 1667 - collapsed text coexists with vectorAssemblerHandleInvalid keep and defaultCopy") {
+    val trainingDataset = spark.createDataFrame(Seq(
+      (0, "always the same", 1.0),
+      (1, "always the same", 2.0),
+      (2, "always the same", 3.0)))
+      .toDF(mockLabelColumn, "constantText", "numeric")
+    val scoringDataset = spark.createDataFrame(Seq[(Int, String, JDouble)](
+      (0, null, null),
+      (1, "", 4.0),
+      (2, "novel scoring text", Double.NaN)))
+      .toDF(mockLabelColumn, "constantText", "numeric")
+
+    val featurize = new Featurize()
+      .setNumFeatures(1024)
+      .setOutputCol(featuresColumn)
+      .setInputCols(Array("constantText", "numeric"))
+      .setImputeMissing(false)
+      .setVectorAssemblerHandleInvalid("keep")
+    val copied = featurize.copy(new ParamMap()).asInstanceOf[Featurize]
+
+    assert(copied.getVectorAssemblerHandleInvalid == "keep")
+    val result = copied.fit(trainingDataset).transform(scoringDataset)
+    val byLabel = result.select(mockLabelColumn, featuresColumn).collect().map { row =>
+      row.getAs[Int](mockLabelColumn) -> row.getAs[Vector](featuresColumn)
+    }.toMap
+
+    assert(byLabel.values.forall(_.size == 1))
+    assert(byLabel(0)(0).isNaN)
+    assert(byLabel(1)(0) == 4.0)
+    assert(byLabel(2)(0).isNaN)
+    val attributes = AttributeGroup.fromStructField(result.schema(featuresColumn))
+    assert(attributes.size == 1)
+    assert(attributes.attributes.get.flatMap(_.name).toSeq == Seq("numeric"))
+  }
+
+  test("issue 1667 - featurize fails clearly when all text features are constant") {
+    val dataset = spark.createDataFrame(Seq(Tuple1("2"), Tuple1("2"), Tuple1("2"))).toDF("text")
+
+    val ex = intercept[IllegalArgumentException] {
+      new Featurize()
+        .setNumFeatures(1024)
+        .setOutputCol(featuresColumn)
+        .setInputCols(Array("text"))
+        .fit(dataset)
+    }
+
+    assert(ex.getMessage.toLowerCase.contains("no usable"))
+    assert(ex.getMessage.contains("text"))
+  }
+
+  test("issue 1667 - featurize fails clearly when text vocabulary is empty or null") {
+    val dataset = spark.createDataFrame(Seq[(Int, String)](
+      (0, null),
+      (1, ""),
+      (2, null)))
+      .toDF(mockLabelColumn, "emptyText")
+
+    val ex = intercept[IllegalArgumentException] {
+      new Featurize()
+        .setNumFeatures(1024)
+        .setOutputCol(featuresColumn)
+        .setInputCols(Array("emptyText"))
+        .fit(dataset)
+    }
+
+    assert(ex.getMessage.toLowerCase.contains("no usable"))
+    assert(ex.getMessage.contains("'emptyText'"))
+    assert(ex.getMessage.contains("constant, empty"))
+  }
+
+  test("issue 1667 - constant numeric columns keep their original semantics") {
+    val dataset = spark.createDataFrame(Seq(
+      (0, 5.0, 1.0),
+      (1, 5.0, 2.0),
+      (0, 5.0, 3.0)))
+      .toDF(mockLabelColumn, "constantNum", "varyingNum")
+
+    val result = featurize(dataset).select(featuresColumn).collect().map(_.getAs[Vector](0)).toSeq
+    assert(result.forall(_.size == 2))
+    assert(result.map(_.toArray.sorted.toSeq) === Seq(
+      Seq(1.0, 5.0),
+      Seq(2.0, 5.0),
+      Seq(3.0, 5.0)))
+  }
+
+  test("issue 1667 - constant categorical columns keep Spark one-hot validation") {
+    val dataset = spark.createDataFrame(Seq(
+      (0, "cat"),
+      (1, "cat"),
+      (0, "cat")))
+      .toDF(mockLabelColumn, "animal")
+
+    val indexed = new ValueIndexer().setInputCol("animal").setOutputCol("animal").fit(dataset).transform(dataset)
+
+    val ex = intercept[IllegalArgumentException] {
+      new Featurize()
+        .setOutputCol(featuresColumn)
+        .setInputCols(Array("animal"))
+        .setOneHotEncodeCategoricals(true)
+        .fit(indexed)
+    }
+
+    assert(ex.getMessage.contains("animal"))
+    assert(ex.getMessage.contains("at least two distinct values"))
+  }
+
   // This test currently fails on ValueIndexer, where we should handle missing values (unlike spark,
   // which fails with a null reference exception)
   ignore("Featurizing with categorical columns that have missings - using one hot encoding") {

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyTrainRegressor.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyTrainRegressor.scala
@@ -51,6 +51,90 @@ class VerifyTrainRegressor extends EstimatorFuzzing[TrainRegressor] {
     TrainRegressorTestUtilities.trainScoreDataset(mockLabelColumn, dataset, linearRegressor)
   }
 
+  test("issue 1667 - TrainRegressor ignores constant text columns when useful features remain") {
+    val dataset = spark.createDataFrame(Seq(
+      (0.0, "always the same", "red fox", 1.0),
+      (1.0, "always the same", "blue fox", 2.0),
+      (2.0, "always the same", "red dog", 3.0),
+      (3.0, "always the same", "blue dog", 4.0),
+      (4.0, "always the same", "green fox", 5.0),
+      (5.0, "always the same", "green dog", 6.0)))
+      .toDF(mockLabelColumn, "constantText", "informativeText", "numeric")
+
+    val baselineModel = TrainRegressorTestUtilities.createLinearRegressor(mockLabelColumn)
+      .setInputCols(Array("informativeText", "numeric"))
+      .setNumFeatures(1024)
+      .fit(dataset)
+
+    val modelWithConstantText = TrainRegressorTestUtilities.createLinearRegressor(mockLabelColumn)
+      .setInputCols(Array("constantText", "informativeText", "numeric"))
+      .setNumFeatures(1024)
+      .fit(dataset)
+
+    val baselineScores = baselineModel.transform(dataset)
+      .select("prediction")
+      .collect()
+      .map(_.getDouble(0))
+      .toSeq
+    val scoresWithConstantText = modelWithConstantText.transform(dataset)
+      .select("prediction")
+      .collect()
+      .map(_.getDouble(0))
+      .toSeq
+
+    assert(baselineScores.length == scoresWithConstantText.length)
+    baselineScores.zip(scoresWithConstantText).foreach { case (expected, actual) =>
+      assert(math.abs(expected - actual) < 1e-8)
+    }
+  }
+
+  test("issue 1667 - TrainRegressor fails clearly when all text features are constant") {
+    val dataset = spark.createDataFrame(Seq(
+      (0.0, "2"),
+      (1.0, "2"),
+      (2.0, "2"),
+      (3.0, "2")))
+      .toDF(mockLabelColumn, "text")
+
+    val ex = intercept[IllegalArgumentException] {
+      TrainRegressorTestUtilities.createLinearRegressor(mockLabelColumn)
+        .setInputCols(Array("text"))
+        .setNumFeatures(1024)
+        .fit(dataset)
+    }
+
+    assert(ex.getMessage.toLowerCase.contains("no usable"))
+    assert(ex.getMessage.contains("text"))
+  }
+
+  test("issue 1667 - TrainRegressor fits the original RandomForest constant-text repro") {
+    val dataset = spark.createDataFrame(Seq(
+      (0.0, "2", 0.50, 0.60, 0),
+      (1.0, "2", 0.40, 0.50, 1),
+      (2.0, "2", 0.78, 0.99, 2),
+      (3.0, "2", 0.12, 0.34, 3),
+      (0.0, "2", 0.50, 0.60, 0),
+      (1.0, "2", 0.40, 0.50, 1),
+      (2.0, "2", 0.78, 0.99, 2),
+      (3.0, "2", 0.12, 0.34, 3)))
+      .toDF(mockLabelColumn, "col1", "col2", "col3", "col4")
+
+    val model = TrainRegressorTestUtilities.createRandomForestRegressor(mockLabelColumn)
+      .setInputCols(Array("col1", "col2", "col3", "col4"))
+      .setNumFeatures(1024)
+      .fit(dataset)
+    val predictions = model.transform(dataset).select("prediction").collect().map(_.getDouble(0))
+
+    assert(predictions.length == dataset.count())
+    assert(predictions.forall(value => !value.isNaN && !value.isInfinity))
+
+    val modelFile = new File(tmpDir.toFile, "rf")
+    model.write.overwrite().save(modelFile.toString)
+    val loadedModel = TrainedRegressorModel.load(modelFile.toString)
+    val loadedPredictions = loadedModel.transform(dataset).select("prediction").collect().map(_.getDouble(0))
+    assert(predictions.toSeq === loadedPredictions.toSeq)
+  }
+
   test("Verify you can score on a dataset without a label column") {
     val dataset: DataFrame = createMockDataset
 


### PR DESCRIPTION
Fixes #1667

## Problem and behavior
`CountSelectorModel` previously delegated an empty selection to Spark `VectorSlicer`, which throws `VectorSlicer requires that at least one feature be selected`. Constant or empty text can legitimately produce that state after TF-IDF/count selection.

This change:
- represents an empty selection as a nullable zero-width sparse vector with size-0 metadata;
- preserves null rows and keeps the existing `VectorSlicer` path unchanged for non-empty selections;
- lets `Featurize`, `TrainRegressor`, and the shared classifier path ignore collapsed text inputs when useful features remain;
- fails early with a column-specific message when every requested input collapses;
- preserves constant numeric and categorical behavior, feature ordering, public Params, and serialized shapes.

The exact RandomForest example from #1667 fails on unchanged `master` and passes with this patch, including nested trained-model save/load.

## Integration after #2638 and #2633
Rebased surgically onto `master` `dde02aec92eb5dfc4b9634c96bfa11ef6102315f` after #2638 and #2633 merged. The `VerifyFeaturize.scala` conflict was resolved by combining both sides rather than choosing either wholesale.

Preserved from #2638:
- `vectorAssemblerHandleInvalid` with default `skip` and `keep`/`error` modes;
- final `VectorAssembler` wiring;
- `defaultCopy` behavior;
- persistence, metadata, and public Python tests.

Preserved from #2629:
- zero-width selector handling and nullable size-0 metadata;
- direct null handling with one reusable sparse vector;
- nested empty-selector discovery and all-collapsed validation;
- RandomForest/`TrainRegressor`, schema, copy, persistence, and generated-wrapper coverage.

Added a combined regression proving collapsed text coexists with `handleInvalid=keep`, missing/NaN numeric values, `defaultCopy`, and correct one-feature metadata. Test-preservation comparison found no tests missing from either pre-rebase side. The only post-rebase compatibility adjustment sorts values in a constant-numeric assertion so it does not depend on Scala 2.12 versus 2.13 mutable-map iteration order.

## Performance and Spark compatibility
- Reuses one immutable zero-width sparse vector instead of allocating a result vector per row.
- Uses a direct null check rather than a per-row `Option` allocation.
- Adds no production RDD API, driver collection, shuffle, repartition, or unbounded materialization.
- Keeps the implementation Scala-first; generated Python wrappers expose the same behavior.

## Local validation
Validated at head `e303ba32d25c79f2297889439b4ed95700b1b15b`.

### Spark 3.5 / JDK 11
- global `compile` and `Test/compile`: passed;
- global `scalastyle` and `Test/scalastyle`: 0 findings;
- affected Scala suites: **47 passed, 0 failed, 1 intentionally ignored**:
  - `VerifyCountSelector` + `VerifyCountSelectorModel`: 11 passed;
  - `VerifyFeaturize`: 24 passed, 1 ignored;
  - `VerifyTrainRegressor`: 12 passed;
- persistence-heavy suites were rerun on Linux tmpfs to avoid unrelated WSL DrvFS commit-protocol I/O errors.

### Codegen and Python
- `core/codegen` and `core/publishLocal`: passed;
- generated `CountSelectorModel.py` and `Featurize.py`: `py_compile` passed;
- public generated-wrapper regressions from #2629 and #2638: **4 passed**;
- Black 22.3.0: **192 files unchanged**.

### Spark 4.1 compatibility replay
The current head declares merged #2638 as the compatibility prerequisite, then replays this patch onto live `upstream/spark4.1` `3364aba80e` (Spark 4.1.1, Scala 2.13.17, Java 17, Python 3.13 baseline):
- full `test:compile` compatibility gate: passed;
- `VerifyCountSelector` + `VerifyCountSelectorModel`: 11 passed;
- `VerifyFeaturize`: 24 passed, 1 ignored;
- `VerifyTrainRegressor -- -z "issue 1667"`: 3 passed;
- total: **38 passed, 0 failed, 1 intentionally ignored**.

## Review dispositions
- Suppressed performance finding: replaced per-row `Option(vector)` with a direct null check and retained null propagation.
- Suppressed test-cleanliness finding: removed the unused standalone `spark` expression.
- Exact-head review finding: assert equal score-sequence lengths before zip, preventing row-count regressions from being truncated silently.

## Current-head CI and review
- exact head: `e303ba32d25c79f2297889439b4ed95700b1b15b`;
- exact base: `dde02aec92eb5dfc4b9634c96bfa11ef6102315f`;
- rebased patch integrity: the original #2629 source patch is unchanged; the only new commit declares #2638 for release replay;
- Azure build `231604593` exposed stale, already-synced prerequisites; the current head removes those entries, retains only required #2638, and passes the exact Spark 4.1 replay plus full `test:compile`;
- GitHub checks and exact-head Copilot review are rerunning after the push;
- the previous Azure run belongs to the superseded head and is not readiness evidence; fresh pull-request validation is being queued for this head.
## Overlap / merge risk
#2638 and #2633 are now part of the base. Their behavior and tests are incorporated and validated above, so there is no remaining merge-order dependency between those merged PRs and #2629. A stale branch that still carries pre-merge edits to `Featurize.scala` or `VerifyFeaturize.scala` may still need a normal conflict resolution against current `master`.



