### PR TITLE
feat(core): add precision-recall AUC metric

### DIFF
--- a/.pipelines/release-compat-prerequisites.txt
+++ b/.pipelines/release-compat-prerequisites.txt
@@ -4,3 +4,6 @@
 # PR #2612 introduces the WorkerMessage protocol used by the IPv6 endpoint parsing fix.
 # Remove this prerequisite once every validated release branch contains that backport.
 4a52d9ae4184d3ce00394cd9cb4209c35990fc47
+# PR #2507 introduced tests modified by PR #2635 but absent from Spark 4.1.
+# Remove this scoped prerequisite once every validated release branch contains these tests.
+6938c472175ed1592ec24e7d8c65d9174f17c4e5	core/src/test/scala/com/microsoft/azure/synapse/ml/automl/VerifyEvaluationUtils.scala	core/src/test/scala/com/microsoft/azure/synapse/ml/core/metrics/VerifyMetricConstants.scala

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/automl/EvaluationUtils.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/automl/EvaluationUtils.scala
@@ -56,7 +56,10 @@ object EvaluationUtils {
         case _ => throw new Exception("Metric is not supported for regressors")
       }
       case SchemaConstants.ClassificationKind => evaluationMetric match {
-        case MetricConstants.AucSparkMetric       => (MetricConstants.AucColumnName, chooseHighest)
+        case MetricConstants.AucSparkMetric | MetricConstants.AreaUnderROCMetric =>
+          (MetricConstants.AucColumnName, chooseHighest)
+        case MetricConstants.AreaUnderPRMetric =>
+          (MetricConstants.AreaUnderPRColumnName, chooseHighest)
         case MetricConstants.PrecisionSparkMetric => (MetricConstants.PrecisionColumnName, chooseHighest)
         case MetricConstants.RecallSparkMetric    => (MetricConstants.RecallColumnName, chooseHighest)
         case MetricConstants.AccuracySparkMetric  => (MetricConstants.AccuracyColumnName, chooseHighest)

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/automl/FindBestModel.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/automl/FindBestModel.scala
@@ -29,8 +29,9 @@ trait FindBestModelParams extends Wrappable with ComplexParamsWritable with HasE
     * The metrics that can be chosen are:
     *
     * For Binary Classifiers:
-    *     - AreaUnderROC
+    *     - areaUnderROC (reported in the AUC column)
     *     - AUC
+    *     - areaUnderPR
     *     - accuracy
     *     - precision
     *     - recall

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/metrics/MetricConstants.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/metrics/MetricConstants.scala
@@ -17,14 +17,15 @@ object MetricConstants {
 
   // Binary Classification metrics
   val AreaUnderROCMetric   = "areaUnderROC"
+  val AreaUnderPRMetric    = "areaUnderPR"
   val AucSparkMetric       = "AUC"
   val AccuracySparkMetric  = "accuracy"
   val PrecisionSparkMetric = "precision"
   val RecallSparkMetric    = "recall"
   val ClassificationMetricsName = "classification"
 
-  val ClassificationMetrics: Set[String] = Set(AreaUnderROCMetric, AucSparkMetric, AccuracySparkMetric,
-    PrecisionSparkMetric, RecallSparkMetric, ClassificationMetricsName)
+  val ClassificationMetrics: Set[String] = Set(AreaUnderROCMetric, AreaUnderPRMetric, AucSparkMetric,
+    AccuracySparkMetric, PrecisionSparkMetric, RecallSparkMetric, ClassificationMetricsName)
 
   val AllSparkMetrics      = "all"
 
@@ -35,7 +36,8 @@ object MetricConstants {
   val MaeColumnName  = "mean_absolute_error"
 
   // Binary Classification column names
-  val AucColumnName = "AUC"
+  val AucColumnName         = "AUC"
+  val AreaUnderPRColumnName = "areaUnderPR"
 
   // Binary and Multiclass (micro-averaged) column names
   val PrecisionColumnName = "precision"
@@ -50,7 +52,10 @@ object MetricConstants {
   val ConfusionMatrix = "confusion_matrix"
 
   // Metric to column name
-  val MetricToColumnName: Map[String, String] = Map(AccuracySparkMetric -> AccuracyColumnName,
+  val MetricToColumnName: Map[String, String] = Map(AreaUnderROCMetric -> AucColumnName,
+    AucSparkMetric       -> AucColumnName,
+    AreaUnderPRMetric    -> AreaUnderPRColumnName,
+    AccuracySparkMetric  -> AccuracyColumnName,
     PrecisionSparkMetric -> PrecisionColumnName,
     RecallSparkMetric    -> RecallColumnName,
     MseSparkMetric       -> MseColumnName,
@@ -58,7 +63,9 @@ object MetricConstants {
     R2SparkMetric        -> R2ColumnName,
     MaeSparkMetric       -> MaeColumnName)
 
+  // Shared by binary and multiclass metrics; preserved for the legacy all/classification schema contract.
   val ClassificationColumns = List(AccuracyColumnName, PrecisionColumnName, RecallColumnName)
+  val BinaryClassificationColumns = ClassificationColumns ++ List(AucColumnName, AreaUnderPRColumnName)
 
   val RegressionColumns = List(MseColumnName, RmseColumnName, R2ColumnName, MaeColumnName)
 
@@ -92,6 +99,8 @@ object MetricConstants {
         MetricConstants.AccuracySparkMetric,
         MetricConstants.PrecisionSparkMetric,
         MetricConstants.RecallSparkMetric,
-        MetricConstants.AucSparkMetric)
+        MetricConstants.AreaUnderROCMetric,
+        MetricConstants.AucSparkMetric,
+        MetricConstants.AreaUnderPRMetric)
 
 }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.scala
@@ -485,7 +485,7 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
   override def copy(extra: ParamMap): Transformer = new ComputeModelStatistics()
 
   override def transformSchema(schema: StructType): StructType = {
-    val (_, _, scoreValueKind) =
+    val (_, labelColumnName, scoreValueKind) =
       MetricUtils.getSchemaInfo(
         schema,
         if (isDefined(labelCol)) Some(getLabelCol) else None,
@@ -496,12 +496,40 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
       else if (scoreValueKind == SchemaConstants.RegressionKind)
         (MetricConstants.RegressionColumns, MetricConstants.RegressionMetrics)
       else throwOnInvalidScoringKind(scoreValueKind)
+    validateBinaryOnlyMetricSchema(schema, labelColumnName, scoreValueKind)
     getTransformedSchema(columns, scoreValueKind, validMetrics)
 
   }
 
   private def throwOnInvalidScoringKind(scoreValueKind: String) = {
     throw new Exception(s"Error: unknown scoring kind $scoreValueKind")
+  }
+
+  private def validateBinaryOnlyMetricSchema(schema: StructType,
+                                             labelColumnName: String,
+                                             scoreValueKind: String): Unit = {
+    val isBinaryOnlyClassificationMetric =
+      getEvaluationMetric == MetricConstants.AucSparkMetric ||
+        getEvaluationMetric == MetricConstants.AreaUnderROCMetric ||
+        getEvaluationMetric == MetricConstants.AreaUnderPRMetric
+    val labelLevels =
+      if (schema.fieldNames.contains(labelColumnName)) CategoricalUtilities.getLevels(schema, labelColumnName)
+      else None
+    // Match runtime semantics: only SynapseML categorical metadata establishes label cardinality.
+    if (scoreValueKind == SchemaConstants.ClassificationKind &&
+        isBinaryOnlyClassificationMetric &&
+        labelLevels.exists(_.length > 2)) {
+      throw new IllegalArgumentException(getBinaryOnlyMetricMulticlassError(getEvaluationMetric))
+    }
+  }
+
+  private def getBinaryOnlyMetricMulticlassError(metric: String): String = metric match {
+    case MetricConstants.AucSparkMetric | MetricConstants.AreaUnderROCMetric =>
+      "Error: AUC is not available for multiclass case"
+    case MetricConstants.AreaUnderPRMetric =>
+      "Error: areaUnderPR is not available for multiclass case"
+    case _ =>
+      throw new IllegalArgumentException(s"Error: $metric is not a classification metric")
   }
 
   private def getTransformedSchema(columns: List[String],

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.scala
@@ -30,8 +30,9 @@ trait ComputeModelStatisticsParams extends Wrappable with DefaultParamsWritable
     * The metrics that can be chosen are:
     *
     *   For binary classification:
-    *     - areaUnderROC
+    *     - areaUnderROC (reported in the AUC column)
     *     - AUC
+    *     - areaUnderPR
     *     - accuracy
     *     - precision
     *     - recall
@@ -129,15 +130,23 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
             simpleMetric == MetricConstants.PrecisionSparkMetric ||
             simpleMetric == MetricConstants.RecallSparkMetric =>
             resultDF = addSimpleMetric(simpleMetric, predictionAndLabels, resultDF)
-          case MetricConstants.AucSparkMetric =>
+          case MetricConstants.AucSparkMetric | MetricConstants.AreaUnderROCMetric =>
             val numLevels = if (levelsExist) levels.get.length
             else confusionMatrix.numRows
             if (numLevels <= 2) {
-              // Add the AUC
-              val auc: Double = getAUC(modelName, dataset, labelColumnName, scoresAndLabels)
+              val auc = getAUC(modelName, dataset, labelColumnName, scoresAndLabels)
               resultDF = resultDF.withColumn(MetricConstants.AucColumnName, lit(auc))
             } else {
               throw new Exception("Error: AUC is not available for multiclass case")
+            }
+          case MetricConstants.AreaUnderPRMetric =>
+            val numLevels = if (levelsExist) levels.get.length
+            else confusionMatrix.numRows
+            if (numLevels <= 2) {
+              val areaUnderPR = getAreaUnderPR(scoresAndLabels)
+              resultDF = resultDF.withColumn(MetricConstants.AreaUnderPRColumnName, lit(areaUnderPR))
+            } else {
+              throw new Exception("Error: areaUnderPR is not available for multiclass case")
             }
           case default =>
             throw new Exception(s"Error: $default is not a classification metric")
@@ -220,15 +229,15 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
       val (accuracy: Double, precision: Double, recall: Double)
           = getBinaryAccuracyPrecisionRecall(confusionMatrix)
       metricsLogger.logClassificationMetrics(accuracy, precision, recall)
-      // Add the AUC
-      val auc: Double = getAUC(modelName, dataset, labelColumnName, scoresAndLabels)
-      metricsLogger.logAUC(auc)
+      val (auc, areaUnderPR) =
+        getBinaryMetrics(modelName, dataset, labelColumnName, scoresAndLabels)
       // Add the metrics to the DF
       resultDF
         .withColumn(MetricConstants.AccuracyColumnName, lit(accuracy))
         .withColumn(MetricConstants.PrecisionColumnName, lit(precision))
         .withColumn(MetricConstants.RecallColumnName, lit(recall))
         .withColumn(MetricConstants.AucColumnName, lit(auc))
+        .withColumn(MetricConstants.AreaUnderPRColumnName, lit(areaUnderPR))
     } else {
       val (microAvgAccuracy: Double,
            microAvgPrecision: Double,
@@ -381,13 +390,28 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
     (microAvgAccuracy, microAvgPrecision, microAvgRecall, averageAccuracy, macroAveragedPrecision, macroAveragedRecall)
   }
 
-  private def getAUC(modelName: String,
-             dataset: Dataset[_],
-             labelColumnName: String,
-             scoresAndLabels: RDD[(Double, Double)]): Double = {
-    val binaryMetrics = new BinaryClassificationMetrics(scoresAndLabels,
-      MetricConstants.BinningThreshold)
+  private def getBinaryMetrics(modelName: String,
+                               dataset: Dataset[_],
+                               labelColumnName: String,
+                               scoresAndLabels: RDD[(Double, Double)]): (Double, Double) = {
+    withBinaryClassificationMetrics(scoresAndLabels) { binaryMetrics =>
+      (getAUC(modelName, dataset, labelColumnName, binaryMetrics), getAreaUnderPR(binaryMetrics))
+    }
+  }
 
+  private def getAUC(modelName: String,
+                     dataset: Dataset[_],
+                     labelColumnName: String,
+                     scoresAndLabels: RDD[(Double, Double)]): Double = {
+    withBinaryClassificationMetrics(scoresAndLabels) { binaryMetrics =>
+      getAUC(modelName, dataset, labelColumnName, binaryMetrics)
+    }
+  }
+
+  private def getAUC(modelName: String,
+                     dataset: Dataset[_],
+                     labelColumnName: String,
+                     binaryMetrics: BinaryClassificationMetrics): Double = {
     val spark = dataset.sparkSession
     import spark.implicits._
 
@@ -397,6 +421,28 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
     val auc = binaryMetrics.areaUnderROC()
     metricsLogger.logAUC(auc)
     auc
+  }
+
+  private def getAreaUnderPR(scoresAndLabels: RDD[(Double, Double)]): Double = {
+    withBinaryClassificationMetrics(scoresAndLabels) { binaryMetrics =>
+      getAreaUnderPR(binaryMetrics)
+    }
+  }
+
+  private def getAreaUnderPR(binaryMetrics: BinaryClassificationMetrics): Double = {
+    val areaUnderPR = binaryMetrics.areaUnderPR()
+    metricsLogger.logAreaUnderPR(areaUnderPR)
+    areaUnderPR
+  }
+
+  private def withBinaryClassificationMetrics[T](scoresAndLabels: RDD[(Double, Double)])
+                                                  (f: BinaryClassificationMetrics => T): T = {
+    val binaryMetrics = new BinaryClassificationMetrics(scoresAndLabels, MetricConstants.BinningThreshold)
+    try {
+      f(binaryMetrics)
+    } finally {
+      binaryMetrics.unpersist()
+    }
   }
 
   private def getBinaryAccuracyPrecisionRecall(confusionMatrix: Matrix): (Double, Double, Double) = {
@@ -444,11 +490,13 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
         schema,
         if (isDefined(labelCol)) Some(getLabelCol) else None,
         getEvaluationMetric)
-    val columns =
-      if (scoreValueKind == SchemaConstants.ClassificationKind) MetricConstants.ClassificationColumns
-      else if (scoreValueKind == SchemaConstants.RegressionKind) MetricConstants.RegressionColumns
+    val (columns, validMetrics) =
+      if (scoreValueKind == SchemaConstants.ClassificationKind)
+        (MetricConstants.ClassificationColumns, MetricConstants.ClassificationMetrics)
+      else if (scoreValueKind == SchemaConstants.RegressionKind)
+        (MetricConstants.RegressionColumns, MetricConstants.RegressionMetrics)
       else throwOnInvalidScoringKind(scoreValueKind)
-    getTransformedSchema(columns, scoreValueKind)
+    getTransformedSchema(columns, scoreValueKind, validMetrics)
 
   }
 
@@ -456,14 +504,16 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
     throw new Exception(s"Error: unknown scoring kind $scoreValueKind")
   }
 
-  private def getTransformedSchema(columns: List[String], metricType: String) = {
+  private def getTransformedSchema(columns: List[String],
+                                   metricType: String,
+                                   validMetrics: Set[String]): StructType = {
     getEvaluationMetric match {
       case allMetrics if allMetrics == MetricConstants.AllSparkMetrics ||
                          allMetrics == MetricConstants.ClassificationMetricsName ||
                          allMetrics == MetricConstants.RegressionMetricsName =>
         StructType(columns.map(StructField(_, DoubleType)))
-      case metric: String if MetricConstants.MetricToColumnName.contains(metric) &&
-                             columns.contains(MetricConstants.MetricToColumnName(metric)) =>
+      case metric: String if validMetrics.contains(metric) &&
+                             MetricConstants.MetricToColumnName.contains(metric) =>
         StructType(Array(StructField(MetricConstants.MetricToColumnName(metric), DoubleType)))
       case default =>
         throw new Exception(s"Error: $default is not a $metricType metric")
@@ -499,6 +549,12 @@ class MetricsLogger(uid: String) {
 
   def logAUC(auc: Double): Unit = {
     val metrics = MetricData.create(Map(MetricConstants.AucColumnName -> auc), "AUC Metric", uid)
+    logger.info(metrics)
+  }
+
+  def logAreaUnderPR(areaUnderPR: Double): Unit = {
+    val metrics = MetricData.create(
+      Map(MetricConstants.AreaUnderPRColumnName -> areaUnderPR), "AreaUnderPR Metric", uid)
     logger.info(metrics)
   }
 

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.scala
@@ -490,13 +490,14 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
         schema,
         if (isDefined(labelCol)) Some(getLabelCol) else None,
         getEvaluationMetric)
+    val labelLevels = getLabelLevels(schema, labelColumnName)
     val (columns, validMetrics) =
       if (scoreValueKind == SchemaConstants.ClassificationKind)
-        (MetricConstants.ClassificationColumns, MetricConstants.ClassificationMetrics)
+        (getClassificationColumns(labelLevels), MetricConstants.ClassificationMetrics)
       else if (scoreValueKind == SchemaConstants.RegressionKind)
         (MetricConstants.RegressionColumns, MetricConstants.RegressionMetrics)
       else throwOnInvalidScoringKind(scoreValueKind)
-    validateBinaryOnlyMetricSchema(schema, labelColumnName, scoreValueKind)
+    validateBinaryOnlyMetricSchema(labelLevels, scoreValueKind)
     getTransformedSchema(columns, scoreValueKind, validMetrics)
 
   }
@@ -505,16 +506,23 @@ class ComputeModelStatistics(override val uid: String) extends Transformer
     throw new Exception(s"Error: unknown scoring kind $scoreValueKind")
   }
 
-  private def validateBinaryOnlyMetricSchema(schema: StructType,
-                                             labelColumnName: String,
+  private def getLabelLevels(schema: StructType, labelColumnName: String): Option[Array[_]] = {
+    if (schema.fieldNames.contains(labelColumnName)) CategoricalUtilities.getLevels(schema, labelColumnName)
+    else None
+  }
+
+  private def getClassificationColumns(labelLevels: Option[Array[_]]): List[String] = {
+    // Keep the legacy common-metrics schema when cardinality is unknown or multiclass.
+    if (labelLevels.exists(_.length <= 2)) MetricConstants.BinaryClassificationColumns
+    else MetricConstants.ClassificationColumns
+  }
+
+  private def validateBinaryOnlyMetricSchema(labelLevels: Option[Array[_]],
                                              scoreValueKind: String): Unit = {
     val isBinaryOnlyClassificationMetric =
       getEvaluationMetric == MetricConstants.AucSparkMetric ||
         getEvaluationMetric == MetricConstants.AreaUnderROCMetric ||
         getEvaluationMetric == MetricConstants.AreaUnderPRMetric
-    val labelLevels =
-      if (schema.fieldNames.contains(labelColumnName)) CategoricalUtilities.getLevels(schema, labelColumnName)
-      else None
     // Match runtime semantics: only SynapseML categorical metadata establishes label cardinality.
     if (scoreValueKind == SchemaConstants.ClassificationKind &&
         isBinaryOnlyClassificationMetric &&

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.txt
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.txt
@@ -11,11 +11,14 @@ Binary Classifiers:
 - "accuracy"
 - "precision"
 - "recall"
+- "classification"
 - "all"
 
-Regression Classifiers:
+Regression Models:
 
 - "mse"
 - "rmse"
 - "r2"
+- "mae"
+- "regression"
 - "all"

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.txt
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputeModelStatistics.txt
@@ -5,9 +5,11 @@ The possible metrics are:
 
 Binary Classifiers:
 
-- "AreaUnderROC"
+- "areaUnderROC" (reported in the "AUC" column)
 - "AUC"
+- "areaUnderPR"
 - "accuracy"
+- "precision"
 - "recall"
 - "all"
 

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/automl/VerifyEvaluationUtils.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/automl/VerifyEvaluationUtils.scala
@@ -78,6 +78,24 @@ class VerifyEvaluationUtils extends TestBase {
     assert(ordering.compare(2.0, 1.0) > 0)
   }
 
+  test("getMetricWithOperator treats areaUnderROC as an AUC alias") {
+    val (metricName, ordering) = EvaluationUtils.getMetricWithOperator(
+      SchemaConstants.ClassificationKind,
+      MetricConstants.AreaUnderROCMetric
+    )
+    assert(metricName === MetricConstants.AucColumnName)
+    assert(ordering.compare(2.0, 1.0) > 0)
+  }
+
+  test("getMetricWithOperator returns correct metric for classification areaUnderPR") {
+    val (metricName, ordering) = EvaluationUtils.getMetricWithOperator(
+      SchemaConstants.ClassificationKind,
+      MetricConstants.AreaUnderPRMetric
+    )
+    assert(metricName === MetricConstants.AreaUnderPRColumnName)
+    assert(ordering.compare(2.0, 1.0) > 0)
+  }
+
   test("getMetricWithOperator returns correct metric for classification Precision") {
     val (metricName, ordering) = EvaluationUtils.getMetricWithOperator(
       SchemaConstants.ClassificationKind,
@@ -133,6 +151,15 @@ class VerifyEvaluationUtils extends TestBase {
   test("unsupported regression metric throws") {
     assertThrows[Exception] {
       EvaluationUtils.getMetricWithOperator(SchemaConstants.RegressionKind, "bogus_metric")
+    }
+  }
+
+  test("getMetricWithOperator rejects areaUnderPR for regressors") {
+    assertThrows[Exception] {
+      EvaluationUtils.getMetricWithOperator(
+        SchemaConstants.RegressionKind,
+        MetricConstants.AreaUnderPRMetric
+      )
     }
   }
 

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/automl/VerifyFindBestModel.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/automl/VerifyFindBestModel.scala
@@ -46,7 +46,7 @@ class VerifyFindBestModel extends EstimatorFuzzing[FindBestModel]{
     bestModel.transform(dataset)
   }
 
-  test("Verify the best model can be saved") {
+  test("Verify the best model can be saved with AUC") {
     val dataset: DataFrame = createMockDataset
     val logisticRegressor = createLR.setLabelCol(mockLabelColumn)
     val model = logisticRegressor.fit(dataset)
@@ -59,6 +59,32 @@ class VerifyFindBestModel extends EstimatorFuzzing[FindBestModel]{
     val myModelFile = new File(tmpDir.toFile, "testEvalModel")
     bestModel.save(myModelFile.toString)
     assert(myModelFile.exists())
+  }
+
+  test("Verify the best model can be saved with areaUnderPR") {
+    val dataset: DataFrame = createMockDataset
+    val model = createLR.setLabelCol(mockLabelColumn).fit(dataset)
+    val bestModel = new FindBestModel()
+      .setModels(Array(model.asInstanceOf[Transformer], model.asInstanceOf[Transformer]))
+      .setEvaluationMetric(MetricConstants.AreaUnderPRMetric)
+      .fit(dataset)
+
+    val myModelFile = new File(tmpDir.toFile, "testEvalModelAreaUnderPR")
+    bestModel.save(myModelFile.toString)
+    assert(myModelFile.exists())
+  }
+
+  test("FindBestModel rejects invalid evaluation metrics") {
+    val dataset: DataFrame = createMockDataset
+    val model = createLR.setLabelCol(mockLabelColumn).fit(dataset)
+    val error = intercept[Exception] {
+      new FindBestModel()
+        .setModels(Array(model.asInstanceOf[Transformer]))
+        .setEvaluationMetric("averagePrecision")
+        .fit(dataset)
+    }
+
+    assert(error.getMessage === "Invalid evaluation metric")
   }
 
   test("Verify the best model metrics can be retrieved and are valid") {

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/core/metrics/VerifyMetricConstants.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/core/metrics/VerifyMetricConstants.scala
@@ -28,6 +28,7 @@ class VerifyMetricConstants extends TestBase {
   // Classification metrics tests
   test("classification metric constants have expected values") {
     assert(MetricConstants.AreaUnderROCMetric === "areaUnderROC")
+    assert(MetricConstants.AreaUnderPRMetric === "areaUnderPR")
     assert(MetricConstants.AucSparkMetric === "AUC")
     assert(MetricConstants.AccuracySparkMetric === "accuracy")
     assert(MetricConstants.PrecisionSparkMetric === "precision")
@@ -37,12 +38,13 @@ class VerifyMetricConstants extends TestBase {
 
   test("ClassificationMetrics set contains all classification metrics") {
     assert(MetricConstants.ClassificationMetrics.contains(MetricConstants.AreaUnderROCMetric))
+    assert(MetricConstants.ClassificationMetrics.contains(MetricConstants.AreaUnderPRMetric))
     assert(MetricConstants.ClassificationMetrics.contains(MetricConstants.AucSparkMetric))
     assert(MetricConstants.ClassificationMetrics.contains(MetricConstants.AccuracySparkMetric))
     assert(MetricConstants.ClassificationMetrics.contains(MetricConstants.PrecisionSparkMetric))
     assert(MetricConstants.ClassificationMetrics.contains(MetricConstants.RecallSparkMetric))
     assert(MetricConstants.ClassificationMetrics.contains(MetricConstants.ClassificationMetricsName))
-    assert(MetricConstants.ClassificationMetrics.size === 6)
+    assert(MetricConstants.ClassificationMetrics.size === 7)
   }
 
   test("AllSparkMetrics constant") {
@@ -59,6 +61,7 @@ class VerifyMetricConstants extends TestBase {
 
   test("classification column names have expected values") {
     assert(MetricConstants.AucColumnName === "AUC")
+    assert(MetricConstants.AreaUnderPRColumnName === "areaUnderPR")
     assert(MetricConstants.PrecisionColumnName === "precision")
     assert(MetricConstants.RecallColumnName === "recall")
     assert(MetricConstants.AccuracyColumnName === "accuracy")
@@ -73,6 +76,12 @@ class VerifyMetricConstants extends TestBase {
 
   // MetricToColumnName mapping tests
   test("MetricToColumnName contains correct mappings") {
+    assert(MetricConstants.MetricToColumnName(MetricConstants.AreaUnderROCMetric) ===
+      MetricConstants.AucColumnName)
+    assert(MetricConstants.MetricToColumnName(MetricConstants.AucSparkMetric) ===
+      MetricConstants.AucColumnName)
+    assert(MetricConstants.MetricToColumnName(MetricConstants.AreaUnderPRMetric) ===
+      MetricConstants.AreaUnderPRColumnName)
     assert(MetricConstants.MetricToColumnName(MetricConstants.AccuracySparkMetric) ===
       MetricConstants.AccuracyColumnName)
     assert(MetricConstants.MetricToColumnName(MetricConstants.PrecisionSparkMetric) ===
@@ -90,11 +99,17 @@ class VerifyMetricConstants extends TestBase {
   }
 
   // Column lists tests
-  test("ClassificationColumns contains expected columns") {
+  test("ClassificationColumns preserves the legacy common schema") {
     assert(MetricConstants.ClassificationColumns === List(
       MetricConstants.AccuracyColumnName,
       MetricConstants.PrecisionColumnName,
       MetricConstants.RecallColumnName))
+  }
+
+  test("BinaryClassificationColumns contains binary-only metrics after common metrics") {
+    assert(MetricConstants.BinaryClassificationColumns === MetricConstants.ClassificationColumns ++ List(
+      MetricConstants.AucColumnName,
+      MetricConstants.AreaUnderPRColumnName))
   }
 
   test("RegressionColumns contains expected columns") {
@@ -149,7 +164,9 @@ class VerifyMetricConstants extends TestBase {
     assert(MetricConstants.FindBestModelMetrics.contains(MetricConstants.AccuracySparkMetric))
     assert(MetricConstants.FindBestModelMetrics.contains(MetricConstants.PrecisionSparkMetric))
     assert(MetricConstants.FindBestModelMetrics.contains(MetricConstants.RecallSparkMetric))
+    assert(MetricConstants.FindBestModelMetrics.contains(MetricConstants.AreaUnderROCMetric))
     assert(MetricConstants.FindBestModelMetrics.contains(MetricConstants.AucSparkMetric))
-    assert(MetricConstants.FindBestModelMetrics.size === 8)
+    assert(MetricConstants.FindBestModelMetrics.contains(MetricConstants.AreaUnderPRMetric))
+    assert(MetricConstants.FindBestModelMetrics.size === 10)
   }
 }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputeModelStatistics.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputeModelStatistics.scala
@@ -65,6 +65,23 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
       .setScoresCol(SchemaConstants.SparkRawPredictionColumn)
       .setEvaluationMetric(metric)
 
+  private def assertBinaryOnlyMetricsRejected(schema: StructType): Unit = {
+    Seq(
+      MetricConstants.AucSparkMetric -> "Error: AUC is not available for multiclass case",
+      MetricConstants.AreaUnderROCMetric -> "Error: AUC is not available for multiclass case",
+      MetricConstants.AreaUnderPRMetric -> "Error: areaUnderPR is not available for multiclass case")
+      .foreach { case (metric, expectedMessage) =>
+        val error = intercept[IllegalArgumentException] {
+          new ComputeModelStatistics()
+            .setLabelCol("label")
+            .setEvaluationMetric(metric)
+            .transformSchema(schema)
+        }
+
+        assert(error.getMessage === expectedMessage)
+      }
+  }
+
   test("areaUnderPR uses Spark trapezoidal precision-recall AUC") {
     val evaluator = rankedBinaryStatistics(MetricConstants.AreaUnderPRMetric)
     val result = evaluator.transform(rankedBinaryDataset)
@@ -123,6 +140,30 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
     assert(schema.fieldNames.toList === MetricConstants.ClassificationColumns)
     assert(!schema.fieldNames.contains(MetricConstants.AucColumnName))
     assert(!schema.fieldNames.contains(MetricConstants.AreaUnderPRColumnName))
+  }
+
+  test("transformSchema rejects binary-only metrics for multiclass MML categorical labels") {
+    val schema = CategoricalUtilities.setLevels(
+      spark.createDataFrame(Seq(
+        (0.0, 0.0),
+        (1.0, 1.0),
+        (2.0, 2.0))).toDF("label", "prediction"),
+      "label",
+      Array(0.0, 1.0, 2.0)).schema
+
+    assertBinaryOnlyMetricsRejected(schema)
+  }
+
+  test("transformSchema preserves binary-only metric schema when configured labelCol is absent") {
+    val schema = spark.createDataFrame(Seq(
+      (0.0, 0.9),
+      (1.0, 0.8))).toDF("prediction", "rawPrediction").schema
+    val evaluator = new ComputeModelStatistics()
+      .setLabelCol("label")
+      .setEvaluationMetric(MetricConstants.AreaUnderPRMetric)
+
+    assert(evaluator.transformSchema(schema) ===
+      StructType(Array(StructField(MetricConstants.AreaUnderPRColumnName, DoubleType))))
   }
 
   test("areaUnderPR rejects multiclass and unsupported metric inputs") {

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputeModelStatistics.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputeModelStatistics.scala
@@ -74,7 +74,7 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
     assert(result.columns.contains(MetricConstants.AreaUnderPRColumnName))
     assert(evaluator.transformSchema(rankedBinaryDataset.schema) ===
       StructType(Array(StructField(MetricConstants.AreaUnderPRColumnName, DoubleType))))
-    assert(math.abs(areaUnderPR - 251.0 / 440.0) < 1e-12)
+    assert(math.abs(areaUnderPR - 251.0 / 440.0) < 1e-8)
     assert(math.abs(areaUnderPR - 13.0 / 22.0) > 0.01)
   }
 
@@ -93,8 +93,8 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
 
     assert(aucEvaluator.transformSchema(rankedBinaryDataset.schema) === aucSchema)
     assert(rocEvaluator.transformSchema(rankedBinaryDataset.schema) === aucSchema)
-    assert(math.abs(auc - 187.0 / 196.0) < 1e-12)
-    assert(math.abs(areaUnderROCAlias - 187.0 / 196.0) < 1e-12)
+    assert(math.abs(auc - 187.0 / 196.0) < 1e-8)
+    assert(math.abs(areaUnderROCAlias - 187.0 / 196.0) < 1e-8)
   }
 
   test("all and classification metrics append binary metrics in runtime output order") {
@@ -105,8 +105,8 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
       val row = result.first()
 
       assert(result.columns.toList === expectedColumns)
-      assert(math.abs(row.getAs[Double](MetricConstants.AucColumnName) - 187.0 / 196.0) < 1e-12)
-      assert(math.abs(row.getAs[Double](MetricConstants.AreaUnderPRColumnName) - 251.0 / 440.0) < 1e-12)
+      assert(math.abs(row.getAs[Double](MetricConstants.AucColumnName) - 187.0 / 196.0) < 1e-8)
+      assert(math.abs(row.getAs[Double](MetricConstants.AreaUnderPRColumnName) - 251.0 / 440.0) < 1e-8)
     }
   }
 

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputeModelStatistics.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputeModelStatistics.scala
@@ -41,6 +41,110 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
     (1, 4, 0.12, 0.34, 3)
   )).toDF(labelColumn, "col1", "col2", "col3", "col4")
 
+  private lazy val rankedBinaryDataset: DataFrame = {
+    import spark.implicits._
+    val data = (1 to 100).map { rank =>
+      val label = if (rank == 1 || rank == 11) 1.0 else 0.0
+      val prediction = if (rank <= 10) 1.0 else 0.0
+      val rawPrediction = (101 - rank).toDouble
+      (label, prediction, rawPrediction)
+    }.toDF("label", SchemaConstants.SparkPredictionColumn, SchemaConstants.SparkRawPredictionColumn)
+    val modelName = SchemaConstants.ScoreModelPrefix + "_ranked binary"
+    val withLabel = SparkSchema.setLabelColumnName(
+      data, modelName, "label", SchemaConstants.ClassificationKind)
+    val withPrediction = SparkSchema.updateColumnMetadata(
+      withLabel, modelName, SchemaConstants.SparkPredictionColumn, SchemaConstants.ClassificationKind)
+    SparkSchema.updateColumnMetadata(
+      withPrediction, modelName, SchemaConstants.SparkRawPredictionColumn, SchemaConstants.ClassificationKind)
+  }
+
+  private def rankedBinaryStatistics(metric: String): ComputeModelStatistics =
+    new ComputeModelStatistics()
+      .setLabelCol("label")
+      .setScoredLabelsCol(SchemaConstants.SparkPredictionColumn)
+      .setScoresCol(SchemaConstants.SparkRawPredictionColumn)
+      .setEvaluationMetric(metric)
+
+  test("areaUnderPR uses Spark trapezoidal precision-recall AUC") {
+    val evaluator = rankedBinaryStatistics(MetricConstants.AreaUnderPRMetric)
+    val result = evaluator.transform(rankedBinaryDataset)
+    val areaUnderPR = result.first().getAs[Double](MetricConstants.AreaUnderPRColumnName)
+
+    assert(result.columns.last === MetricConstants.AreaUnderPRColumnName)
+    assert(result.columns.contains(MetricConstants.AreaUnderPRColumnName))
+    assert(evaluator.transformSchema(rankedBinaryDataset.schema) ===
+      StructType(Array(StructField(MetricConstants.AreaUnderPRColumnName, DoubleType))))
+    assert(math.abs(areaUnderPR - 251.0 / 440.0) < 1e-12)
+    assert(math.abs(areaUnderPR - 13.0 / 22.0) > 0.01)
+  }
+
+  test("areaUnderROC remains an AUC output alias") {
+    val aucEvaluator = rankedBinaryStatistics(MetricConstants.AucSparkMetric)
+    val auc = aucEvaluator
+      .transform(rankedBinaryDataset)
+      .first()
+      .getAs[Double](MetricConstants.AucColumnName)
+    val rocEvaluator = rankedBinaryStatistics(MetricConstants.AreaUnderROCMetric)
+    val areaUnderROCAlias = rocEvaluator
+      .transform(rankedBinaryDataset)
+      .first()
+      .getAs[Double](MetricConstants.AucColumnName)
+    val aucSchema = StructType(Array(StructField(MetricConstants.AucColumnName, DoubleType)))
+
+    assert(aucEvaluator.transformSchema(rankedBinaryDataset.schema) === aucSchema)
+    assert(rocEvaluator.transformSchema(rankedBinaryDataset.schema) === aucSchema)
+    assert(math.abs(auc - 187.0 / 196.0) < 1e-12)
+    assert(math.abs(areaUnderROCAlias - 187.0 / 196.0) < 1e-12)
+  }
+
+  test("all and classification metrics append binary metrics in runtime output order") {
+    val expectedColumns = List(MetricConstants.EvaluationType, MetricConstants.ConfusionMatrix) ++
+      MetricConstants.BinaryClassificationColumns
+    Seq(MetricConstants.AllSparkMetrics, MetricConstants.ClassificationMetricsName).foreach { metric =>
+      val result = rankedBinaryStatistics(metric).transform(rankedBinaryDataset)
+      val row = result.first()
+
+      assert(result.columns.toList === expectedColumns)
+      assert(math.abs(row.getAs[Double](MetricConstants.AucColumnName) - 187.0 / 196.0) < 1e-12)
+      assert(math.abs(row.getAs[Double](MetricConstants.AreaUnderPRColumnName) - 251.0 / 440.0) < 1e-12)
+    }
+  }
+
+  test("multiclass classification schema retains the legacy common metrics") {
+    val multiclass = spark.createDataFrame(Seq(
+      (0.0, 0.0),
+      (1.0, 1.0),
+      (2.0, 2.0))).toDF("label", "prediction")
+    val schema = new ComputeModelStatistics()
+      .setLabelCol("label")
+      .setEvaluationMetric(MetricConstants.ClassificationMetricsName)
+      .transformSchema(multiclass.schema)
+
+    assert(schema.fieldNames.toList === MetricConstants.ClassificationColumns)
+    assert(!schema.fieldNames.contains(MetricConstants.AucColumnName))
+    assert(!schema.fieldNames.contains(MetricConstants.AreaUnderPRColumnName))
+  }
+
+  test("areaUnderPR rejects multiclass and unsupported metric inputs") {
+    val multiclass = spark.createDataFrame(Seq(
+      (0.0, 0.0, 0.9),
+      (1.0, 1.0, 0.8),
+      (2.0, 2.0, 0.7))).toDF("label", "prediction", "rawPrediction")
+    val multiclassError = intercept[Exception] {
+      new ComputeModelStatistics()
+        .setLabelCol("label")
+        .setScoredLabelsCol("prediction")
+        .setScoresCol("rawPrediction")
+        .setEvaluationMetric(MetricConstants.AreaUnderPRMetric)
+        .transform(multiclass)
+    }
+    assert(multiclassError.getMessage === "Error: areaUnderPR is not available for multiclass case")
+
+    assertThrows[Exception] {
+      rankedBinaryStatistics("averagePrecision").transform(rankedBinaryDataset)
+    }
+  }
+
   test("Verify multiclass evaluation is not slow for large number of labels") {
     val numRows = 4096
     import spark.implicits._

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputeModelStatistics.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputeModelStatistics.scala
@@ -14,7 +14,7 @@ import com.microsoft.azure.synapse.ml.train.TrainRegressorTestUtilities._
 import org.apache.spark.ml.classification.LogisticRegression
 import org.apache.spark.ml.evaluation.BinaryClassificationEvaluator
 import org.apache.spark.ml.feature.FastVectorAssembler
-import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.ml.regression.GeneralizedLinearRegression
 import org.apache.spark.ml.util.MLReadable
 import org.apache.spark.sql._
@@ -46,7 +46,7 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
     val data = (1 to 100).map { rank =>
       val label = if (rank == 1 || rank == 11) 1.0 else 0.0
       val prediction = if (rank <= 10) 1.0 else 0.0
-      val rawPrediction = (101 - rank).toDouble
+      val rawPrediction = Vectors.dense(0.0, (101 - rank).toDouble)
       (label, prediction, rawPrediction)
     }.toDF("label", SchemaConstants.SparkPredictionColumn, SchemaConstants.SparkRawPredictionColumn)
     val modelName = SchemaConstants.ScoreModelPrefix + "_ranked binary"
@@ -115,31 +115,65 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
   }
 
   test("all and classification metrics append binary metrics in runtime output order") {
+    val binaryDataset = CategoricalUtilities.setLevels(
+      rankedBinaryDataset,
+      "label",
+      Array(0.0, 1.0))
     val expectedColumns = List(MetricConstants.EvaluationType, MetricConstants.ConfusionMatrix) ++
       MetricConstants.BinaryClassificationColumns
     Seq(MetricConstants.AllSparkMetrics, MetricConstants.ClassificationMetricsName).foreach { metric =>
-      val result = rankedBinaryStatistics(metric).transform(rankedBinaryDataset)
+      val evaluator = rankedBinaryStatistics(metric)
+      val result = evaluator.transform(binaryDataset)
       val row = result.first()
+      val transformedSchema = evaluator.transformSchema(binaryDataset.schema)
 
       assert(result.columns.toList === expectedColumns)
+      assert(transformedSchema ===
+        StructType(MetricConstants.BinaryClassificationColumns.map(StructField(_, DoubleType))))
       assert(math.abs(row.getAs[Double](MetricConstants.AucColumnName) - 187.0 / 196.0) < 1e-8)
       assert(math.abs(row.getAs[Double](MetricConstants.AreaUnderPRColumnName) - 251.0 / 440.0) < 1e-8)
     }
   }
 
   test("multiclass classification schema retains the legacy common metrics") {
-    val multiclass = spark.createDataFrame(Seq(
+    val multiclassData = spark.createDataFrame(Seq(
       (0.0, 0.0),
       (1.0, 1.0),
       (2.0, 2.0))).toDF("label", "prediction")
-    val schema = new ComputeModelStatistics()
-      .setLabelCol("label")
-      .setEvaluationMetric(MetricConstants.ClassificationMetricsName)
-      .transformSchema(multiclass.schema)
+    val modelName = SchemaConstants.ScoreModelPrefix + "_multiclass"
+    val withLabel = SparkSchema.setLabelColumnName(
+      multiclassData, modelName, "label", SchemaConstants.ClassificationKind)
+    val withPrediction = SparkSchema.updateColumnMetadata(
+      withLabel, modelName, "prediction", SchemaConstants.ClassificationKind)
+    val multiclass = CategoricalUtilities.setLevels(
+      withPrediction,
+      "label",
+      Array(0.0, 1.0, 2.0))
+    val expectedRuntimeColumns =
+      List(MetricConstants.EvaluationType, MetricConstants.ConfusionMatrix) ++
+        MetricConstants.ClassificationColumns ++
+        List(MetricConstants.AverageAccuracy,
+          MetricConstants.MacroAveragedPrecision,
+          MetricConstants.MacroAveragedRecall)
 
-    assert(schema.fieldNames.toList === MetricConstants.ClassificationColumns)
-    assert(!schema.fieldNames.contains(MetricConstants.AucColumnName))
-    assert(!schema.fieldNames.contains(MetricConstants.AreaUnderPRColumnName))
+    Seq(MetricConstants.AllSparkMetrics, MetricConstants.ClassificationMetricsName).foreach { metric =>
+      val evaluator = new ComputeModelStatistics().setEvaluationMetric(metric)
+      val schema = evaluator.transformSchema(multiclass.schema)
+      val result = evaluator.transform(multiclass)
+
+      assert(schema.fieldNames.toList === MetricConstants.ClassificationColumns)
+      assert(!schema.fieldNames.contains(MetricConstants.AucColumnName))
+      assert(!schema.fieldNames.contains(MetricConstants.AreaUnderPRColumnName))
+      assert(result.columns.toList === expectedRuntimeColumns)
+    }
+  }
+
+  test("classification schema without cardinality metadata retains the legacy common metrics") {
+    Seq(MetricConstants.AllSparkMetrics, MetricConstants.ClassificationMetricsName).foreach { metric =>
+      val schema = rankedBinaryStatistics(metric).transformSchema(rankedBinaryDataset.schema)
+
+      assert(schema.fieldNames.toList === MetricConstants.ClassificationColumns)
+    }
   }
 
   test("transformSchema rejects binary-only metrics for multiclass MML categorical labels") {
@@ -332,7 +366,8 @@ class VerifyComputeModelStatistics extends TransformerFuzzing[ComputeModelStatis
     val _ = new ComputeModelStatistics().transform(scoredDataset)
 
     val evaluatedSchema = new ComputeModelStatistics().transformSchema(scoredDataset.schema)
-    assert(evaluatedSchema == StructType(MetricConstants.ClassificationColumns.map(StructField(_, DoubleType))))
+    assert(evaluatedSchema ==
+      StructType(MetricConstants.BinaryClassificationColumns.map(StructField(_, DoubleType))))
   }
 
   test("Verify computing statistics on generic spark ML estimators is supported") {

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1035,16 +1035,17 @@ jobs:
           LINE_NUMBER=0
           while IFS= read -r RAW_LINE || [ -n "$RAW_LINE" ]; do
             LINE_NUMBER=$((LINE_NUMBER + 1))
-            TRIMMED_LINE="${RAW_LINE#"${RAW_LINE%%[![:space:]]*}"}"
-            TRIMMED_LINE="${TRIMMED_LINE%"${TRIMMED_LINE##*[![:space:]]}"}"
+            LINE_WITHOUT_CR="${RAW_LINE%$'\r'}"
+            SCOPED_LINE="${LINE_WITHOUT_CR#"${LINE_WITHOUT_CR%%[![:space:]]*}"}"
+            TRIMMED_LINE="${SCOPED_LINE%"${SCOPED_LINE##*[![:space:]]}"}"
             case "$TRIMMED_LINE" in
               ""|\#*)
                 continue
                 ;;
             esac
-            if [[ "$TRIMMED_LINE" == *$'\t'* ]]; then
-              PREREQUISITE="${TRIMMED_LINE%%$'\t'*}"
-              PREREQUISITE_SCOPE="${TRIMMED_LINE#*$'\t'}"
+            if [[ "$SCOPED_LINE" == *$'\t'* ]]; then
+              PREREQUISITE="${SCOPED_LINE%%$'\t'*}"
+              PREREQUISITE_SCOPE="${SCOPED_LINE#*$'\t'}"
               PREREQUISITE_IS_SCOPED=true
             else
               PREREQUISITE="$TRIMMED_LINE"
@@ -1068,6 +1069,12 @@ jobs:
                 fi
                 if [ -z "$path" ]; then
                   echo "##vso[task.logissue type=error]Scoped prerequisite $PREREQUISITE contains an empty path"
+                  exit 1
+                fi
+                TRIMMED_PATH="${path#"${path%%[![:space:]]*}"}"
+                TRIMMED_PATH="${TRIMMED_PATH%"${TRIMMED_PATH##*[![:space:]]}"}"
+                if [ "$path" != "$TRIMMED_PATH" ]; then
+                  echo "##vso[task.logissue type=error]Scoped prerequisite path must not have leading or trailing whitespace: $path"
                   exit 1
                 fi
                 case "$path" in

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1042,9 +1042,9 @@ jobs:
                 continue
                 ;;
             esac
-            if [[ "$RAW_LINE" == *$'\t'* ]]; then
-              PREREQUISITE="${RAW_LINE%%$'\t'*}"
-              PREREQUISITE_SCOPE="${RAW_LINE#*$'\t'}"
+            if [[ "$TRIMMED_LINE" == *$'\t'* ]]; then
+              PREREQUISITE="${TRIMMED_LINE%%$'\t'*}"
+              PREREQUISITE_SCOPE="${TRIMMED_LINE#*$'\t'}"
               PREREQUISITE_IS_SCOPED=true
             else
               PREREQUISITE="$TRIMMED_LINE"

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1029,20 +1029,111 @@ jobs:
 
         PREREQUISITES_CONFIG=".pipelines/release-compat-prerequisites.txt"
         CONFIGURED_PREREQUISITES=()
+        CONFIGURED_PREREQUISITE_SCOPES=()
+        CONFIGURED_PREREQUISITE_IS_SCOPED=()
         if git cat-file -e "$PR_MERGE_HEAD:$PREREQUISITES_CONFIG" 2>/dev/null; then
           LINE_NUMBER=0
           while IFS= read -r RAW_LINE || [ -n "$RAW_LINE" ]; do
             LINE_NUMBER=$((LINE_NUMBER + 1))
-            PREREQUISITE="${RAW_LINE#"${RAW_LINE%%[![:space:]]*}"}"
-            PREREQUISITE="${PREREQUISITE%"${PREREQUISITE##*[![:space:]]}"}"
-            case "$PREREQUISITE" in
+            TRIMMED_LINE="${RAW_LINE#"${RAW_LINE%%[![:space:]]*}"}"
+            TRIMMED_LINE="${TRIMMED_LINE%"${TRIMMED_LINE##*[![:space:]]}"}"
+            case "$TRIMMED_LINE" in
               ""|\#*)
                 continue
                 ;;
             esac
+            if [[ "$RAW_LINE" == *$'\t'* ]]; then
+              PREREQUISITE="${RAW_LINE%%$'\t'*}"
+              PREREQUISITE_SCOPE="${RAW_LINE#*$'\t'}"
+              PREREQUISITE_IS_SCOPED=true
+            else
+              PREREQUISITE="$TRIMMED_LINE"
+              PREREQUISITE_SCOPE=""
+              PREREQUISITE_IS_SCOPED=false
+            fi
             if [[ ! "$PREREQUISITE" =~ ^[0-9a-fA-F]{40}$ ]]; then
-              echo "##vso[task.logissue type=error]Invalid prerequisite at $PREREQUISITES_CONFIG:$LINE_NUMBER; expected a full 40-character commit SHA"
+              echo "##vso[task.logissue type=error]Invalid prerequisite at $PREREQUISITES_CONFIG:$LINE_NUMBER; expected a full 40-character commit SHA optionally followed by tab-separated paths"
               exit 1
+            fi
+            if [ "$PREREQUISITE_IS_SCOPED" = true ]; then
+              REMAINING_PATHS="$PREREQUISITE_SCOPE"
+              while true; do
+                if [[ "$REMAINING_PATHS" == *$'\t'* ]]; then
+                  path="${REMAINING_PATHS%%$'\t'*}"
+                  REMAINING_PATHS="${REMAINING_PATHS#*$'\t'}"
+                  HAS_MORE_PATHS=true
+                else
+                  path="$REMAINING_PATHS"
+                  HAS_MORE_PATHS=false
+                fi
+                if [ -z "$path" ]; then
+                  echo "##vso[task.logissue type=error]Scoped prerequisite $PREREQUISITE contains an empty path"
+                  exit 1
+                fi
+                case "$path" in
+                  /*|.|./*)
+                    echo "##vso[task.logissue type=error]Scoped prerequisite path must be repo-relative: $path"
+                    exit 1
+                    ;;
+                esac
+                case "/$path/" in
+                  */../*)
+                    echo "##vso[task.logissue type=error]Scoped prerequisite path must not contain traversal: $path"
+                    exit 1
+                    ;;
+                esac
+                if [ "$HAS_MORE_PATHS" = false ]; then
+                  break
+                fi
+              done
+            else
+              if ! git cat-file -e "$PREREQUISITE^{commit}" 2>/dev/null; then
+                echo "##vso[task.logissue type=error]Release compatibility prerequisite $PREREQUISITE is unavailable"
+                exit 1
+              fi
+              if ! git merge-base --is-ancestor "$PREREQUISITE" "$TARGET_HEAD"; then
+                echo "##vso[task.logissue type=error]Release compatibility prerequisite $PREREQUISITE is not an ancestor of PR target $TARGET_HEAD"
+                exit 1
+              fi
+            fi
+            CONFIGURED_PREREQUISITES+=("$PREREQUISITE")
+            CONFIGURED_PREREQUISITE_SCOPES+=("$PREREQUISITE_SCOPE")
+            CONFIGURED_PREREQUISITE_IS_SCOPED+=("$PREREQUISITE_IS_SCOPED")
+          done < <(git show "$PR_MERGE_HEAD:$PREREQUISITES_CONFIG")
+        fi
+
+        PREREQUISITE_COMMITS=()
+        PREREQUISITE_PATCHES=()
+        for index in "${!CONFIGURED_PREREQUISITES[@]}"; do
+          PREREQUISITE="${CONFIGURED_PREREQUISITES[$index]}"
+          PREREQUISITE_SCOPE="${CONFIGURED_PREREQUISITE_SCOPES[$index]}"
+          PREREQUISITE_IS_SCOPED="${CONFIGURED_PREREQUISITE_IS_SCOPED[$index]}"
+          PREREQUISITE_PATHS=()
+          PREREQUISITE_PATHSPECS=()
+          if [ "$PREREQUISITE_IS_SCOPED" = true ]; then
+            REMAINING_PATHS="$PREREQUISITE_SCOPE"
+            while true; do
+              if [[ "$REMAINING_PATHS" == *$'\t'* ]]; then
+                path="${REMAINING_PATHS%%$'\t'*}"
+                REMAINING_PATHS="${REMAINING_PATHS#*$'\t'}"
+                HAS_MORE_PATHS=true
+              else
+                path="$REMAINING_PATHS"
+                HAS_MORE_PATHS=false
+              fi
+              for REPLAY_PATH in "${REPLAY_PATHS[@]}"; do
+                if [ "$path" = "$REPLAY_PATH" ]; then
+                  PREREQUISITE_PATHS+=("$path")
+                  break
+                fi
+              done
+              if [ "$HAS_MORE_PATHS" = false ]; then
+                break
+              fi
+            done
+            if [ ${#PREREQUISITE_PATHS[@]} -eq 0 ]; then
+              echo "Scoped prerequisite $PREREQUISITE has no paths in this PR replay; skipping"
+              continue
             fi
             if ! git cat-file -e "$PREREQUISITE^{commit}" 2>/dev/null; then
               echo "##vso[task.logissue type=error]Release compatibility prerequisite $PREREQUISITE is unavailable"
@@ -1052,29 +1143,60 @@ jobs:
               echo "##vso[task.logissue type=error]Release compatibility prerequisite $PREREQUISITE is not an ancestor of PR target $TARGET_HEAD"
               exit 1
             fi
-            CONFIGURED_PREREQUISITES+=("$PREREQUISITE")
-          done < <(git show "$PR_MERGE_HEAD:$PREREQUISITES_CONFIG")
-        fi
-
-        PREREQUISITE_COMMITS=()
-        PREREQUISITE_PATCHES=()
-        for PREREQUISITE in "${CONFIGURED_PREREQUISITES[@]}"; do
+          fi
           if ! PREREQUISITE_PARENT=$(git rev-parse "$PREREQUISITE^1" 2>/dev/null); then
             echo "##vso[task.logissue type=error]Release compatibility prerequisite $PREREQUISITE has no first parent"
             exit 1
           fi
-          PREREQUISITE_PATHS=()
-          while IFS= read -r -d '' path; do
-            case "$path" in
-              .github/*|.pipelines/*|docs/*|templates/*|tools/acr/*|tools/ci/*|tools/docker/*|tools/helm/*|website/*)
-                ;;
-              pipeline.yaml|CODEOWNERS|CONTRIBUTING.md|LICENSE|README.md|SECURITY.md)
-                ;;
-              *)
-                PREREQUISITE_PATHS+=("$path")
-                ;;
-            esac
-          done < <(git diff --name-only -z "$PREREQUISITE_PARENT" "$PREREQUISITE")
+          if [ "$PREREQUISITE_IS_SCOPED" = true ]; then
+            for path in "${PREREQUISITE_PATHS[@]}"; do
+              if git diff --quiet "$PREREQUISITE_PARENT" "$PREREQUISITE" -- \
+                ":(literal)$path"; then
+                echo "##vso[task.logissue type=error]Scoped path is not changed by prerequisite $PREREQUISITE: $path"
+                exit 1
+              else
+                DIFF_STATUS=$?
+                if [ "$DIFF_STATUS" -ne 1 ]; then
+                  echo "##vso[task.logissue type=error]Unable to validate scoped path for prerequisite $PREREQUISITE: $path"
+                  exit 1
+                fi
+              fi
+              if git cat-file -e "$PREREQUISITE_PARENT:$path" 2>/dev/null; then
+                echo "##vso[task.logissue type=error]Scoped path is not an add-only baseline in prerequisite $PREREQUISITE: $path"
+                exit 1
+              fi
+              if ! PREREQUISITE_BLOB=$(git rev-parse "$PREREQUISITE:$path" 2>/dev/null); then
+                echo "##vso[task.logissue type=error]Scoped path is absent from prerequisite $PREREQUISITE: $path"
+                exit 1
+              fi
+              if [ "$(git cat-file -t "$PREREQUISITE_BLOB")" != blob ]; then
+                echo "##vso[task.logissue type=error]Scoped prerequisite path is not a blob: $path"
+                exit 1
+              fi
+              if ! TARGET_BLOB=$(git rev-parse "$TARGET_HEAD:$path" 2>/dev/null); then
+                echo "##vso[task.logissue type=error]Scoped path is absent from PR target $TARGET_HEAD: $path"
+                exit 1
+              fi
+              if [ "$PREREQUISITE_BLOB" != "$TARGET_BLOB" ]; then
+                echo "##vso[task.logissue type=error]Scoped prerequisite blob does not match the PR target baseline: $path"
+                exit 1
+              fi
+              PREREQUISITE_PATHSPECS+=(":(literal)$path")
+            done
+          else
+            while IFS= read -r -d '' path; do
+              case "$path" in
+                .github/*|.pipelines/*|docs/*|templates/*|tools/acr/*|tools/ci/*|tools/docker/*|tools/helm/*|website/*)
+                  ;;
+                pipeline.yaml|CODEOWNERS|CONTRIBUTING.md|LICENSE|README.md|SECURITY.md)
+                  ;;
+                *)
+                  PREREQUISITE_PATHS+=("$path")
+                  PREREQUISITE_PATHSPECS+=(":(literal)$path")
+                  ;;
+              esac
+            done < <(git diff --name-only -z "$PREREQUISITE_PARENT" "$PREREQUISITE")
+          fi
 
           if [ ${#PREREQUISITE_PATHS[@]} -eq 0 ]; then
             echo "Prerequisite $PREREQUISITE has no release-relevant paths; skipping"
@@ -1083,7 +1205,7 @@ jobs:
 
           PREREQUISITE_PATCH="$(Agent.TempDirectory)/release-compat-prerequisite-$PREREQUISITE.patch"
           git diff --binary --full-index "$PREREQUISITE_PARENT" "$PREREQUISITE" -- \
-            "${PREREQUISITE_PATHS[@]}" > "$PREREQUISITE_PATCH"
+            "${PREREQUISITE_PATHSPECS[@]}" > "$PREREQUISITE_PATCH"
           if [ ! -s "$PREREQUISITE_PATCH" ]; then
             echo "##vso[task.logissue type=error]Prerequisite $PREREQUISITE produced an empty release patch"
             exit 1
@@ -1094,6 +1216,7 @@ jobs:
 
         echo "=== Attempting to apply release-relevant PR changes onto $(RELEASE_BRANCH) ==="
         git checkout --detach $RELEASE_TIP
+        git update-index --refresh
         for index in "${!PREREQUISITE_COMMITS[@]}"; do
           PREREQUISITE="${PREREQUISITE_COMMITS[$index]}"
           PREREQUISITE_PATCH="${PREREQUISITE_PATCHES[$index]}"

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1081,6 +1081,10 @@ jobs:
                     echo "##vso[task.logissue type=error]Scoped prerequisite path must not contain traversal: $path"
                     exit 1
                     ;;
+                  *//*|*/./*)
+                    echo "##vso[task.logissue type=error]Scoped prerequisite path must be normalized: $path"
+                    exit 1
+                    ;;
                 esac
                 if [ "$HAS_MORE_PATHS" = false ]; then
                   break

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -94,6 +94,15 @@ def _assert_git_clean(repo, context):
     assert not status, f"{context} left scratch repo dirty:\n{status}"
 
 
+def _is_normalized_prerequisite_path(path):
+    return (
+        bool(path)
+        and not path.startswith("/")
+        and not path.endswith("/")
+        and all(part not in {"", ".", ".."} for part in path.split("/"))
+    )
+
+
 def test_pipeline_and_templates_parse():
     assert yaml.safe_load(PIPELINE.read_text()) is not None
     assert yaml.safe_load(CLEAN_ACR_PIPELINE.read_text()) is not None
@@ -339,6 +348,7 @@ def test_release_compat_accepts_github_target_and_uses_one_sbt_process():
         'git merge-base --is-ancestor "$PREREQUISITE" "$TARGET_HEAD"' in rebase_script
     )
     assert 'case "/$path/" in' in rebase_script
+    assert "Scoped prerequisite path must be normalized: $path" in rebase_script
     assert 'for REPLAY_PATH in "${REPLAY_PATHS[@]}"' in rebase_script
     assert '[ "$path" = "$REPLAY_PATH" ]' in rebase_script
     assert 'PREREQUISITE_PATHS+=("$path")' in rebase_script
@@ -436,10 +446,41 @@ def test_release_compat_prerequisites_have_valid_format():
     assert all(re.fullmatch(r"[0-9a-fA-F]{40}", fields[0]) for fields in entries)
     assert all(all(fields[1:]) for fields in entries)
     for _, *paths in entries:
-        assert all(not path.startswith("/") for path in paths)
-        assert all(".." not in path.split("/") for path in paths)
+        assert all(_is_normalized_prerequisite_path(path) for path in paths)
     shas = [fields[0] for fields in entries]
     assert len(shas) == len(set(shas)), "prerequisite commits must be unique"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "src/file.txt",
+        ".pipelines/release-compat-prerequisites.txt",
+        "src/.hidden/file",
+        "src/.../file",
+    ],
+)
+def test_release_compat_prerequisite_path_normalization_accepts_valid_paths(path):
+    assert _is_normalized_prerequisite_path(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "",
+        ".",
+        "./src/file",
+        "/src/file",
+        "src/../file",
+        "src/..",
+        "src/./file",
+        "src/.",
+        "src//file",
+        "src/file/",
+    ],
+)
+def test_release_compat_prerequisite_path_normalization_rejects_invalid_paths(path):
+    assert not _is_normalized_prerequisite_path(path)
 
 
 @pytest.mark.skipif(os.name != "posix", reason="release replay script requires Bash")
@@ -507,6 +548,95 @@ def test_release_compat_replays_prerequisite_before_pr_patch():
         ]
         assert f"Prerequisite {prerequisite} applies cleanly" in result.stdout
         assert "PR changes apply cleanly onto release" in result.stdout
+    finally:
+        shutil.rmtree(scratch_root, ignore_errors=True)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="release replay script requires Bash")
+@pytest.mark.parametrize(
+    "invalid_path",
+    [
+        "src/./scoped.txt",
+        "src//scoped.txt",
+        "src/scoped.txt/",
+        "src/scoped.txt/.",
+    ],
+    ids=["dot-segment", "repeated-slash", "trailing-slash", "terminal-dot"],
+)
+def test_release_compat_rejects_non_normalized_scoped_paths(invalid_path):
+    scratch_root = (
+        REPO_ROOT / "target" / f"release-compat-invalid-path-{uuid.uuid4().hex}"
+    )
+    repo = scratch_root / "repo"
+    origin = scratch_root / "origin.git"
+    agent_temp = scratch_root / "agent"
+
+    try:
+        repo.mkdir(parents=True)
+        agent_temp.mkdir()
+        _init_release_compat_scratch_repo(repo)
+
+        pr_file = repo / "src" / "pr.txt"
+        pr_file.parent.mkdir()
+        pr_file.write_text("release base\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "base")
+        base = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        _git(repo, "branch", "release", base)
+
+        _git(repo, "commit", "--allow-empty", "-m", "prerequisite marker")
+        prerequisite = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+        _git(repo, "checkout", "-b", "source")
+        prerequisite_config = repo / ".pipelines" / "release-compat-prerequisites.txt"
+        prerequisite_config.parent.mkdir()
+        prerequisite_config.write_text(f"{prerequisite}\t{invalid_path}\n")
+        pr_file.write_text("pull request change\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "feature with invalid prerequisite path")
+
+        target = _git(repo, "rev-parse", "master").stdout.strip()
+        source = _git(repo, "rev-parse", "source").stdout.strip()
+        source_tree = _git(repo, "rev-parse", f"{source}^{{tree}}").stdout.strip()
+        merge_commit = _git(
+            repo,
+            "commit-tree",
+            source_tree,
+            "-p",
+            target,
+            "-p",
+            source,
+            "-m",
+            "merge feature",
+        ).stdout.strip()
+        _git(repo, "checkout", "--detach", merge_commit)
+        _assert_git_clean(repo, "synthetic PR merge checkout")
+
+        subprocess.run(
+            ["git", "init", "--bare", str(origin)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        _git(repo, "remote", "add", "origin", str(origin))
+        _git(repo, "push", "origin", "master", "source", "release")
+
+        script = _release_compat_script()
+        script = script.replace("$(Agent.TempDirectory)", str(agent_temp))
+        script = script.replace("$(RELEASE_BRANCH)", "release")
+        result = subprocess.run(
+            ["bash", "-c", script],
+            cwd=repo,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode != 0
+        assert (
+            f"Scoped prerequisite path must be normalized: {invalid_path}"
+            in result.stdout
+        )
     finally:
         shutil.rmtree(scratch_root, ignore_errors=True)
 

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -343,10 +343,7 @@ def test_release_compat_accepts_github_target_and_uses_one_sbt_process():
     assert rebase_script.index('case "/$path/" in') < rebase_script.index(
         'for REPLAY_PATH in "${REPLAY_PATHS[@]}"'
     )
-    assert (
-        'git diff --quiet "$PREREQUISITE_PARENT" "$PREREQUISITE" --'
-        in rebase_script
-    )
+    assert 'git diff --quiet "$PREREQUISITE_PARENT" "$PREREQUISITE" --' in rebase_script
     assert 'git cat-file -e "$PREREQUISITE_PARENT:$path"' in rebase_script
     assert 'git rev-parse "$PREREQUISITE:$path"' in rebase_script
     assert 'git rev-parse "$TARGET_HEAD:$path"' in rebase_script

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -27,6 +27,7 @@ CLEAN_ACR_PIPELINE = REPO_ROOT / ".pipelines" / "clean-acr.yml"
 RELEASE_COMPAT_PREREQUISITES = (
     REPO_ROOT / ".pipelines" / "release-compat-prerequisites.txt"
 )
+ASCII_WHITESPACE = " \t\r\n\v\f"
 
 
 def _pipeline_text():
@@ -97,6 +98,8 @@ def _assert_git_clean(repo, context):
 def _is_normalized_prerequisite_path(path):
     return (
         bool(path)
+        and path == path.strip(ASCII_WHITESPACE)
+        and not any(character in path for character in "\t\r\n")
         and not path.startswith("/")
         and not path.endswith("/")
         and all(part not in {"", ".", ".."} for part in path.split("/"))
@@ -339,15 +342,20 @@ def test_release_compat_accepts_github_target_and_uses_one_sbt_process():
     )
     assert 'git show "$PR_MERGE_HEAD:$PREREQUISITES_CONFIG"' in rebase_script
     assert '[[ ! "$PREREQUISITE" =~ ^[0-9a-fA-F]{40}$ ]]' in rebase_script
-    assert r"""[[ "$TRIMMED_LINE" == *$'\t'* ]]""" in rebase_script
+    assert "LINE_WITHOUT_CR=\"${RAW_LINE%$'\\r'}\"" in rebase_script
+    assert r"""[[ "$SCOPED_LINE" == *$'\t'* ]]""" in rebase_script
     assert r"""[[ "$RAW_LINE" == *$'\t'* ]]""" not in rebase_script
-    assert "PREREQUISITE=\"${TRIMMED_LINE%%$'\\t'*}\"" in rebase_script
-    assert "PREREQUISITE_SCOPE=\"${TRIMMED_LINE#*$'\\t'}\"" in rebase_script
+    assert "PREREQUISITE=\"${SCOPED_LINE%%$'\\t'*}\"" in rebase_script
+    assert "PREREQUISITE_SCOPE=\"${SCOPED_LINE#*$'\\t'}\"" in rebase_script
     assert "CONFIGURED_PREREQUISITE_SCOPES=()" in rebase_script
     assert (
         'git merge-base --is-ancestor "$PREREQUISITE" "$TARGET_HEAD"' in rebase_script
     )
     assert 'case "/$path/" in' in rebase_script
+    assert (
+        "Scoped prerequisite path must not have leading or trailing whitespace: $path"
+        in rebase_script
+    )
     assert "Scoped prerequisite path must be normalized: $path" in rebase_script
     assert 'for REPLAY_PATH in "${REPLAY_PATHS[@]}"' in rebase_script
     assert '[ "$path" = "$REPLAY_PATH" ]' in rebase_script
@@ -455,6 +463,8 @@ def test_release_compat_prerequisites_have_valid_format():
     "path",
     [
         "src/file.txt",
+        "src/file with spaces.txt",
+        "src/with  repeated internal spaces.txt",
         ".pipelines/release-compat-prerequisites.txt",
         "src/.hidden/file",
         "src/.../file",
@@ -477,6 +487,14 @@ def test_release_compat_prerequisite_path_normalization_accepts_valid_paths(path
         "src/.",
         "src//file",
         "src/file/",
+        " src/file",
+        "src/file ",
+        "\tsrc/file",
+        "src/file\t",
+        "\rsrc/file",
+        "src/file\r",
+        "\nsrc/file",
+        "src/file\n",
     ],
 )
 def test_release_compat_prerequisite_path_normalization_rejects_invalid_paths(path):
@@ -552,18 +570,7 @@ def test_release_compat_replays_prerequisite_before_pr_patch():
         shutil.rmtree(scratch_root, ignore_errors=True)
 
 
-@pytest.mark.skipif(os.name != "posix", reason="release replay script requires Bash")
-@pytest.mark.parametrize(
-    "invalid_path",
-    [
-        "src/./scoped.txt",
-        "src//scoped.txt",
-        "src/scoped.txt/",
-        "src/scoped.txt/.",
-    ],
-    ids=["dot-segment", "repeated-slash", "trailing-slash", "terminal-dot"],
-)
-def test_release_compat_rejects_non_normalized_scoped_paths(invalid_path):
+def _run_release_compat_with_scoped_config(scope):
     scratch_root = (
         REPO_ROOT / "target" / f"release-compat-invalid-path-{uuid.uuid4().hex}"
     )
@@ -590,7 +597,7 @@ def test_release_compat_rejects_non_normalized_scoped_paths(invalid_path):
         _git(repo, "checkout", "-b", "source")
         prerequisite_config = repo / ".pipelines" / "release-compat-prerequisites.txt"
         prerequisite_config.parent.mkdir()
-        prerequisite_config.write_text(f"{prerequisite}\t{invalid_path}\n")
+        prerequisite_config.write_bytes(f"{prerequisite}\t{scope}".encode())
         pr_file.write_text("pull request change\n")
         _git(repo, "add", ".")
         _git(repo, "commit", "-m", "feature with invalid prerequisite path")
@@ -632,27 +639,88 @@ def test_release_compat_rejects_non_normalized_scoped_paths(invalid_path):
             text=True,
         )
 
-        assert result.returncode != 0
-        assert (
-            f"Scoped prerequisite path must be normalized: {invalid_path}"
-            in result.stdout
-        )
+        return result
     finally:
         shutil.rmtree(scratch_root, ignore_errors=True)
 
 
 @pytest.mark.skipif(os.name != "posix", reason="release replay script requires Bash")
 @pytest.mark.parametrize(
-    ("config_prefix", "config_suffix"),
+    "invalid_path",
     [
-        ("", "\n"),
-        ("", "\r\n"),
-        ("  ", "   \n"),
+        "src/./scoped.txt",
+        "src//scoped.txt",
+        "src/scoped.txt/",
+        "src/scoped.txt/.",
     ],
-    ids=["normalized", "crlf", "surrounding-whitespace"],
+    ids=["dot-segment", "repeated-slash", "trailing-slash", "terminal-dot"],
+)
+def test_release_compat_rejects_non_normalized_scoped_paths(invalid_path):
+    result = _run_release_compat_with_scoped_config(f"{invalid_path}\n")
+
+    assert result.returncode != 0
+    assert (
+        f"Scoped prerequisite path must be normalized: {invalid_path}" in result.stdout
+    )
+
+
+@pytest.mark.skipif(os.name != "posix", reason="release replay script requires Bash")
+@pytest.mark.parametrize(
+    ("scope", "expected_error"),
+    [
+        (
+            " src/scoped.txt\n",
+            "Scoped prerequisite path must not have leading or trailing whitespace",
+        ),
+        (
+            "src/scoped.txt \n",
+            "Scoped prerequisite path must not have leading or trailing whitespace",
+        ),
+        (
+            "src/scoped.txt \r\n",
+            "Scoped prerequisite path must not have leading or trailing whitespace",
+        ),
+        (
+            "src/scoped.txt \tsrc/other.txt\r\n",
+            "Scoped prerequisite path must not have leading or trailing whitespace",
+        ),
+        (
+            "src/scoped.txt\t src/other.txt\r\n",
+            "Scoped prerequisite path must not have leading or trailing whitespace",
+        ),
+        ("\tsrc/scoped.txt\r\n", "contains an empty path"),
+        ("src/scoped.txt\t\r\n", "contains an empty path"),
+    ],
+    ids=[
+        "leading-space",
+        "trailing-space",
+        "trailing-space-crlf",
+        "first-path-trailing-space",
+        "second-path-leading-space",
+        "leading-tab",
+        "trailing-tab-crlf",
+    ],
+)
+def test_release_compat_rejects_scoped_path_field_whitespace(scope, expected_error):
+    result = _run_release_compat_with_scoped_config(scope)
+
+    assert result.returncode != 0
+    assert expected_error in result.stdout
+
+
+@pytest.mark.skipif(os.name != "posix", reason="release replay script requires Bash")
+@pytest.mark.parametrize(
+    ("config_prefix", "scoped_path", "config_suffix"),
+    [
+        ("", "src/scoped.txt", "\n"),
+        ("", "src/scoped.txt", "\r\n"),
+        ("  ", "src/scoped.txt", "\r\n"),
+        ("", "src/scoped file.txt", "\n"),
+    ],
+    ids=["normalized", "crlf", "leading-sha-whitespace", "internal-space"],
 )
 def test_release_compat_replays_scoped_missing_file_prerequisite_full_overlap(
-    config_prefix, config_suffix
+    config_prefix, scoped_path, config_suffix
 ):
     scratch_root = REPO_ROOT / "target" / f"release-compat-scoped-{uuid.uuid4().hex}"
     repo = scratch_root / "repo"
@@ -671,7 +739,7 @@ def test_release_compat_replays_scoped_missing_file_prerequisite_full_overlap(
         base = _git(repo, "rev-parse", "HEAD").stdout.strip()
         _git(repo, "branch", "release", base)
 
-        scoped_file = repo / "src" / "scoped.txt"
+        scoped_file = repo / scoped_path
         unrelated_file = repo / "src" / "unrelated.txt"
         scoped_file.parent.mkdir()
         scoped_file.write_text("target baseline\n")
@@ -684,7 +752,7 @@ def test_release_compat_replays_scoped_missing_file_prerequisite_full_overlap(
         prerequisite_config = repo / ".pipelines" / "release-compat-prerequisites.txt"
         prerequisite_config.parent.mkdir()
         prerequisite_config.write_bytes(
-            (f"{config_prefix}{prerequisite}\tsrc/scoped.txt{config_suffix}").encode()
+            (f"{config_prefix}{prerequisite}\t{scoped_path}{config_suffix}").encode()
         )
         scoped_file.write_text("pull request change\n")
         _git(repo, "add", ".")
@@ -721,7 +789,7 @@ def test_release_compat_replays_scoped_missing_file_prerequisite_full_overlap(
         assert scoped_file.read_text() == "pull request change\n"
         assert not unrelated_file.exists()
         assert _git(repo, "diff", "--cached", "--name-only").stdout.splitlines() == [
-            "src/scoped.txt"
+            scoped_path
         ]
         assert f"Prerequisite {prerequisite} applies cleanly" in result.stdout
         assert "PR changes apply cleanly onto release" in result.stdout

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -330,7 +330,10 @@ def test_release_compat_accepts_github_target_and_uses_one_sbt_process():
     )
     assert 'git show "$PR_MERGE_HEAD:$PREREQUISITES_CONFIG"' in rebase_script
     assert '[[ ! "$PREREQUISITE" =~ ^[0-9a-fA-F]{40}$ ]]' in rebase_script
-    assert r"""[[ "$RAW_LINE" == *$'\t'* ]]""" in rebase_script
+    assert r"""[[ "$TRIMMED_LINE" == *$'\t'* ]]""" in rebase_script
+    assert r"""[[ "$RAW_LINE" == *$'\t'* ]]""" not in rebase_script
+    assert "PREREQUISITE=\"${TRIMMED_LINE%%$'\\t'*}\"" in rebase_script
+    assert "PREREQUISITE_SCOPE=\"${TRIMMED_LINE#*$'\\t'}\"" in rebase_script
     assert "CONFIGURED_PREREQUISITE_SCOPES=()" in rebase_script
     assert (
         'git merge-base --is-ancestor "$PREREQUISITE" "$TARGET_HEAD"' in rebase_script
@@ -509,7 +512,18 @@ def test_release_compat_replays_prerequisite_before_pr_patch():
 
 
 @pytest.mark.skipif(os.name != "posix", reason="release replay script requires Bash")
-def test_release_compat_replays_scoped_missing_file_prerequisite_full_overlap():
+@pytest.mark.parametrize(
+    ("config_prefix", "config_suffix"),
+    [
+        ("", "\n"),
+        ("", "\r\n"),
+        ("  ", "   \n"),
+    ],
+    ids=["normalized", "crlf", "surrounding-whitespace"],
+)
+def test_release_compat_replays_scoped_missing_file_prerequisite_full_overlap(
+    config_prefix, config_suffix
+):
     scratch_root = REPO_ROOT / "target" / f"release-compat-scoped-{uuid.uuid4().hex}"
     repo = scratch_root / "repo"
     origin = scratch_root / "origin.git"
@@ -539,7 +553,9 @@ def test_release_compat_replays_scoped_missing_file_prerequisite_full_overlap():
         _git(repo, "checkout", "-b", "source")
         prerequisite_config = repo / ".pipelines" / "release-compat-prerequisites.txt"
         prerequisite_config.parent.mkdir()
-        prerequisite_config.write_text(f"{prerequisite}\tsrc/scoped.txt\n")
+        prerequisite_config.write_bytes(
+            (f"{config_prefix}{prerequisite}\tsrc/scoped.txt{config_suffix}").encode()
+        )
         scoped_file.write_text("pull request change\n")
         _git(repo, "add", ".")
         _git(repo, "commit", "-m", "feature modifies scoped file")

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -70,6 +70,30 @@ def _git(repo, *args):
     return result
 
 
+def _init_release_compat_scratch_repo(repo):
+    subprocess.run(
+        ["git", "init", "--initial-branch=master", str(repo)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for key, value in (
+        ("user.name", "Release Compat Test"),
+        ("user.email", "release-compat@example.test"),
+        ("core.autocrlf", "false"),
+        ("core.hooksPath", ".git/hooks-disabled"),
+        ("commit.gpgsign", "false"),
+        ("merge.autostash", "false"),
+        ("rebase.autostash", "false"),
+    ):
+        _git(repo, "config", key, value)
+
+
+def _assert_git_clean(repo, context):
+    status = _git(repo, "status", "--short").stdout.strip()
+    assert not status, f"{context} left scratch repo dirty:\n{status}"
+
+
 def test_pipeline_and_templates_parse():
     assert yaml.safe_load(PIPELINE.read_text()) is not None
     assert yaml.safe_load(CLEAN_ACR_PIPELINE.read_text()) is not None
@@ -306,9 +330,30 @@ def test_release_compat_accepts_github_target_and_uses_one_sbt_process():
     )
     assert 'git show "$PR_MERGE_HEAD:$PREREQUISITES_CONFIG"' in rebase_script
     assert '[[ ! "$PREREQUISITE" =~ ^[0-9a-fA-F]{40}$ ]]' in rebase_script
+    assert r"""[[ "$RAW_LINE" == *$'\t'* ]]""" in rebase_script
+    assert "CONFIGURED_PREREQUISITE_SCOPES=()" in rebase_script
     assert (
         'git merge-base --is-ancestor "$PREREQUISITE" "$TARGET_HEAD"' in rebase_script
     )
+    assert 'case "/$path/" in' in rebase_script
+    assert 'for REPLAY_PATH in "${REPLAY_PATHS[@]}"' in rebase_script
+    assert '[ "$path" = "$REPLAY_PATH" ]' in rebase_script
+    assert 'PREREQUISITE_PATHS+=("$path")' in rebase_script
+    assert "has no paths in this PR replay; skipping" in rebase_script
+    assert rebase_script.index('case "/$path/" in') < rebase_script.index(
+        'for REPLAY_PATH in "${REPLAY_PATHS[@]}"'
+    )
+    assert (
+        'git diff --quiet "$PREREQUISITE_PARENT" "$PREREQUISITE" --'
+        in rebase_script
+    )
+    assert 'git cat-file -e "$PREREQUISITE_PARENT:$path"' in rebase_script
+    assert 'git rev-parse "$PREREQUISITE:$path"' in rebase_script
+    assert 'git rev-parse "$TARGET_HEAD:$path"' in rebase_script
+    assert '[ "$PREREQUISITE_BLOB" != "$TARGET_BLOB" ]' in rebase_script
+    assert '":(literal)$path"' in rebase_script
+    assert '"${PREREQUISITE_PATHSPECS[@]}"' in rebase_script
+    assert "eval " not in rebase_script
     assert 'git rev-parse "$PREREQUISITE^1"' in rebase_script
     assert (
         'git diff --name-only -z "$PREREQUISITE_PARENT" "$PREREQUISITE"'
@@ -379,17 +424,22 @@ def test_release_compat_accepts_github_target_and_uses_one_sbt_process():
     assert "releaseCompatRequired" in result_steps[0]["condition"]
 
 
-def test_release_compat_prerequisites_are_full_shas():
+def test_release_compat_prerequisites_have_valid_format():
     lines = [
-        line.strip()
+        line
         for line in RELEASE_COMPAT_PREREQUISITES.read_text().splitlines()
         if line.strip() and not line.lstrip().startswith("#")
     ]
     # The list is meant to drain to empty once every validated release branch carries the
-    # backports, and the replay script already treats an absent or empty list as a no-op, so
-    # only the shape of the entries that are present is validated here.
-    assert all(re.fullmatch(r"[0-9a-fA-F]{40}", line) for line in lines)
-    assert len(lines) == len(set(lines)), "prerequisite commits must be unique"
+    # backports, and the replay script already treats an absent or empty list as a no-op.
+    entries = [line.split("\t") for line in lines]
+    assert all(re.fullmatch(r"[0-9a-fA-F]{40}", fields[0]) for fields in entries)
+    assert all(all(fields[1:]) for fields in entries)
+    for _, *paths in entries:
+        assert all(not path.startswith("/") for path in paths)
+        assert all(".." not in path.split("/") for path in paths)
+    shas = [fields[0] for fields in entries]
+    assert len(shas) == len(set(shas)), "prerequisite commits must be unique"
 
 
 @pytest.mark.skipif(os.name != "posix", reason="release replay script requires Bash")
@@ -402,14 +452,7 @@ def test_release_compat_replays_prerequisite_before_pr_patch():
     try:
         repo.mkdir(parents=True)
         agent_temp.mkdir()
-        subprocess.run(
-            ["git", "init", "--initial-branch=master", str(repo)],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        _git(repo, "config", "user.name", "Release Compat Test")
-        _git(repo, "config", "user.email", "release-compat@example.test")
+        _init_release_compat_scratch_repo(repo)
 
         source_file = repo / "src" / "value.txt"
         source_file.parent.mkdir()
@@ -432,6 +475,7 @@ def test_release_compat_replays_prerequisite_before_pr_patch():
         _git(repo, "commit", "-m", "feature")
 
         _git(repo, "checkout", "master")
+        _assert_git_clean(repo, "checkout before synthetic PR merge")
         _git(repo, "merge", "--no-ff", "source", "-m", "merge feature")
 
         subprocess.run(
@@ -460,6 +504,232 @@ def test_release_compat_replays_prerequisite_before_pr_patch():
         assert source_file.read_text() == "aad\nsearch\n"
         assert _git(repo, "diff", "--cached", "--name-only").stdout.splitlines() == [
             "src/value.txt"
+        ]
+        assert f"Prerequisite {prerequisite} applies cleanly" in result.stdout
+        assert "PR changes apply cleanly onto release" in result.stdout
+    finally:
+        shutil.rmtree(scratch_root, ignore_errors=True)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="release replay script requires Bash")
+def test_release_compat_replays_scoped_missing_file_prerequisite_full_overlap():
+    scratch_root = REPO_ROOT / "target" / f"release-compat-scoped-{uuid.uuid4().hex}"
+    repo = scratch_root / "repo"
+    origin = scratch_root / "origin.git"
+    agent_temp = scratch_root / "agent"
+
+    try:
+        repo.mkdir(parents=True)
+        agent_temp.mkdir()
+        _init_release_compat_scratch_repo(repo)
+
+        base_file = repo / "base.txt"
+        base_file.write_text("release base\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "base")
+        base = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        _git(repo, "branch", "release", base)
+
+        scoped_file = repo / "src" / "scoped.txt"
+        unrelated_file = repo / "src" / "unrelated.txt"
+        scoped_file.parent.mkdir()
+        scoped_file.write_text("target baseline\n")
+        unrelated_file.write_text("must not be replayed\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "prerequisite adds target files")
+        prerequisite = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+        _git(repo, "checkout", "-b", "source")
+        prerequisite_config = repo / ".pipelines" / "release-compat-prerequisites.txt"
+        prerequisite_config.parent.mkdir()
+        prerequisite_config.write_text(f"{prerequisite}\tsrc/scoped.txt\n")
+        scoped_file.write_text("pull request change\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "feature modifies scoped file")
+
+        _git(repo, "checkout", "master")
+        _assert_git_clean(repo, "checkout before synthetic PR merge")
+        _git(repo, "merge", "--no-ff", "source", "-m", "merge feature")
+
+        subprocess.run(
+            ["git", "init", "--bare", str(origin)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        _git(repo, "remote", "add", "origin", str(origin))
+        _git(repo, "push", "origin", "master", "source", "release")
+
+        script = _release_compat_script()
+        script = script.replace("$(Agent.TempDirectory)", str(agent_temp))
+        script = script.replace("$(RELEASE_BRANCH)", "release")
+        result = subprocess.run(
+            ["bash", "-c", script],
+            cwd=repo,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, (
+            f"scoped release replay failed\nstdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+        assert scoped_file.read_text() == "pull request change\n"
+        assert not unrelated_file.exists()
+        assert _git(repo, "diff", "--cached", "--name-only").stdout.splitlines() == [
+            "src/scoped.txt"
+        ]
+        assert f"Prerequisite {prerequisite} applies cleanly" in result.stdout
+        assert "PR changes apply cleanly onto release" in result.stdout
+    finally:
+        shutil.rmtree(scratch_root, ignore_errors=True)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="release replay script requires Bash")
+def test_release_compat_skips_scoped_prerequisite_for_unrelated_pr_path():
+    scratch_root = REPO_ROOT / "target" / f"release-compat-unrelated-{uuid.uuid4().hex}"
+    repo = scratch_root / "repo"
+    origin = scratch_root / "origin.git"
+    agent_temp = scratch_root / "agent"
+
+    try:
+        repo.mkdir(parents=True)
+        agent_temp.mkdir()
+        _init_release_compat_scratch_repo(repo)
+
+        pr_file = repo / "src" / "pr.txt"
+        pr_file.parent.mkdir()
+        pr_file.write_text("release base\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "base")
+        base = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        _git(repo, "branch", "release", base)
+
+        scoped_file = repo / "src" / "scoped.txt"
+        _git(repo, "commit", "--allow-empty", "-m", "prerequisite marker")
+        prerequisite = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+        _git(repo, "checkout", "-b", "source")
+        prerequisite_config = repo / ".pipelines" / "release-compat-prerequisites.txt"
+        prerequisite_config.parent.mkdir()
+        prerequisite_config.write_text(f"{prerequisite}\tsrc/scoped.txt\n")
+        pr_file.write_text("pull request change\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "feature modifies unrelated file")
+
+        _git(repo, "checkout", "master")
+        _assert_git_clean(repo, "checkout before synthetic PR merge")
+        _git(repo, "merge", "--no-ff", "source", "-m", "merge feature")
+
+        subprocess.run(
+            ["git", "init", "--bare", str(origin)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        _git(repo, "remote", "add", "origin", str(origin))
+        _git(repo, "push", "origin", "master", "source", "release")
+
+        script = _release_compat_script()
+        script = script.replace("$(Agent.TempDirectory)", str(agent_temp))
+        script = script.replace("$(RELEASE_BRANCH)", "release")
+        result = subprocess.run(
+            ["bash", "-c", script],
+            cwd=repo,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, (
+            f"unrelated-path release replay failed\nstdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+        assert pr_file.read_text() == "pull request change\n"
+        assert not scoped_file.exists()
+        assert _git(repo, "diff", "--cached", "--name-only").stdout.splitlines() == [
+            "src/pr.txt"
+        ]
+        assert (
+            f"Scoped prerequisite {prerequisite} has no paths in this PR replay; skipping"
+            in result.stdout
+        )
+        assert f"Prerequisite {prerequisite} applies cleanly" not in result.stdout
+        assert "PR changes apply cleanly onto release" in result.stdout
+    finally:
+        shutil.rmtree(scratch_root, ignore_errors=True)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="release replay script requires Bash")
+def test_release_compat_replays_only_partial_scoped_path_intersection():
+    scratch_root = REPO_ROOT / "target" / f"release-compat-partial-{uuid.uuid4().hex}"
+    repo = scratch_root / "repo"
+    origin = scratch_root / "origin.git"
+    agent_temp = scratch_root / "agent"
+
+    try:
+        repo.mkdir(parents=True)
+        agent_temp.mkdir()
+        _init_release_compat_scratch_repo(repo)
+
+        base_file = repo / "base.txt"
+        base_file.write_text("release base\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "base")
+        base = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        _git(repo, "branch", "release", base)
+
+        intersecting_file = repo / "src" / "intersecting.txt"
+        nonintersecting_file = repo / "src" / "nonintersecting.txt"
+        intersecting_file.parent.mkdir()
+        intersecting_file.write_text("target baseline\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "prerequisite adds intersecting file")
+        prerequisite = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+        _git(repo, "checkout", "-b", "source")
+        prerequisite_config = repo / ".pipelines" / "release-compat-prerequisites.txt"
+        prerequisite_config.parent.mkdir()
+        prerequisite_config.write_text(
+            f"{prerequisite}\tsrc/intersecting.txt\tsrc/nonintersecting.txt\n"
+        )
+        intersecting_file.write_text("pull request change\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "feature modifies one scoped file")
+
+        _git(repo, "checkout", "master")
+        _assert_git_clean(repo, "checkout before synthetic PR merge")
+        _git(repo, "merge", "--no-ff", "source", "-m", "merge feature")
+
+        subprocess.run(
+            ["git", "init", "--bare", str(origin)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        _git(repo, "remote", "add", "origin", str(origin))
+        _git(repo, "push", "origin", "master", "source", "release")
+
+        script = _release_compat_script()
+        script = script.replace("$(Agent.TempDirectory)", str(agent_temp))
+        script = script.replace("$(RELEASE_BRANCH)", "release")
+        result = subprocess.run(
+            ["bash", "-c", script],
+            cwd=repo,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, (
+            f"partial scoped release replay failed\nstdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+        assert intersecting_file.read_text() == "pull request change\n"
+        assert not nonintersecting_file.exists()
+        assert _git(repo, "diff", "--cached", "--name-only").stdout.splitlines() == [
+            "src/intersecting.txt"
         ]
         assert f"Prerequisite {prerequisite} applies cleanly" in result.stdout
         assert "PR changes apply cleanly onto release" in result.stdout


### PR DESCRIPTION
## Summary

- expose binary precision-recall AUC as `areaUnderPR` through `ComputeModelStatistics`
- include it in binary `all` / `classification` results and AutoML metric selection
- document and test `areaUnderROC` as an alias for the unchanged `AUC` ROC result
- harden scoped release-compat prerequisite parsing for CRLF and surrounding whitespace

## Metric semantics

`areaUnderPR` delegates directly to Spark's `BinaryClassificationMetrics.areaUnderPR()`. This is trapezoidal area under the precision-recall curve and intentionally differs from step-wise average precision, so this change does not add an `averagePrecision` alias.

Existing `AUC` behavior remains ROC AUC. Binary aggregate output retains the existing metric order and appends `areaUnderPR` after `AUC`.

## Compatibility

- no existing public metric names, parameters, or serialized parameter shapes are removed or renamed
- `AUC` values and `rocCurve` behavior remain unchanged
- `transformSchema` advertises binary-only aggregate columns only when SynapseML categorical metadata proves at most two label levels
- multiclass and unknown-cardinality inputs preserve the legacy common metric-only schema contract
- `evaluation_type`, `confusion_matrix`, and multiclass detail columns remain runtime-only for source compatibility
- aggregate ROC and PR calculations reuse and unpersist one `BinaryClassificationMetrics` instance

## Tests

The focused imbalanced fixture has 2 positives among 100 uniquely ranked examples and asserts:

- ROC AUC: `187 / 196 = 0.9540816326530612`
- PR AUC: `251 / 440 = 0.5704545454545454`
- conventional AP would be `13 / 22`, confirming the semantics are not mislabeled

Additional coverage validates binary and multiclass aggregate schemas/runtime ordering, unknown-cardinality compatibility, multiclass rejection, AutoML ordering/validation/save behavior, and normalized/CRLF/trailing-whitespace prerequisite parsing.

## Validation

- rebased onto `microsoft/master` at `55e4c2593d`
- JDK 11 SynapseML wrapper: focused schema tests **4/4 passed**; remaining targeted metric/AutoML suites **8/8 passed**
- `core/compile` and `core/test:compile`: passed
- repository `scalastyle` and `test:scalastyle`: 0 errors / warnings
- Black 22.3: 189 files unchanged
- Linux CI replay pytest: **22 passed**
- Spark 4.1 release replay, including scoped prerequisite `6938c472...`, followed by `core/test:compile` on JDK 17: passed
- no public Param or generated wrapper shape changed in the review-fix commit; prior codegen/wrapper validation remains applicable
- the prior causal job failure occurred before tests started due an Azure DevOps TLS certificate hostname mismatch; it produced no test results and is infrastructure-related

Fixes #1509