### PR TITLE
fix: resolve current model metadata deterministically

### DIFF
--- a/.pipelines/release-compat-prerequisites.txt
+++ b/.pipelines/release-compat-prerequisites.txt
@@ -7,3 +7,6 @@
 # PR #2507 introduced tests modified by PR #2635 but absent from Spark 4.1.
 # Remove this scoped prerequisite once every validated release branch contains these tests.
 6938c472175ed1592ec24e7d8c65d9174f17c4e5	core/src/test/scala/com/microsoft/azure/synapse/ml/automl/VerifyEvaluationUtils.scala	core/src/test/scala/com/microsoft/azure/synapse/ml/core/metrics/VerifyMetricConstants.scala
+# PR #2635 changed ComputeModelStatistics and its tests before this metadata fix.
+# Remove this prerequisite once every validated release branch contains that backport.
+f7a1dc50d09d400d279d08bf69a1fac322896748

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/metrics/MetricUtils.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/metrics/MetricUtils.scala
@@ -4,9 +4,11 @@
 package com.microsoft.azure.synapse.ml.core.metrics
 
 import com.microsoft.azure.synapse.ml.core.schema.SchemaConstants.MMLTag
-import com.microsoft.azure.synapse.ml.core.schema.{SchemaConstants, SparkSchema}
+import com.microsoft.azure.synapse.ml.core.schema.SchemaConstants
 import org.apache.spark.sql.types.injections.MetadataUtilities
 import org.apache.spark.sql.types.{Metadata, StructType}
