### PR TITLE
fix(onnx): upgrade runtime for Spark 3.5 local inference

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -330,7 +330,12 @@ lazy val deepLearning = (project in file("deep-learning"))
   .settings(settings ++ Seq(
     libraryDependencies ++= Seq(
       "com.microsoft.azure" % "onnx-protobuf_2.12" % "0.9.3",
-      "com.microsoft.onnxruntime" % "onnxruntime_gpu" % "1.8.1",
+      // Default to the CPU-only, cross-platform ONNX Runtime artifact (ships native libraries for
+      // Windows x64, Linux x64/aarch64, and macOS x64/aarch64) so ONNXModel works out of the box on
+      // every supported platform. CUDA support is an explicit opt-in: the onnxruntime_gpu artifact
+      // adds NVIDIA CUDA/TensorRT execution providers (Linux/Windows only, ~300+MB) and is never
+      // bundled by default. See docs/Explore Algorithms/Deep Learning/ONNX.md for GPU setup.
+      "com.microsoft.onnxruntime" % "onnxruntime" % "1.8.1",
       "org.apache.hadoop" % "hadoop-common" % "3.3.4" % "test",
       "org.apache.hadoop" % "hadoop-azure" % "3.3.4" % "test",
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -336,6 +336,7 @@ lazy val deepLearning = (project in file("deep-learning"))
     ),
     name := "synapseml-deep-learning"
   ): _*)
+  .settings(OnnxRuntimeDependency.settings: _*)
 
 lazy val lightgbm = (project in file("lightgbm"))
   .dependsOn(core % "test->test;compile->compile")

--- a/deep-learning/src/main/scala/com/microsoft/azure/synapse/ml/onnx/ONNXModel.scala
+++ b/deep-learning/src/main/scala/com/microsoft/azure/synapse/ml/onnx/ONNXModel.scala
@@ -86,6 +86,15 @@ trait ONNXModelParams extends Params with HasMiniBatcher with HasFeedFetchDicts 
 
   def setDeviceType(value: String): this.type = set(deviceType, value)
 
+  /**
+    * Returns the configured deviceType normalized to upper-case ("CPU"/"CUDA"), if set. The deviceType
+    * Param validator accepts any case (validated via `x.toUpperCase()`), so all internal deviceType
+    * comparisons (GPU auto-detection, explicit-CUDA fail-fast) must read this normalized accessor
+    * instead of the raw Param value -- otherwise a validator-accepted but differently-cased value like
+    * "cuda" or "Cuda" would silently bypass CUDA handling entirely.
+    */
+  def getNormalizedDeviceType: Option[String] = get(deviceType).map(_.toUpperCase)
+
   val optimizationLevel: Param[String] = new Param[String](
     this,
     "optimizationLevel",
@@ -237,7 +246,8 @@ class ONNXModel(override val uid: String)
     val batchedDF = getMiniBatcher.transform(dataset)
     val (coerced, feedDict) = coerceBatchedDf(batchedDF)
     val modelBc = broadcastedModelPayload.getOrElse(rebroadcastModelPayload(dataset.sparkSession))
-    val (fetchDicts, devType, optLevel) = (getFetchDict, get(deviceType), OptLevel.valueOf(getOptimizationLevel))
+    val (fetchDicts, devType, optLevel) =
+      (getFetchDict, getNormalizedDeviceType, OptLevel.valueOf(getOptimizationLevel))
 
     val outputDf = coerced.mapPartitions {
       rows =>
@@ -246,7 +256,8 @@ class ONNXModel(override val uid: String)
         val gpuDeviceId = selectGpuDevice(devType)
         val env = OrtEnvironment.getEnvironment
         logInfo(s"Task:$taskId;DeviceType=$devType;DeviceId=$gpuDeviceId;OptimizationLevel=$optLevel")
-        val session = createOrtSession(payload, env, optLevel, gpuDeviceId)
+        val session = createOrtSession(
+          payload, env, optLevel, gpuDeviceId, explicitCudaRequested = devType.contains("CUDA"))
         applyModel(session, env, feedDict, fetchDicts, inputSchema)(rows)
     }
 

--- a/deep-learning/src/main/scala/com/microsoft/azure/synapse/ml/onnx/ONNXRuntime.scala
+++ b/deep-learning/src/main/scala/com/microsoft/azure/synapse/ml/onnx/ONNXRuntime.scala
@@ -86,7 +86,10 @@ object ONNXRuntime extends Logging {
               case (_, outputName) =>
                 val i = session.getOutputInfo.asScala.keysIterator.indexOf(outputName)
                 val outputValue: OnnxValue = result.get(i)
-                mapOnnxValueToArray(outputValue)
+                outputValue.getInfo match {
+                  case _: SequenceInfo => ONNXValueConverter.mapSequenceToArray(outputValue)
+                  case _ => mapOnnxValueToArray(outputValue)
+                }
             }.toSeq
         }.get
 

--- a/deep-learning/src/main/scala/com/microsoft/azure/synapse/ml/onnx/ONNXRuntime.scala
+++ b/deep-learning/src/main/scala/com/microsoft/azure/synapse/ml/onnx/ONNXRuntime.scala
@@ -3,7 +3,6 @@
 
 package com.microsoft.azure.synapse.ml.onnx
 
-import ai.onnxruntime.OrtException.OrtErrorCode
 import ai.onnxruntime.OrtSession.SessionOptions
 import ai.onnxruntime.OrtSession.SessionOptions.OptLevel
 import ai.onnxruntime._
