### PR TITLE
fix: validate ComputeModelStatistics input columns

### DIFF
--- a/.pipelines/release-compat-prerequisites.txt
+++ b/.pipelines/release-compat-prerequisites.txt
@@ -10,3 +10,6 @@
 # PR #2635 changed ComputeModelStatistics and its tests before this metadata fix.
 # Remove this prerequisite once every validated release branch contains that backport.
 f7a1dc50d09d400d279d08bf69a1fac322896748
+# PR #2632 then added deterministic scored-model metadata resolution used by this change.
+# Remove this prerequisite once every validated release branch contains that backport.
+704fb34a51072af56157bf4dade33f4b82dcf129

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.scala
@@ -21,7 +21,15 @@ import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 
-object ComputeModelStatistics extends DefaultParamsReadable[ComputeModelStatistics]
+object ComputeModelStatistics extends DefaultParamsReadable[ComputeModelStatistics] {
+  private def getPositiveClassScore(scores: Vector, scoresColumnName: String): Double = {
+    if (scores.size < 2) {
+      throw new IllegalArgumentException(
+        s"ComputeModelStatistics scoresCol '$scoresColumnName' vectors must contain at least two values.")
+    }
+    scores(1)
+  }
+}
 
 trait ComputeModelStatisticsParams extends Wrappable with DefaultParamsWritable
   with HasLabelCol with HasScoresCol with HasScoredLabelsCol with HasEvaluationMetric {
@@ -46,9 +54,9 @@ trait ComputeModelStatisticsParams extends Wrappable with DefaultParamsWritable
     *   Or, for either:
     *     - all - This will report all the relevant metrics
     *
-    *   If using a native Spark ML model, you will need to specify either "classifier" or "regressor"
-    *     - classifier
-    *     - regressor
+    *   If scoring metadata is unavailable, specify the evaluation kind:
+    *     - classification
+    *     - regression
     *
     * @group param
     */
@@ -66,6 +74,8 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
   var rocCurve: DataFrame = _
 
   lazy val metricsLogger = new MetricsLogger(uid)
+  private val selectedPredictionColumn = "__synapseml_prediction"
+  private val selectedLabelColumn = "__synapseml_label"
 
   /** Calculates the metrics for the given dataset and model.
     * @param dataset the dataset to calculate the metrics for
@@ -75,26 +85,20 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
   //scalastyle:off cyclomatic.complexity
   override def transform(dataset: Dataset[_]): DataFrame = {
     logTransform[DataFrame]({
+      val caseSensitive = isCaseSensitive(dataset.sparkSession)
       val (modelName, resolvedLabelColumnName, scoreValueKind) =
-        resolveSchemaInfo(dataset.schema, isCaseSensitive(dataset.sparkSession))
-      val labelColumnName = validateColumn(
-        dataset, resolvedLabelColumnName, "label", "setLabelCol")
+        resolveSchemaInfo(dataset.schema, caseSensitive)
+      val inputColumns =
+        validateInputColumns(
+          dataset.schema, modelName, resolvedLabelColumnName, scoreValueKind, caseSensitive)
+      val labelColumnName = inputColumns.labelColumnName
 
       // For creating the result dataframe in classification or regression case
       val spark = dataset.sparkSession
       import spark.implicits._
 
       if (scoreValueKind == SchemaConstants.ClassificationKind) {
-        val scoredLabelsColumnName = validateColumn(
-          dataset,
-          if (isDefined(scoredLabelsCol)) getScoredLabelsCol
-          else MetricUtils.getScoreColumnName(
-            dataset.schema,
-            modelName,
-            SchemaConstants.SparkPredictionColumn,
-            scoreValueKind).orNull,
-          "classification prediction",
-          "setScoredLabelsCol")
+        val scoredLabelsColumnName = inputColumns.scoredLabelsColumnName.get
         var resultDF: DataFrame =
           Seq(MetricConstants.ClassificationEvaluationType)
             .toDF(MetricConstants.EvaluationType)
@@ -113,18 +117,7 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
             selectAndCastToRDD(dataset, scoredLabelsColumnName, labelColumnName)
 
         lazy val scoresAndLabels = {
-          val scoresColumnName =
-            if (isDefined(scoresCol)) {
-              Some(validateColumn(dataset, getScoresCol, "classification score", "setScoresCol"))
-            } else {
-              MetricUtils.getScoreColumnName(
-                dataset.schema,
-                modelName,
-                SchemaConstants.SparkRawPredictionColumn,
-                scoreValueKind)
-                .map(columnName => validateColumn(dataset, columnName, "classification score", "setScoresCol"))
-            }
-          scoresColumnName match {
+          inputColumns.scoresColumnName match {
             case Some(columnName) if levelsExist =>
               getScoresAndLabels(dataset, labelColumnName, columnName, levelsToIndexMap)
             case Some(columnName) => getScalarScoresAndLabels(dataset, labelColumnName, columnName)
@@ -165,26 +158,15 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
               throw new Exception("Error: areaUnderPR is not available for multiclass case")
             }
           case default =>
-            throw new Exception(s"Error: $default is not a classification metric")
+            throwOnInvalidEvaluationMetric(
+              default, SchemaConstants.ClassificationKind, MetricConstants.ClassificationMetrics)
         }
         resultDF
       } else if (scoreValueKind == SchemaConstants.RegressionKind) {
-        val scoresColumnName = validateColumn(
-          dataset,
-          if (isDefined(scoresCol)) getScoresCol
-          else MetricUtils.getScoreColumnName(
-            dataset.schema,
-            modelName,
-            SchemaConstants.SparkPredictionColumn,
-            scoreValueKind).orNull,
-          "regression prediction/score",
-          "setScoresCol")
+        val scoresColumnName = inputColumns.scoresColumnName.get
 
         val scoresAndLabels = selectAndCastToRDD(dataset, scoresColumnName, labelColumnName)
-
         val regressionMetrics = new RegressionMetrics(scoresAndLabels)
-
-        // get all spark metrics possible: "mse", "rmse", "r2", "mae"
         val mse = regressionMetrics.meanSquaredError
         val rmse = regressionMetrics.rootMeanSquaredError
         val r2 = regressionMetrics.r2
@@ -192,10 +174,24 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
 
         metricsLogger.logRegressionMetrics(mse, rmse, r2, mae)
 
-        Seq((mse, rmse, r2, mae)).toDF(MetricConstants.MseColumnName,
-          MetricConstants.RmseColumnName,
-          MetricConstants.R2ColumnName,
-          MetricConstants.MaeColumnName)
+        getEvaluationMetric match {
+          case MetricConstants.AllSparkMetrics | MetricConstants.RegressionMetricsName =>
+            Seq((mse, rmse, r2, mae)).toDF(MetricConstants.MseColumnName,
+              MetricConstants.RmseColumnName,
+              MetricConstants.R2ColumnName,
+              MetricConstants.MaeColumnName)
+          case MetricConstants.MseSparkMetric =>
+            Seq(mse).toDF(MetricConstants.MseColumnName)
+          case MetricConstants.RmseSparkMetric =>
+            Seq(rmse).toDF(MetricConstants.RmseColumnName)
+          case MetricConstants.R2SparkMetric =>
+            Seq(r2).toDF(MetricConstants.R2ColumnName)
+          case MetricConstants.MaeSparkMetric =>
+            Seq(mae).toDF(MetricConstants.MaeColumnName)
+          case default =>
+            throwOnInvalidEvaluationMetric(
+              default, SchemaConstants.RegressionKind, MetricConstants.RegressionMetrics)
+        }
       } else {
         throwOnInvalidScoringKind(scoreValueKind)
       }
@@ -204,48 +200,103 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
   //scalastyle:on method.length
   //scalastyle:on cyclomatic.complexity
 
-  private def validateColumn(dataset: Dataset[_],
-                             columnName: String,
-                             columnRole: String,
-                             setterName: String): String = {
-    val requestedColumn = Option(columnName).filter(_.nonEmpty)
-    val columns = dataset.columns
-    val caseSensitive = dataset.sparkSession.conf.get("spark.sql.caseSensitive", "false").toBoolean
-    val matchingColumns = requestedColumn.toSeq.flatMap { column =>
-      if (caseSensitive) columns.filter(_ == column)
-      else columns.filter(_.equalsIgnoreCase(column))
-    }
-    if (matchingColumns.size > 1) {
-      throw new IllegalArgumentException(
-        s"Unable to resolve $columnRole column '${requestedColumn.get}' unambiguously. " +
-          s"Matching columns: ${matchingColumns.sorted.mkString("[", ", ", "]")}")
-    } else if (matchingColumns.isEmpty) {
-      val requestedDescription = requestedColumn.map(name => s"'$name'").getOrElse("<unresolved>")
-      val availableColumns = columns.sorted.mkString("[", ", ", "]")
-      throw new IllegalArgumentException(
-        s"Unable to resolve $columnRole column $requestedDescription. " +
-          s"Call $setterName(...) with an existing column. Available columns: $availableColumns")
-    }
-    matchingColumns.head
+  private def validateInputColumns(schema: StructType,
+                                   modelName: String,
+                                   labelColumnName: String,
+                                   scoreValueKind: String,
+                                   caseSensitive: Boolean):
+      ComputeModelStatisticsInputValidator.ValidatedInputColumns = {
+    ComputeModelStatisticsInputValidator.validate(
+      schema,
+      modelName,
+      labelColumnName,
+      scoreValueKind,
+      if (isDefined(scoredLabelsCol)) Some(getScoredLabelsCol) else None,
+      if (isDefined(scoresCol)) Some(getScoresCol) else None,
+      getEvaluationMetric,
+      caseSensitive)
   }
 
   private def resolveSchemaInfo(schema: StructType,
                                 caseSensitive: Boolean): (String, String, String) = {
+    validateEvaluationMetric(schema, caseSensitive)
     if (canEvaluateWithoutMetadata) {
-      val scoreValueKind =
-        if (MetricUtils.isClassificationMetric(getEvaluationMetric)) SchemaConstants.ClassificationKind
-        else SchemaConstants.RegressionKind
-      val resolvedLabelCol =
-        MetricUtils.resolveLabelColumn(schema, Some(getLabelCol), caseSensitive).get
-      ("custom model", resolvedLabelCol, scoreValueKind)
+      getExplicitSchemaInfo(schema, caseSensitive)
     } else {
-      MetricUtils.getSchemaInfo(
-        schema,
-        if (isDefined(labelCol)) Some(getLabelCol) else None,
-        getEvaluationMetric,
-        caseSensitive)
+      getMetadataSchemaInfo(schema, caseSensitive)
     }
   }
+
+  private def validateEvaluationMetric(schema: StructType, caseSensitive: Boolean): Unit = {
+    if (!validEvaluationMetrics.contains(getEvaluationMetric)) {
+      inferScoreValueKind(schema, caseSensitive) match {
+        case Some(SchemaConstants.ClassificationKind) =>
+          throwOnInvalidEvaluationMetric(
+            getEvaluationMetric,
+            SchemaConstants.ClassificationKind,
+            MetricConstants.ClassificationMetrics)
+        case Some(SchemaConstants.RegressionKind) =>
+          throwOnInvalidEvaluationMetric(
+            getEvaluationMetric,
+            SchemaConstants.RegressionKind,
+            MetricConstants.RegressionMetrics)
+        case _ =>
+          throwOnInvalidEvaluationMetric(
+            getEvaluationMetric,
+            "classification or regression",
+            MetricConstants.ClassificationMetrics ++ MetricConstants.RegressionMetrics)
+      }
+    }
+  }
+
+  private def inferScoreValueKind(schema: StructType, caseSensitive: Boolean): Option[String] = {
+    try {
+      Some(MetricUtils.getSchemaInfo(
+        schema,
+        configuredLabelCol,
+        MetricConstants.AllSparkMetrics,
+        caseSensitive)._3)
+    } catch {
+      case _: IllegalArgumentException => None
+    }
+  }
+
+  private def getExplicitSchemaInfo(schema: StructType,
+                                    caseSensitive: Boolean): (String, String, String) = {
+    val resolvedLabelCol = MetricUtils.resolveLabelColumn(schema, configuredLabelCol, caseSensitive).get
+    ("custom model", resolvedLabelCol, scoreValueKindForMetric)
+  }
+
+  private def getMetadataSchemaInfo(schema: StructType,
+                                    caseSensitive: Boolean): (String, String, String) = {
+    try {
+      MetricUtils.getSchemaInfo(
+        schema,
+        configuredLabelCol,
+        getEvaluationMetric,
+        caseSensitive)
+    } catch {
+      case error: IllegalArgumentException =>
+        if (canFallBackToExplicitSchema(error)) {
+          ("custom model", configuredLabelCol.getOrElse(""), scoreValueKindForMetric)
+        } else {
+          throw error
+        }
+    }
+  }
+
+  private def canFallBackToExplicitSchema(error: IllegalArgumentException): Boolean = {
+    getEvaluationMetric != MetricConstants.AllSparkMetrics &&
+      error.getMessage.startsWith("Unable to determine a complete scored model")
+  }
+
+  private def scoreValueKindForMetric: String = {
+    if (MetricUtils.isClassificationMetric(getEvaluationMetric)) SchemaConstants.ClassificationKind
+    else SchemaConstants.RegressionKind
+  }
+
+  private def configuredLabelCol: Option[String] =
+    if (isDefined(labelCol)) Some(getLabelCol) else None
 
   private def isCaseSensitive(sparkSession: SparkSession): Boolean =
     sparkSession.conf.get("spark.sql.caseSensitive", "false").toBoolean
@@ -254,19 +305,16 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
     if (!isDefined(labelCol) || getEvaluationMetric == MetricConstants.AllSparkMetrics) {
       false
     } else if (MetricUtils.isClassificationMetric(getEvaluationMetric)) {
-      isDefined(scoredLabelsCol) &&
-        (!classificationMetricRequiresScores || isDefined(scoresCol))
+      isDefined(scoredLabelsCol)
     } else {
       isDefined(scoresCol)
     }
   }
 
-  private def classificationMetricRequiresScores: Boolean = {
-    getEvaluationMetric == MetricConstants.ClassificationMetricsName ||
-      getEvaluationMetric == MetricConstants.AucSparkMetric ||
-      getEvaluationMetric == MetricConstants.AreaUnderROCMetric ||
-      getEvaluationMetric == MetricConstants.AreaUnderPRMetric
-  }
+  private def validEvaluationMetrics: Set[String] =
+    MetricConstants.ClassificationMetrics ++
+      MetricConstants.RegressionMetrics +
+      MetricConstants.AllSparkMetrics
 
   private def addSimpleMetric(simpleMetric: String,
                               predictionAndLabels: RDD[(Double, Double)],
@@ -354,12 +402,11 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
   private def selectAndCastToDF(dataset: Dataset[_],
                                 predictionColumnName: String,
                                 labelColumnName: String): DataFrame = {
-    // TODO: We call cache in order to avoid a bug with catalyst where CMS seems to get stuck in a loop
-    // For future spark upgrade past 2.2.0, we should try to see if the cache() call can be removed
-    dataset.select(col(predictionColumnName), col(labelColumnName).cast(DoubleType))
-      .cache()
+    dataset.select(
+      inputColumn(predictionColumnName).cast(DoubleType).as(selectedPredictionColumn),
+      inputColumn(labelColumnName).cast(DoubleType).as(selectedLabelColumn))
       .na
-      .drop(Array(predictionColumnName, labelColumnName))
+      .drop(Array(selectedPredictionColumn, selectedLabelColumn))
   }
 
   private def selectAndCastToRDD(dataset: Dataset[_],
@@ -378,12 +425,11 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
                                      scoredLabelsColumnName: String,
                                      levelsToIndexMap: Map[Any, Double]): RDD[(Double, Double)] = {
     // Calculate confusion matrix and output it as DataFrame
-    // TODO: We call cache in order to avoid a bug with catalyst where CMS seems to get stuck in a loop
-    // For future spark upgrade past 2.2.0, we should try to see if the cache() call can be removed
-    dataset.select(col(scoredLabelsColumnName).cast(DoubleType), col(labelColumnName))
-      .cache()
+    dataset.select(
+      inputColumn(scoredLabelsColumnName).cast(DoubleType).as(selectedPredictionColumn),
+      inputColumn(labelColumnName).as(selectedLabelColumn))
       .na
-      .drop(Array(scoredLabelsColumnName, labelColumnName))
+      .drop(Array(selectedPredictionColumn, selectedLabelColumn))
       .rdd
       .map {
         case Row(prediction: Double, label) => (prediction, levelsToIndexMap(label))
@@ -395,30 +441,47 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
                                        labelColumnName: String,
                                        scoresColumnName: String): RDD[(Double, Double)] = {
 
-    selectAndCastToDF(dataset, scoresColumnName, labelColumnName)
+    selectScoresAndLabels(dataset, labelColumnName, scoresColumnName, castLabel = true)
       .rdd
       .map {
-        case Row(prediction: Vector, label: Double) => (prediction(1), label)
+        case Row(prediction: Vector, label: Double) =>
+          (ComputeModelStatistics.getPositiveClassScore(prediction, scoresColumnName), label)
         case Row(prediction: Double, label: Double) => (prediction, label)
         case _ => throw new Exception(s"Error: prediction and label columns invalid or missing")
       }
   }
 
   private def getScoresAndLabels(dataset: Dataset[_],
-                         labelColumnName: String,
-                         scoresColumnName: String,
-                         levelsToIndexMap: Map[Any, Double]): RDD[(Double, Double)] = {
-    // TODO: We call cache in order to avoid a bug with catalyst where CMS seems to get stuck in a loop
-    // For future spark upgrade past 2.2.0, we should try to see if the cache() call can be removed
-    dataset.select(col(scoresColumnName), col(labelColumnName))
-      .cache()
-      .na
-      .drop(Array(scoresColumnName, labelColumnName))
+                                labelColumnName: String,
+                                scoresColumnName: String,
+                                levelsToIndexMap: Map[Any, Double]): RDD[(Double, Double)] = {
+    selectScoresAndLabels(dataset, labelColumnName, scoresColumnName, castLabel = false)
       .rdd
       .map {
-        case Row(prediction: Vector, label) => (prediction(1), levelsToIndexMap(label))
+        case Row(prediction: Vector, label) =>
+          (ComputeModelStatistics.getPositiveClassScore(prediction, scoresColumnName), levelsToIndexMap(label))
+        case Row(prediction: Double, label) => (prediction, levelsToIndexMap(label))
         case _ => throw new Exception(s"Error: prediction and label columns invalid or missing")
       }
+  }
+
+  private def selectScoresAndLabels(dataset: Dataset[_],
+                                   labelColumnName: String,
+                                   scoresColumnName: String,
+                                   castLabel: Boolean): DataFrame = {
+    val scores = if (dataset.schema(scoresColumnName).dataType == SQLDataTypes.VectorType)
+      inputColumn(scoresColumnName).as(selectedPredictionColumn)
+    else
+      inputColumn(scoresColumnName).cast(DoubleType).as(selectedPredictionColumn)
+    val label = if (castLabel) inputColumn(labelColumnName).cast(DoubleType).as(selectedLabelColumn)
+    else inputColumn(labelColumnName).as(selectedLabelColumn)
+    dataset.select(scores, label)
+      .na
+      .drop(Array(selectedPredictionColumn, selectedLabelColumn))
+  }
+
+  private def inputColumn(columnName: String): Column = {
+    col(s"`${columnName.replace("`", "``")}`")
   }
 
   private def getLevelsToIndexMap(levels: Array[_]): Map[Any, Double] = {
@@ -572,13 +635,15 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
   override def copy(extra: ParamMap): Transformer = defaultCopy(extra)
 
   override def transformSchema(schema: StructType): StructType = {
-    val (_, labelColumnName, scoreValueKind) =
-      resolveSchemaInfo(
-        schema,
-        SparkSession.getActiveSession
-          .orElse(SparkSession.getDefaultSession)
-          .exists(isCaseSensitive))
-    val labelLevels = getLabelLevels(schema, labelColumnName)
+    val caseSensitive = SparkSession.getActiveSession
+      .orElse(SparkSession.getDefaultSession)
+      .exists(isCaseSensitive)
+    val (modelName, resolvedLabelColumnName, scoreValueKind) =
+      resolveSchemaInfo(schema, caseSensitive)
+    val inputColumns =
+      validateInputColumns(
+        schema, modelName, resolvedLabelColumnName, scoreValueKind, caseSensitive)
+    val labelLevels = getLabelLevels(schema, inputColumns.labelColumnName)
     val (columns, validMetrics) =
       if (scoreValueKind == SchemaConstants.ClassificationKind)
         (getClassificationColumns(labelLevels), MetricConstants.ClassificationMetrics)
@@ -587,11 +652,24 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
       else throwOnInvalidScoringKind(scoreValueKind)
     validateBinaryOnlyMetricSchema(labelLevels, scoreValueKind)
     getTransformedSchema(columns, scoreValueKind, validMetrics)
-
   }
 
   private def throwOnInvalidScoringKind(scoreValueKind: String) = {
     throw new Exception(s"Error: unknown scoring kind $scoreValueKind")
+  }
+
+  private def throwOnInvalidEvaluationMetric(metric: String,
+                                             metricType: String,
+                                             validMetrics: Set[String]): Nothing = {
+    val validValues = (validMetrics + MetricConstants.AllSparkMetrics).toSeq.sorted.mkString(", ")
+    val metricTypeName = metricType match {
+      case SchemaConstants.ClassificationKind => "classification"
+      case SchemaConstants.RegressionKind => "regression"
+      case _ => metricType
+    }
+    throw new IllegalArgumentException(
+      s"ComputeModelStatistics evaluationMetric '$metric' is not valid for $metricTypeName data. " +
+        s"Valid values: $validValues.")
   }
 
   private def getLabelLevels(schema: StructType, labelColumnName: String): Option[Array[_]] = {
@@ -640,7 +718,7 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
                              MetricConstants.MetricToColumnName.contains(metric) =>
         StructType(Array(StructField(MetricConstants.MetricToColumnName(metric), DoubleType)))
       case default =>
-        throw new Exception(s"Error: $default is not a $metricType metric")
+        throwOnInvalidEvaluationMetric(default, metricType, validMetrics)
     }
   }
 }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.txt
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.txt
@@ -1,6 +1,20 @@
 ``ComputeModelStatistics`` returns the specified statistics on all the
 models specified
 
+Input columns are inferred from SynapseML scoring metadata when that metadata is present.
+For an unannotated Spark DataFrame:
+
+- ``labelCol`` is the observed or true label.
+- ``scoredLabelsCol`` is the predicted label and is required for classification metrics.
+- ``scoresCol`` is the prediction for regression or the raw prediction for classification.
+  Classification uses ``scoredLabelsCol`` as the score when ``scoresCol`` is not available.
+
+Set these parameters to existing DataFrame columns when metadata inference is unavailable.
+Also set ``evaluationMetric`` to ``classification`` or ``regression`` so the model kind can be determined.
+Explicit column parameters override inferred metadata. Labels, predictions, and regression scores must
+be numeric unless the label has categorical metadata. Classification scores may be numeric scalars or
+Spark ML vectors; vector scores use the positive-class value at index 1. Null label or score rows are ignored.
+
 The possible metrics are:
 
 Binary Classifiers:

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatisticsInputValidator.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatisticsInputValidator.scala
@@ -1,0 +1,198 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.train
+
+import com.microsoft.azure.synapse.ml.core.metrics.{MetricConstants, MetricUtils}
+import com.microsoft.azure.synapse.ml.core.schema.{CategoricalUtilities, SchemaConstants}
+import org.apache.spark.ml.linalg.SQLDataTypes
+import org.apache.spark.sql.types.{NumericType, StructField, StructType}
+
+private[train] object ComputeModelStatisticsInputValidator {
+
+  final case class ValidatedInputColumns(labelColumnName: String,
+                                         scoredLabelsColumnName: Option[String],
+                                         scoresColumnName: Option[String])
+
+  private val ClassificationRequirements =
+    "Classification metrics require labelCol and scoredLabelsCol; " +
+      "scoresCol supplies raw scores when available."
+  private val RegressionRequirements = "Regression metrics require labelCol and scoresCol."
+
+  def validate(schema: StructType,
+               modelName: String,
+               labelColumnName: String,
+               scoreValueKind: String,
+               scoredLabelsCol: Option[String],
+               scoresCol: Option[String],
+               evaluationMetric: String,
+               caseSensitive: Boolean): ValidatedInputColumns = {
+    val labelField = validateColumn(
+      schema,
+      labelColumnName,
+      "labelCol",
+      "setLabelCol",
+      "label",
+      if (scoreValueKind == SchemaConstants.ClassificationKind) ClassificationRequirements
+      else RegressionRequirements,
+      caseSensitive)
+    val hasCategoricalLevels =
+      scoreValueKind == SchemaConstants.ClassificationKind &&
+        CategoricalUtilities.getLevels(schema, labelField.name).isDefined
+    if (!hasCategoricalLevels) {
+      validateType(labelField, "labelCol", "a numeric scalar")
+    }
+
+    scoreValueKind match {
+      case SchemaConstants.ClassificationKind =>
+        validateClassificationColumns(
+          schema,
+          modelName,
+          labelField,
+          scoredLabelsCol,
+          scoresCol,
+          evaluationMetric,
+          caseSensitive)
+      case SchemaConstants.RegressionKind =>
+        validateRegressionColumns(schema, modelName, labelField, scoresCol, caseSensitive)
+      case _ =>
+        ValidatedInputColumns(labelField.name, None, None)
+    }
+  }
+
+  private def validateClassificationColumns(
+      schema: StructType,
+      modelName: String,
+      labelField: StructField,
+      scoredLabelsCol: Option[String],
+      scoresCol: Option[String],
+      evaluationMetric: String,
+      caseSensitive: Boolean): ValidatedInputColumns = {
+    val scoredLabelsColumnName = scoredLabelsCol.orElse(
+      MetricUtils.getScoreColumnName(
+        schema,
+        modelName,
+        SchemaConstants.SparkPredictionColumn,
+        SchemaConstants.ClassificationKind)).getOrElse("")
+    val scoredLabelsField = validateColumn(
+      schema,
+      scoredLabelsColumnName,
+      "scoredLabelsCol",
+      "setScoredLabelsCol",
+      "classification prediction",
+      ClassificationRequirements,
+      caseSensitive)
+    validateType(scoredLabelsField, "scoredLabelsCol", "a numeric scalar")
+
+    val scoresColumnName =
+      if (!classificationUsesScores(evaluationMetric)) {
+        None
+      } else {
+        scoresCol.map { columnName =>
+          validateClassificationScores(schema, columnName, caseSensitive)
+        }.orElse {
+          MetricUtils.getScoreColumnName(
+            schema,
+            modelName,
+            SchemaConstants.SparkRawPredictionColumn,
+            SchemaConstants.ClassificationKind).map { columnName =>
+            validateClassificationScores(schema, columnName, caseSensitive)
+          }
+        }
+      }
+    ValidatedInputColumns(labelField.name, Some(scoredLabelsField.name), scoresColumnName)
+  }
+
+  private def validateClassificationScores(
+      schema: StructType,
+      columnName: String,
+      caseSensitive: Boolean): String = {
+    val scoresField = validateColumn(
+      schema,
+      columnName,
+      "scoresCol",
+      "setScoresCol",
+      "classification score",
+      ClassificationRequirements,
+      caseSensitive)
+    if (scoresField.dataType != SQLDataTypes.VectorType) {
+      validateType(scoresField, "scoresCol", "a numeric scalar or Spark ML vector")
+    }
+    scoresField.name
+  }
+
+  private def validateRegressionColumns(
+      schema: StructType,
+      modelName: String,
+      labelField: StructField,
+      scoresCol: Option[String],
+      caseSensitive: Boolean): ValidatedInputColumns = {
+    val scoresColumnName = scoresCol.orElse(
+      MetricUtils.getScoreColumnName(
+        schema,
+        modelName,
+        SchemaConstants.SparkPredictionColumn,
+        SchemaConstants.RegressionKind)).getOrElse("")
+    val scoresField = validateColumn(
+      schema,
+      scoresColumnName,
+      "scoresCol",
+      "setScoresCol",
+      "regression prediction/score",
+      RegressionRequirements,
+      caseSensitive)
+    validateType(scoresField, "scoresCol", "a numeric scalar")
+    ValidatedInputColumns(labelField.name, None, Some(scoresField.name))
+  }
+
+  private def classificationUsesScores(evaluationMetric: String): Boolean = {
+    evaluationMetric == MetricConstants.AllSparkMetrics ||
+      evaluationMetric == MetricConstants.ClassificationMetricsName ||
+      evaluationMetric == MetricConstants.AucSparkMetric ||
+      evaluationMetric == MetricConstants.AreaUnderROCMetric ||
+      evaluationMetric == MetricConstants.AreaUnderPRMetric
+  }
+
+  private def validateColumn(schema: StructType,
+                             columnName: String,
+                             paramName: String,
+                             setterName: String,
+                             role: String,
+                             requirements: String,
+                             caseSensitive: Boolean): StructField = {
+    val availableColumns = schema.fieldNames.sorted.mkString("[", ", ", "]")
+    if (Option(columnName).forall(_.isEmpty)) {
+      throw new IllegalArgumentException(
+        s"ComputeModelStatistics requires the $role column. " +
+          s"Unable to resolve $role column <unresolved>. " +
+          s"Call $setterName(...) with an existing dataset column when scoring metadata is unavailable. " +
+          s"$requirements Available columns: $availableColumns")
+    }
+
+    val matchingFields =
+      if (caseSensitive) schema.fields.filter(_.name == columnName)
+      else schema.fields.filter(_.name.equalsIgnoreCase(columnName))
+    if (matchingFields.isEmpty) {
+      throw new IllegalArgumentException(
+        s"ComputeModelStatistics $paramName '$columnName' does not exist in the dataset; " +
+          s"unable to resolve $role column '$columnName'. " +
+          s"Call $setterName(...) with an existing column. " +
+          s"$requirements Available columns: $availableColumns")
+    } else if (matchingFields.length > 1) {
+      throw new IllegalArgumentException(
+        s"ComputeModelStatistics $paramName '$columnName' is ambiguous because the dataset contains " +
+          s"${matchingFields.length} columns with that name. Rename or select one column before evaluation.")
+    }
+    matchingFields.head
+  }
+
+  private def validateType(field: StructField, paramName: String, expectedType: String): Unit = {
+    field.dataType match {
+      case _: NumericType => ()
+      case _ =>
+        throw new IllegalArgumentException(
+          s"ComputeModelStatistics $paramName '${field.name}' has type ${field.dataType.catalogString}; " +
+            s"expected $expectedType.")
+    }
+  }
+}

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatisticsValidationSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatisticsValidationSuite.scala
@@ -1,0 +1,337 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.train
+
+import com.microsoft.azure.synapse.ml.build.BuildInfo
+import com.microsoft.azure.synapse.ml.core.metrics.MetricConstants
+import com.microsoft.azure.synapse.ml.core.schema.{CategoricalUtilities, SchemaConstants, SparkSchema}
+import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import org.apache.commons.io.FileUtils
+import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.apache.spark.ml.linalg.{SQLDataTypes, Vectors}
+import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.{DoubleType, StructField, StructType}
+
+import java.io.File
+import java.util.UUID
+
+class ComputeModelStatisticsValidationSuite extends TestBase {
+
+  test("Explicit labels override scoring metadata and incomplete metadata remains actionable") {
+    val data = spark.createDataFrame(Seq(
+      (1.0, 0.0, 0.0),
+      (0.0, 1.0, 1.0))).toDF("metadataLabel", "explicitLabel", "prediction")
+    val modelName = SchemaConstants.ScoreModelPrefix + "_override"
+    val withLabel = SparkSchema.setLabelColumnName(
+      data, modelName, "metadataLabel", SchemaConstants.ClassificationKind)
+    val scored = SparkSchema.updateColumnMetadata(
+      withLabel, modelName, "prediction", SchemaConstants.ClassificationKind)
+    val evaluator = new ComputeModelStatistics()
+      .setLabelCol("explicitLabel")
+      .setScoredLabelsCol("prediction")
+      .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
+
+    assert(evaluator.transform(scored).first().getAs[Double](MetricConstants.AccuracyColumnName) === 1.0)
+
+    val predictionOnlyMetadata = SparkSchema.updateColumnMetadata(
+      data, modelName, "prediction", SchemaConstants.ClassificationKind)
+    assert(evaluator.transform(predictionOnlyMetadata).first()
+      .getAs[Double](MetricConstants.AccuracyColumnName) === 1.0)
+
+    val error = intercept[IllegalArgumentException] {
+      new ComputeModelStatistics()
+        .setScoredLabelsCol("prediction")
+        .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
+        .transformSchema(predictionOnlyMetadata.schema)
+    }
+    assert(error.getMessage.contains("requires the label column"))
+    assert(error.getMessage.contains("setLabelCol"))
+  }
+
+  test("Column validation rejects ambiguous and incompatible input types") {
+    val numeric = spark.createDataFrame(Seq((0.0, 0.0), (1.0, 1.0))).toDF("label", "prediction")
+
+    val missingLabel = intercept[IllegalArgumentException] {
+      new ComputeModelStatistics()
+        .setLabelCol("missingLabel")
+        .setScoredLabelsCol("prediction")
+        .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
+        .transform(numeric)
+    }
+    assert(missingLabel.getMessage.contains("labelCol 'missingLabel' does not exist"))
+    assert(missingLabel.getMessage.contains("setLabelCol"))
+
+    val missingScoredLabels = intercept[IllegalArgumentException] {
+      new ComputeModelStatistics()
+        .setLabelCol("label")
+        .setScoresCol("prediction")
+        .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
+        .transformSchema(numeric.schema)
+    }
+    assert(missingScoredLabels.getMessage.contains("setScoredLabelsCol"))
+    assert(missingScoredLabels.getMessage.contains("labelCol and scoredLabelsCol"))
+
+    val duplicateLabel = numeric.select(col("label"), col("prediction").as("label"), col("prediction"))
+    val ambiguous = intercept[IllegalArgumentException] {
+      new ComputeModelStatistics()
+        .setLabelCol("label")
+        .setScoredLabelsCol("prediction")
+        .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
+        .transformSchema(duplicateLabel.schema)
+    }
+    assert(ambiguous.getMessage.contains("labelCol 'label' is ambiguous"))
+
+    val stringLabels = spark.createDataFrame(Seq(("zero", 0.0), ("one", 1.0))).toDF("label", "prediction")
+    val invalidLabel = intercept[IllegalArgumentException] {
+      new ComputeModelStatistics()
+        .setLabelCol("label")
+        .setScoredLabelsCol("prediction")
+        .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
+        .transformSchema(stringLabels.schema)
+    }
+    assert(invalidLabel.getMessage.contains("labelCol 'label' has type string"))
+
+    val vectorPrediction = spark.createDataFrame(Seq(
+      (0.0, Vectors.dense(1.0, 0.0)),
+      (1.0, Vectors.dense(0.0, 1.0)))).toDF("label", "prediction")
+    val invalidPrediction = intercept[IllegalArgumentException] {
+      new ComputeModelStatistics()
+        .setLabelCol("label")
+        .setScoredLabelsCol("prediction")
+        .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
+        .transformSchema(vectorPrediction.schema)
+    }
+    assert(invalidPrediction.getMessage.contains("scoredLabelsCol 'prediction' has type"))
+    assert(invalidPrediction.getMessage.contains("expected a numeric scalar"))
+
+    val invalidRegression = intercept[IllegalArgumentException] {
+      new ComputeModelStatistics()
+        .setLabelCol("label")
+        .setScoresCol("prediction")
+        .setEvaluationMetric(MetricConstants.RegressionMetricsName)
+        .transformSchema(vectorPrediction.schema)
+    }
+    assert(invalidRegression.getMessage.contains("scoresCol 'prediction' has type"))
+    assert(invalidRegression.getMessage.contains("expected a numeric scalar"))
+
+    val stringScores = spark.createDataFrame(Seq(
+      (0.0, 0.0, "low"),
+      (1.0, 1.0, "high"))).toDF("label", "prediction", "scores")
+    val invalidClassificationScores = intercept[IllegalArgumentException] {
+      new ComputeModelStatistics()
+        .setLabelCol("label")
+        .setScoredLabelsCol("prediction")
+        .setScoresCol("scores")
+        .setEvaluationMetric(MetricConstants.AucSparkMetric)
+        .transformSchema(stringScores.schema)
+    }
+    assert(invalidClassificationScores.getMessage.contains("scoresCol 'scores' has type string"))
+    assert(invalidClassificationScores.getMessage.contains("expected a numeric scalar or Spark ML vector"))
+
+    val missingAreaUnderPRScores = intercept[IllegalArgumentException] {
+      new ComputeModelStatistics()
+        .setLabelCol("label")
+        .setScoredLabelsCol("prediction")
+        .setScoresCol("missingScores")
+        .setEvaluationMetric(MetricConstants.AreaUnderPRMetric)
+        .transformSchema(numeric.schema)
+    }
+    assert(missingAreaUnderPRScores.getMessage.contains("scoresCol 'missingScores' does not exist"))
+  }
+
+  test("Empty configured column names fail with setter guidance") {
+    val data = spark.createDataFrame(Seq((0.0, 0.0))).toDF("label", "prediction")
+
+    val emptyLabel = intercept[IllegalArgumentException] {
+      new ComputeModelStatistics()
+        .setLabelCol("")
+        .setScoredLabelsCol("prediction")
+        .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
+        .transformSchema(data.schema)
+    }
+    assert(emptyLabel.getMessage.contains("requires the label column"))
+    assert(emptyLabel.getMessage.contains("setLabelCol"))
+
+    val emptyScoredLabels = intercept[IllegalArgumentException] {
+      new ComputeModelStatistics()
+        .setLabelCol("label")
+        .setScoredLabelsCol("")
+        .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
+        .transformSchema(data.schema)
+    }
+    assert(emptyScoredLabels.getMessage.contains("classification prediction column <unresolved>"))
+    assert(emptyScoredLabels.getMessage.contains("setScoredLabelsCol"))
+
+    val emptyScores = intercept[IllegalArgumentException] {
+      new ComputeModelStatistics()
+        .setLabelCol("label")
+        .setScoresCol("")
+        .setEvaluationMetric(MetricConstants.RegressionMetricsName)
+        .transformSchema(data.schema)
+    }
+    assert(emptyScores.getMessage.contains("regression prediction/score column <unresolved>"))
+    assert(emptyScores.getMessage.contains("setScoresCol"))
+  }
+
+  test("Column resolution follows Spark case sensitivity") {
+    val data = spark.createDataFrame(Seq(
+      ("no", 0.0),
+      ("yes", 1.0))).toDF("Label", "Prediction")
+    val categorical = CategoricalUtilities.setLevels(data, "Label", Array("no", "yes"))
+    val evaluator = new ComputeModelStatistics()
+      .setLabelCol("label")
+      .setScoredLabelsCol("prediction")
+      .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
+
+    assert(evaluator.transform(categorical).first()
+      .getAs[Double](MetricConstants.AccuracyColumnName) === 1.0)
+
+    val originalCaseSensitivity = spark.conf.get("spark.sql.caseSensitive")
+    try {
+      spark.conf.set("spark.sql.caseSensitive", "true")
+      val error = intercept[IllegalArgumentException] {
+        evaluator.transformSchema(categorical.schema)
+      }
+      assert(error.getMessage.contains("labelCol 'label' does not exist"))
+      assert(error.getMessage.contains("[Label, Prediction]"))
+    } finally {
+      spark.conf.set("spark.sql.caseSensitive", originalCaseSensitivity)
+    }
+  }
+
+  test("Scalar and vector classification scores agree and null rows are ignored") {
+    val scalarData = spark.createDataFrame(Seq(
+      ("no", 0, 0.1),
+      ("yes", 1, 0.9))).toDF("label", "prediction", "scores")
+    val categorical = CategoricalUtilities.setLevels(scalarData, "label", Array("no", "yes"))
+    val predictionFallback = new ComputeModelStatistics()
+      .setLabelCol("label")
+      .setScoredLabelsCol("prediction")
+      .setEvaluationMetric(MetricConstants.ClassificationMetricsName)
+      .transform(categorical.select("label", "prediction"))
+      .first()
+    assert(predictionFallback.getAs[Double](MetricConstants.AccuracyColumnName) === 1.0)
+    assert(predictionFallback.getAs[Double](MetricConstants.AucColumnName) === 1.0)
+
+    val scalarResult = new ComputeModelStatistics()
+      .setLabelCol("label")
+      .setScoredLabelsCol("prediction")
+      .setScoresCol("scores")
+      .setEvaluationMetric(MetricConstants.ClassificationMetricsName)
+      .transform(categorical)
+      .first()
+    assert(scalarResult.getAs[Double](MetricConstants.AucColumnName) === 1.0)
+    assert(scalarResult.getAs[Double](MetricConstants.AreaUnderPRColumnName) === 1.0)
+
+    val vectorSchema = StructType(Array(
+      StructField("label", DoubleType, nullable = true),
+      StructField("prediction", DoubleType, nullable = true),
+      StructField("scores", SQLDataTypes.VectorType, nullable = true)))
+    // scalastyle:off null
+    val vectorData = spark.createDataFrame(spark.sparkContext.parallelize(Seq(
+      Row(0.0, 0.0, Vectors.dense(0.9, 0.1)),
+      Row(1.0, 1.0, Vectors.sparse(2, Array(1), Array(0.9))),
+      Row(null, null, null))), vectorSchema)
+    // scalastyle:on null
+    val vectorResult = new ComputeModelStatistics()
+      .setLabelCol("label")
+      .setScoredLabelsCol("prediction")
+      .setScoresCol("scores")
+      .setEvaluationMetric(MetricConstants.ClassificationMetricsName)
+      .transform(vectorData)
+      .first()
+    assert(vectorResult.getAs[Double](MetricConstants.AucColumnName) === 1.0)
+    assert(vectorResult.getAs[Double](MetricConstants.AreaUnderPRColumnName) === 1.0)
+
+    val invalidVectorData = spark.createDataFrame(Seq(
+      (0.0, 0.0, Vectors.dense(0.1)),
+      (1.0, 1.0, Vectors.dense(0.9)))).toDF("label", "prediction", "scores")
+    val invalidVector = intercept[Exception] {
+      new ComputeModelStatistics()
+        .setLabelCol("label")
+        .setScoredLabelsCol("prediction")
+        .setScoresCol("scores")
+        .setEvaluationMetric(MetricConstants.AucSparkMetric)
+        .transform(invalidVectorData)
+        .first()
+    }
+    val messages = Iterator.iterate[Throwable](invalidVector)(_.getCause)
+      .takeWhile(_ != null)
+      .map(_.getMessage)
+      .filter(_ != null)
+      .mkString(" ")
+    assert(messages.contains("vectors must contain at least two values"))
+  }
+
+  test("Regression schemas, copies, and persisted pipelines preserve configured behavior") {
+    val data = spark.createDataFrame(Seq((0, 0.0f), (2, 1.0f))).toDF("label", "prediction")
+    val evaluator = new ComputeModelStatistics()
+      .setLabelCol("label")
+      .setScoresCol("prediction")
+      .setEvaluationMetric(MetricConstants.MseSparkMetric)
+    val result = evaluator.transform(data)
+    val transformedSchema = evaluator.transformSchema(data.schema)
+    assert(result.schema.fieldNames === transformedSchema.fieldNames)
+    assert(result.schema.fields.map(_.dataType) === transformedSchema.fields.map(_.dataType))
+    assert(result.columns.toSeq === Seq(MetricConstants.MseColumnName))
+    assert(result.first().getDouble(0) === 0.5)
+
+    val copied = evaluator.copy(new ParamMap()
+      .put(evaluator.evaluationMetric, MetricConstants.RmseSparkMetric))
+      .asInstanceOf[ComputeModelStatistics]
+    assert(copied.getLabelCol === "label")
+    assert(copied.getScoresCol === "prediction")
+    assert(copied.getEvaluationMetric === MetricConstants.RmseSparkMetric)
+
+    val pipelineModel = new Pipeline().setStages(Array(evaluator)).fit(data)
+    val path = new File(BuildInfo.baseDirectory,
+      s"target/compute-model-statistics-pipeline-${UUID.randomUUID()}").getAbsoluteFile
+    try {
+      pipelineModel.write.overwrite().save(path.toString)
+      val loaded = PipelineModel.load(path.toString)
+      val loadedResult = loaded.transform(data)
+      assert(loadedResult.schema === result.schema)
+      assert(loadedResult.first().getDouble(0) === 0.5)
+    } finally {
+      if (path.exists()) FileUtils.forceDelete(path)
+    }
+  }
+
+  test("Invalid evaluation metrics report the valid values") {
+    val data = spark.createDataFrame(Seq((0.0, 0.0), (1.0, 1.0))).toDF("label", "prediction")
+    val modelName = SchemaConstants.ScoreModelPrefix + "_invalid_metric"
+    val withLabel = SparkSchema.setLabelColumnName(
+      data, modelName, "label", SchemaConstants.RegressionKind)
+    val scored = SparkSchema.updateColumnMetadata(
+      withLabel, modelName, "prediction", SchemaConstants.RegressionKind)
+    val evaluator = new ComputeModelStatistics()
+      .setEvaluationMetric("unsupported")
+
+    val schemaError = intercept[IllegalArgumentException] {
+      evaluator.transformSchema(scored.schema)
+    }
+    assert(schemaError.getMessage.contains("evaluationMetric 'unsupported'"))
+    assert(schemaError.getMessage.contains("not valid for regression data"))
+    assert(schemaError.getMessage.contains("Valid values: all, mae, mse, r2, regression, rmse"))
+
+    val runtimeError = intercept[IllegalArgumentException] {
+      evaluator.transform(scored)
+    }
+    assert(runtimeError.getMessage === schemaError.getMessage)
+  }
+
+  test("Top-level columns with SQL punctuation remain addressable") {
+    val data = spark.createDataFrame(Seq((0.0, 0.0), (1.0, 1.0)))
+      .toDF("label.with.dot", "prediction`quoted")
+    val result = new ComputeModelStatistics()
+      .setLabelCol("label.with.dot")
+      .setScoredLabelsCol("prediction`quoted")
+      .setEvaluationMetric(MetricConstants.AccuracySparkMetric)
+      .transform(data)
+
+    assert(result.first().getAs[Double](MetricConstants.AccuracyColumnName) === 1.0)
+  }
+}

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputeModelStatistics.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputeModelStatistics.scala
@@ -75,7 +75,7 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
       .foreach { case (metric, expectedMessage) =>
         val error = intercept[IllegalArgumentException] {
           new ComputeModelStatistics()
-            .setLabelCol("label")
+            .setLabelCol("label").setScoredLabelsCol("prediction")
             .setEvaluationMetric(metric)
             .transformSchema(schema)
         }
@@ -190,7 +190,7 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
     assertBinaryOnlyMetricsRejected(schema)
   }
 
-  test("transformSchema preserves binary-only metric schema when configured labelCol is absent") {
+  test("transformSchema validates required columns before returning a binary-only metric schema") {
     val schema = spark.createDataFrame(Seq(
       (0.0, 0.9),
       (1.0, 0.8))).toDF("prediction", "rawPrediction").schema
@@ -198,8 +198,9 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
       .setLabelCol("label")
       .setEvaluationMetric(MetricConstants.AreaUnderPRMetric)
 
-    assert(evaluator.transformSchema(schema) ===
-      StructType(Array(StructField(MetricConstants.AreaUnderPRColumnName, DoubleType))))
+    val error = intercept[IllegalArgumentException] { evaluator.transformSchema(schema) }
+    assert(error.getMessage.contains("labelCol 'label' does not exist") &&
+      error.getMessage.contains("setLabelCol"))
   }
 
   test("areaUnderPR rejects multiclass and unsupported metric inputs") {
@@ -333,7 +334,7 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
         .setEvaluationMetric(MetricConstants.RegressionMetricsName)
         .transformSchema(input.schema)
     }
-    assert(error.getMessage.contains("Set labelCol, or score the dataset"))
+    assert(error.getMessage.contains("requires the label column") && error.getMessage.contains("setLabelCol"))
     assert(!error.getMessage.contains(
       s"evaluationMetric must not be '${MetricConstants.AllSparkMetrics}'"))
   }
@@ -792,9 +793,8 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
     val auc = binaryEvaluator.evaluate(predictionAndLabels)
     assert(auc === cmsAUC)
   }
-
-  override def testObjects(): Seq[TestObject[ComputeModelStatistics]] = Seq(new TestObject(
-    new ComputeModelStatistics(), scoredDataset))
+  override def testObjects(): Seq[TestObject[ComputeModelStatistics]] = Seq(
+    new TestObject(new ComputeModelStatistics(), scoredDataset))
 
   override def reader: MLReadable[_] = ComputeModelStatistics
 }


### PR DESCRIPTION
## Related Issues/PRs

Fixes #736
Depends on merged #2635 and #2632 for release-replay baselines

## What changes are proposed in this pull request?

- Resolve and validate label, scored-label, and score columns before metadata or Catalyst access.
- Reject missing, duplicate/ambiguous, empty, and unsupported scalar/vector inputs with actionable parameter-specific errors.
- Preserve explicit column overrides when SynapseML scoring metadata is present or incomplete.
- Support numeric scalar classification scores plus dense/sparse Spark ML vectors; reject vectors without a positive-class slot.
- Ignore null metric rows, safely quote top-level Spark column names, and remove obsolete unbounded input caching.
- Align specific regression metric runtime columns with `transformSchema`.
- Preserve configured params through `copy`, Pipeline fitting, save/load, codegen, and generated Python wrappers.
- Keep `pipeline.yaml` unchanged and replay merged #2635 followed by #2632 on Spark 4.1, matching target history.

## How was this patch tested?

- JDK 11 / Spark 3.5: `ComputeModelStatisticsValidationSuite` 8/8, `VerifyComputeModelStatistics` 32/32, and `VerifyComputePerInstanceStatistics` 5/5.
- JDK 11: `core/compile`, `core/Test/compile`, `core/scalastyle`, and `core/Test/scalastyle` passed.
- Python: Black 22.3.0 checked 189 files; `sbt codegen` passed; the generated wrapper passed AST and `py_compile` checks.
- CI scripts: `tools/ci/tests/test_pipeline_yaml.py` 61/61; the amended prerequisite config format test passed on the final head.
- Spark 4.1.1 / Scala 2.13.17 / JDK 17: ordered prerequisites and the final release-relevant patch produced exact expected blobs; full `test:compile` passed and the focused suite passed 8/8.
- Azure build [231493934](https://msdata.visualstudio.com/b9b2accc-2d1c-45b3-9d24-0eb5d78cc47f/_build/results?buildId=231493934): succeeded, 66/66 jobs, `reason=pullRequest`, including Spark 4.1 compatibility and CPU/GPU/Fabric E2E.
- Current-head Copilot review covered 6/6 files with 0 new comments; all review threads are resolved and no suppressed findings exist.

## Compatibility

No public JVM signatures or serialized parameter shapes were removed or changed. `ComputeModelStatistics.copy(ParamMap)` retains its `Transformer` return type and now uses `defaultCopy`. Generated Python parameter APIs are unchanged.