+
+import scala.util.control.NonFatal
 
 /** Utilities used by modules for metrics. */
 object MetricUtils {
@@ -14,11 +16,71 @@ object MetricUtils {
   private case class ScoredModelCandidate(modelName: String,
                                           labelColumnName: String,
                                           scoreValueKind: String,
-                                          predictionColumnName: String) {
+                                          predictionColumnName: String,
+                                          otherColumns: Seq[ScoreColumnMetadata]) {
     def schemaInfo: (String, String, String) = (modelName, labelColumnName, scoreValueKind)
 
     def description: String =
       s"$modelName (label=$labelColumnName, kind=$scoreValueKind, prediction=$predictionColumnName)"
+
+    def signature(includeOtherColumns: Boolean): (String, String, String, Seq[(String, String, String)]) =
+      (labelColumnName, scoreValueKind, predictionColumnName,
+        if (includeOtherColumns) {
+          otherColumns.map(column => (column.columnKind, column.columnName, column.scoreValueKind))
+        } else {
+          Seq.empty
+        })
+  }
+
+  private case class ScoreColumnMetadata(modelName: String,
+                                         columnName: String,
+                                         columnKind: String,
+                                         scoreValueKind: String)
+
+  private case class ScoredModelMetadata(modelName: String, columns: Seq[ScoreColumnMetadata]) {
+    private val labelColumns = columns.filter(_.columnKind == SchemaConstants.TrueLabelsColumn)
+    private val predictionColumns = columns.filter(_.columnKind == SchemaConstants.SparkPredictionColumn)
+    private val otherColumns = columns
+      .filter(column =>
+        column.columnKind == SchemaConstants.SparkRawPredictionColumn ||
+          column.columnKind == SchemaConstants.SparkProbabilityColumn)
+      .sortBy(column => (column.columnKind, column.columnName, column.scoreValueKind))
+
+    def candidates: Seq[ScoredModelCandidate] = {
+      for {
+        label <- labelColumns
+        prediction <- predictionColumns
+        if label.scoreValueKind == prediction.scoreValueKind
+        if ValidScoreValueKinds.contains(label.scoreValueKind)
+      } yield ScoredModelCandidate(
+        modelName,
+        label.columnName,
+        label.scoreValueKind,
+        prediction.columnName,
+        otherColumns)
+    }
+
+    def conflictDescription(labelCol: Option[String],
+                            requestedKind: Option[String]): Option[String] = {
+      val couldMatchLabel = labelCol.forall(label => labelColumns.exists(_.columnName == label))
+      val availableKinds = (labelColumns ++ predictionColumns).map(_.scoreValueKind).toSet
+      val couldMatchKind = requestedKind.forall(availableKinds.contains)
+      if (labelColumns.nonEmpty && predictionColumns.nonEmpty &&
+          candidates.isEmpty && couldMatchLabel && couldMatchKind) {
+        val labels = describeColumns(labelColumns)
+        val predictions = describeColumns(predictionColumns)
+        Some(s"$modelName has incompatible label metadata $labels and prediction metadata $predictions")
+      } else {
+        None
+      }
+    }
+
+    private def describeColumns(scoreColumns: Seq[ScoreColumnMetadata]): String =
+      scoreColumns
+        .map(column => s"${column.columnName}:${column.scoreValueKind}")
+        .distinct
+        .sorted
+        .mkString("[", ", ", "]")
   }
 
   private val ValidScoreValueKinds = Set(SchemaConstants.ClassificationKind, SchemaConstants.RegressionKind)
@@ -32,7 +94,11 @@ object MetricUtils {
   def getSchemaInfo(schema: StructType, labelCol: Option[String],
                     evaluationMetric: String): (String, String, String) = {
     val requestedKind = getRequestedScoreValueKind(evaluationMetric)
-    tryGetSchemaInfo(schema, labelCol, requestedKind).map(_.schemaInfo).getOrElse {
+    tryGetSchemaInfo(
+      schema,
+      labelCol,
+      requestedKind,
+      requiresAuxiliaryMetadata(evaluationMetric, requestedKind)).map(_.schemaInfo).getOrElse {
       (labelCol, requestedKind) match {
         case (Some(labelColumnName), Some(scoreValueKind)) =>
           ("custom model", labelColumnName, scoreValueKind)
@@ -53,21 +119,75 @@ object MetricUtils {
     }
   }
 
+  private[ml] def getScoreColumnName(schema: StructType,
+                                     modelName: String,
+                                     columnKind: String,
+                                     scoreValueKind: String): Option[String] = {
+    val matchingColumns = getScoredModelMetadata(schema)
+      .find(_.modelName == modelName)
+      .toSeq
+      .flatMap(_.columns)
+      .filter(_.columnKind == columnKind)
+    val descriptions = matchingColumns
+      .map(column => s"${column.columnName}:${column.scoreValueKind}")
+      .distinct
+      .sorted
+    matchingColumns.map(_.scoreValueKind).distinct match {
+      case Seq(kind) if kind == scoreValueKind && descriptions.size == 1 =>
+        Some(matchingColumns.head.columnName)
+      case Seq() => None
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Conflicting scored-model metadata. $modelName has $columnKind columns " +
+            descriptions.mkString("[", ", ", "]."))
+    }
+  }
+
   private def getRequestedScoreValueKind(evaluationMetric: String): Option[String] = {
     if (evaluationMetric == MetricConstants.AllSparkMetrics) None
     else if (isClassificationMetric(evaluationMetric)) Some(SchemaConstants.ClassificationKind)
     else Some(SchemaConstants.RegressionKind)
   }
 
+  private def requiresAuxiliaryMetadata(evaluationMetric: String,
+                                        requestedKind: Option[String]): Boolean = {
+    requestedKind match {
+      case Some(SchemaConstants.RegressionKind) => false
+      case Some(SchemaConstants.ClassificationKind) =>
+        evaluationMetric != MetricConstants.AccuracySparkMetric &&
+          evaluationMetric != MetricConstants.PrecisionSparkMetric &&
+          evaluationMetric != MetricConstants.RecallSparkMetric
+      case _ => true
+    }
+  }
+
   private def tryGetSchemaInfo(schema: StructType,
                                labelCol: Option[String],
-                               requestedKind: Option[String]): Option[ScoredModelCandidate] = {
-    val matchingCandidates = getScoredModelNames(schema)
-      .flatMap(modelName => getScoredModelCandidate(schema, modelName))
+                               requestedKind: Option[String],
+                               includeOtherColumns: Boolean): Option[ScoredModelCandidate] = {
+    val scoredModels = getScoredModelMetadata(schema)
+    val conflicts = scoredModels
+      .flatMap(_.conflictDescription(labelCol, requestedKind))
+      .sorted
+    if (conflicts.nonEmpty) {
+      throw new IllegalArgumentException(
+        "Conflicting scored-model metadata. " + conflicts.mkString("[", ", ", "]."))
+    }
+
+    val matchingCandidates = scoredModels
+      .flatMap(_.candidates)
       .filter(candidate => labelCol.forall(_ == candidate.labelColumnName))
       .filter(candidate => requestedKind.forall(_ == candidate.scoreValueKind))
+    val distinctCandidates = matchingCandidates
+      .groupBy(_.signature(includeOtherColumns))
+      .values
+      .map(_.minBy(_.modelName))
+      .toSeq
+      .sortBy(candidate =>
+        (candidate.modelName, candidate.labelColumnName,
+          candidate.scoreValueKind, candidate.predictionColumnName))
 
-    matchingCandidates match {
+    distinctCandidates match {
       case Seq(candidate) => Some(candidate)
       case candidates if candidates.nonEmpty =>
         throw new IllegalArgumentException(
@@ -78,32 +198,48 @@ object MetricUtils {
     }
   }
 
-  private def getScoredModelCandidate(schema: StructType,
-                                      modelName: String): Option[ScoredModelCandidate] = {
-    for {
-      labelColumnName <- Option(SparkSchema.getLabelColumnName(schema, modelName))
-      scoreValueKind <- Option(SparkSchema.getScoreValueKind(schema, modelName, labelColumnName))
-      if ValidScoreValueKinds.contains(scoreValueKind)
-      predictionColumnName <- Option(SparkSchema.getSparkPredictionColumnName(schema, modelName))
-    } yield ScoredModelCandidate(modelName, labelColumnName, scoreValueKind, predictionColumnName)
-  }
-
-  private def getScoredModelNames(schema: StructType): Seq[String] = {
+  private def getScoredModelMetadata(schema: StructType): Seq[ScoredModelMetadata] = {
     schema.fields
-      .flatMap(field => getScoredModelNames(field.metadata))
-      .distinct
-      .sorted
+      .flatMap(field => getScoreColumnMetadata(field.name, field.metadata))
+      .groupBy(_.modelName)
       .toSeq
+      .sortBy(_._1)
+      .map { case (modelName, columns) =>
+        ScoredModelMetadata(
+          modelName,
+          columns.sortBy(column => (column.columnKind, column.columnName, column.scoreValueKind)))
+      }
   }
 
-  private def getScoredModelNames(colMetadata: Metadata): Seq[String] = {
-    if (!colMetadata.contains(MMLTag)) Seq.empty
-    else {
-      val mlTagMetadata = colMetadata.getMetadata(MMLTag)
+  private def getScoreColumnMetadata(columnName: String,
+                                     colMetadata: Metadata): Seq[ScoreColumnMetadata] = {
+    getMetadata(colMetadata, MMLTag).toSeq.flatMap { mlTagMetadata =>
       MetadataUtilities.getMetadataKeys(mlTagMetadata)
         .filter(_.startsWith(SchemaConstants.ScoreModelPrefix))
         .toSeq
+        .sorted
+        .flatMap { modelName =>
+          for {
+            modelMetadata <- getMetadata(mlTagMetadata, modelName)
+            columnKind <- getString(modelMetadata, SchemaConstants.ScoreColumnKind)
+            scoreValueKind <- getString(modelMetadata, SchemaConstants.ScoreValueKind)
+          } yield ScoreColumnMetadata(modelName, columnName, columnKind, scoreValueKind)
+        }
     }
   }
+
+  private def getMetadata(metadata: Metadata, key: String): Option[Metadata] =
+    try {
+      if (metadata.contains(key)) Some(metadata.getMetadata(key)) else None
+    } catch {
+      case NonFatal(_) => None
+    }
+
+  private def getString(metadata: Metadata, key: String): Option[String] =
+    try {
+      if (metadata.contains(key)) Option(metadata.getString(key)) else None
+    } catch {
+      case NonFatal(_) => None
+    }
 
 }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/metrics/MetricUtils.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/metrics/MetricUtils.scala
@@ -6,10 +6,22 @@ package com.microsoft.azure.synapse.ml.core.metrics
 import com.microsoft.azure.synapse.ml.core.schema.SchemaConstants.MMLTag
 import com.microsoft.azure.synapse.ml.core.schema.{SchemaConstants, SparkSchema}
 import org.apache.spark.sql.types.injections.MetadataUtilities
-import org.apache.spark.sql.types.{Metadata, StructField, StructType}
+import org.apache.spark.sql.types.{Metadata, StructType}
 
 /** Utilities used by modules for metrics. */
 object MetricUtils {
+
+  private case class ScoredModelCandidate(modelName: String,
+                                          labelColumnName: String,
+                                          scoreValueKind: String,
+                                          predictionColumnName: String) {
+    def schemaInfo: (String, String, String) = (modelName, labelColumnName, scoreValueKind)
+
+    def description: String =
+      s"$modelName (label=$labelColumnName, kind=$scoreValueKind, prediction=$predictionColumnName)"
+  }
+
+  private val ValidScoreValueKinds = Set(SchemaConstants.ClassificationKind, SchemaConstants.RegressionKind)
 
   def isClassificationMetric(metric: String): Boolean = {
     if (MetricConstants.RegressionMetrics.contains(metric)) false
@@ -19,45 +31,76 @@ object MetricUtils {
 
   def getSchemaInfo(schema: StructType, labelCol: Option[String],
                     evaluationMetric: String): (String, String, String) = {
-    val schemaInfo = tryGetSchemaInfo(schema)
-    if (schemaInfo.isDefined) {
-      schemaInfo.get
-    } else {
-      if (labelCol.isEmpty) {
-        throw new Exception("Please score the model prior to evaluating")
-      } else if (evaluationMetric == MetricConstants.AllSparkMetrics) {
-        throw new Exception("Please specify whether you are using evaluation for " +
-          MetricConstants.ClassificationMetricsName + " or " + MetricConstants.RegressionMetricsName +
-          " instead of " + MetricConstants.AllSparkMetrics)
+    val requestedKind = getRequestedScoreValueKind(evaluationMetric)
+    tryGetSchemaInfo(schema, labelCol, requestedKind).map(_.schemaInfo).getOrElse {
+      (labelCol, requestedKind) match {
+        case (Some(labelColumnName), Some(scoreValueKind)) =>
+          ("custom model", labelColumnName, scoreValueKind)
+        case _ =>
+          val missingSettings = Seq(
+            if (labelCol.isEmpty) Some("labelCol") else None,
+            if (requestedKind.isEmpty) Some("evaluationMetric") else None).flatten
+          val availableColumns = schema.fieldNames.sorted.mkString("[", ", ", "]")
+          throw new IllegalArgumentException(
+            "Unable to determine a complete scored model from schema metadata. " +
+              s"Set ${missingSettings.mkString(" and ")} " +
+              s"(evaluationMetric must not be '${MetricConstants.AllSparkMetrics}'), " +
+              "or score the dataset so one model has both label and prediction metadata. " +
+              s"Available columns: $availableColumns")
       }
-      ("custom model", labelCol.get,
-        if (isClassificationMetric(evaluationMetric))
-          SchemaConstants.ClassificationKind
-        else SchemaConstants.RegressionKind)
     }
   }
 
-  private def tryGetSchemaInfo(schema: StructType): Option[(String, String, String)] = {
-    // TODO: evaluate all models; for now, get first model name found
-    val firstModelName = schema.collectFirst {
-      case StructField(_, _, _, m) if getFirstModelName(m) != null && getFirstModelName(m).isDefined =>
-          getFirstModelName(m).get
-    }
-    if (firstModelName.isEmpty) None
-    else {
-      val modelName = firstModelName.get
-      val labelColumnName = SparkSchema.getLabelColumnName(schema, modelName)
-      val scoreValueKind = SparkSchema.getScoreValueKind(schema, modelName, labelColumnName)
-      Option((modelName, labelColumnName, scoreValueKind))
+  private def getRequestedScoreValueKind(evaluationMetric: String): Option[String] = {
+    if (evaluationMetric == MetricConstants.AllSparkMetrics) None
+    else if (isClassificationMetric(evaluationMetric)) Some(SchemaConstants.ClassificationKind)
+    else Some(SchemaConstants.RegressionKind)
+  }
+
+  private def tryGetSchemaInfo(schema: StructType,
+                               labelCol: Option[String],
+                               requestedKind: Option[String]): Option[ScoredModelCandidate] = {
+    val matchingCandidates = getScoredModelNames(schema)
+      .flatMap(modelName => getScoredModelCandidate(schema, modelName))
+      .filter(candidate => labelCol.forall(_ == candidate.labelColumnName))
+      .filter(candidate => requestedKind.forall(_ == candidate.scoreValueKind))
+
+    matchingCandidates match {
+      case Seq(candidate) => Some(candidate)
+      case candidates if candidates.nonEmpty =>
+        throw new IllegalArgumentException(
+          "Ambiguous scored-model metadata. Multiple complete candidates match: " +
+            candidates.map(_.description).mkString("[", ", ", "]. ") +
+            "Set labelCol and evaluationMetric to select one candidate; remove stale score metadata if needed.")
+      case _ => None
     }
   }
 
-  private def getFirstModelName(colMetadata: Metadata): Option[String] = {
-    if (!colMetadata.contains(MMLTag)) null  //scalastyle:ignore null
+  private def getScoredModelCandidate(schema: StructType,
+                                      modelName: String): Option[ScoredModelCandidate] = {
+    for {
+      labelColumnName <- Option(SparkSchema.getLabelColumnName(schema, modelName))
+      scoreValueKind <- Option(SparkSchema.getScoreValueKind(schema, modelName, labelColumnName))
+      if ValidScoreValueKinds.contains(scoreValueKind)
+      predictionColumnName <- Option(SparkSchema.getSparkPredictionColumnName(schema, modelName))
+    } yield ScoredModelCandidate(modelName, labelColumnName, scoreValueKind, predictionColumnName)
+  }
+
+  private def getScoredModelNames(schema: StructType): Seq[String] = {
+    schema.fields
+      .flatMap(field => getScoredModelNames(field.metadata))
+      .distinct
+      .sorted
+      .toSeq
+  }
+
+  private def getScoredModelNames(colMetadata: Metadata): Seq[String] = {
+    if (!colMetadata.contains(MMLTag)) Seq.empty
     else {
       val mlTagMetadata = colMetadata.getMetadata(MMLTag)
-      val metadataKeys = MetadataUtilities.getMetadataKeys(mlTagMetadata)
-      metadataKeys.find(key => key.startsWith(SchemaConstants.ScoreModelPrefix))
+      MetadataUtilities.getMetadataKeys(mlTagMetadata)
+        .filter(_.startsWith(SchemaConstants.ScoreModelPrefix))
+        .toSeq
     }
   }
 

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/metrics/MetricUtils.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/metrics/MetricUtils.scala
@@ -93,13 +93,21 @@ object MetricUtils {
 
   def getSchemaInfo(schema: StructType, labelCol: Option[String],
                     evaluationMetric: String): (String, String, String) = {
+    getSchemaInfo(schema, labelCol, evaluationMetric, caseSensitive = true)
+  }
+
+  private[ml] def getSchemaInfo(schema: StructType,
+                                labelCol: Option[String],
+                                evaluationMetric: String,
+                                caseSensitive: Boolean): (String, String, String) = {
+    val resolvedLabelCol = resolveLabelColumn(schema, labelCol, caseSensitive)
     val requestedKind = getRequestedScoreValueKind(evaluationMetric)
     tryGetSchemaInfo(
       schema,
-      labelCol,
+      resolvedLabelCol,
       requestedKind,
       requiresAuxiliaryMetadata(evaluationMetric, requestedKind)).map(_.schemaInfo).getOrElse {
-      (labelCol, requestedKind) match {
+      (resolvedLabelCol, requestedKind) match {
         case (Some(labelColumnName), Some(scoreValueKind)) =>
           ("custom model", labelColumnName, scoreValueKind)
         case _ =>
@@ -193,8 +201,24 @@ object MetricUtils {
         throw new IllegalArgumentException(
           "Ambiguous scored-model metadata. Multiple complete candidates match: " +
             candidates.map(_.description).mkString("[", ", ", "]. ") +
-            "Set labelCol and evaluationMetric to select one candidate; remove stale score metadata if needed.")
+            "Set labelCol and evaluationMetric to narrow candidates. If metadata still overlaps, " +
+            "set scoredLabelsCol/scoresCol explicitly or remove stale score metadata.")
       case _ => None
+    }
+  }
+
+  private[ml] def resolveLabelColumn(schema: StructType,
+                                     labelCol: Option[String],
+                                     caseSensitive: Boolean): Option[String] = {
+    labelCol.map { requestedLabel =>
+      if (caseSensitive) {
+        requestedLabel
+      } else {
+        schema.fieldNames.filter(_.equalsIgnoreCase(requestedLabel)) match {
+          case Array(resolvedLabel) => resolvedLabel
+          case _ => requestedLabel
+        }
+      }
     }
   }
 

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/metrics/MetricUtils.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/metrics/MetricUtils.scala
@@ -41,10 +41,12 @@ object MetricUtils {
             if (labelCol.isEmpty) Some("labelCol") else None,
             if (requestedKind.isEmpty) Some("evaluationMetric") else None).flatten
           val availableColumns = schema.fieldNames.sorted.mkString("[", ", ", "]")
+          val metricHint =
+            if (requestedKind.isEmpty) s" (evaluationMetric must not be '${MetricConstants.AllSparkMetrics}')"
+            else ""
           throw new IllegalArgumentException(
             "Unable to determine a complete scored model from schema metadata. " +
-              s"Set ${missingSettings.mkString(" and ")} " +
-              s"(evaluationMetric must not be '${MetricConstants.AllSparkMetrics}'), " +
+              s"Set ${missingSettings.mkString(" and ")}$metricHint, " +
               "or score the dataset so one model has both label and prediction metadata. " +
               s"Available columns: $availableColumns")
       }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.scala
@@ -6,7 +6,7 @@ package com.microsoft.azure.synapse.ml.train
 import com.microsoft.azure.synapse.ml.codegen.Wrappable
 import com.microsoft.azure.synapse.ml.core.contracts._
 import com.microsoft.azure.synapse.ml.core.metrics.{MetricConstants, MetricUtils}
-import com.microsoft.azure.synapse.ml.core.schema.{CategoricalUtilities, SchemaConstants, SparkSchema}
+import com.microsoft.azure.synapse.ml.core.schema.{CategoricalUtilities, SchemaConstants}
 import com.microsoft.azure.synapse.ml.logging.{FeatureNames, SynapseMLLogging}
 import org.apache.log4j.Logger
 import org.apache.spark.ml.Transformer
@@ -76,10 +76,7 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
   override def transform(dataset: Dataset[_]): DataFrame = {
     logTransform[DataFrame]({
       val (modelName, resolvedLabelColumnName, scoreValueKind) =
-        MetricUtils.getSchemaInfo(
-          dataset.schema,
-          if (isDefined(labelCol)) Some(getLabelCol) else None,
-          getEvaluationMetric)
+        resolveSchemaInfo(dataset.schema)
       val labelColumnName = validateColumn(
         dataset, resolvedLabelColumnName, "label", "setLabelCol")
 
@@ -91,7 +88,11 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
         val scoredLabelsColumnName = validateColumn(
           dataset,
           if (isDefined(scoredLabelsCol)) getScoredLabelsCol
-          else SparkSchema.getSparkPredictionColumnName(dataset.schema, modelName),
+          else MetricUtils.getScoreColumnName(
+            dataset.schema,
+            modelName,
+            SchemaConstants.SparkPredictionColumn,
+            scoreValueKind).orNull,
           "classification prediction",
           "setScoredLabelsCol")
         var resultDF: DataFrame =
@@ -116,7 +117,11 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
             if (isDefined(scoresCol)) {
               Some(validateColumn(dataset, getScoresCol, "classification score", "setScoresCol"))
             } else {
-              Option(SparkSchema.getSparkRawPredictionColumnName(dataset.schema, modelName))
+              MetricUtils.getScoreColumnName(
+                dataset.schema,
+                modelName,
+                SchemaConstants.SparkRawPredictionColumn,
+                scoreValueKind)
                 .map(columnName => validateColumn(dataset, columnName, "classification score", "setScoresCol"))
             }
           scoresColumnName match {
@@ -167,7 +172,11 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
         val scoresColumnName = validateColumn(
           dataset,
           if (isDefined(scoresCol)) getScoresCol
-          else SparkSchema.getSparkPredictionColumnName(dataset.schema, modelName),
+          else MetricUtils.getScoreColumnName(
+            dataset.schema,
+            modelName,
+            SchemaConstants.SparkPredictionColumn,
+            scoreValueKind).orNull,
           "regression prediction/score",
           "setScoresCol")
 
@@ -201,14 +210,55 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
                              setterName: String): String = {
     val requestedColumn = Option(columnName).filter(_.nonEmpty)
     val columns = dataset.columns
-    if (!requestedColumn.exists(column => columns.contains(column))) {
+    val caseSensitive = dataset.sparkSession.conf.get("spark.sql.caseSensitive", "false").toBoolean
+    val matchingColumns = requestedColumn.toSeq.flatMap { column =>
+      if (caseSensitive) columns.filter(_ == column)
+      else columns.filter(_.equalsIgnoreCase(column))
+    }
+    if (matchingColumns.size > 1) {
+      throw new IllegalArgumentException(
+        s"Unable to resolve $columnRole column '${requestedColumn.get}' unambiguously. " +
+          s"Matching columns: ${matchingColumns.sorted.mkString("[", ", ", "]")}")
+    } else if (matchingColumns.isEmpty) {
       val requestedDescription = requestedColumn.map(name => s"'$name'").getOrElse("<unresolved>")
       val availableColumns = columns.sorted.mkString("[", ", ", "]")
       throw new IllegalArgumentException(
         s"Unable to resolve $columnRole column $requestedDescription. " +
           s"Call $setterName(...) with an existing column. Available columns: $availableColumns")
     }
-    requestedColumn.get
+    matchingColumns.head
+  }
+
+  private def resolveSchemaInfo(schema: StructType): (String, String, String) = {
+    if (canEvaluateWithoutMetadata) {
+      val scoreValueKind =
+        if (MetricUtils.isClassificationMetric(getEvaluationMetric)) SchemaConstants.ClassificationKind
+        else SchemaConstants.RegressionKind
+      ("custom model", getLabelCol, scoreValueKind)
+    } else {
+      MetricUtils.getSchemaInfo(
+        schema,
+        if (isDefined(labelCol)) Some(getLabelCol) else None,
+        getEvaluationMetric)
+    }
+  }
+
+  private def canEvaluateWithoutMetadata: Boolean = {
+    if (!isDefined(labelCol) || getEvaluationMetric == MetricConstants.AllSparkMetrics) {
+      false
+    } else if (MetricUtils.isClassificationMetric(getEvaluationMetric)) {
+      isDefined(scoredLabelsCol) &&
+        (!classificationMetricRequiresScores || isDefined(scoresCol))
+    } else {
+      isDefined(scoresCol)
+    }
+  }
+
+  private def classificationMetricRequiresScores: Boolean = {
+    getEvaluationMetric == MetricConstants.ClassificationMetricsName ||
+      getEvaluationMetric == MetricConstants.AucSparkMetric ||
+      getEvaluationMetric == MetricConstants.AreaUnderROCMetric ||
+      getEvaluationMetric == MetricConstants.AreaUnderPRMetric
   }
 
   private def addSimpleMetric(simpleMetric: String,
@@ -512,14 +562,11 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
     (labels, confusionMatrix)
   }
 
-  override def copy(extra: ParamMap): Transformer = new ComputeModelStatistics()
+  override def copy(extra: ParamMap): Transformer = defaultCopy(extra)
 
   override def transformSchema(schema: StructType): StructType = {
     val (_, labelColumnName, scoreValueKind) =
-      MetricUtils.getSchemaInfo(
-        schema,
-        if (isDefined(labelCol)) Some(getLabelCol) else None,
-        getEvaluationMetric)
+      resolveSchemaInfo(schema)
     val labelLevels = getLabelLevels(schema, labelColumnName)
     val (columns, validMetrics) =
       if (scoreValueKind == SchemaConstants.ClassificationKind)

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.scala
@@ -76,7 +76,7 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
   override def transform(dataset: Dataset[_]): DataFrame = {
     logTransform[DataFrame]({
       val (modelName, resolvedLabelColumnName, scoreValueKind) =
-        resolveSchemaInfo(dataset.schema)
+        resolveSchemaInfo(dataset.schema, isCaseSensitive(dataset.sparkSession))
       val labelColumnName = validateColumn(
         dataset, resolvedLabelColumnName, "label", "setLabelCol")
 
@@ -229,19 +229,26 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
     matchingColumns.head
   }
 
-  private def resolveSchemaInfo(schema: StructType): (String, String, String) = {
+  private def resolveSchemaInfo(schema: StructType,
+                                caseSensitive: Boolean): (String, String, String) = {
     if (canEvaluateWithoutMetadata) {
       val scoreValueKind =
         if (MetricUtils.isClassificationMetric(getEvaluationMetric)) SchemaConstants.ClassificationKind
         else SchemaConstants.RegressionKind
-      ("custom model", getLabelCol, scoreValueKind)
+      val resolvedLabelCol =
+        MetricUtils.resolveLabelColumn(schema, Some(getLabelCol), caseSensitive).get
+      ("custom model", resolvedLabelCol, scoreValueKind)
     } else {
       MetricUtils.getSchemaInfo(
         schema,
         if (isDefined(labelCol)) Some(getLabelCol) else None,
-        getEvaluationMetric)
+        getEvaluationMetric,
+        caseSensitive)
     }
   }
+
+  private def isCaseSensitive(sparkSession: SparkSession): Boolean =
+    sparkSession.conf.get("spark.sql.caseSensitive", "false").toBoolean
 
   private def canEvaluateWithoutMetadata: Boolean = {
     if (!isDefined(labelCol) || getEvaluationMetric == MetricConstants.AllSparkMetrics) {
@@ -566,7 +573,11 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
 
   override def transformSchema(schema: StructType): StructType = {
     val (_, labelColumnName, scoreValueKind) =
-      resolveSchemaInfo(schema)
+      resolveSchemaInfo(
+        schema,
+        SparkSession.getActiveSession
+          .orElse(SparkSession.getDefaultSession)
+          .exists(isCaseSensitive))
     val labelLevels = getLabelLevels(schema, labelColumnName)
     val (columns, validMetrics) =
       if (scoreValueKind == SchemaConstants.ClassificationKind)

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.scala
@@ -75,24 +75,28 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
   //scalastyle:off cyclomatic.complexity
   override def transform(dataset: Dataset[_]): DataFrame = {
     logTransform[DataFrame]({
-      val (modelName, labelColumnName, scoreValueKind) =
+      val (modelName, resolvedLabelColumnName, scoreValueKind) =
         MetricUtils.getSchemaInfo(
           dataset.schema,
           if (isDefined(labelCol)) Some(getLabelCol) else None,
           getEvaluationMetric)
+      val labelColumnName = validateColumn(
+        dataset, resolvedLabelColumnName, "label", "setLabelCol")
 
       // For creating the result dataframe in classification or regression case
       val spark = dataset.sparkSession
       import spark.implicits._
 
       if (scoreValueKind == SchemaConstants.ClassificationKind) {
-
+        val scoredLabelsColumnName = validateColumn(
+          dataset,
+          if (isDefined(scoredLabelsCol)) getScoredLabelsCol
+          else SparkSchema.getSparkPredictionColumnName(dataset.schema, modelName),
+          "classification prediction",
+          "setScoredLabelsCol")
         var resultDF: DataFrame =
           Seq(MetricConstants.ClassificationEvaluationType)
             .toDF(MetricConstants.EvaluationType)
-        val scoredLabelsColumnName =
-          if (isDefined(scoredLabelsCol)) getScoredLabelsCol
-          else SparkSchema.getSparkPredictionColumnName(dataset.schema, modelName)
 
         // Get levels for label column if categorical
         val levels = CategoricalUtilities.getLevels(dataset.schema, labelColumnName)
@@ -109,11 +113,18 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
 
         lazy val scoresAndLabels = {
           val scoresColumnName =
-            if (isDefined(scoresCol)) getScoresCol
-            else SparkSchema.getSparkRawPredictionColumnName(dataset.schema, modelName)
-          if (scoresColumnName == null) predictionAndLabels
-          else if (levelsExist) getScoresAndLabels(dataset, labelColumnName, scoresColumnName, levelsToIndexMap)
-          else getScalarScoresAndLabels(dataset, labelColumnName, scoresColumnName)
+            if (isDefined(scoresCol)) {
+              Some(validateColumn(dataset, getScoresCol, "classification score", "setScoresCol"))
+            } else {
+              Option(SparkSchema.getSparkRawPredictionColumnName(dataset.schema, modelName))
+                .map(columnName => validateColumn(dataset, columnName, "classification score", "setScoresCol"))
+            }
+          scoresColumnName match {
+            case Some(columnName) if levelsExist =>
+              getScoresAndLabels(dataset, labelColumnName, columnName, levelsToIndexMap)
+            case Some(columnName) => getScalarScoresAndLabels(dataset, labelColumnName, columnName)
+            case None => predictionAndLabels
+          }
         }
 
         lazy val (labels: Array[Double], confusionMatrix: Matrix) = createConfusionMatrix(predictionAndLabels)
@@ -153,9 +164,12 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
         }
         resultDF
       } else if (scoreValueKind == SchemaConstants.RegressionKind) {
-        val scoresColumnName =
+        val scoresColumnName = validateColumn(
+          dataset,
           if (isDefined(scoresCol)) getScoresCol
-          else SparkSchema.getSparkPredictionColumnName(dataset.schema, modelName)
+          else SparkSchema.getSparkPredictionColumnName(dataset.schema, modelName),
+          "regression prediction/score",
+          "setScoresCol")
 
         val scoresAndLabels = selectAndCastToRDD(dataset, scoresColumnName, labelColumnName)
 
@@ -180,6 +194,22 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
   }
   //scalastyle:on method.length
   //scalastyle:on cyclomatic.complexity
+
+  private def validateColumn(dataset: Dataset[_],
+                             columnName: String,
+                             columnRole: String,
+                             setterName: String): String = {
+    val requestedColumn = Option(columnName).filter(_.nonEmpty)
+    val columns = dataset.columns
+    if (!requestedColumn.exists(column => columns.contains(column))) {
+      val requestedDescription = requestedColumn.map(name => s"'$name'").getOrElse("<unresolved>")
+      val availableColumns = columns.sorted.mkString("[", ", ", "]")
+      throw new IllegalArgumentException(
+        s"Unable to resolve $columnRole column $requestedDescription. " +
+          s"Call $setterName(...) with an existing column. Available columns: $availableColumns")
+    }
+    requestedColumn.get
+  }
 
   private def addSimpleMetric(simpleMetric: String,
                               predictionAndLabels: RDD[(Double, Double)],

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputePerInstanceStatistics.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputePerInstanceStatistics.scala
@@ -54,7 +54,8 @@ class ComputePerInstanceStatistics(override val uid: String) extends Transformer
         MetricUtils.getSchemaInfo(
           dataset.schema,
           if (isDefined(labelCol)) Some(getLabelCol) else None,
-          getEvaluationMetric)
+          getEvaluationMetric,
+          dataset.sparkSession.conf.get("spark.sql.caseSensitive", "false").toBoolean)
 
       val dataframe = dataset.toDF()
 

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputeModelStatistics.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputeModelStatistics.scala
@@ -326,7 +326,6 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
     assert(error.getMessage.contains(expectedCandidates))
     assert(error.getMessage.contains("Set labelCol and evaluationMetric"))
   }
-
   test("Explicit evaluation metric omits irrelevant all-metrics hint when labelCol is missing") {
     val input = spark.createDataFrame(Seq((0.0, 1.0))).toDF("label", "feature")
     val error = intercept[IllegalArgumentException] {
@@ -334,7 +333,6 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
         .setEvaluationMetric(MetricConstants.RegressionMetricsName)
         .transformSchema(input.schema)
     }
-
     assert(error.getMessage.contains("Set labelCol, or score the dataset"))
     assert(!error.getMessage.contains(
       s"evaluationMetric must not be '${MetricConstants.AllSparkMetrics}'"))
@@ -349,7 +347,6 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
         .setEvaluationMetric(MetricConstants.RegressionMetricsName)
         .transform(input)
     }
-
     assert(error.getMessage.contains("regression prediction/score column <unresolved>"))
     assert(error.getMessage.contains("setScoresCol"))
     assert(error.getMessage.contains("Available columns: [feature, label]"))
@@ -363,34 +360,40 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
       .setLabelCol(label)
       .setScoredLabelsCol(prediction)
       .setScoresCol("missingScore")
-
     val accuracy = statistics
       .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
       .transform(input)
       .first()
       .getAs[Double](MetricConstants.AccuracyColumnName)
     assert(accuracy === 1.0)
-
     val error = intercept[IllegalArgumentException] {
       statistics
         .setEvaluationMetric(MetricConstants.AucSparkMetric)
         .transform(input)
     }
-
     assert(error.getMessage.contains("classification score column 'missingScore'"))
     assert(error.getMessage.contains("setScoresCol"))
     assert(error.getMessage.contains("Available columns: [label, selectedPrediction]"))
   }
-
   test("Single complete scored-model metadata remains supported") {
     val modelName = SchemaConstants.ScoreModelPrefix + "_single"
     val label = "label"
     val input = spark.createDataFrame(Seq((0.0, 0.0), (1.0, 1.0)))
       .toDF(label, SchemaConstants.SparkPredictionColumn)
     val scored = addScoredModelMetadata(input, modelName, label, SchemaConstants.RegressionKind)
-
-    val result = new ComputeModelStatistics().transform(scored)
-
+    val evaluator = new ComputeModelStatistics()
+      .setLabelCol(label.toUpperCase)
+      .setEvaluationMetric(MetricConstants.RegressionMetricsName)
+    val activeSession = SparkSession.getActiveSession
+    val defaultSession = SparkSession.getDefaultSession
+    SparkSession.clearActiveSession()
+    SparkSession.setDefaultSession(spark)
+    try assert(evaluator.transformSchema(scored.schema).fieldNames.contains(MetricConstants.MseColumnName))
+    finally {
+      activeSession.fold(SparkSession.clearActiveSession())(SparkSession.setActiveSession)
+      defaultSession.fold(SparkSession.clearDefaultSession())(SparkSession.setDefaultSession)
+    }
+    val result = evaluator.transform(scored)
     assert(result.first().getAs[Double](MetricConstants.MseColumnName) === 0.0)
   }
 
@@ -402,9 +405,7 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
       .toDF(label, SchemaConstants.SparkPredictionColumn)
     val withModelB = addScoredModelMetadata(input, modelB, label, SchemaConstants.RegressionKind)
     val withDuplicates = addScoredModelMetadata(withModelB, modelA, label, SchemaConstants.RegressionKind)
-
     val result = new ComputeModelStatistics().transform(withDuplicates)
-
     assert(result.first().getAs[Double](MetricConstants.MseColumnName) === 0.0)
   }
 
@@ -456,12 +457,12 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
       withModelBLabel, modelB, metadataPredictionB,
       SchemaConstants.SparkPredictionColumn, SchemaConstants.ClassificationKind)
 
-    val result = new ComputeModelStatistics()
-      .setLabelCol(label)
+    val evaluator = new ComputeModelStatistics()
+      .setLabelCol(label.toUpperCase)
       .setScoredLabelsCol(selectedPrediction)
       .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
-      .transform(ambiguous)
-
+    val result = evaluator.transform(ambiguous)
+    assert(evaluator.transformSchema(ambiguous.schema).fieldNames.contains(MetricConstants.AccuracyColumnName))
     assert(result.first().getAs[Double](MetricConstants.AccuracyColumnName) === 1.0)
   }
 

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputeModelStatistics.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputeModelStatistics.scala
@@ -218,6 +218,140 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
     assertThrows[Exception] {
       rankedBinaryStatistics("averagePrecision").transform(rankedBinaryDataset)
     }
+  private def addScoredModelMetadata(dataset: DataFrame,
+                                     modelName: String,
+                                     labelCol: String,
+                                     scoreValueKind: String): DataFrame = {
+    val withLabel = SparkSchema.setLabelColumnName(dataset, modelName, labelCol, scoreValueKind)
+    SparkSchema.updateColumnMetadata(
+      withLabel, modelName, SchemaConstants.SparkPredictionColumn, scoreValueKind)
+  }
+
+  test("Explicit settings select classification after a stale regression score is dropped") {
+    val regressionLabel = "regressionLabel"
+    val input = dataset
+      .withColumn(regressionLabel, col("col2") + col("col3"))
+      .select(col(regressionLabel), col(labelColumn), col("col1"), col("col2"), col("col3"), col("col4"))
+    val regressionScored = createLinearRegressor(regressionLabel).fit(input).transform(input)
+
+    val regressionEvaluation = new ComputeModelStatistics().transform(regressionScored)
+    assert(regressionEvaluation.columns.contains(MetricConstants.MseColumnName))
+
+    val classifierInput = regressionScored.drop(SchemaConstants.SparkPredictionColumn)
+    assert(classifierInput.schema(regressionLabel).metadata.contains(SchemaConstants.MMLTag))
+    val classificationScored = createLR.setLabelCol(labelColumn).fit(classifierInput).transform(classifierInput)
+    val classificationEvaluation = new ComputeModelStatistics()
+      .setLabelCol(labelColumn)
+      .setScoredLabelsCol(SchemaConstants.SparkPredictionColumn)
+      .setEvaluationMetric(MetricConstants.ClassificationMetricsName)
+      .transform(classificationScored)
+
+    assert(classificationEvaluation.columns.contains(MetricConstants.AccuracyColumnName))
+    assert(!classificationEvaluation.columns.contains(MetricConstants.MseColumnName))
+  }
+
+  test("Explicit columns and metric beat unrelated scored-model metadata") {
+    val unrelatedLabel = "unrelatedLabel"
+    val selectedLabel = "selectedLabel"
+    val selectedPrediction = "selectedPrediction"
+    val unrelatedModel = SchemaConstants.ScoreModelPrefix + "_unrelated"
+    val wrongKindModel = SchemaConstants.ScoreModelPrefix + "_wrong_kind"
+    val input = spark.createDataFrame(Seq(
+      (1.0, 0.0, 1.0, 0.0),
+      (0.0, 1.0, 0.0, 1.0),
+      (1.0, 0.0, 1.0, 0.0),
+      (0.0, 1.0, 0.0, 1.0)))
+      .toDF(unrelatedLabel, selectedLabel, SchemaConstants.SparkPredictionColumn, selectedPrediction)
+    val withUnrelatedModel = addScoredModelMetadata(
+      input, unrelatedModel, unrelatedLabel, SchemaConstants.ClassificationKind)
+    val scored = addScoredModelMetadata(
+      withUnrelatedModel, wrongKindModel, selectedLabel, SchemaConstants.RegressionKind)
+
+    val result = new ComputeModelStatistics()
+      .setLabelCol(selectedLabel)
+      .setScoredLabelsCol(selectedPrediction)
+      .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
+      .transform(scored)
+
+    assert(result.first().getAs[Double](MetricConstants.AccuracyColumnName) === 1.0)
+  }
+
+  test("Multiple complete scored-model metadata candidates fail deterministically") {
+    val modelA = SchemaConstants.ScoreModelPrefix + "_a"
+    val modelB = SchemaConstants.ScoreModelPrefix + "_b"
+    val labelA = "labelA"
+    val labelB = "labelB"
+    val input = spark.createDataFrame(Seq((0.0, 1.0, 0.0)))
+      .toDF(labelA, labelB, SchemaConstants.SparkPredictionColumn)
+    val withModelB = addScoredModelMetadata(
+      input, modelB, labelB, SchemaConstants.ClassificationKind)
+    val withBothModels = addScoredModelMetadata(
+      withModelB, modelA, labelA, SchemaConstants.RegressionKind)
+
+    val error = intercept[IllegalArgumentException] {
+      new ComputeModelStatistics().transformSchema(withBothModels.schema)
+    }
+    val expectedCandidates =
+      s"[$modelA (label=$labelA, kind=${SchemaConstants.RegressionKind}, " +
+        s"prediction=${SchemaConstants.SparkPredictionColumn}), " +
+        s"$modelB (label=$labelB, kind=${SchemaConstants.ClassificationKind}, " +
+        s"prediction=${SchemaConstants.SparkPredictionColumn})]"
+    assert(error.getMessage.contains(expectedCandidates))
+    assert(error.getMessage.contains("Set labelCol and evaluationMetric"))
+  }
+
+  test("Missing default score column produces an actionable error") {
+    val label = "label"
+    val input = spark.createDataFrame(Seq((0.0, 1.0), (1.0, 2.0))).toDF(label, "feature")
+    val error = intercept[IllegalArgumentException] {
+      new ComputeModelStatistics()
+        .setLabelCol(label)
+        .setEvaluationMetric(MetricConstants.RegressionMetricsName)
+        .transform(input)
+    }
+
+    assert(error.getMessage.contains("regression prediction/score column <unresolved>"))
+    assert(error.getMessage.contains("setScoresCol"))
+    assert(error.getMessage.contains("Available columns: [feature, label]"))
+  }
+
+  test("Invalid explicit scores column fails only for score-consuming metrics") {
+    val label = "label"
+    val prediction = "selectedPrediction"
+    val input = spark.createDataFrame(Seq((0.0, 0.0), (1.0, 1.0))).toDF(label, prediction)
+    val statistics = new ComputeModelStatistics()
+      .setLabelCol(label)
+      .setScoredLabelsCol(prediction)
+      .setScoresCol("missingScore")
+
+    val accuracy = statistics
+      .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
+      .transform(input)
+      .first()
+      .getAs[Double](MetricConstants.AccuracyColumnName)
+    assert(accuracy === 1.0)
+
+    val error = intercept[IllegalArgumentException] {
+      statistics
+        .setEvaluationMetric(MetricConstants.AucSparkMetric)
+        .transform(input)
+    }
+
+    assert(error.getMessage.contains("classification score column 'missingScore'"))
+    assert(error.getMessage.contains("setScoresCol"))
+    assert(error.getMessage.contains("Available columns: [label, selectedPrediction]"))
+  }
+
+  test("Single complete scored-model metadata remains supported") {
+    val modelName = SchemaConstants.ScoreModelPrefix + "_single"
+    val label = "label"
+    val input = spark.createDataFrame(Seq((0.0, 0.0), (1.0, 1.0)))
+      .toDF(label, SchemaConstants.SparkPredictionColumn)
+    val scored = addScoredModelMetadata(input, modelName, label, SchemaConstants.RegressionKind)
+
+    val result = new ComputeModelStatistics().transform(scored)
+
+    assert(result.first().getAs[Double](MetricConstants.MseColumnName) === 0.0)
   }
 
   test("Verify multiclass evaluation is not slow for large number of labels") {

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputeModelStatistics.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputeModelStatistics.scala
@@ -300,6 +300,19 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
     assert(error.getMessage.contains("Set labelCol and evaluationMetric"))
   }
 
+  test("Explicit evaluation metric omits irrelevant all-metrics hint when labelCol is missing") {
+    val input = spark.createDataFrame(Seq((0.0, 1.0))).toDF("label", "feature")
+    val error = intercept[IllegalArgumentException] {
+      new ComputeModelStatistics()
+        .setEvaluationMetric(MetricConstants.RegressionMetricsName)
+        .transformSchema(input.schema)
+    }
+
+    assert(error.getMessage.contains("Set labelCol, or score the dataset"))
+    assert(!error.getMessage.contains(
+      s"evaluationMetric must not be '${MetricConstants.AllSparkMetrics}'"))
+  }
+
   test("Missing default score column produces an actionable error") {
     val label = "label"
     val input = spark.createDataFrame(Seq((0.0, 1.0), (1.0, 2.0))).toDF(label, "feature")

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputeModelStatistics.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputeModelStatistics.scala
@@ -11,15 +11,17 @@ import com.microsoft.azure.synapse.ml.core.test.benchmarks.DatasetUtils
 import com.microsoft.azure.synapse.ml.core.test.fuzzing.{TestObject, TransformerFuzzing}
 import com.microsoft.azure.synapse.ml.train.TrainClassifierTestUtilities._
 import com.microsoft.azure.synapse.ml.train.TrainRegressorTestUtilities._
+import org.apache.spark.ml.Pipeline
 import org.apache.spark.ml.classification.LogisticRegression
 import org.apache.spark.ml.evaluation.BinaryClassificationEvaluator
 import org.apache.spark.ml.feature.FastVectorAssembler
 import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.regression.GeneralizedLinearRegression
 import org.apache.spark.ml.util.MLReadable
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.{DoubleType, StructField, StructType}
+import org.apache.spark.sql.types.{DoubleType, MetadataBuilder, StructField, StructType}
 
 import scala.util.Random
 
@@ -218,6 +220,31 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
     assertThrows[Exception] {
       rankedBinaryStatistics("averagePrecision").transform(rankedBinaryDataset)
     }
+  }
+
+  private def addScoreColumnMetadata(dataset: DataFrame,
+                                     modelName: String,
+                                     columnName: String,
+                                     columnKind: String,
+                                     scoreValueKind: String): DataFrame = {
+    val existingMetadata = dataset.schema(columnName).metadata
+    val mmlBuilder = new MetadataBuilder()
+    if (existingMetadata.contains(SchemaConstants.MMLTag)) {
+      mmlBuilder.withMetadata(existingMetadata.getMetadata(SchemaConstants.MMLTag))
+    }
+    val modelMetadata = new MetadataBuilder()
+      .putString(SchemaConstants.ScoreColumnKind, columnKind)
+      .putString(SchemaConstants.ScoreValueKind, scoreValueKind)
+      .build()
+    val updatedMetadata = new MetadataBuilder()
+      .withMetadata(existingMetadata)
+      .putMetadata(
+        SchemaConstants.MMLTag,
+        mmlBuilder.putMetadata(modelName, modelMetadata).build())
+      .build()
+    dataset.withColumn(columnName, col(columnName).as(columnName, updatedMetadata))
+  }
+
   private def addScoredModelMetadata(dataset: DataFrame,
                                      modelName: String,
                                      labelCol: String,
@@ -365,6 +392,127 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
     val result = new ComputeModelStatistics().transform(scored)
 
     assert(result.first().getAs[Double](MetricConstants.MseColumnName) === 0.0)
+  }
+
+  test("Equivalent complete model metadata is de-duplicated deterministically") {
+    val modelA = SchemaConstants.ScoreModelPrefix + "_duplicate_a"
+    val modelB = SchemaConstants.ScoreModelPrefix + "_duplicate_b"
+    val label = "label"
+    val input = spark.createDataFrame(Seq((0.0, 0.0), (1.0, 1.0)))
+      .toDF(label, SchemaConstants.SparkPredictionColumn)
+    val withModelB = addScoredModelMetadata(input, modelB, label, SchemaConstants.RegressionKind)
+    val withDuplicates = addScoredModelMetadata(withModelB, modelA, label, SchemaConstants.RegressionKind)
+
+    val result = new ComputeModelStatistics().transform(withDuplicates)
+
+    assert(result.first().getAs[Double](MetricConstants.MseColumnName) === 0.0)
+  }
+
+  test("Conflicting prediction metadata fails independently of schema column order") {
+    val model = SchemaConstants.ScoreModelPrefix + "_conflicting"
+    val label = "label"
+    val predictionA = "predictionA"
+    val predictionB = "predictionB"
+    val input = spark.createDataFrame(Seq((0.0, 0.0, 0.0), (1.0, 1.0, 1.0)))
+      .toDF(label, predictionA, predictionB)
+    val withLabel = SparkSchema.setLabelColumnName(input, model, label, SchemaConstants.RegressionKind)
+    val withPredictionA = addScoreColumnMetadata(
+      withLabel, model, predictionA, SchemaConstants.SparkPredictionColumn, SchemaConstants.RegressionKind)
+    val conflicting = addScoreColumnMetadata(
+      withPredictionA, model, predictionB, SchemaConstants.SparkPredictionColumn, SchemaConstants.RegressionKind)
+    val schemas = Seq(
+      conflicting.schema,
+      conflicting.select(col(predictionB), col(label), col(predictionA)).schema)
+
+    val messages = schemas.map { schema =>
+      intercept[IllegalArgumentException] {
+        new ComputeModelStatistics().transformSchema(schema)
+      }.getMessage
+    }
+
+    assert(messages.distinct.size === 1)
+    assert(messages.head.indexOf(s"prediction=$predictionA") < messages.head.indexOf(s"prediction=$predictionB"))
+  }
+
+  test("Complete explicit settings override ambiguous scored-model metadata") {
+    val label = "label"
+    val selectedPrediction = "selectedPrediction"
+    val metadataPredictionA = "metadataPredictionA"
+    val metadataPredictionB = "metadataPredictionB"
+    val input = spark.createDataFrame(Seq(
+      (0.0, 0.0, 1.0, 1.0),
+      (1.0, 1.0, 0.0, 0.0)))
+      .toDF(label, selectedPrediction, metadataPredictionA, metadataPredictionB)
+    val modelA = SchemaConstants.ScoreModelPrefix + "_explicit_a"
+    val modelB = SchemaConstants.ScoreModelPrefix + "_explicit_b"
+    val withModelALabel = SparkSchema.setLabelColumnName(
+      input, modelA, label, SchemaConstants.ClassificationKind)
+    val withModelA = addScoreColumnMetadata(
+      withModelALabel, modelA, metadataPredictionA,
+      SchemaConstants.SparkPredictionColumn, SchemaConstants.ClassificationKind)
+    val withModelBLabel = SparkSchema.setLabelColumnName(
+      withModelA, modelB, label, SchemaConstants.ClassificationKind)
+    val ambiguous = addScoreColumnMetadata(
+      withModelBLabel, modelB, metadataPredictionB,
+      SchemaConstants.SparkPredictionColumn, SchemaConstants.ClassificationKind)
+
+    val result = new ComputeModelStatistics()
+      .setLabelCol(label)
+      .setScoredLabelsCol(selectedPrediction)
+      .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
+      .transform(ambiguous)
+
+    assert(result.first().getAs[Double](MetricConstants.AccuracyColumnName) === 1.0)
+  }
+
+  test("Duplicate raw-score metadata is rejected only when the metric consumes it") {
+    val model = SchemaConstants.ScoreModelPrefix + "_duplicate_raw"
+    val input = spark.createDataFrame(Seq(
+      (0.0, 0.0, 0.2, 0.3),
+      (1.0, 1.0, 0.8, 0.7))).toDF("label", "prediction", "rawA", "rawB")
+    val withLabel = SparkSchema.setLabelColumnName(
+      input, model, "label", SchemaConstants.ClassificationKind)
+    val withPrediction = addScoreColumnMetadata(
+      withLabel, model, "prediction",
+      SchemaConstants.SparkPredictionColumn, SchemaConstants.ClassificationKind)
+    val withRawA = addScoreColumnMetadata(
+      withPrediction, model, "rawA",
+      SchemaConstants.SparkRawPredictionColumn, SchemaConstants.ClassificationKind)
+    val scored = addScoreColumnMetadata(
+      withRawA, model, "rawB",
+      SchemaConstants.SparkRawPredictionColumn, SchemaConstants.ClassificationKind)
+
+    val accuracy = new ComputeModelStatistics()
+      .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
+      .transform(scored)
+    assert(accuracy.first().getAs[Double](MetricConstants.AccuracyColumnName) === 1.0)
+
+    val error = intercept[IllegalArgumentException] {
+      new ComputeModelStatistics().setEvaluationMetric(MetricConstants.AucSparkMetric).transform(scored)
+    }
+    assert(error.getMessage.contains("rawPrediction columns [rawA:Classification, rawB:Classification]"))
+  }
+
+  test("Copy and pipeline preserve explicit statistics parameters") {
+    val label = "label"
+    val prediction = "selectedPrediction"
+    val input = spark.createDataFrame(Seq((0.0, 0.0), (1.0, 1.0))).toDF(label, prediction)
+    val configured = new ComputeModelStatistics()
+      .setLabelCol(label.toUpperCase)
+      .setScoresCol(prediction.toUpperCase)
+      .setEvaluationMetric(MetricConstants.MseSparkMetric)
+    val copied = configured.copy(ParamMap.empty).asInstanceOf[ComputeModelStatistics]
+
+    assert(copied.uid === configured.uid)
+    assert(copied.getLabelCol === label.toUpperCase)
+    assert(copied.getScoresCol === prediction.toUpperCase)
+    assert(copied.getEvaluationMetric === MetricConstants.MseSparkMetric)
+
+    val pipelineResult = new Pipeline()
+      .setStages(Array(configured))
+      .fit(input)
+      .transform(input)
+    assert(pipelineResult.first().getAs[Double](MetricConstants.MseColumnName) === 0.0)
   }
 
   test("Verify multiclass evaluation is not slow for large number of labels") {

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1138,6 +1138,30 @@ jobs:
                   break
                 fi
               done
+              if [ ${#PREREQUISITE_PATHS[@]} -eq 0 ] ||
+                 [ "${PREREQUISITE_PATHS[-1]}" != "$path" ]; then
+                for ((later_index=index + 1;
+                      later_index<${#CONFIGURED_PREREQUISITES[@]};
+                      later_index++)); do
+                  if [ "${CONFIGURED_PREREQUISITE_IS_SCOPED[$later_index]}" = false ]; then
+                    LATER_PREREQUISITE="${CONFIGURED_PREREQUISITES[$later_index]}"
+                    LATER_PARENT=$(git rev-parse "$LATER_PREREQUISITE^1")
+                    if git diff --quiet "$LATER_PARENT" "$LATER_PREREQUISITE" -- \
+                      ":(literal)$path"; then
+                      :
+                    else
+                      DIFF_STATUS=$?
+                      if [ "$DIFF_STATUS" -ne 1 ]; then
+                        echo "##vso[task.logissue type=error]Unable to inspect dependent prerequisite $LATER_PREREQUISITE for path: $path"
+                        exit 1
+                      fi
+                      echo "Scoped prerequisite $PREREQUISITE path $path is required by later prerequisite $LATER_PREREQUISITE"
+                      PREREQUISITE_PATHS+=("$path")
+                      break
+                    fi
+                  fi
+                done
+              fi
               if [ "$HAS_MORE_PATHS" = false ]; then
                 break
               fi
@@ -1184,12 +1208,33 @@ jobs:
                 echo "##vso[task.logissue type=error]Scoped prerequisite path is not a blob: $path"
                 exit 1
               fi
-              if ! TARGET_BLOB=$(git rev-parse "$TARGET_HEAD:$path" 2>/dev/null); then
-                echo "##vso[task.logissue type=error]Scoped path is absent from PR target $TARGET_HEAD: $path"
+              BASELINE_COMMIT="$TARGET_HEAD"
+              for ((later_index=index + 1;
+                    later_index<${#CONFIGURED_PREREQUISITES[@]};
+                    later_index++)); do
+                if [ "${CONFIGURED_PREREQUISITE_IS_SCOPED[$later_index]}" = false ]; then
+                  LATER_PREREQUISITE="${CONFIGURED_PREREQUISITES[$later_index]}"
+                  LATER_PARENT=$(git rev-parse "$LATER_PREREQUISITE^1")
+                  if git diff --quiet "$LATER_PARENT" "$LATER_PREREQUISITE" -- \
+                    ":(literal)$path"; then
+                    :
+                  else
+                    DIFF_STATUS=$?
+                    if [ "$DIFF_STATUS" -ne 1 ]; then
+                      echo "##vso[task.logissue type=error]Unable to inspect dependent prerequisite $LATER_PREREQUISITE for path: $path"
+                      exit 1
+                    fi
+                    BASELINE_COMMIT="$LATER_PARENT"
+                    break
+                  fi
+                fi
+              done
+              if ! BASELINE_BLOB=$(git rev-parse "$BASELINE_COMMIT:$path" 2>/dev/null); then
+                echo "##vso[task.logissue type=error]Scoped path is absent from expected baseline $BASELINE_COMMIT: $path"
                 exit 1
               fi
-              if [ "$PREREQUISITE_BLOB" != "$TARGET_BLOB" ]; then
-                echo "##vso[task.logissue type=error]Scoped prerequisite blob does not match the PR target baseline: $path"
+              if [ "$PREREQUISITE_BLOB" != "$BASELINE_BLOB" ]; then
+                echo "##vso[task.logissue type=error]Scoped prerequisite blob does not match expected baseline $BASELINE_COMMIT: $path"
                 exit 1
               fi
               PREREQUISITE_PATHSPECS+=(":(literal)$path")
@@ -1227,6 +1272,7 @@ jobs:
 
         echo "=== Attempting to apply release-relevant PR changes onto $(RELEASE_BRANCH) ==="
         git checkout --detach $RELEASE_TIP
+        git reset --hard $RELEASE_TIP
         git update-index --refresh
         for index in "${!PREREQUISITE_COMMITS[@]}"; do
           PREREQUISITE="${PREREQUISITE_COMMITS[$index]}"

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1132,20 +1132,24 @@ jobs:
                 path="$REMAINING_PATHS"
                 HAS_MORE_PATHS=false
               fi
+              PATH_SELECTED=false
               for REPLAY_PATH in "${REPLAY_PATHS[@]}"; do
                 if [ "$path" = "$REPLAY_PATH" ]; then
                   PREREQUISITE_PATHS+=("$path")
+                  PATH_SELECTED=true
                   break
                 fi
               done
-              if [ ${#PREREQUISITE_PATHS[@]} -eq 0 ] ||
-                 [ "${PREREQUISITE_PATHS[-1]}" != "$path" ]; then
+              if [ "$PATH_SELECTED" = false ]; then
                 for ((later_index=index + 1;
                       later_index<${#CONFIGURED_PREREQUISITES[@]};
                       later_index++)); do
                   if [ "${CONFIGURED_PREREQUISITE_IS_SCOPED[$later_index]}" = false ]; then
                     LATER_PREREQUISITE="${CONFIGURED_PREREQUISITES[$later_index]}"
-                    LATER_PARENT=$(git rev-parse "$LATER_PREREQUISITE^1")
+                        if ! LATER_PARENT=$(git rev-parse "$LATER_PREREQUISITE^1" 2>/dev/null); then
+                          echo "##vso[task.logissue type=error]Dependent release compatibility prerequisite $LATER_PREREQUISITE has no first parent"
+                          exit 1
+                        fi
                     if git diff --quiet "$LATER_PARENT" "$LATER_PREREQUISITE" -- \
                       ":(literal)$path"; then
                       :
@@ -1157,6 +1161,7 @@ jobs:
                       fi
                       echo "Scoped prerequisite $PREREQUISITE path $path is required by later prerequisite $LATER_PREREQUISITE"
                       PREREQUISITE_PATHS+=("$path")
+                      PATH_SELECTED=true
                       break
                     fi
                   fi
@@ -1214,7 +1219,10 @@ jobs:
                     later_index++)); do
                 if [ "${CONFIGURED_PREREQUISITE_IS_SCOPED[$later_index]}" = false ]; then
                   LATER_PREREQUISITE="${CONFIGURED_PREREQUISITES[$later_index]}"
-                  LATER_PARENT=$(git rev-parse "$LATER_PREREQUISITE^1")
+                  if ! LATER_PARENT=$(git rev-parse "$LATER_PREREQUISITE^1" 2>/dev/null); then
+                    echo "##vso[task.logissue type=error]Dependent release compatibility prerequisite $LATER_PREREQUISITE has no first parent"
+                    exit 1
+                  fi
                   if git diff --quiet "$LATER_PARENT" "$LATER_PREREQUISITE" -- \
                     ":(literal)$path"; then
                     :

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -374,6 +374,18 @@ def test_release_compat_accepts_github_target_and_uses_one_sbt_process():
     assert '"${PREREQUISITE_PATHSPECS[@]}"' in rebase_script
     assert "eval " not in rebase_script
     assert 'git rev-parse "$PREREQUISITE^1"' in rebase_script
+    guarded_dependent_parent = (
+        'if ! LATER_PARENT=$(git rev-parse "$LATER_PREREQUISITE^1" '
+        "2>/dev/null); then"
+    )
+    assert rebase_script.count(guarded_dependent_parent) == 2
+    assert (
+        rebase_script.count(
+            "Dependent release compatibility prerequisite "
+            "$LATER_PREREQUISITE has no first parent"
+        )
+        == 2
+    )
     assert (
         'git diff --name-only -z "$PREREQUISITE_PARENT" "$PREREQUISITE"'
         in rebase_script
@@ -954,6 +966,87 @@ def test_release_compat_replays_scoped_baseline_for_later_prerequisite():
             in result.stdout
         )
         assert "PR changes apply cleanly onto release" in result.stdout
+    finally:
+        shutil.rmtree(scratch_root, ignore_errors=True)
+
+
+@pytest.mark.parametrize("modify_scoped_path", [False, True])
+@pytest.mark.skipif(os.name != "posix", reason="release replay script requires Bash")
+def test_release_compat_reports_dependent_prerequisite_without_parent(
+    modify_scoped_path,
+):
+    scratch_root = (
+        REPO_ROOT
+        / "target"
+        / (f"release-compat-parent-{modify_scoped_path}-{uuid.uuid4().hex}")
+    )
+    repo = scratch_root / "repo"
+    origin = scratch_root / "origin.git"
+    agent_temp = scratch_root / "agent"
+
+    try:
+        repo.mkdir(parents=True)
+        agent_temp.mkdir()
+        _init_release_compat_scratch_repo(repo)
+
+        base_file = repo / "src" / "base.txt"
+        base_file.parent.mkdir()
+        base_file.write_text("release base\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "root base")
+        root_prerequisite = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        _git(repo, "branch", "release", root_prerequisite)
+
+        scoped_file = repo / "src" / "scoped.txt"
+        scoped_file.write_text("scoped baseline\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "add scoped baseline")
+        scoped_prerequisite = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+        _git(repo, "checkout", "-b", "source")
+        prerequisite_config = repo / ".pipelines" / "release-compat-prerequisites.txt"
+        prerequisite_config.parent.mkdir()
+        prerequisite_config.write_text(
+            f"{scoped_prerequisite}\tsrc/scoped.txt\n{root_prerequisite}\n"
+        )
+        if modify_scoped_path:
+            scoped_file.write_text("pull request change\n")
+        else:
+            pr_file = repo / "src" / "pr.txt"
+            pr_file.write_text("pull request change\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "feature change")
+
+        _git(repo, "checkout", "master")
+        _assert_git_clean(repo, "checkout before synthetic PR merge")
+        _git(repo, "merge", "--no-ff", "source", "-m", "merge feature")
+
+        subprocess.run(
+            ["git", "init", "--bare", str(origin)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        _git(repo, "remote", "add", "origin", str(origin))
+        _git(repo, "push", "origin", "master", "source", "release")
+
+        script = _release_compat_script()
+        script = script.replace("$(Agent.TempDirectory)", str(agent_temp))
+        script = script.replace("$(RELEASE_BRANCH)", "release")
+        result = subprocess.run(
+            ["bash", "-c", script],
+            cwd=repo,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 1
+        assert (
+            "##vso[task.logissue type=error]Dependent release compatibility "
+            f"prerequisite {root_prerequisite} has no first parent" in result.stdout
+        )
+        assert "fatal:" not in result.stderr
     finally:
         shutil.rmtree(scratch_root, ignore_errors=True)
 

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -367,8 +367,9 @@ def test_release_compat_accepts_github_target_and_uses_one_sbt_process():
     assert 'git diff --quiet "$PREREQUISITE_PARENT" "$PREREQUISITE" --' in rebase_script
     assert 'git cat-file -e "$PREREQUISITE_PARENT:$path"' in rebase_script
     assert 'git rev-parse "$PREREQUISITE:$path"' in rebase_script
-    assert 'git rev-parse "$TARGET_HEAD:$path"' in rebase_script
-    assert '[ "$PREREQUISITE_BLOB" != "$TARGET_BLOB" ]' in rebase_script
+    assert 'BASELINE_COMMIT="$TARGET_HEAD"' in rebase_script
+    assert 'git rev-parse "$BASELINE_COMMIT:$path"' in rebase_script
+    assert '[ "$PREREQUISITE_BLOB" != "$BASELINE_BLOB" ]' in rebase_script
     assert '":(literal)$path"' in rebase_script
     assert '"${PREREQUISITE_PATHSPECS[@]}"' in rebase_script
     assert "eval " not in rebase_script
@@ -387,6 +388,7 @@ def test_release_compat_accepts_github_target_and_uses_one_sbt_process():
         in rebase_script
     )
     assert "git checkout --detach $RELEASE_TIP" in rebase_script
+    assert "git reset --hard $RELEASE_TIP" in rebase_script
     assert 'git apply --reverse --check --index "$PREREQUISITE_PATCH"' in rebase_script
     assert 'git apply --3way --index "$PREREQUISITE_PATCH"' in rebase_script
     assert 'git apply --3way --index "$PATCH_PATH"' in rebase_script
@@ -867,6 +869,90 @@ def test_release_compat_skips_scoped_prerequisite_for_unrelated_pr_path():
             in result.stdout
         )
         assert f"Prerequisite {prerequisite} applies cleanly" not in result.stdout
+        assert "PR changes apply cleanly onto release" in result.stdout
+    finally:
+        shutil.rmtree(scratch_root, ignore_errors=True)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="release replay script requires Bash")
+def test_release_compat_replays_scoped_baseline_for_later_prerequisite():
+    scratch_root = REPO_ROOT / "target" / f"release-compat-dependent-{uuid.uuid4().hex}"
+    repo = scratch_root / "repo"
+    origin = scratch_root / "origin.git"
+    agent_temp = scratch_root / "agent"
+
+    try:
+        repo.mkdir(parents=True)
+        agent_temp.mkdir()
+        _init_release_compat_scratch_repo(repo)
+
+        pr_file = repo / "src" / "pr.txt"
+        pr_file.parent.mkdir()
+        pr_file.write_text("release base\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "base")
+        base = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        _git(repo, "branch", "release", base)
+
+        scoped_file = repo / "src" / "scoped.txt"
+        scoped_file.write_text("target baseline\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "add scoped baseline")
+        scoped_prerequisite = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+        scoped_file.write_text("dependent prerequisite\n")
+        _git(repo, "commit", "-am", "modify scoped baseline")
+        dependent_prerequisite = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+        _git(repo, "checkout", "-b", "source")
+        prerequisite_config = repo / ".pipelines" / "release-compat-prerequisites.txt"
+        prerequisite_config.parent.mkdir()
+        prerequisite_config.write_text(
+            f"{scoped_prerequisite}\tsrc/scoped.txt\n{dependent_prerequisite}\n"
+        )
+        pr_file.write_text("pull request change\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "feature modifies unrelated file")
+
+        _git(repo, "checkout", "master")
+        _assert_git_clean(repo, "checkout before synthetic PR merge")
+        _git(repo, "merge", "--no-ff", "source", "-m", "merge feature")
+
+        subprocess.run(
+            ["git", "init", "--bare", str(origin)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        _git(repo, "remote", "add", "origin", str(origin))
+        _git(repo, "push", "origin", "master", "source", "release")
+
+        script = _release_compat_script()
+        script = script.replace("$(Agent.TempDirectory)", str(agent_temp))
+        script = script.replace("$(RELEASE_BRANCH)", "release")
+        result = subprocess.run(
+            ["bash", "-c", script],
+            cwd=repo,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, (
+            f"dependent release replay failed\nstdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+        assert pr_file.read_text() == "pull request change\n"
+        assert scoped_file.read_text() == "dependent prerequisite\n"
+        assert _git(repo, "diff", "--cached", "--name-only").stdout.splitlines() == [
+            "src/pr.txt",
+            "src/scoped.txt",
+        ]
+        assert (
+            f"Scoped prerequisite {scoped_prerequisite} path src/scoped.txt "
+            f"is required by later prerequisite {dependent_prerequisite}"
+            in result.stdout
+        )
         assert "PR changes apply cleanly onto release" in result.stdout
     finally:
         shutil.rmtree(scratch_root, ignore_errors=True)


### PR DESCRIPTION
## Summary

Fixes #1697.

`ComputeModelStatistics` now resolves scored-model metadata deterministically after repeated training/evaluation in the same DataFrame lineage. It ignores orphaned entries, collapses semantically equivalent duplicates, rejects conflicting metadata independently of column order, honors complete explicit settings, and reports actionable missing/ambiguous column errors instead of reaching `col(null)`.

## Key changes

- Build a one-pass immutable index of score-model metadata rather than selecting the first schema/metadata entry.
- Require compatible label + prediction metadata and valid classification/regression kind.
- De-duplicate equivalent model IDs by semantic column signature and sort all diagnostics.
- Detect conflicting label/prediction/raw-score/probability roles deterministically.
- Preserve explicit classification/regression columns when they fully define evaluation.
- Resolve columns with Spark case-sensitivity semantics and validate them before expression construction.
- Keep classification score lookup lazy for score-independent metrics.
- Preserve uid/params through `copy`, pipelines, and serialization via `defaultCopy`.
- Replay merged #2635 as a Spark 4.1 release-compatibility prerequisite.

## Coverage

Added regression and negative coverage for:

- regressor → classifier reuse with stale lineage metadata;
- explicit columns versus unrelated/ambiguous metadata;
- equivalent duplicates and conflicting roles;
- schema column-order independence;
- missing/default/invalid columns and lazy score validation;
- classification and regression behavior;
- copy, PipelineModel, serialization, getters, codegen, and Python wrapper surface;
- #2635 binary metric/schema ordering interactions.

## Validation

- JDK 11 `VerifyComputeModelStatistics`: **32/32 passed**.
- JDK 11 `VerifyComputePerInstanceStatistics`: **5/5 passed**.
- JDK 11 core compile + test compile: passed.
- Scala style + test style: passed.
- Serialization fuzzing + getters/setters: passed.
- `core/codegen`: passed; generated `ComputeModelStatistics.py` compiles.
- Black **22.3.0**: 189 files unchanged.
- CI pytest `tools/ci/tests/test_pipeline_yaml.py`: **59/59 passed**.
- Exact Spark 4.1 replay with configured prerequisites and JDK 17 `test:compile`: passed.

No existing public method signature was removed or changed; the original `MetricUtils.getSchemaInfo` and `ComputeModelStatistics.copy` signatures remain intact.