@@ -22,25 +21,76 @@ import scala.jdk.CollectionConverters.mapAsScalaMapConverter
  * ONNXRuntime: A wrapper around the ONNX Runtime (ORT)
  */
 object ONNXRuntime extends Logging {
+  // Extracted so createOrtSession's control flow fits scalastyle's method-length limit; the message
+  // text/rationale is unchanged from what was previously inlined at each throw/log call site.
+  private def noGpuResourceAssignedMessage: String =
+    "deviceType=CUDA was explicitly requested, but no Spark \"gpu\" resource is assigned to this " +
+      "executor/task, so there is no GPU device id to use. Configure Spark's GPU resource " +
+      "allocation (for example spark.executor.resource.gpu.amount and " +
+      "spark.task.resource.gpu.amount) so a gpu resource is assigned to this task, or set " +
+      "deviceType=CPU to run on CPU intentionally."
+
+  private def explicitCudaProviderFailedMessage(gpuDeviceId: Option[Int], exp: OrtException): String =
+    s"deviceType=CUDA was explicitly requested and a GPU device (id ${gpuDeviceId.get}) was " +
+      s"found on this executor, but adding CUDA support failed with error code ${exp.getCode}. " +
+      s"Most likely the ONNX runtime supplied to the cluster is the default " +
+      s"com.microsoft.onnxruntime:onnxruntime (CPU-only) artifact, or CUDA/cuDNN aren't " +
+      s"installed on this node. Add com.microsoft.onnxruntime:onnxruntime_gpu:{version} " +
+      s"(excluding the transitive onnxruntime CPU artifact) and a matching CUDA/cuDNN runtime " +
+      s"for GPU acceleration, or set deviceType=CPU to run on CPU intentionally."
+
+  private def autoFallbackProviderFailedMessage(gpuDeviceId: Option[Int], exp: OrtException): String =
+    s"GPU device is found on executor nodes with id ${gpuDeviceId.get}, " +
+      s"but adding CUDA support failed with error code ${exp.getCode}. Most likely the ONNX " +
+      s"runtime supplied to the cluster is the default com.microsoft.onnxruntime:onnxruntime " +
+      s"(CPU-only) artifact, or CUDA/cuDNN aren't installed on this node. Add " +
+      s"com.microsoft.onnxruntime:onnxruntime_gpu:{version} (excluding the transitive onnxruntime " +
+      s"CPU artifact) and a matching CUDA/cuDNN runtime for GPU acceleration. Falling back to CPU. " +
+      s"Exception details: ${exp.toString}"
+
   private[onnx] def createOrtSession(modelContent: Array[Byte],
                                      ortEnv: OrtEnvironment,
                                      optLevel: OptLevel = OptLevel.ALL_OPT,
-                                     gpuDeviceId: Option[Int] = None): OrtSession = {
-    val options = new SessionOptions()
-
-    try {
-      gpuDeviceId.foreach(options.addCUDA)
-    } catch {
-      case exp: OrtException if exp.getCode == OrtErrorCode.ORT_INVALID_ARGUMENT =>
-        val err = s"GPU device is found on executor nodes with id ${gpuDeviceId.get}, " +
-          s"but adding CUDA support failed. Most likely the ONNX runtime supplied to the cluster " +
-          s"does not support GPU. Please install com.microsoft.onnxruntime:onnxruntime_gpu:{version} " +
-          s"instead for optimal performance. Exception details: ${exp.toString}"
-        logError(err)
+                                     gpuDeviceId: Option[Int] = None,
+                                     explicitCudaRequested: Boolean = false): OrtSession = {
+    // deviceType=CUDA is an explicit request for GPU acceleration. If Spark never assigned a "gpu"
+    // resource to this executor/task, gpuDeviceId is None and addCUDA below would simply never be
+    // attempted -- silently handing back a working CPU session with no error at all. That is the same
+    // "silently broken GPU" failure mode this change must not reintroduce, so fail before creating any
+    // session rather than let CPU inference proceed unannounced.
+    if (explicitCudaRequested && gpuDeviceId.isEmpty) {
+      throw new IllegalStateException(noGpuResourceAssignedMessage)
     }
 
-    options.setOptimizationLevel(optLevel)
-    ortEnv.createSession(modelContent, options)
+    // SessionOptions owns a native handle that ONNX Runtime's own examples close via try-with-resources
+    // right after createSession returns: the session copies what it needs from options during
+    // construction and never needs the options object again, so closing it afterward is safe on every
+    // path. Use this file's established using(...) resource-cleanup pattern (see applyModel below) so
+    // SessionOptions is closed whether we fall through to a normal/auto-fallback session, or throw the
+    // explicit-CUDA fail-fast error -- but never before createSession has actually consumed it.
+    using(new SessionOptions()) { options =>
+      try {
+        gpuDeviceId.foreach(options.addCUDA)
+      } catch {
+        // A "gpu" resource was assigned (gpuDeviceId is defined) but adding CUDA support still failed.
+        // Silently continuing on CPU here would produce a success-shaped result while hiding a severe,
+        // hard-to-notice performance regression -- exactly the "silently broken GPU" failure mode this
+        // dependency change must not reintroduce. Fail fast with an actionable error instead. There is
+        // currently no parameter to opt in to a graceful CPU fallback for an explicit CUDA request; add
+        // one deliberately before relaxing this if that behavior is ever needed -- do not silently
+        // reinstate it here.
+        case exp: OrtException if explicitCudaRequested =>
+          throw new IllegalStateException(explicitCudaProviderFailedMessage(gpuDeviceId, exp), exp)
+        // deviceType was left unset (auto-detection): a "gpu" Spark resource was found, but CUDA isn't
+        // usable here. This wasn't an explicit ask for GPU, so log a clear, actionable error and
+        // continue on CPU rather than failing an otherwise-working job.
+        case exp: OrtException =>
+          logError(autoFallbackProviderFailedMessage(gpuDeviceId, exp))
+      }
+
+      options.setOptimizationLevel(optLevel)
+      ortEnv.createSession(modelContent, options)
+    }.get
   }
 
   private[onnx] def selectGpuDevice(deviceType: Option[String]): Option[Int] = {

--- a/deep-learning/src/main/scala/com/microsoft/azure/synapse/ml/onnx/ONNXValueConverter.scala
+++ b/deep-learning/src/main/scala/com/microsoft/azure/synapse/ml/onnx/ONNXValueConverter.scala
@@ -1,0 +1,68 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.onnx
+
+import ai.onnxruntime.OnnxValue
+
+private[onnx] object ONNXValueConverter {
+
+  /**
+    * Eagerly copies a sequence to JVM values and closes every child handle returned by ONNX Runtime.
+    * The caller remains responsible for closing the outer value through its owning OrtSession.Result.
+    */
+  def mapSequenceToArray(value: OnnxValue): Seq[Any] = {
+    value.getValue match {
+      case values: java.util.List[_] => unwrapList(values)
+      case other =>
+        val valueType = Option(other).map(_.getClass.getName).getOrElse("null")
+        throw new IllegalArgumentException(s"Expected an ONNX sequence value, but found $valueType")
+    }
+  }
+
+  private def unwrapValue(value: Any): Any = value match {
+    case values: java.util.List[_] => unwrapList(values)
+    case map: java.util.Map[_, _] => unwrapMap(map)
+    case other => other
+  }
+
+  private def unwrapOnnxValue(value: OnnxValue): Any = unwrapValue(value.getValue)
+
+  private def unwrapList(values: java.util.List[_]): Vector[Any] = {
+    val elements = values.toArray
+    val closeables = elements.collect { case value: OnnxValue => value }
+
+    try {
+      elements.iterator.map {
+        case value: OnnxValue => unwrapOnnxValue(value)
+        case other => unwrapValue(other)
+      }.toVector
+    } finally {
+      closeables.foreach(_.close())
+    }
+  }
+
+  private def unwrapMap(map: java.util.Map[_, _]): Map[Any, Any] = {
+    val entries = map.entrySet().toArray.iterator.map {
+      case entry: java.util.Map.Entry[_, _] => entry.getKey -> entry.getValue
+    }.toVector
+    val closeables = entries.iterator.flatMap {
+      case (key, value) => Iterator(key, value).collect { case onnxValue: OnnxValue => onnxValue }
+    }.toVector
+
+    try {
+      entries.iterator.map {
+        case (key: OnnxValue, value: OnnxValue) =>
+          unwrapOnnxValue(key) -> unwrapOnnxValue(value)
+        case (key: OnnxValue, value) =>
+          unwrapOnnxValue(key) -> unwrapValue(value)
+        case (key, value: OnnxValue) =>
+          unwrapValue(key) -> unwrapOnnxValue(value)
+        case (key, value) =>
+          unwrapValue(key) -> unwrapValue(value)
+      }.toMap
+    } finally {
+      closeables.foreach(_.close())
+    }
+  }
+}

--- a/deep-learning/src/test/scala/com/microsoft/azure/synapse/ml/onnx/ONNXModelSuite.scala
+++ b/deep-learning/src/test/scala/com/microsoft/azure/synapse/ml/onnx/ONNXModelSuite.scala
@@ -129,9 +129,20 @@ class ONNXModelSuite extends TestBase
     assert(caught.getMessage.contains("IllegalArgumentException"))
   }
 
+  // Minimal dotted-version comparator (e.g. "1.17.3" vs "1.16.3"). Avoids hard-coding an exact ONNX
+  // Runtime version so the GH2417 regression check keeps passing across future confirmed upgrades.
+  private def versionAtLeast(actual: String, minimum: String): Boolean = {
+    def parts(v: String): Seq[Int] = v.split("\\.").map(_.takeWhile(_.isDigit)).map(s => if (s.isEmpty) 0 else s.toInt)
+    val (a, m) = (parts(actual), parts(minimum))
+    Ordering.Iterable[Int].gteq(a.padTo(m.length, 0), m.padTo(a.length, 0))
+  }
+
   test("ONNXModel loads upgraded runtime for local CPU inference (GH2417)") {
     val runtimeVersion = StreamUtilities.using(OrtEnvironment.getEnvironment)(_.getVersion).get
-    assert(runtimeVersion == "1.16.3")
+    // GH2417: ONNX Runtime 1.8.1 fails to load its natives for local Spark 3.5 inference (macOS/Linux/
+    // Windows). 1.16.3 was the smallest version confirmed to fix it; guard against ever regressing below it.
+    assert(versionAtLeast(runtimeVersion, "1.16.3"),
+      s"Expected ONNX Runtime >= 1.16.3 to keep GH2417 fixed, but found $runtimeVersion")
 
     val predictions = onnxIris.copy(ParamMap.empty)
       .setDeviceType("CPU")
@@ -142,6 +153,134 @@ class ONNXModelSuite extends TestBase
 
     assert(predictions.map(_._1).toSet == Set(0L, 1L, 2L))
     assert(predictions.forall(_._2.keySet == Set(0L, 1L, 2L)))
+  }
+
+  test("ONNXRuntime.createOrtSession falls back to CPU with a clear log when CUDA is unavailable and was " +
+    "not explicitly requested (GH2417)") {
+    // Auto-detection (deviceType left unset): the default packaged dependency is the CPU-only,
+    // cross-platform `onnxruntime` artifact (no CUDA execution provider). A "gpu" resource was found,
+    // but this wasn't an explicit ask for GPU, so ONNXRuntime.createOrtSession should log a clear,
+    // actionable error naming onnxruntime_gpu and gracefully continue on CPU rather than fail the task.
+    val env = OrtEnvironment.getEnvironment
+    val session = ONNXRuntime.createOrtSession(
+      onnxIris.getModelPayload, env, gpuDeviceId = Some(0), explicitCudaRequested = false)
+    try {
+      assert(!session.getInputInfo.isEmpty)
+    } finally {
+      session.close()
+    }
+  }
+
+  test("ONNXRuntime.createOrtSession fails fast before touching the provider when CUDA is explicitly " +
+    "requested but no Spark gpu resource was assigned (GH2417)") {
+    // gpuDeviceId=None here models a Spark task with no "gpu" resource assigned (the common case on a
+    // CPU-only cluster). Without this check, createOrtSession would never call addCUDA at all (there's
+    // no device id to add) and would silently hand back a working CPU session -- the same
+    // "silently broken GPU" failure mode this dependency change must not reintroduce.
+    val env = OrtEnvironment.getEnvironment
+    val caught = intercept[IllegalStateException] {
+      ONNXRuntime.createOrtSession(
+        onnxIris.getModelPayload, env, gpuDeviceId = None, explicitCudaRequested = true)
+    }
+    assert(caught.getMessage.contains("deviceType=CUDA was explicitly requested"))
+    assert(caught.getMessage.contains("no Spark \"gpu\" resource is assigned"))
+  }
+
+  test("ONNXRuntime.createOrtSession fails fast with an actionable error when CUDA is explicitly " +
+    "requested but the provider is unavailable (GH2417)") {
+    // deviceType=CUDA is an explicit request for GPU acceleration. Silently continuing on CPU would be
+    // a success-shaped result that hides a severe, hard-to-notice performance regression -- the same
+    // "silently broken GPU" failure mode this dependency change must not reintroduce. There is no
+    // opt-in parameter to request a graceful CPU fallback for an explicit CUDA request, so this must
+    // throw a clear, actionable error rather than swallow it and return CPU results.
+    val env = OrtEnvironment.getEnvironment
+    val caught = intercept[IllegalStateException] {
+      ONNXRuntime.createOrtSession(
+        onnxIris.getModelPayload, env, gpuDeviceId = Some(0), explicitCudaRequested = true)
+    }
+    assert(caught.getMessage.contains("deviceType=CUDA was explicitly requested"))
+    assert(caught.getMessage.contains("onnxruntime_gpu"))
+    assert(caught.getCause != null)
+  }
+
+  test("ONNXRuntime.createOrtSession closes SessionOptions without invalidating the returned session " +
+    "(GH2417)") {
+    // SessionOptions.close() runs (via the using(...) resource-cleanup pattern) right after
+    // ortEnv.createSession(...) returns. If that close happened too early -- or corrupted the session
+    // it had just been used to build -- the returned OrtSession would fail to actually run inference.
+    // Running real inference through it is the most direct observable proof the cleanup is correct.
+    val env = OrtEnvironment.getEnvironment
+    val session = ONNXRuntime.createOrtSession(onnxIris.getModelPayload, env, gpuDeviceId = None)
+    try {
+      val input = java.nio.FloatBuffer.wrap(Array(6.7f, 3.1f, 4.7f, 1.5f))
+      val tensor = ai.onnxruntime.OnnxTensor.createTensor(env, input, Array(1L, 4L))
+      try {
+        val result = session.run(java.util.Collections.singletonMap("float_input", tensor))
+        try {
+          assert(result.size() > 0)
+        } finally {
+          result.close()
+        }
+      } finally {
+        tensor.close()
+      }
+    } finally {
+      session.close()
+    }
+  }
+
+  test("ONNXRuntime.createOrtSession does not leak across repeated create/close cycles on any path " +
+    "(GH2417)") {
+    // Exercises all three createOrtSession outcomes (plain CPU, auto-fallback log-and-continue, and
+    // the explicit-CUDA fail-fast throw) repeatedly. SessionOptions is a local variable inside
+    // createOrtSession with no public isClosed() accessor to assert against directly (unlike OnnxValue
+    // in ORT 1.17+), so this loop is the practical, observable regression check available: if the
+    // using(...) refactor ever re-leaked SessionOptions, mishandled double-closing, or broke the
+    // fail-fast throw's cleanup ordering, repeated cycles are the most likely way to surface it.
+    val env = OrtEnvironment.getEnvironment
+    val payload = onnxIris.getModelPayload
+    for (_ <- 1 to 25) {
+      val cpuSession = ONNXRuntime.createOrtSession(payload, env, gpuDeviceId = None)
+      cpuSession.close()
+
+      val fallbackSession = ONNXRuntime.createOrtSession(
+        payload, env, gpuDeviceId = Some(0), explicitCudaRequested = false)
+      fallbackSession.close()
+
+      intercept[IllegalStateException] {
+        ONNXRuntime.createOrtSession(payload, env, gpuDeviceId = Some(0), explicitCudaRequested = true)
+      }
+    }
+  }
+
+  // End-to-end: local test Spark sessions never assign a "gpu" TaskContext resource, so any explicit
+  // CUDA request here must hit the new "no GPU resource assigned" fail-fast path in
+  // ONNXRuntime.createOrtSession, exercised through the public setDeviceType API and normalization.
+  private def assertExplicitCudaFailsFastEndToEnd(requestedDeviceType: String): Unit = {
+    val caught = intercept[SparkException] {
+      onnxIris.copy(ParamMap.empty)
+        .setDeviceType(requestedDeviceType)
+        .transform(testDfIrisFloat)
+        .collect()
+    }
+    assert(caught.getMessage.contains("IllegalStateException"))
+    assert(caught.getMessage.contains("deviceType=CUDA was explicitly requested"))
+    assert(caught.getMessage.contains("no Spark \"gpu\" resource is assigned"))
+  }
+
+  test("ONNXModel fails fast end-to-end when deviceType=CUDA is explicitly requested but no Spark gpu " +
+    "resource is assigned (GH2417)") {
+    assertExplicitCudaFailsFastEndToEnd("CUDA")
+  }
+
+  test("ONNXModel fails fast end-to-end for a lower-case deviceType=\"cuda\" request (GH2417)") {
+    // The deviceType Param validator accepts any case (`x.toUpperCase()`), so a differently-cased but
+    // still-valid value must not silently bypass CUDA handling and fall through to CPU.
+    assertExplicitCudaFailsFastEndToEnd("cuda")
+  }
+
+  test("ONNXModel fails fast end-to-end for a mixed-case deviceType=\"CuDa\" request (GH2417)") {
+    assertExplicitCudaFailsFastEndToEnd("CuDa")
   }
 
   test("ONNXModel can infer observations of matching input types") {

--- a/deep-learning/src/test/scala/com/microsoft/azure/synapse/ml/onnx/ONNXModelSuite.scala
+++ b/deep-learning/src/test/scala/com/microsoft/azure/synapse/ml/onnx/ONNXModelSuite.scala
@@ -3,9 +3,10 @@
 
 package com.microsoft.azure.synapse.ml.onnx
 
+import ai.onnxruntime.OrtEnvironment
 import breeze.linalg.{argmax, argtopk}
 import com.microsoft.azure.synapse.ml.build.BuildInfo
-import com.microsoft.azure.synapse.ml.core.env.FileUtilities
+import com.microsoft.azure.synapse.ml.core.env.{FileUtilities, StreamUtilities}
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 import com.microsoft.azure.synapse.ml.core.test.fuzzing.{TestObject, TransformerFuzzing}
 import com.microsoft.azure.synapse.ml.core.utils.BreezeUtils._
@@ -16,7 +17,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.injections.UDFUtils
 import org.apache.spark.ml.image.ImageSchema
 import org.apache.spark.ml.linalg.{DenseVector, Vector, Vectors}
-import org.apache.spark.ml.param.Param
+import org.apache.spark.ml.param.{Param, ParamMap}
 import org.apache.spark.ml.util.MLReadable
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions._
@@ -126,6 +127,21 @@ class ONNXModelSuite extends TestBase
       onnxIris.transform(testDfIrisEmptyDimension).collect()
     }
     assert(caught.getMessage.contains("IllegalArgumentException"))
+  }
+
+  test("ONNXModel loads upgraded runtime for local CPU inference (GH2417)") {
+    val runtimeVersion = StreamUtilities.using(OrtEnvironment.getEnvironment)(_.getVersion).get
+    assert(runtimeVersion == "1.16.3")
+
+    val predictions = onnxIris.copy(ParamMap.empty)
+      .setDeviceType("CPU")
+      .transform(testDfIrisFloat)
+      .select("prediction", "rawProbability")
+      .as[(Long, Map[Long, Float])]
+      .collect()
+
+    assert(predictions.map(_._1).toSet == Set(0L, 1L, 2L))
+    assert(predictions.forall(_._2.keySet == Set(0L, 1L, 2L)))
   }
 
   test("ONNXModel can infer observations of matching input types") {

--- a/deep-learning/src/test/scala/com/microsoft/azure/synapse/ml/onnx/ONNXRuntimeDependencySuite.scala
+++ b/deep-learning/src/test/scala/com/microsoft/azure/synapse/ml/onnx/ONNXRuntimeDependencySuite.scala
@@ -1,0 +1,96 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.onnx
+
+import com.microsoft.azure.synapse.ml.build.BuildInfo
+import com.microsoft.azure.synapse.ml.core.env.FileUtilities
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+  * GH2417: verifies the published dependency strategy for ONNX Runtime, independent of whatever version
+  * happens to be resolved on the test classpath (that runtime behavior is covered by ONNXModelSuite and
+  * ONNXRuntime's own tests). This reads the build definitions directly so a future edit that re-adds
+  * onnxruntime_gpu as a default/compile dependency -- reintroducing the ~300+MB, macOS-incompatible
+  * artifact for every user -- fails a fast, local test instead of only being caught by a live macOS run.
+  *
+  * A live "does this resolve from Maven Central" integration test isn't practical here: it would need
+  * network access and a version of SynapseML already published under the coordinate being tested, which
+  * doesn't exist for an unmerged change (the same reason VerifyPackageUtils.scala only checks coordinate
+  * *format*, not live resolution). Instead, the tests below regression-guard the documented opt-in
+  * coordinate/exclusion syntax in ONNX.md itself, and a separate scratch sbt project (not committed) was
+  * used to empirically confirm resolution behavior before writing that guidance -- see the PR description.
+  */
+class ONNXRuntimeDependencySuite extends AnyFunSuite {
+
+  private val repoRoot: String = BuildInfo.baseDirectory.getParent
+  private val buildSbt = FileUtilities.readFile(FileUtilities.join(repoRoot, "build.sbt"))
+  private val onnxRuntimeDependencyScala = FileUtilities.readFile(
+    FileUtilities.join(repoRoot, "project", "OnnxRuntimeDependency.scala"))
+  private val onnxDoc = FileUtilities.readFile(
+    FileUtilities.join(repoRoot, "docs", "Explore Algorithms", "Deep Learning", "ONNX.md"))
+
+  private val deepLearningBlock: String = {
+    val start = buildSbt.indexOf("lazy val deepLearning")
+    require(start >= 0, "Could not find the deepLearning project definition in build.sbt")
+    val nextProject = buildSbt.indexOf("\nlazy val ", start + 1)
+    buildSbt.substring(start, if (nextProject >= 0) nextProject else buildSbt.length)
+  }
+
+  test("deep-learning declares the CPU-only, cross-platform onnxruntime artifact as its default dependency") {
+    assert(deepLearningBlock.contains(""""com.microsoft.onnxruntime" % "onnxruntime""""),
+      "build.sbt must declare com.microsoft.onnxruntime:onnxruntime (CPU-only, cross-platform, " +
+        "including macOS) as the default deep-learning dependency so ONNXModel works out of the box " +
+        "on macOS/Linux/Windows.")
+  }
+
+  test("deep-learning does not force the GPU-only onnxruntime_gpu artifact on every user by default") {
+    assert(!deepLearningBlock.contains(""""onnxruntime_gpu""""),
+      "onnxruntime_gpu (Linux/Windows-only CUDA build, ~300+MB) must not be a default/compile " +
+        "dependency of synapseml-deep-learning; it should remain an explicit, documented opt-in " +
+        "(see docs/Explore Algorithms/Deep Learning/ONNX.md) so it is never forced on macOS or " +
+        "CPU-only users.")
+  }
+
+  test("the shared ONNX Runtime version is pinned at or above the confirmed GH2417 fix version") {
+    val versionPattern = """val Version = "([\d.]+)"""".r
+    val version = versionPattern.findFirstMatchIn(onnxRuntimeDependencyScala).map(_.group(1))
+      .getOrElse(fail("Could not find `val Version = \"...\"` in project/OnnxRuntimeDependency.scala"))
+
+    def parts(v: String): Seq[Int] = v.split("\\.").map(_.toInt)
+    assert(Ordering.Iterable[Int].gteq(parts(version), parts("1.16.3")),
+      s"Expected the ONNX Runtime version pinned in project/OnnxRuntimeDependency.scala ($version) " +
+        s"to stay at or above 1.16.3, the smallest version confirmed to fix GH2417.")
+  }
+
+  test("ONNX.md documents the Spark --packages/--exclude-packages exclusion syntax for the GPU opt-in") {
+    assert(onnxDoc.contains("--exclude-packages") && onnxDoc.contains("spark.jars.excludes"),
+      "ONNX.md must document both the spark-submit CLI form (--packages/--exclude-packages) and the " +
+        "equivalent Spark conf keys (spark.jars.packages/spark.jars.excludes) for excluding the " +
+        "transitive CPU-only onnxruntime artifact when opting in to onnxruntime_gpu.")
+    assert(onnxDoc.contains("com.microsoft.onnxruntime:onnxruntime_gpu"),
+      "ONNX.md must name the exact onnxruntime_gpu Maven coordinate for the --packages/spark.jars." +
+        "packages example.")
+  }
+
+  test("ONNX.md documents the Databricks Maven library Exclusions field on the correct entry") {
+    assert(onnxDoc.contains("\"exclusions\""),
+      "ONNX.md must show the Databricks Maven library JSON \"exclusions\" field for the GPU opt-in.")
+    assert(onnxDoc.contains("Exclusions"),
+      "ONNX.md must name the Databricks UI \"Exclusions\" field for the GPU opt-in.")
+    // The exclusion must be documented on the SynapseML entry (the one that actually depends
+    // transitively on the CPU-only onnxruntime), not on the onnxruntime_gpu entry -- an exclusion on
+    // onnxruntime_gpu would be a no-op since it never depends on the plain onnxruntime artifact.
+    assert(onnxDoc.contains("not on the onnxruntime_gpu entry") ||
+      onnxDoc.contains("not on `onnxruntime_gpu`"),
+      "ONNX.md must call out that the Databricks Exclusions field belongs on the SynapseML library " +
+        "entry, not the onnxruntime_gpu entry, since Databricks resolves each Maven library's " +
+        "dependency tree independently.")
+  }
+
+  test("ONNX.md states the exactly-one-ai.onnxruntime-jar invariant for the GPU opt-in") {
+    assert(onnxDoc.contains("exactly one `ai.onnxruntime` jar"),
+      "ONNX.md must state that exactly one ai.onnxruntime jar must be present after opting in to " +
+        "onnxruntime_gpu, so users have a concrete way to verify their exclusion actually worked.")
+  }
+}

--- a/deep-learning/src/test/scala/com/microsoft/azure/synapse/ml/onnx/ONNXValueConverterSuite.scala
+++ b/deep-learning/src/test/scala/com/microsoft/azure/synapse/ml/onnx/ONNXValueConverterSuite.scala
@@ -36,6 +36,9 @@ class ONNXValueConverterSuite extends AnyFunSuite {
 
     override def getType: OnnxValue.OnnxValueType = OnnxValue.OnnxValueType.ONNX_TYPE_SEQUENCE
 
+    // ONNX Runtime 1.17 added OnnxValue.isClosed as an abstract method (GH2417 runtime upgrade).
+    override def isClosed: Boolean = closed
+
     override def close(): Unit = {
       closed = true
     }

--- a/deep-learning/src/test/scala/com/microsoft/azure/synapse/ml/onnx/ONNXValueConverterSuite.scala
+++ b/deep-learning/src/test/scala/com/microsoft/azure/synapse/ml/onnx/ONNXValueConverterSuite.scala
@@ -1,0 +1,43 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.onnx
+
+import ai.onnxruntime.{OnnxValue, ValueInfo}
+import org.scalatest.funsuite.AnyFunSuite
+
+class ONNXValueConverterSuite extends AnyFunSuite {
+
+  test("ONNX sequence conversion recursively materializes and closes nested values") {
+    val leaf = new StubOnnxValue(java.lang.Long.valueOf(42L))
+    val nestedValues = new java.util.ArrayList[OnnxValue]()
+    nestedValues.add(leaf)
+    val nestedSequence = new StubOnnxValue(nestedValues)
+    val outerValues = new java.util.ArrayList[OnnxValue]()
+    outerValues.add(nestedSequence)
+    val outerSequence = new StubOnnxValue(outerValues)
+
+    val converted = ONNXValueConverter.mapSequenceToArray(outerSequence)
+
+    assert(converted == Vector(Vector(42L)))
+    assert(nestedSequence.closed)
+    assert(leaf.closed)
+    assert(!outerSequence.closed)
+  }
+
+  private object StubValueInfo extends ValueInfo
+
+  private class StubOnnxValue(rawValue: AnyRef) extends OnnxValue {
+    var closed: Boolean = false
+
+    override def getValue: AnyRef = rawValue
+
+    override def getInfo: ValueInfo = StubValueInfo
+
+    override def getType: OnnxValue.OnnxValueType = OnnxValue.OnnxValueType.ONNX_TYPE_SEQUENCE
+
+    override def close(): Unit = {
+      closed = true
+    }
+  }
+}

--- a/docs/Explore Algorithms/Deep Learning/ONNX.md
+++ b/docs/Explore Algorithms/Deep Learning/ONNX.md
@@ -13,6 +13,136 @@ description: Learn how to use the ONNX model transformer to run inference for an
 
 SynapseML now includes a Spark transformer to bring a trained ONNX model to Apache Spark, so you can run inference on your data with Spark's large-scale data processing power.
 
+## Runtime selection: CPU by default, CUDA as an explicit opt-in
+
+SynapseML depends on `com.microsoft.onnxruntime:onnxruntime` (the CPU-only ONNX Runtime artifact) by
+default. It bundles native libraries for Windows x64, Linux x64/aarch64, and **macOS x64/aarch64**, so
+`ONNXModel` works out of the box for CPU inference on every platform SynapseML supports, including local
+Spark on a Mac.
+
+CUDA/GPU acceleration is **not** bundled by default:
+
+- NVIDIA's CUDA execution provider only exists for Linux and Windows -- it has no macOS build, so
+  shipping it by default would still leave macOS broken.
+- The artifact that adds it, `com.microsoft.onnxruntime:onnxruntime_gpu`, is roughly 300+ MB (mostly the
+  embedded CUDA/TensorRT provider binaries and Windows debug symbols), and forcing that onto every
+  CPU-only and macOS user just to support Linux/Windows GPU clusters isn't reasonable.
+
+To opt in to GPU acceleration on a Linux or Windows cluster with a matching NVIDIA GPU and CUDA/cuDNN
+installed, add `com.microsoft.onnxruntime:onnxruntime_gpu` at the same version SynapseML pins in
+`project/OnnxRuntimeDependency.scala`, and exclude the transitive CPU-only `onnxruntime` artifact that
+comes from `synapseml-deep-learning` (or the aggregate `synapseml` package) so you don't end up with two
+copies of the `ai.onnxruntime` classes on your classpath. **The exclusion must be attached to the
+SynapseML dependency itself** (the one that transitively depends on `onnxruntime`), not to the
+`onnxruntime_gpu` dependency (which never depends on the CPU-only artifact, so excluding anything from it
+would be a no-op). After installing, verify that exactly one `ai.onnxruntime` jar is present -- if you
+ever see both `onnxruntime-<version>.jar` and `onnxruntime_gpu-<version>.jar` on the same classpath, the
+exclusion is missing or attached to the wrong dependency.
+
+- **sbt** (per-dependency exclusion, attached to the SynapseML dependency):
+
+  ```scala
+  libraryDependencies ++= Seq(
+    ("com.microsoft.azure" %% "synapseml-deep-learning" % "<version>")
+      .exclude("com.microsoft.onnxruntime", "onnxruntime"),
+    "com.microsoft.onnxruntime" % "onnxruntime_gpu" % "<onnxruntime-version>"
+  )
+  ```
+
+  (A project-wide `excludeDependencies += ExclusionRule("com.microsoft.onnxruntime", "onnxruntime")`
+  works too and is simpler if nothing else in your build needs the CPU-only artifact.)
+
+- **Maven**: add an `<exclusion>` for `com.microsoft.onnxruntime:onnxruntime` to your
+  `synapseml-deep-learning` (or `synapseml`) `<dependency>`, and add `onnxruntime_gpu` as a separate,
+  unexcluded dependency:
+
+  ```xml
+  <dependency>
+    <groupId>com.microsoft.azure</groupId>
+    <artifactId>synapseml-deep-learning_2.12</artifactId>
+    <version>...</version>
+    <exclusions>
+      <exclusion>
+        <groupId>com.microsoft.onnxruntime</groupId>
+        <artifactId>onnxruntime</artifactId>
+      </exclusion>
+    </exclusions>
+  </dependency>
+  <dependency>
+    <groupId>com.microsoft.onnxruntime</groupId>
+    <artifactId>onnxruntime_gpu</artifactId>
+    <version>1.17.3</version>
+  </dependency>
+  ```
+
+- **spark-submit / spark-shell / pyspark (`--packages`)**: pass the SynapseML and `onnxruntime_gpu`
+  coordinates via `--packages`, and exclude the CPU-only artifact via the separate `--exclude-packages`
+  flag (format `groupId:artifactId`, no version):
+
+  ```bash
+  spark-submit \
+    --packages com.microsoft.azure:synapseml_2.12:<version>,com.microsoft.onnxruntime:onnxruntime_gpu:1.17.3 \
+    --exclude-packages com.microsoft.onnxruntime:onnxruntime \
+    your_script.py
+  ```
+
+  The equivalent Spark configuration keys (for a `SparkConf`/notebook `%%configure` cell instead of CLI
+  flags) are `spark.jars.packages` and `spark.jars.excludes`:
+
+  ```
+  spark.jars.packages=com.microsoft.azure:synapseml_2.12:<version>,com.microsoft.onnxruntime:onnxruntime_gpu:1.17.3
+  spark.jars.excludes=com.microsoft.onnxruntime:onnxruntime
+  ```
+
+- **Databricks cluster library UI/API**: install the SynapseML package and `onnxruntime_gpu` as **two
+  separate Maven libraries**, and set the library's **Exclusions** field (format `groupId:artifactId`) on
+  the **SynapseML library entry**, not on `onnxruntime_gpu`:
+
+  ```json
+  [
+    {
+      "maven": {
+        "coordinates": "com.microsoft.azure:synapseml-deep-learning_2.12:<version>",
+        "exclusions": ["com.microsoft.onnxruntime:onnxruntime"]
+      }
+    },
+    { "maven": { "coordinates": "com.microsoft.onnxruntime:onnxruntime_gpu:1.17.3" } }
+  ]
+  ```
+
+  Each Databricks Maven library entry resolves its own dependency tree independently, so an exclusion
+  set on the `onnxruntime_gpu` entry has no effect on what the SynapseML entry pulls in -- it must be on
+  the entry that actually depends on the CPU-only artifact.
+
+### What happens if CUDA is requested but unavailable
+
+`deviceType` is matched case-insensitively (`"CUDA"`, `"cuda"`, and `"CuDa"` are all treated the same), so
+the behavior below cannot be bypassed by casing. It differs depending on whether you explicitly asked for
+GPU acceleration:
+
+- **`deviceType` explicitly set to `CUDA`:** `ONNXModel` **fails the task** with a clear, actionable error
+  rather than silently falling back to CPU, in either of these cases:
+  - No Spark `gpu` resource is assigned to the executor/task (the common case on a CPU-only cluster) --
+    there is no GPU device id to use at all, so the error explains how to configure Spark's GPU resource
+    allocation (or to set `deviceType` to `CPU` instead).
+  - A `gpu` resource *is* assigned, but the CUDA execution provider still isn't usable (for example, only
+    the default CPU-only artifact is installed, or CUDA/cuDNN aren't installed on the node) -- the error
+    names the `onnxruntime_gpu` artifact to install.
+
+  In both cases, silently continuing on CPU would produce a success-shaped result that quietly hides a
+  severe performance regression, which is the same class of problem this dependency change is meant to
+  fix, not reintroduce. There is currently no parameter to opt in to a graceful CPU fallback for an
+  explicit CUDA request; set `deviceType` to `CPU` if you intend to run on CPU.
+- **`deviceType` left unset (auto-detection):** if a `gpu` resource happens to be present but CUDA isn't
+  usable, `ONNXModel` logs a clear, actionable error (again naming `onnxruntime_gpu`) and continues on
+  CPU, since GPU was never explicitly requested in this case. If no `gpu` resource is present, CPU is
+  used with no error, since auto-detection found nothing to use.
+
+> **Note:** Real GPU acceleration (the `onnxruntime_gpu` artifact actually engaging the CUDA execution
+> provider end-to-end on hardware such as an NVIDIA T4) is not covered by an automated CI test in this
+> repository; only the CPU default, the explicit-CUDA fail-fast errors, and the auto-detect fallback are.
+> Validate GPU throughput on real GPU hardware before relying on it in production.
+
 ## ONNXHub
 Although you can use your own local model, many popular existing models are provided through the ONNXHub. You can use
 a model's ONNXHub name (for example "MNIST") and download the bytes of the model, and some metadata about the model. You can also list
@@ -70,7 +200,7 @@ available models, optionally filtering by name or tags.
     | miniBatcher       | Specify the MiniBatcher to use.                                                                                                                                                                                                                                                                                                                                                                                                                                                                | `FixedMiniBatchTransformer` with batch size 10 |
     | softMaxDict       | A map between output DataFrame columns, where the value column will be computed from taking the softmax of the key column. If the 'rawPrediction' column contains logits outputs, then one can set softMaxDict to `Map("rawPrediction" -> "probability")` to obtain the probability outputs.                                                                                                                                                                                                   | None                                           |
     | argMaxDict        | A map between output DataFrame columns, where the value column will be computed from taking the argmax of the key column. This parameter can be used to convert probability or logits output to the predicted label.                                                                                                                                                                                                                                                                           | None                                           |
-    | deviceType        | Specify a device type the model inference runs on. Supported types are: CPU or CUDA. If not specified, auto detection will be used.                                                                                                                                                                                                                                                                                                                                                            | None                                           |
+    | deviceType        | Specify a device type the model inference runs on. Supported types are: CPU or CUDA. If not specified, auto detection will be used. CUDA requires the opt-in `onnxruntime_gpu` artifact; if explicitly set to CUDA and the CUDA provider is unavailable, transform **fails fast** rather than silently running on CPU -- see [Runtime selection](#runtime-selection-cpu-by-default-cuda-as-an-explicit-opt-in).                                                                                                                                                                                                                                                                                                                                                                                                                                                            | None                                           |
     | optimizationLevel | Specify the [optimization level](https://onnxruntime.ai/docs/performance/model-optimizations/graph-optimizations.html#graph-optimization-levels) for the ONNX graph optimizations. Supported values are: `NO_OPT`, `BASIC_OPT`, `EXTENDED_OPT`, `ALL_OPT`.                                                                                                                                                                                                                                                           | `ALL_OPT`                                      |
 
 4. Call `transform` method to run inference on the input DataFrame.

--- a/project/OnnxRuntimeDependency.scala
+++ b/project/OnnxRuntimeDependency.scala
@@ -1,0 +1,25 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+import sbt._
+import sbt.Keys._
+
+/**
+  * Rewrites the existing dependency as the final deep-learning project setting. Keeping the version
+  * separate lets the same change replay across Spark branches with different adjacent protobuf coordinates.
+  */
+object OnnxRuntimeDependency {
+  val Version = "1.16.3"
+
+  val settings: Seq[Setting[_]] = Seq(
+    libraryDependencies ~= {
+      _.map {
+        case dependency
+            if dependency.organization == "com.microsoft.onnxruntime" &&
+              dependency.name == "onnxruntime_gpu" =>
+          dependency.withRevision(Version)
+        case dependency => dependency
+      }
+    }
+  )
+}

--- a/project/OnnxRuntimeDependency.scala
+++ b/project/OnnxRuntimeDependency.scala
@@ -5,19 +5,43 @@ import sbt._
 import sbt.Keys._
 
 /**
-  * Rewrites the existing dependency as the final deep-learning project setting. Keeping the version
-  * separate lets the same change replay across Spark branches with different adjacent protobuf coordinates.
+  * Rewrites the known ONNX Runtime artifacts (`onnxruntime`, the default CPU-only artifact, and
+  * `onnxruntime_gpu`, the opt-in CUDA artifact) to a single shared version, as the final deep-learning
+  * project setting. Keeping the version separate lets the same change replay across Spark branches with
+  * different adjacent protobuf coordinates, and covers a branch that still declares `onnxruntime_gpu` on
+  * its own test classpath.
+  *
+  * Matching is restricted to `ManagedArtifactIds` (not just the `com.microsoft.onnxruntime` organization):
+  * a plain org-wide match would silently coerce the version of any future, unrelated artifact published
+  * under the same organization (for example one with its own independent release cadence) without anyone
+  * noticing. Any dependency declaration this setting actually changes -- or any unmanaged artifact under
+  * this organization it deliberately leaves untouched -- is logged so the override is never silent.
+  *
+  * GH2417: 1.8.1 fails to load its natives for local Spark 3.5 inference, and the GPU-only artifact never
+  * ships macOS natives at all (CUDA has no macOS support), so upgrading `onnxruntime_gpu` alone cannot fix
+  * macOS. 1.17.3 is confirmed to fix local CPU inference and additionally publishes a CPU-only `onnxruntime`
+  * artifact with macOS x64/aarch64 natives, so it is used as the default cross-platform dependency in
+  * build.sbt. See docs/Explore Algorithms/Deep Learning/ONNX.md for the CUDA opt-in instructions.
   */
 object OnnxRuntimeDependency {
-  val Version = "1.16.3"
+  val Version = "1.17.3"
+  private val Organization = "com.microsoft.onnxruntime"
+  private val ManagedArtifactIds: Set[String] = Set("onnxruntime", "onnxruntime_gpu")
 
   val settings: Seq[Setting[_]] = Seq(
     libraryDependencies ~= {
       _.map {
-        case dependency
-            if dependency.organization == "com.microsoft.onnxruntime" &&
-              dependency.name == "onnxruntime_gpu" =>
+        case dependency if dependency.organization == Organization && ManagedArtifactIds(dependency.name) =>
+          if (dependency.revision != Version) {
+            println(s"[info] OnnxRuntimeDependency: overriding $Organization:${dependency.name} " +
+              s"${dependency.revision} -> $Version (see project/OnnxRuntimeDependency.scala).")
+          }
           dependency.withRevision(Version)
+        case dependency if dependency.organization == Organization =>
+          println(s"[warn] OnnxRuntimeDependency: leaving unmanaged $Organization:${dependency.name}:" +
+            s"${dependency.revision} at its declared version -- add it to ManagedArtifactIds in " +
+            s"project/OnnxRuntimeDependency.scala if it should track the shared $Version instead.")
+          dependency
         case dependency => dependency
       }
     }


### PR DESCRIPTION
## Root cause

SynapseML's previous ONNX Runtime dependency was too old for the local Spark 3.5 inference scenario in #2417. ONNX Runtime's newer Java API also returns native-backed nested `OnnxValue` objects that require recursive materialization and deterministic cleanup.

## Change

- use cross-platform CPU `onnxruntime:1.17.3` by default, shipping Linux, Windows, macOS x64/ARM64, and Linux ARM64 natives
- keep GPU execution as an explicit `onnxruntime_gpu:1.17.3` opt-in and document mandatory exclusion of SynapseML's CPU artifact so exactly one ONNX Runtime jar is loaded
- normalize device selection and fail fast when explicit CUDA lacks a Spark GPU resource or a usable CUDA provider, rather than silently running on CPU
- recursively materialize nested ONNX sequence/map values and close child native handles safely
- close `SessionOptions` on success, fallback, and failure paths
- add dependency, lifecycle, CPU/CUDA selection, mixed-case, missing-resource, nested-value, and cleanup regression tests

## Validation

- real Databricks Tesla T4 validation with Spark-assigned executor GPU resource
- exactly one `onnxruntime_gpu:1.17.3` jar loaded; CPU, CUDA, and TensorRT providers available
- ORT profiling confirmed kernels executed through `CUDAExecutionProvider`
- CPU and CUDA predictions matched exactly
- T4 timings for the small validation model: CPU cold 1.9178 s / warm average 0.3000 s; CUDA cold 3.6622 s / warm average 0.2975 s
- 9/9 focused GH2417 tests passed; dependency/documentation guards and repeated native cleanup tests passed
- `deepLearning/codegen`, compile, and style checks passed
- full suite after `getDatasets`: modified branch 62 tests / 42 pass / 20 environmental failures; unmodified baseline 48 tests / 28 pass / the identical 20 failures
- GitHub compile, style, dependency review, CodeQL, and build checks passed on `8ce82aee39`

## Compatibility and risk

The default artifact is smaller and supports more operating systems than the GPU artifact. CPU and GPU ONNX Runtime artifacts expose the same Java classes and must not coexist; the documented exclusions enforce this. Explicit CUDA requests now fail clearly when requirements are unmet, while automatic selection retains fallback behavior.

Fixes #2417
