### PR TITLE
fix(lightgbm): support IPv6 worker endpoints

### DIFF
--- a/.pipelines/release-compat-prerequisites.txt
+++ b/.pipelines/release-compat-prerequisites.txt
@@ -1,3 +1,6 @@
 # PR #2591 adds Azure AI Search AAD auth required by this change.
 # Remove this prerequisite once every validated release branch contains that backport.
 04897bae9baa08f0d67855566f7bad235791d508
+# PR #2612 introduces the WorkerMessage protocol used by the IPv6 endpoint parsing fix.
+# Remove this prerequisite once every validated release branch contains that backport.
+4a52d9ae4184d3ce00394cd9cb4209c35990fc47

--- a/docs/Explore Algorithms/LightGBM/Overview.md
+++ b/docs/Explore Algorithms/LightGBM/Overview.md
@@ -277,3 +277,69 @@ most recent attempt, this can hide the failure that actually caused the retry.
 When this happens, the reported error explains that it's a retry that could not rejoin the network, and
 names the partition to investigate. Look for the **first** failed attempt of that partition in the executor
 logs — that attempt holds the real cause.
+
+### IPv6 clusters
+
+Distributed training works on clusters whose executors only have IPv6 addresses.
+
+The native LightGBM library is IPv4-only in every released version: it splits each machine list entry on
+`:` and keeps the entry only when that yields exactly two parts, and it builds every socket with `AF_INET`
+and `inet_pton(AF_INET, ...)`. An IPv6 endpoint is therefore dropped or misread by the native parser, and
+could not be dialed or accepted even if it survived parsing.
+
+SynapseML handles this itself. The topology exchange publishes IPv6 endpoints in the unambiguous
+`[address]:port` form, and each task then bridges the transport for the native library:
+
+- the port a task advertised to its peers is owned by SynapseML, which accepts peer connections over
+  either address family and forwards them to the native listener over IPv4 loopback;
+- each IPv6 peer gets an IPv4 loopback relay that forwards what the native library sends to that peer's
+  real IPv6 address;
+- the machine list handed to the native library has the same entries in the same order, with every bridged
+  endpoint rewritten to `127.0.0.1:port` and an explicit rank, so LightGBM ranks are unchanged.
+
+An IPv4 machine list is passed to the native library exactly as before, with no relay and no rewriting, so
+IPv4 clusters see no behavior or performance change. On an IPv6 cluster, peer traffic takes one extra
+loopback hop on each side, and IPv4 loopback must be available on the executors. Measured on a 16 core
+developer machine over loopback, a bridged link sustains roughly a third of the throughput of a direct one
+(about 0.6 GB/s per direction) for about four times the CPU per transferred byte, and adds roughly 200
+microseconds to a small message round trip per hop. Links faster than a few Gb/s can therefore be limited
+by the bridge rather than by the network. The relays never buffer in the JVM heap: a reader that stops
+reading stops the sender, with only the socket buffers in between.
+
+The advertised port is the one address peers know, so SynapseML binds it on every interface, exactly as the
+native listener did before this change, and performs the LightGBM link handshake there itself. A machine
+opens a LightGBM link by sending its rank, so a connection has to produce a valid, unused, lower rank within
+a timeout before any of its bytes reach the native library; connections that stall, repeat a rank, or claim
+a rank the topology does not have are closed by the bridge. That matters because the native accept loop has
+no timeout and treats the first four bytes of any connection as a rank.
+
+The native listener itself is the one thing this library cannot rebind: `TcpSocket::Bind` hardcodes
+`0.0.0.0`, so while it is open it is reachable on every IPv4 interface. The bridge therefore claims each of
+that listener's link slots itself, over IPv4 loopback, as soon as the port is bound — one slot per lower
+rank, which is exactly how many the native library accepts before closing the listener. In practice the
+listener is open for milliseconds on an unadvertised ephemeral port rather than for the whole handshake
+phase, and every byte the native library reads from it comes from the bridge. Closing that window entirely
+requires an upstream change to LightGBM: `TcpSocket::Bind` would have to take a bind address so that
+`Linkers::TryBind` can pass a loopback one. Until then, a LightGBM training port must only be reachable
+from the cluster's own executors, which was already true before this change.
+
+The per peer relays are bound to IPv4 loopback and are not reachable from outside the machine, the number of
+links a bridge will relay is capped at twice the machine count, and each lower rank may link only once. One
+event loop thread serves every listener and every link, so a bridge runs exactly one thread whatever the
+machine count is, with two fixed size buffers per link.
+
+A connection the topology cannot need — an unsolicited one, one past the cap, or one that fails its
+handshake — is refused without consuming any of that budget, so it cannot starve the links the native
+library itself opens. Transport failures are retried while they can be: a dial that fails, immediately or
+later, backs off and retries until its deadline, and a failure while handling one connection never closes
+the listener that accepted it. A failure that cannot be retried away is recorded and fails the Spark task
+with that cause, both before and after the native initialization call, rather than leaving the task waiting
+on a transport that will not recover.
+
+Link-local addresses (`fe80::/10`) are supported only when a peer advertises a zone identifier
+(`fe80::1%eth0`) that names an interface on every other machine, since a link-local address is scoped to a
+single interface. A task normalizes a numeric scope (an interface index, which only means something on the
+machine that produced it) to the interface name before publishing its endpoint, and a peer that still
+advertises a numeric scope is rejected. A link-local peer without a zone, or with a zone this machine does
+not have, fails immediately with an error naming the address instead of hanging. Use a globally routable or
+unique-local IPv6 address for distributed training.

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/BasePartitionTask.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/BasePartitionTask.scala
@@ -131,7 +131,7 @@ abstract class BasePartitionTask extends Serializable with Logging {
     // Start with initialization
     val taskCtx = initialize(ctx, inputRows)
 
-    NetworkManager.withCleanupPreservingPrimary(taskCtx.networkTopologyInfo.releasePortReservation()) {
+    NetworkManager.withCleanupPreservingPrimary(taskCtx.networkTopologyInfo.releaseNetworkResources()) {
       if (taskCtx.isEmptyPartition) {
         log.warn("LightGBM task encountered empty partition, for best performance ensure no partitions are empty")
         Array { PartitionResult(None, taskCtx.measures) }.toIterator
@@ -199,7 +199,7 @@ abstract class BasePartitionTask extends Serializable with Logging {
                                                           shouldExecuteTraining,
                                                           taskMeasures)
 
-    NetworkManager.withCleanupOnFailurePreservingPrimary(networkInfo.releasePortReservation()) {
+    NetworkManager.withCleanupOnFailurePreservingPrimary(networkInfo.releaseNetworkResources()) {
       // Return booster only from main worker to reduce network communication overhead
       val shouldReturnBooster = if (isEmptyPartition) false
         else if (!shouldExecuteTraining) false

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMNetworkBridge.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMNetworkBridge.scala
@@ -1,0 +1,346 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm
+
+import org.slf4j.Logger
+
+import java.io.Closeable
+import java.net.{InetAddress, InetSocketAddress, NetworkInterface, SocketException, UnknownHostException}
+import java.nio.channels.ServerSocketChannel
+import java.util.concurrent.atomic.AtomicInteger
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.util.control.NonFatal
+
+/** The machine list, listen port, and machine count to hand to the native LGBM_NetworkInit call. */
+private[lightgbm] final case class BridgedNetwork(machineList: String,
+                                                  localListenPort: Int,
+                                                  machineCount: Int,
+                                                  rank: Int)
+
+/** Bridges an IPv6 LightGBM training network onto the IPv4-only native transport.
+  *
+  * The native LightGBM socket layer is IPv4-only in every released version, including the
+  * lightgbmlib artifact this project depends on. `Linkers::ParseMachineList` splits each machine
+  * entry on ':' and keeps it only when it has exactly two parts, so `[2001:db8::1]:12400` is
+  * discarded and `2001:db8::1:12400` is misread as the host `1`; `TcpSocket` then builds every
+  * address with `socket(AF_INET, ...)`, `sockaddr_in`, and `inet_pton(AF_INET, ...)`, so even a
+  * parsed IPv6 literal could neither be dialed nor accepted.
+  *
+  * Rather than fail, this bridge keeps the native library on the transport it understands and
+  * carries the traffic itself:
+  *
+  *  - an inbound relay owns the port this task advertised to its peers, accepts their connections
+  *    on either address family, checks the LightGBM rank handshake, and forwards each link to the
+  *    native listener over IPv4 loopback;
+  *  - one outbound relay per IPv6 peer listens on IPv4 loopback and forwards whatever the native
+  *    library sends to that peer's real IPv6 endpoint;
+  *  - the machine list handed to the native library is rewritten so every bridged endpoint becomes
+  *    a `127.0.0.1:port` entry, prefixed with an explicit `rank=` so the native library never has
+  *    to infer its own position from a loopback address.
+  *
+  * Entry order is preserved because a LightGBM rank is an index into the machine list, and an IPv4
+  * peer keeps its original entry so it stays a direct native connection. A machine list without any
+  * IPv6 entry never reaches this class: `requiresBridge` is false and the native call is made
+  * exactly as it always was.
+  *
+  * The native listener is the one thing this library cannot rebind: `TcpSocket::Bind` hardcodes
+  * `0.0.0.0`, so it is reachable on every IPv4 interface for as long as it is open, and the native
+  * accept loop has no timeout and trusts the first four bytes of every connection as a rank. The
+  * bridge therefore claims each of that listener's link slots itself, from loopback, as soon as the
+  * port is bound, which closes the listener within milliseconds of `LGBM_NetworkInit` binding it,
+  * and it performs the rank handshake with peers on its own port instead, where a stalled or
+  * invalid handshake is rejected rather than left to block the native accept loop. Removing the
+  * remaining window needs an upstream change: `TcpSocket::Bind` taking a bind address so that
+  * `Linkers::TryBind` can pass a loopback address.
+  */
+private[lightgbm] object LightGBMNetworkBridge {
+  /** Native LightGBM resolves this with inet_pton(AF_INET), so it has to stay a numeric IPv4 literal. */
+  private[lightgbm] val LoopbackHost: String = "127.0.0.1"
+
+  /** LightGBM reads this prefix from the machine list and skips its own local-address lookup. */
+  private[lightgbm] val RankPrefix: String = "rank="
+
+  /** Covers the native connect-retry budget (20 attempts with a 1.3x backoff from 200ms). */
+  private[lightgbm] val DefaultConnectTimeoutMillis: Long = 180000L
+
+  /** A peer that has opened a connection has to identify itself well within the native timeout. */
+  private[lightgbm] val DefaultHandshakeTimeoutMillis: Long = 30000L
+
+  /** Headroom over the links a topology can actually need, which is one per other machine. */
+  private val RelayedConnectionsPerMachine: Int = 2
+
+  private val BridgeCount = new AtomicInteger(0)
+
+  private def nextBridgeId(): Int = BridgeCount.incrementAndGet()
+
+  /** Parse a LightGBM machine list into its endpoints, preserving order. */
+  def parseMachineList(machineList: String): Seq[WorkerEndpoint] = {
+    val entries = splitEntries(machineList)
+    if (entries.isEmpty) {
+      throw new IllegalArgumentException(
+        s"LightGBM machine list ${WorkerEndpoint.preview(machineList)} does not contain any endpoint")
+    }
+    entries.map(WorkerEndpoint.parse)
+  }
+
+  /** Whether the native library would have to speak IPv6 to establish this network.
+    *
+    * This deliberately classifies without parsing, so an IPv4 machine list keeps reaching the
+    * native call unchanged even if it holds an entry this library would reject.
+    */
+  def requiresBridge(machineList: String): Boolean = splitEntries(machineList).exists(isIpv6Entry)
+
+  private def splitEntries(machineList: String): Seq[String] =
+    Option(machineList).getOrElse("").split(",").map(_.trim).filter(_.nonEmpty).toSeq
+
+  /** An IPv6 entry is either bracketed or has more colons than the single host:port separator. */
+  private def isIpv6Entry(entry: String): Boolean = entry.startsWith("[") || entry.count(_ == ':') > 1
+
+  /** Build the machine list handed to the native library. */
+  private[lightgbm] def formatMachineList(rank: Int, entries: Seq[String]): String =
+    (Seq(s"$RankPrefix$rank") ++ entries).mkString(",")
+
+  /** Locate this task's own entry, which is also its LightGBM rank.
+    *
+    * The driver echoes back the exact host string the task reported, so an exact match is the
+    * normal path. The fallbacks only matter when a host string is rewritten on the way (a
+    * differently compressed IPv6 literal, for example), and each one is anchored on the advertised
+    * port so it can never select another machine's entry.
+    */
+  private[lightgbm] def findSelf(entries: Seq[WorkerEndpoint], advertisedHost: String, advertisedPort: Int): Int = {
+    val candidates = entries.zipWithIndex.filter { case (entry, _) => entry.port == advertisedPort }
+    val self = candidates.find { case (entry, _) => entry.host == advertisedHost }
+      .orElse(candidates.find { case (entry, _) => sameAddress(entry.host, advertisedHost) })
+      .orElse(if (candidates.lengthCompare(1) == 0) candidates.headOption else None)
+      .orElse(candidates.find { case (entry, _) => isLocalAddress(entry.host) })
+    self.map { case (_, index) => index }.getOrElse {
+      throw new IllegalArgumentException(
+        s"LightGBM machine list ${WorkerEndpoint.preview(entries.map(_.wireString).mkString(","))} does not " +
+          "contain this task's own endpoint " +
+          s"${WorkerEndpoint.preview(s"${WorkerEndpoint.wireHost(advertisedHost)}:$advertisedPort")}. " +
+          "The endpoint a task advertises to the driver has to appear in the machine list the driver sends back.")
+    }
+  }
+
+  /** Resolve a peer host, failing with an actionable message instead of a bare UnknownHostException. */
+  private[lightgbm] def resolvePeer(entry: WorkerEndpoint, log: Logger): InetAddress = {
+    if (entry.hasNumericZone) {
+      throw new IllegalArgumentException(s"Cannot reach LightGBM peer ${entry.wireString}: its IPv6 zone " +
+        s"identifier '${entry.zoneId.getOrElse("")}' is a numeric interface index, which only means " +
+        "anything on the machine that produced it. A peer has to advertise an interface name, such as " +
+        "fe80::1%eth0.")
+    }
+    val address = try {
+      InetAddress.getByName(entry.address)
+    } catch {
+      case failure: UnknownHostException =>
+        throw new IllegalArgumentException(s"Cannot reach LightGBM peer ${entry.wireString}: " +
+          "the host could not be resolved on this machine.", failure)
+    }
+    if (address.isLinkLocalAddress) scopedLinkLocalAddress(entry, log) else address
+  }
+
+  /** Attach a link-local peer's zone to a locally meaningful interface, or explain why it cannot be. */
+  private def scopedLinkLocalAddress(entry: WorkerEndpoint, log: Logger): InetAddress = {
+    log.warn(s"LightGBM peer ${entry.wireString} is an IPv6 link-local address. A link-local address is only " +
+      "meaningful within one interface's scope, so its zone identifier is resolved against this machine's " +
+      "interfaces. Prefer a globally routable or unique-local IPv6 address for distributed training.")
+    entry.zoneId match {
+      case None =>
+        throw new IllegalArgumentException(s"Cannot reach LightGBM peer ${entry.wireString}: an IPv6 " +
+          "link-local peer has to advertise a zone identifier (for example fe80::1%eth0), because a " +
+          "link-local address alone does not say which interface to send from.")
+      case Some(zone) =>
+        try {
+          InetAddress.getByName(entry.host)
+        } catch {
+          case failure: UnknownHostException =>
+            throw new IllegalArgumentException(s"Cannot reach LightGBM peer ${entry.wireString}: its IPv6 " +
+              s"zone identifier '$zone' does not name an interface on this machine, so the link-local " +
+              "address cannot be reached from here.", failure)
+        }
+    }
+  }
+
+  private def sameAddress(host: String, otherHost: String): Boolean = {
+    if (host.isEmpty || otherHost.isEmpty) {
+      false
+    } else {
+      try {
+        InetAddress.getByName(host) == InetAddress.getByName(otherHost)
+      } catch {
+        case _: UnknownHostException => false
+      }
+    }
+  }
+
+  private def isLocalAddress(host: String): Boolean = {
+    try {
+      val address = InetAddress.getByName(host)
+      address.isAnyLocalAddress || address.isLoopbackAddress ||
+        NetworkInterface.getNetworkInterfaces.asScala.exists(_.getInetAddresses.asScala.contains(address))
+    } catch {
+      case _: UnknownHostException => false
+      case _: SocketException => false
+    }
+  }
+
+  /** Start the relays for a machine list and return a running bridge.
+    *
+    * The caller owns the returned bridge and has to close it once the native network is done with
+    * it, including when the native initialization it wraps fails.
+    */
+  def open(machineList: String,
+           advertisedHost: String,
+           advertisedPort: Int,
+           log: Logger,
+           connectTimeoutMillis: Long = DefaultConnectTimeoutMillis,
+           handshakeTimeoutMillis: Long = DefaultHandshakeTimeoutMillis,
+           connectAttempt: LightGBMNetworkRelay.ConnectAttempt =
+             LightGBMNetworkRelay.DefaultConnect): LightGBMNetworkBridge = {
+    requireIpv6CapableJvm()
+    val entries = parseMachineList(machineList)
+    val rank = findSelf(entries, advertisedHost, advertisedPort)
+    val bridge = new LightGBMNetworkBridge(entries, rank, advertisedPort, log, connectTimeoutMillis,
+      handshakeTimeoutMillis, connectAttempt)
+    NetworkManagerSocketSupport.withCleanupOnFailurePreservingPrimary(bridge.close())(bridge.start())
+    bridge
+  }
+
+  /** A JVM forced onto the IPv4 stack cannot open an IPv6 socket at all, whatever the bridge does. */
+  private def requireIpv6CapableJvm(): Unit = {
+    if (java.lang.Boolean.getBoolean("java.net.preferIPv4Stack")) {
+      throw new IllegalStateException("This LightGBM training network has IPv6 endpoints, but this JVM was " +
+        "started with -Djava.net.preferIPv4Stack=true, which prevents it from opening any IPv6 socket. " +
+        "Remove that option from the Spark executor JVM options, or give the executors IPv4 addresses.")
+    }
+  }
+
+  private[lightgbm] def maxLinksFor(machineCount: Int): Int = machineCount * RelayedConnectionsPerMachine
+}
+
+/** Owns the sockets and the single relay loop for one task. Created through its companion's `open`. */
+private[lightgbm] final class LightGBMNetworkBridge private(entries: Seq[WorkerEndpoint],
+                                                            rank: Int,
+                                                            advertisedPort: Int,
+                                                            log: Logger,
+                                                            connectTimeoutMillis: Long,
+                                                            handshakeTimeoutMillis: Long,
+                                                            connectAttempt: LightGBMNetworkRelay.ConnectAttempt)
+  extends Closeable {
+  import LightGBMNetworkBridge._
+
+  /** The name the relay thread of this bridge carries, so a thread dump attributes it. */
+  private[lightgbm] val threadNamePrefix: String = s"lightgbm-network-bridge-${nextBridgeId()}-rank$rank"
+
+  private val relay = new LightGBMNetworkRelay(threadNamePrefix, log, maxLinksFor(entries.length),
+    connectTimeoutMillis, handshakeTimeoutMillis, connectAttempt)
+  private val listeners = mutable.ListBuffer.empty[ServerSocketChannel]
+  private var nativeListenPort: Int = -1
+  private var bridgedMachineList: String = ""
+
+  /** The values to pass to the native LGBM_NetworkInit call. */
+  def bridgedNetwork: BridgedNetwork = synchronized {
+    require(nativeListenPort > 0, "The LightGBM network bridge has not been started")
+    BridgedNetwork(bridgedMachineList, nativeListenPort, entries.length, rank)
+  }
+
+  /** A failure the relay could not retry away, which leaves this task's transport unusable. */
+  def terminalFailure: Option[Throwable] = relay.failure
+
+  private[lightgbm] def relayLinkCount: Int = relay.linkCount
+
+  private[lightgbm] def isRunning: Boolean = relay.isLoopAlive
+
+  private[lightgbm] def start(): Unit = synchronized {
+    // Resolve every peer before binding anything, so an unreachable address fails immediately.
+    val peerAddresses = entries.zipWithIndex.map { case (entry, index) =>
+      if (index == rank || !entry.isIpv6Literal) None else Some(resolvePeer(entry, log))
+    }
+
+    // Own the advertised port first: it is the only port peers know, and taking it before the
+    // native port is chosen guarantees the two cannot collide.
+    val inbound = bindWildcard(advertisedPort)
+    nativeListenPort = findFreePort()
+    relay.expectInboundRanks((0 until rank).toSet)
+    relay.start()
+
+    val bridgedEntries = entries.zipWithIndex.map { case (entry, index) =>
+      if (index == rank) {
+        WorkerEndpoint.wireString(LoopbackHost, nativeListenPort)
+      } else {
+        peerAddresses(index)
+          .map(address => WorkerEndpoint.wireString(LoopbackHost, startOutboundRelay(index, entry, address)))
+          .getOrElse(entry.wireString)
+      }
+    }
+    bridgedMachineList = formatMachineList(rank, bridgedEntries)
+
+    relay.addInboundListener(inbound)
+    // Claim every slot of the native listener from loopback, so it closes as soon as it opens.
+    val nativeAddress = new InetSocketAddress(InetAddress.getByName(LoopbackHost), nativeListenPort)
+    (0 until rank).foreach(peerRank => relay.primeNativeLink(nativeAddress, peerRank))
+
+    log.info(s"LightGBM IPv6 network bridge is rank $rank of ${entries.length}, relaying peer traffic from " +
+      s"advertised port $advertisedPort to native listen port $nativeListenPort with machine list " +
+      s"$bridgedMachineList")
+  }
+
+  private def startOutboundRelay(index: Int, entry: WorkerEndpoint, address: InetAddress): Int = {
+    val listener = bindLoopback()
+    relay.addOutboundListener(listener, new InetSocketAddress(address, entry.port),
+      s"LightGBM machine $index at ${entry.wireString}")
+    listener.socket().getLocalPort
+  }
+
+  private def bindWildcard(port: Int): ServerSocketChannel = {
+    val listener = ServerSocketChannel.open()
+    NetworkManagerSocketSupport.withCleanupOnFailurePreservingPrimary(closeQuietly(listener)) {
+      // A wildcard bind is dual stack, so peers reach this port over either address family.
+      listener.bind(new InetSocketAddress(port))
+      listeners += listener
+      listener
+    }
+  }
+
+  private def bindLoopback(): ServerSocketChannel = {
+    val listener = ServerSocketChannel.open()
+    NetworkManagerSocketSupport.withCleanupOnFailurePreservingPrimary(closeQuietly(listener)) {
+      listener.bind(new InetSocketAddress(InetAddress.getByName(LoopbackHost), 0))
+      listeners += listener
+      listener
+    }
+  }
+
+  /** Pick a port for the native listener. Only this bridge ever dials it, over loopback. */
+  private def findFreePort(): Int = {
+    val probe = ServerSocketChannel.open()
+    try {
+      probe.bind(new InetSocketAddress(0))
+      probe.socket().getLocalPort
+    } finally {
+      closeQuietly(probe)
+    }
+  }
+
+  private def closeQuietly(resource: Closeable): Unit = {
+    try {
+      resource.close()
+    } catch {
+      case NonFatal(failure) => log.debug("LightGBM network bridge could not close a channel", failure)
+    }
+  }
+
+  /** Release every relay socket and the loop thread. Safe to call more than once and from any thread. */
+  override def close(): Unit = {
+    relay.close()
+    val current = synchronized {
+      val snapshot = listeners.toSeq
+      listeners.clear()
+      snapshot
+    }
+    current.foreach(closeQuietly)
+  }
+}

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMNetworkRelay.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMNetworkRelay.scala
@@ -1,0 +1,668 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm
+
+import org.slf4j.Logger
+
+import java.io.{Closeable, IOException}
+import java.net.{InetSocketAddress, StandardSocketOptions}
+import java.nio.channels.{SelectionKey, Selector, ServerSocketChannel, SocketChannel}
+import java.nio.{ByteBuffer, ByteOrder}
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.util.control.NonFatal
+
+private[lightgbm] object LightGBMNetworkRelay {
+  /** LightGBM opens every link by sending its own rank as a host endian int. */
+  val RankBytes: Int = 4
+
+  /** How a dial reaches its address. Injected so tests can fail a connect the way a route can. */
+  type ConnectAttempt = (SocketChannel, InetSocketAddress) => Boolean
+
+  val DefaultConnect: ConnectAttempt = (channel, address) => channel.connect(address)
+
+  private val BufferSize: Int = 65536
+  private val SocketBufferSize: Int = 100000
+  private val SelectTimeoutMillis: Long = 100L
+  private val ShutdownWaitMillis: Long = 2000L
+  private val RetryIntervalMillis: Long = 5L
+  private val MaxRetryIntervalMillis: Long = 200L
+
+  private final case class Timer(deadline: Long, action: () => Unit)
+
+  private val TimerOrder: Ordering[Timer] = Ordering.by[Timer, Long](-_.deadline)
+
+  private[lightgbm] def rankBuffer(rank: Int): ByteBuffer =
+    ByteBuffer.allocate(RankBytes).order(ByteOrder.nativeOrder()).putInt(rank)
+}
+
+/** The event loop that moves LightGBM traffic between peers and the native library.
+  *
+  * One selector thread serves every listener and every relayed link, so the thread count of a
+  * bridge is one no matter how many machines the training network has. Memory is bounded the same
+  * way: two fixed buffers per relayed link, and links are capped, so nothing scales with peers
+  * except the sockets LightGBM itself would have opened.
+  *
+  * The loop also owns the LightGBM link handshake. A machine opens a link by sending its rank, so
+  * an inbound connection has to produce a valid, unused, lower rank within a deadline before any of
+  * its bytes reach the native library. Connections that stall, repeat a rank, or claim a rank the
+  * topology does not have are closed here instead of stalling the native listener thread, which has
+  * no timeout of its own.
+  *
+  * Every dial goes through one retry policy, whether the failure arrives synchronously (a connect
+  * to an address with no route fails on the calling thread) or asynchronously, and a failure while
+  * handling an accepted connection never reaches the listener that accepted it. What cannot be
+  * retried is recorded as a terminal failure, which the caller surfaces instead of leaving a task
+  * waiting on a transport that will not recover.
+  */
+private[lightgbm] final class LightGBMNetworkRelay(threadName: String,
+                                                   log: Logger,
+                                                   maxLinks: Int,
+                                                   connectTimeoutMillis: Long,
+                                                   handshakeTimeoutMillis: Long,
+                                                   connectAttempt: LightGBMNetworkRelay.ConnectAttempt =
+                                                     LightGBMNetworkRelay.DefaultConnect) extends Closeable {
+  import LightGBMNetworkRelay._
+
+  private val selector: Selector = Selector.open()
+  private val tasks = new ConcurrentLinkedQueue[() => Unit]()
+  private val timers = mutable.PriorityQueue.empty[Timer](TimerOrder)
+  private val closed = new AtomicBoolean(false)
+  private val started = new AtomicBoolean(false)
+  private val liveLinks = new AtomicInteger(0)
+  private val terminalFailure = new AtomicReference[Option[Throwable]](None)
+  private val resources = mutable.Set.empty[Closeable]
+
+  // Only the loop thread touches these.
+  private var expectedInboundRanks: Set[Int] = Set.empty
+  private val primedNativeLinks = mutable.Map.empty[Int, SocketChannel]
+  private val peersAwaitingNativeLink = mutable.Map.empty[Int, (SocketChannel, LinkSlot)]
+  private val linkedRanks = mutable.Set.empty[Int]
+
+  private val loopThread: Thread = {
+    val thread = new Thread(new Runnable {
+      override def run(): Unit = runLoop()
+    }, threadName)
+    thread.setDaemon(true)
+    thread
+  }
+
+  /** The ranks allowed to open a link to this task, which LightGBM defines as the lower ranks. */
+  def expectInboundRanks(ranks: Set[Int]): Unit = submit(() => expectedInboundRanks = ranks)
+
+  def start(): Unit = if (started.compareAndSet(false, true)) loopThread.start()
+
+  def linkCount: Int = liveLinks.get()
+
+  /** A failure the relay cannot retry away, which leaves this task's transport unusable. */
+  def failure: Option[Throwable] = terminalFailure.get()
+
+  private[lightgbm] def isLoopAlive: Boolean = loopThread.isAlive
+
+  /** Accept peer connections, which must pass the rank handshake before they are relayed. */
+  def addInboundListener(listener: ServerSocketChannel): Unit =
+    register(listener, SelectionKey.OP_ACCEPT, new InboundAcceptor)
+
+  /** Accept the native library's link to one peer and forward it to that peer's real address. */
+  def addOutboundListener(listener: ServerSocketChannel,
+                          target: InetSocketAddress,
+                          description: String): Unit =
+    register(listener, SelectionKey.OP_ACCEPT, new OutboundAcceptor(target, description))
+
+  /** Take one of the native listener's link slots before anyone else can.
+    *
+    * The native listener accepts exactly one link per lower rank and then closes, so filling those
+    * slots from loopback as soon as the port is bound keeps every other caller out of a listener
+    * that the native library binds on all interfaces and that this library cannot rebind.
+    */
+  def primeNativeLink(nativeAddress: InetSocketAddress, peerRank: Int): Unit =
+    submit(() => dialNative(nativeAddress, peerRank, System.currentTimeMillis() + connectTimeoutMillis,
+      RetryIntervalMillis))
+
+  override def close(): Unit = {
+    if (closed.compareAndSet(false, true)) {
+      selector.wakeup()
+      // Cleanup runs on a cancelled Spark task too, where the thread is already interrupted, so the
+      // wait for the loop has to survive that and hand the interrupt back to the caller.
+      if (started.get()) {
+        try {
+          loopThread.join(ShutdownWaitMillis)
+        } catch {
+          case _: InterruptedException => Thread.currentThread().interrupt()
+        }
+      }
+      closeEverything()
+      closeQuietly(selector)
+      log.info(s"$threadName closed")
+    }
+  }
+
+  private def recordTerminalFailure(reason: String, failure: Throwable): Unit = {
+    log.error(s"$threadName $reason", failure)
+    terminalFailure.compareAndSet(None, Some(new IOException(s"$threadName $reason", failure)))
+  }
+
+  private def submit(task: () => Unit): Unit = {
+    tasks.add(task)
+    selector.wakeup()
+  }
+
+  private def register(channel: java.nio.channels.SelectableChannel,
+                       ops: Int,
+                       handler: Handler): Unit = {
+    track(channel)
+    submit(() => {
+      channel.configureBlocking(false)
+      channel.register(selector, ops, handler)
+      ()
+    })
+  }
+
+  private def track(resource: Closeable): Unit = synchronized {
+    if (closed.get()) closeQuietly(resource) else resources += resource
+  }
+
+  private def closeEverything(): Unit = {
+    val snapshot = synchronized {
+      val current = resources.toSeq
+      resources.clear()
+      current
+    }
+    snapshot.foreach(closeQuietly)
+  }
+
+  private def closeQuietly(resource: Closeable): Unit = {
+    try {
+      resource.close()
+    } catch {
+      case NonFatal(failure) => log.debug(s"$threadName could not close a channel", failure)
+    }
+  }
+
+  @tailrec
+  private def runLoop(): Unit = {
+    if (!closed.get()) {
+      step()
+      runLoop()
+    }
+  }
+
+  private def step(): Unit = {
+    try {
+      runTasks()
+      selector.select(SelectTimeoutMillis)
+      processSelectedKeys()
+      runTimers()
+    } catch {
+      case NonFatal(failure) => if (!closed.get()) log.warn(s"$threadName event loop iteration failed", failure)
+    }
+  }
+
+  @tailrec
+  private def runTasks(): Unit = {
+    val task = tasks.poll()
+    if (task != None.orNull) {
+      try {
+        task()
+      } catch {
+        case NonFatal(failure) => recordTerminalFailure("could not apply a registration", failure)
+      }
+      runTasks()
+    }
+  }
+
+  private def processSelectedKeys(): Unit = {
+    val selected = selector.selectedKeys()
+    val snapshot = selected.asScala.toSeq
+    selected.clear()
+    snapshot.foreach(handleKey)
+  }
+
+  private def handleKey(key: SelectionKey): Unit = {
+    val handler = key.attachment().asInstanceOf[Handler]
+    try {
+      if (key.isValid && key.isAcceptable) handler.onAcceptable(key)
+      if (key.isValid && key.isConnectable) handler.onConnectable(key)
+      if (key.isValid && (key.isReadable || key.isWritable)) handler.onReadWrite(key)
+    } catch {
+      case NonFatal(failure) => handler.onFailure(key, failure)
+    }
+  }
+
+  private def runTimers(): Unit = {
+    val now = System.currentTimeMillis()
+    val due = mutable.ListBuffer.empty[Timer]
+
+    @tailrec
+    def collect(): Unit = {
+      if (timers.nonEmpty && timers.head.deadline <= now) {
+        due += timers.dequeue()
+        collect()
+      }
+    }
+
+    collect()
+    due.foreach { timer =>
+      try {
+        timer.action()
+      } catch {
+        // A retry that cannot even be started is terminal: nothing else will drive it.
+        case NonFatal(failure) => recordTerminalFailure("could not run a scheduled retry", failure)
+      }
+    }
+  }
+
+  private def scheduleAt(delayMillis: Long)(action: => Unit): Unit =
+    timers.enqueue(Timer(System.currentTimeMillis() + delayMillis, () => action))
+
+  private def openChannel(): SocketChannel = {
+    val channel = SocketChannel.open()
+    channel.configureBlocking(false)
+    configure(channel)
+    track(channel)
+    channel
+  }
+
+  private def configure(channel: SocketChannel): Unit = {
+    try {
+      channel.setOption[java.lang.Boolean](StandardSocketOptions.TCP_NODELAY, true)
+      channel.setOption[Integer](StandardSocketOptions.SO_RCVBUF, SocketBufferSize)
+      channel.setOption[Integer](StandardSocketOptions.SO_SNDBUF, SocketBufferSize)
+    } catch {
+      case NonFatal(failure) => log.debug(s"$threadName could not configure a channel", failure)
+    }
+  }
+
+  /** One admitted link, released exactly once however its life ends. */
+  private final class LinkSlot {
+    private val released = new AtomicBoolean(false)
+
+    def release(): Unit = if (released.compareAndSet(false, true)) liveLinks.decrementAndGet()
+  }
+
+  /** Admit a link only while the topology could still need one. */
+  private def admit(): Option[LinkSlot] = {
+    if (liveLinks.get() >= maxLinks) {
+      None
+    } else {
+      liveLinks.incrementAndGet()
+      Some(new LinkSlot)
+    }
+  }
+
+  private def splice(first: SocketChannel, second: SocketChannel, slot: LinkSlot): Unit =
+    new RelayLink(first, second, slot).register()
+
+  /** Open, register, and start a dial, so a synchronous failure follows the same policy as a late one. */
+  private def beginDial(address: InetSocketAddress,
+                        onConnected: SocketChannel => Unit,
+                        onFailed: Throwable => Unit): Unit = {
+    val opened = try {
+      Some(openChannel())
+    } catch {
+      case NonFatal(failure) =>
+        onFailed(failure)
+        None
+    }
+    opened.foreach { channel =>
+      try {
+        val key = channel.register(selector, SelectionKey.OP_CONNECT, new Dialer(channel, onConnected, onFailed))
+        // A connect to an address with no route fails here rather than through the selector.
+        if (connectAttempt(channel, address)) {
+          key.interestOps(0)
+          onConnected(channel)
+        }
+      } catch {
+        case NonFatal(failure) =>
+          closeQuietly(channel)
+          onFailed(failure)
+      }
+    }
+  }
+
+  private def retryOrGiveUp(deadline: Long,
+                            interval: Long,
+                            failure: Throwable,
+                            retry: Long => Unit,
+                            giveUp: Throwable => Unit): Unit = {
+    if (!closed.get()) {
+      if (System.currentTimeMillis() >= deadline) {
+        giveUp(failure)
+      } else {
+        scheduleAt(interval)(retry(math.min(interval * 2, MaxRetryIntervalMillis)))
+      }
+    }
+  }
+
+  private def dialNative(address: InetSocketAddress, peerRank: Int, deadline: Long, interval: Long): Unit = {
+    if (!closed.get()) {
+      beginDial(address,
+        channel => {
+          sendRank(channel, peerRank)
+          log.info(s"$threadName claimed the native link slot for rank $peerRank")
+          nativeLinkReady(channel, peerRank)
+        },
+        failure => retryOrGiveUp(deadline, interval, failure,
+          next => dialNative(address, peerRank, deadline, next),
+          giveUp => nativeLinkFailed(peerRank, giveUp)))
+    }
+  }
+
+  private def dialPeer(native: SocketChannel,
+                       slot: LinkSlot,
+                       address: InetSocketAddress,
+                       description: String,
+                       deadline: Long,
+                       interval: Long): Unit = {
+    if (!closed.get()) {
+      beginDial(address,
+        channel => splice(native, channel, slot),
+        failure => retryOrGiveUp(deadline, interval, failure,
+          next => dialPeer(native, slot, address, description, deadline, next),
+          giveUp => {
+            recordTerminalFailure(s"could not reach $description, so its LightGBM link cannot be relayed", giveUp)
+            slot.release()
+            closeQuietly(native)
+          }))
+    }
+  }
+
+  private def sendRank(channel: SocketChannel, rank: Int): Unit = {
+    val buffer = rankBuffer(rank)
+    buffer.flip()
+
+    @tailrec
+    def write(attemptsLeft: Int): Unit = {
+      if (buffer.hasRemaining && attemptsLeft > 0) {
+        channel.write(buffer)
+        write(attemptsLeft - 1)
+      }
+    }
+
+    write(RankBytes)
+    if (buffer.hasRemaining) throw new IOException(s"$threadName could not send a rank in one write")
+  }
+
+  /** Hand a peer's connection to the native link slot already claimed for its rank. */
+  private def linkPeerToNative(peer: SocketChannel, rank: Int, slot: LinkSlot): Unit = {
+    primedNativeLinks.remove(rank) match {
+      case Some(nativeChannel) => splice(peer, nativeChannel, slot)
+      case None => peersAwaitingNativeLink.put(rank, (peer, slot)).foreach { case (previous, previousSlot) =>
+        previousSlot.release()
+        closeQuietly(previous)
+      }
+    }
+  }
+
+  private def nativeLinkReady(nativeChannel: SocketChannel, rank: Int): Unit = {
+    peersAwaitingNativeLink.remove(rank) match {
+      case Some((peer, slot)) => splice(peer, nativeChannel, slot)
+      case None => primedNativeLinks.put(rank, nativeChannel).foreach(closeQuietly)
+    }
+  }
+
+  private def nativeLinkFailed(rank: Int, failure: Throwable): Unit = {
+    recordTerminalFailure(s"could not claim the native link slot for rank $rank, so the native listener " +
+      "may keep waiting for a link that will never arrive", failure)
+    peersAwaitingNativeLink.remove(rank).foreach { case (peer, slot) =>
+      slot.release()
+      closeQuietly(peer)
+    }
+  }
+
+  private trait Handler {
+    def onAcceptable(key: SelectionKey): Unit = ()
+    def onConnectable(key: SelectionKey): Unit = ()
+    def onReadWrite(key: SelectionKey): Unit = ()
+    def onFailure(key: SelectionKey, failure: Throwable): Unit = {
+      log.debug(s"$threadName closing a channel after a failure", failure)
+      key.cancel()
+      closeQuietly(key.channel())
+    }
+  }
+
+  /** A listener outlives the connections it accepts, so their failures never close it. */
+  private trait ListenerHandler extends Handler {
+    override def onFailure(key: SelectionKey, failure: Throwable): Unit = {
+      if (!key.channel().isOpen) {
+        key.cancel()
+        if (!closed.get()) recordTerminalFailure("lost a listening socket", failure)
+      } else if (!closed.get()) {
+        log.warn(s"$threadName ignored a failure while accepting; the listener stays open", failure)
+      }
+    }
+
+    /** Handle one accepted connection without ever letting its failure reach the listener. */
+    protected def guard(accepted: SocketChannel, slot: Option[LinkSlot])(work: => Unit): Unit = {
+      try {
+        work
+      } catch {
+        case NonFatal(failure) =>
+          log.warn(s"$threadName dropped an accepted connection", failure)
+          slot.foreach(_.release())
+          closeQuietly(accepted)
+      }
+    }
+  }
+
+  /** Accepts peer connections, which have to pass the rank handshake before they are relayed. */
+  private final class InboundAcceptor extends ListenerHandler {
+    override def onAcceptable(key: SelectionKey): Unit = {
+      val listener = key.channel().asInstanceOf[ServerSocketChannel]
+      Option(listener.accept()).foreach { peer =>
+        // Whether a link is wanted at all is decided before admission, so refusing one here can
+        // never consume a slot that the outbound links to peers also draw on.
+        if (expectedInboundRanks.isEmpty) {
+          log.warn(s"$threadName refused a connection from ${remoteAddress(peer)}: this task is the lowest " +
+            "rank, so no machine opens a link to it")
+          closeQuietly(peer)
+        } else {
+          admitPeer(peer)
+        }
+      }
+    }
+
+    private def admitPeer(peer: SocketChannel): Unit = {
+      admit() match {
+        case None =>
+          log.warn(s"$threadName refused a connection from ${remoteAddress(peer)}: this task expects " +
+            s"${expectedInboundRanks.size} inbound links and already holds ${liveLinks.get()}")
+          closeQuietly(peer)
+        case Some(slot) => guard(peer, Some(slot))(beginHandshake(peer, slot))
+      }
+    }
+
+    private def beginHandshake(peer: SocketChannel, slot: LinkSlot): Unit = {
+      peer.configureBlocking(false)
+      configure(peer)
+      track(peer)
+      val handshake = new RankHandshake(peer, slot)
+      peer.register(selector, SelectionKey.OP_READ, handshake)
+      scheduleAt(handshakeTimeoutMillis)(handshake.onDeadline())
+    }
+  }
+
+  /** Reads and validates the rank a peer sends before any of its bytes reach the native library. */
+  private final class RankHandshake(peer: SocketChannel, slot: LinkSlot) extends Handler {
+    private val buffer = ByteBuffer.allocate(RankBytes)
+    private var settled = false
+
+    override def onReadWrite(key: SelectionKey): Unit = {
+      val count = peer.read(buffer)
+      if (count < 0) {
+        reject(key, "closed the connection before sending its rank")
+      } else if (!buffer.hasRemaining) {
+        complete(key)
+      }
+    }
+
+    def onDeadline(): Unit = {
+      if (!settled) {
+        settled = true
+        slot.release()
+        log.warn(s"$threadName closed a connection from ${remoteAddress(peer)} that did not send a " +
+          s"LightGBM rank within ${handshakeTimeoutMillis}ms")
+        closeQuietly(peer)
+      }
+    }
+
+    override def onFailure(key: SelectionKey, failure: Throwable): Unit = reject(key, s"failed: $failure")
+
+    private def complete(key: SelectionKey): Unit = {
+      buffer.flip()
+      val rank = buffer.order(ByteOrder.nativeOrder()).getInt
+      if (!expectedInboundRanks.contains(rank)) {
+        reject(key, s"claimed rank $rank, which is not one of the lower ranks this task expects")
+      } else if (!linkedRanks.add(rank)) {
+        reject(key, s"claimed rank $rank, which is already linked")
+      } else {
+        settled = true
+        // The key is reused by the relayed link, so it must not be cancelled here.
+        key.interestOps(0)
+        log.info(s"$threadName accepted the link from rank $rank at ${remoteAddress(peer)}")
+        linkPeerToNative(peer, rank, slot)
+      }
+    }
+
+    private def reject(key: SelectionKey, reason: String): Unit = {
+      if (!settled) {
+        settled = true
+        slot.release()
+        log.warn(s"$threadName refused a connection from ${remoteAddress(peer)}: it $reason")
+      }
+      key.cancel()
+      closeQuietly(peer)
+    }
+  }
+
+  /** Accepts the native library's link to one peer and forwards it to that peer's real address. */
+  private final class OutboundAcceptor(target: InetSocketAddress, description: String) extends ListenerHandler {
+    override def onAcceptable(key: SelectionKey): Unit = {
+      val listener = key.channel().asInstanceOf[ServerSocketChannel]
+      Option(listener.accept()).foreach { native =>
+        admit() match {
+          case None =>
+            log.warn(s"$threadName refused a native link to $description beyond the $maxLinks links " +
+              "this topology can need")
+            closeQuietly(native)
+          case Some(slot) => guard(native, Some(slot)) {
+            native.configureBlocking(false)
+            configure(native)
+            track(native)
+            native.register(selector, 0, new Handler {})
+            dialPeer(native, slot, target, description,
+              System.currentTimeMillis() + connectTimeoutMillis, RetryIntervalMillis)
+          }
+        }
+      }
+    }
+  }
+
+  /** A non blocking connect whose outcome, early or late, is handed to the same policy. */
+  private final class Dialer(channel: SocketChannel,
+                             onConnected: SocketChannel => Unit,
+                             onFailed: Throwable => Unit) extends Handler {
+    override def onConnectable(key: SelectionKey): Unit = {
+      if (channel.finishConnect()) {
+        key.interestOps(0)
+        onConnected(channel)
+      }
+    }
+
+    override def onFailure(key: SelectionKey, failure: Throwable): Unit = {
+      key.cancel()
+      closeQuietly(channel)
+      onFailed(failure)
+    }
+  }
+
+  private def remoteAddress(channel: SocketChannel): String =
+    try {
+      Option(channel.getRemoteAddress).map(_.toString).getOrElse("an unknown address")
+    } catch {
+      case NonFatal(_) => "an unknown address"
+    }
+
+  /** Two channels relayed in both directions, closed together. */
+  private final class RelayLink(first: SocketChannel, second: SocketChannel, slot: LinkSlot) {
+    private val forward = new Direction(first, second)
+    private val backward = new Direction(second, first)
+    private val ended = new AtomicBoolean(false)
+
+    def register(): Unit = {
+      first.register(selector, SelectionKey.OP_READ, new LinkEnd(this))
+      second.register(selector, SelectionKey.OP_READ, new LinkEnd(this))
+      pump()
+    }
+
+    def pump(): Unit = {
+      forward.pump()
+      backward.pump()
+      if (forward.finished && backward.finished) {
+        finish()
+      } else {
+        updateInterest(first)
+        updateInterest(second)
+      }
+    }
+
+    /** Any I/O failure ends both directions, so the other one can never wait on a dead channel. */
+    def abort(failure: Throwable): Unit = {
+      log.debug(s"$threadName aborting a relayed link", failure)
+      finish()
+    }
+
+    private def finish(): Unit = {
+      if (ended.compareAndSet(false, true)) {
+        slot.release()
+        closeQuietly(first)
+        closeQuietly(second)
+      }
+    }
+
+    private def updateInterest(channel: SocketChannel): Unit = {
+      val key = channel.keyFor(selector)
+      if (key != None.orNull && key.isValid) {
+        val reading = Seq(forward, backward).find(_.source eq channel).exists(_.wantsRead)
+        val writing = Seq(forward, backward).find(_.target eq channel).exists(_.wantsWrite)
+        val ops = (if (reading) SelectionKey.OP_READ else 0) | (if (writing) SelectionKey.OP_WRITE else 0)
+        key.interestOps(ops)
+      }
+    }
+  }
+
+  private final class LinkEnd(link: RelayLink) extends Handler {
+    override def onReadWrite(key: SelectionKey): Unit = link.pump()
+
+    override def onFailure(key: SelectionKey, failure: Throwable): Unit = link.abort(failure)
+  }
+
+  /** One half of a relayed link: read into a fixed buffer, write it out, then propagate the close. */
+  private final class Direction(val source: SocketChannel, val target: SocketChannel) {
+    private val buffer = ByteBuffer.allocate(BufferSize)
+    private var sourceEnded = false
+    private var targetShutdown = false
+
+    def wantsRead: Boolean = !sourceEnded && buffer.hasRemaining
+
+    def wantsWrite: Boolean = buffer.position() > 0
+
+    def finished: Boolean = sourceEnded && buffer.position() == 0 && targetShutdown
+
+    def pump(): Unit = {
+      if (wantsRead && source.read(buffer) < 0) sourceEnded = true
+      buffer.flip()
+      if (buffer.hasRemaining) target.write(buffer)
+      buffer.compact()
+      // A clean end of stream is passed on as a half close, which is what LightGBM sends.
+      if (sourceEnded && buffer.position() == 0 && !targetShutdown) {
+        target.shutdownOutput()
+        targetShutdown = true
+      }
+    }
+  }
+}

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
@@ -394,20 +394,15 @@ object NetworkManager {
     * Used to minimize network communication overhead in reduce step.
     * @return The main node's port number.
     */
+  private[lightgbm] def parseHostAndPort(endpoint: String): (String, Int) = {
+    val parsed = WorkerEndpoint.parse(endpoint)
+    (parsed.host, parsed.port)
+  }
+
   def getMainWorkerPort(nodes: String, log: Logger): Int = {
-    val nodesList = nodes.split(",")
-    if (nodesList.isEmpty) {
-      throw new Exception("Error: could not split nodes list correctly")
-    }
-    val mainNode = nodesList(0)
-    val hostAndPort = mainNode.split(":")
-    if (hostAndPort.length != 2) {
-      throw new Exception("Error: could not parse main worker host and port correctly")
-    }
-    val mainHost = hostAndPort(0)
-    val mainPort = hostAndPort(1)
-    log.info(s"LightGBM setting main worker host: $mainHost and port: $mainPort")
-    mainPort.toInt
+    val mainWorker = WorkerEndpoint.parseFirst(nodes)
+    log.info(s"LightGBM setting main worker host: ${mainWorker.host} and port: ${mainWorker.port}")
+    mainWorker.port
   }
 
   private def findOpenPort(ctx: TrainingContext, log: Logger): Socket = {

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkManager.scala
@@ -22,58 +22,6 @@ import scala.concurrent.duration.{Duration, SECONDS}
 import scala.language.existentials
 import scala.util.control.NonFatal
 
-case class TaskMessageInfo(status: String,
-                           taskHost: String,
-                           localListenPort: Int,
-                           partitionId: Int,
-                           executorId: String) {
-  def this(status: String) = this(status, "", -1, -1, "") // Constructor for general messages, not Task-connected
-
-  val isForTraining: Boolean = status == LightGBMConstants.EnabledTask
-  val isForLoadOnly: Boolean = status == LightGBMConstants.IgnoreStatus
-  val isFinished: Boolean = status == LightGBMConstants.FinishedStatus
-
-  // Format all the information as a delimited string to send to driver
-  override def toString: String = s"$status:$taskHost:$localListenPort:$partitionId:$executorId"
-}
-
-case class NetworkTopologyInfo(lightgbmNetworkString: String,
-                               executorPartitionIdList: Array[Int],
-                               localListenPort: Int) {
-  @transient private var portReservation: Option[Socket] = None
-
-  private def currentPortReservation: Option[Socket] = Option(portReservation).flatten
-
-  private[lightgbm] def hasPortReservation: Boolean = synchronized {
-    currentPortReservation.nonEmpty
-  }
-
-  private[lightgbm] def retainPortReservation(reservation: Socket): NetworkTopologyInfo = synchronized {
-    require(!reservation.isClosed, "Cannot retain a closed port reservation")
-    require(reservation.isBound, "Cannot retain an unbound port reservation")
-    require(reservation.getLocalPort == localListenPort,
-      s"Port reservation ${reservation.getLocalPort} does not match topology port $localListenPort")
-    require(currentPortReservation.isEmpty, s"Port $localListenPort already has a reservation")
-    portReservation = Option(reservation)
-    this
-  }
-
-  /** Release the temporary JVM reservation immediately before LightGBM binds the same port.
-    *
-    * The operation is idempotent so final cleanup can safely call it after any success or failure path.
-    */
-  private[lightgbm] def releasePortReservation(): Unit = synchronized {
-    currentPortReservation.foreach { reservation =>
-      try {
-        NetworkManager.closeSocketWithRetry(reservation)
-      } finally {
-        // Keep an open socket reachable for a later final-cleanup attempt.
-        if (reservation.isClosed) portReservation = None
-      }
-    }
-  }
-}
-
 object NetworkManager {
   private def addSuppressed(primaryFailure: Throwable, secondaryFailure: Throwable): Unit =
     NetworkManagerSocketSupport.addSuppressed(primaryFailure, secondaryFailure)
@@ -222,9 +170,11 @@ object NetworkManager {
 
             // Get message to send to driver with info about this task
             val stageAttemptNumber = Option(TaskContext.get()).map(_.stageAttemptNumber()).getOrElse(0)
+            // A numeric IPv6 scope is an interface index that only means anything here, so it is
+            // replaced with the interface name before any peer sees it.
             val taskStatus = TaskMessageInfo(
               if (shouldExecuteTraining) LightGBMConstants.EnabledTask else LightGBMConstants.IgnoreStatus,
-              driverSocket.getLocalAddress.getHostAddress,
+              WorkerEndpoint.normalizeHost(driverSocket.getLocalAddress.getHostAddress),
               localListenPort,
               partitionId,
               LightGBMUtils.getExecutorId) // TODO can we use host for this?
@@ -257,6 +207,7 @@ object NetworkManager {
             val executorPartitionIds: Array[Int] =
               parseExecutorPartitionList(partitionsByExecutorStr, taskStatus.executorId, log)
             NetworkTopologyInfo(lightGbmMachineList, executorPartitionIds, localListenPort)
+              .withAdvertisedHost(taskStatus.taskHost)
         }.get
     }.get
   }
@@ -284,13 +235,57 @@ object NetworkManager {
       log,
       retry,
       delay,
-      () => LightGBMUtils.validate(lightgbmlib.LGBM_NetworkInit(
-        ctx.lightGBMNetworkString,
-        ctx.localListenPort,
-        LightGBMConstants.DefaultListenTimeout,
-        ctx.lightGBMNetworkMachineCount), "Network init"),
+      () => initNativeNetwork(ctx.networkTopologyInfo, ctx.lightGBMNetworkMachineCount, log),
       port => reserveExactPort(port, log),
       delayMillis => Thread.sleep(delayMillis))
+  }
+
+  /** Initialize the native LightGBM network, bridging the transport when the topology is IPv6.
+    *
+    * Native LightGBM only speaks IPv4, so an IPv6 topology is relayed by [[LightGBMNetworkBridge]]
+    * and the native library is given an equivalent loopback machine list. An IPv4 topology takes
+    * exactly the same path it always has, with no bridge, no relay threads, and no extra sockets.
+    */
+  private[lightgbm] def initNativeNetwork(networkTopologyInfo: NetworkTopologyInfo,
+                                          machineCount: Int,
+                                          log: Logger,
+                                          nativeInit: (String, Int, Int) => Unit = nativeNetworkInit): Unit = {
+    val machineList = networkTopologyInfo.lightgbmNetworkString
+    if (!LightGBMNetworkBridge.requiresBridge(machineList)) {
+      nativeInit(machineList, networkTopologyInfo.localListenPort, machineCount)
+    } else {
+      log.info(s"LightGBM network $machineList contains IPv6 endpoints, which the native library cannot " +
+        "dial, so this task is bridging the transport")
+      val bridge = LightGBMNetworkBridge.open(machineList,
+                                              networkTopologyInfo.taskHost,
+                                              networkTopologyInfo.localListenPort,
+                                              log)
+      // A failed attempt has to give the advertised port back, because the retry re-reserves it.
+      withCleanupOnFailurePreservingPrimary(bridge.close()) {
+        val bridged = bridge.bridgedNetwork
+        // A relay that has already failed can never carry this network, and the native call would
+        // wait on links that will not arrive, so the attempt fails here instead.
+        failIfBridgeIsBroken(bridge)
+        nativeInit(bridged.machineList, bridged.localListenPort, bridged.machineCount)
+        failIfBridgeIsBroken(bridge)
+        networkTopologyInfo.retainNetworkBridge(bridge)
+      }
+    }
+  }
+
+  /** Surface a relay failure as this task's failure, rather than training on a dead transport. */
+  private[lightgbm] def failIfBridgeIsBroken(bridge: LightGBMNetworkBridge): Unit = {
+    bridge.terminalFailure.foreach { failure =>
+      throw new Exception("The LightGBM IPv6 network bridge for this task failed, so its training " +
+        s"network cannot be established: ${failure.getMessage}", failure)
+    }
+  }
+
+  private def nativeNetworkInit(machineList: String, localListenPort: Int, machineCount: Int): Unit = {
+    LightGBMUtils.validate(lightgbmlib.LGBM_NetworkInit(machineList,
+                                                        localListenPort,
+                                                        LightGBMConstants.DefaultListenTimeout,
+                                                        machineCount), "Network init")
   }
 
   /** Retry native network initialization without leaving the advertised port open during backoff. */
@@ -462,7 +457,9 @@ case class NetworkManager(numTasks: Int,
                           useBarrierExecutionMode: Boolean) extends Logging {
 
   private final class TaskConnection(val socket: Socket, val message: WorkerMessage) {
-    def networkInfoString: String = s"${message.taskHost}:${message.localListenPort}"
+    // The machine list is comma delimited and every entry is host:port, so an IPv6 host has to be
+    // bracketed here or peers would read its trailing group as the port.
+    def networkInfoString: String = WorkerEndpoint.wireString(message.taskHost, message.localListenPort)
   }
 
   // Spark can retry a task report within the same stage attempt. Keeping one connection per

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkTopologyInfo.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/NetworkTopologyInfo.scala
@@ -1,0 +1,102 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm
+
+import java.net.Socket
+
+case class TaskMessageInfo(status: String,
+                           taskHost: String,
+                           localListenPort: Int,
+                           partitionId: Int,
+                           executorId: String) {
+  def this(status: String) = this(status, "", -1, -1, "") // Constructor for general messages, not Task-connected
+
+  val isForTraining: Boolean = status == LightGBMConstants.EnabledTask
+  val isForLoadOnly: Boolean = status == LightGBMConstants.IgnoreStatus
+  val isFinished: Boolean = status == LightGBMConstants.FinishedStatus
+
+  // Format all the information as a delimited string to send to driver
+  override def toString: String = s"$status:$taskHost:$localListenPort:$partitionId:$executorId"
+}
+
+case class NetworkTopologyInfo(lightgbmNetworkString: String,
+                               executorPartitionIdList: Array[Int],
+                               localListenPort: Int) {
+  @transient private var portReservation: Option[Socket] = None
+  @transient private var networkBridge: Option[LightGBMNetworkBridge] = None
+  @transient private var advertisedHost: String = ""
+
+  private def currentPortReservation: Option[Socket] = Option(portReservation).flatten
+
+  private def currentNetworkBridge: Option[LightGBMNetworkBridge] = Option(networkBridge).flatten
+
+  /** The endpoint this task advertised to the driver, which is also its entry in the machine list.
+    *
+    * This is task local state rather than a constructor field, so the case class keeps the shape
+    * every existing caller, extractor, and serialized form depends on.
+    */
+  private[lightgbm] def taskHost: String = Option(advertisedHost).getOrElse("")
+
+  private[lightgbm] def withAdvertisedHost(host: String): NetworkTopologyInfo = synchronized {
+    advertisedHost = Option(host).getOrElse("")
+    this
+  }
+
+  private[lightgbm] def hasPortReservation: Boolean = synchronized {
+    currentPortReservation.nonEmpty
+  }
+
+  private[lightgbm] def retainPortReservation(reservation: Socket): NetworkTopologyInfo = synchronized {
+    require(!reservation.isClosed, "Cannot retain a closed port reservation")
+    require(reservation.isBound, "Cannot retain an unbound port reservation")
+    require(reservation.getLocalPort == localListenPort,
+      s"Port reservation ${reservation.getLocalPort} does not match topology port $localListenPort")
+    require(currentPortReservation.isEmpty, s"Port $localListenPort already has a reservation")
+    portReservation = Option(reservation)
+    this
+  }
+
+  /** Keep an IPv6 transport bridge alive for as long as the native network uses it. */
+  private[lightgbm] def retainNetworkBridge(bridge: LightGBMNetworkBridge): NetworkTopologyInfo = synchronized {
+    require(currentNetworkBridge.isEmpty, "This task already has a LightGBM network bridge")
+    networkBridge = Option(bridge)
+    this
+  }
+
+  private[lightgbm] def hasNetworkBridge: Boolean = synchronized {
+    currentNetworkBridge.nonEmpty
+  }
+
+  /** Release the temporary JVM reservation immediately before LightGBM binds the same port.
+    *
+    * The operation is idempotent so final cleanup can safely call it after any success or failure path.
+    */
+  private[lightgbm] def releasePortReservation(): Unit = synchronized {
+    currentPortReservation.foreach { reservation =>
+      try {
+        NetworkManager.closeSocketWithRetry(reservation)
+      } finally {
+        // Keep an open socket reachable for a later final-cleanup attempt.
+        if (reservation.isClosed) portReservation = None
+      }
+    }
+  }
+
+  /** Tear down the IPv6 transport bridge, if this task needed one. Idempotent. */
+  private[lightgbm] def releaseNetworkBridge(): Unit = synchronized {
+    currentNetworkBridge.foreach { bridge =>
+      try {
+        bridge.close()
+      } finally {
+        networkBridge = None
+      }
+    }
+  }
+
+  /** Release every network resource this task owns, whichever transport it ended up using. */
+  private[lightgbm] def releaseNetworkResources(): Unit = {
+    NetworkManagerSocketSupport.withCleanupPreservingPrimary(releaseNetworkBridge())(releasePortReservation())
+  }
+}
+

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/WorkerEndpoint.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/WorkerEndpoint.scala
@@ -1,0 +1,149 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm
+
+import java.net.{InetAddress, UnknownHostException}
+
+private[lightgbm] final case class WorkerEndpoint(host: String, port: Int)
+
+/** Parses the worker addresses exchanged by the LightGBM network handshake. */
+private[lightgbm] object WorkerEndpoint {
+  private val EndpointPreviewLimit = 200
+  private val MinNetworkPort = 1
+
+  /** Parse the first (main) address from a comma-delimited LightGBM machine list. */
+  def parseFirst(nodes: String): WorkerEndpoint = {
+    val nodeList = Option(nodes).getOrElse(invalid(nodes, "network node list is null"))
+    val firstSeparator = nodeList.indexOf(',')
+    parse(if (firstSeparator < 0) nodeList else nodeList.substring(0, firstSeparator))
+  }
+
+  /** Parse one endpoint without resolving or rewriting its host text. */
+  def parse(endpoint: String): WorkerEndpoint = {
+    val value = Option(endpoint).getOrElse(invalid(endpoint, "endpoint is null"))
+    if (value.isEmpty) invalid(value, "endpoint is empty")
+
+    val (host, portText, bracketed) =
+      if (value.startsWith("[")) splitBracketed(value) else splitUnbracketed(value)
+    validateHost(host, value, bracketed)
+    WorkerEndpoint(host, parsePort(portText, value))
+  }
+
+  private def splitBracketed(endpoint: String): (String, String, Boolean) = {
+    val closingBracket = endpoint.indexOf(']')
+    if (closingBracket < 0) invalid(endpoint, "bracketed IPv6 host is missing its closing ']'")
+    val suffix = endpoint.substring(closingBracket + 1)
+    if (suffix.isEmpty) invalid(endpoint, "bracketed IPv6 host is missing its port")
+    if (!suffix.startsWith(":")) {
+      invalid(endpoint, "bracketed IPv6 host must be followed by a ':' port separator")
+    }
+    (endpoint.substring(1, closingBracket), suffix.substring(1), true)
+  }
+
+  private def splitUnbracketed(endpoint: String): (String, String, Boolean) = {
+    if (endpoint.exists(character => character == '[' || character == ']')) {
+      invalid(endpoint, "IPv6 brackets are unbalanced")
+    }
+    val portSeparator = endpoint.lastIndexOf(':')
+    if (portSeparator < 0) invalid(endpoint, "missing ':' port separator")
+    val host = endpoint.substring(0, portSeparator)
+    if (host.contains(":") && isValidIpv6Literal(endpoint)) {
+      invalid(endpoint, "bare IPv6 endpoint is ambiguous; use the unambiguous [IPv6]:port form")
+    }
+    (host, endpoint.substring(portSeparator + 1), false)
+  }
+
+  private def validateHost(host: String, endpoint: String, bracketed: Boolean): Unit = {
+    if (host.isEmpty) invalid(endpoint, "host is empty")
+    if (host.exists(isInvalidHostCharacter)) {
+      invalid(endpoint, "host contains whitespace, control characters, or an endpoint delimiter")
+    }
+
+    val isIpv6Literal = host.contains(":")
+    if (bracketed && !isIpv6Literal) {
+      invalid(endpoint, "brackets are only valid around an IPv6 literal")
+    }
+    if (!isIpv6Literal && host.contains("%")) {
+      invalid(endpoint, "a zone identifier is only valid on an IPv6 literal")
+    }
+    if (isIpv6Literal) validateIpv6Literal(host, endpoint)
+  }
+
+  private def isInvalidHostCharacter(character: Char): Boolean = {
+    Character.isWhitespace(character) || Character.isISOControl(character) ||
+      character == '[' || character == ']' || character == ','
+  }
+
+  private def validateIpv6Literal(host: String, endpoint: String): Unit = {
+    val addressParts = host.split("%", -1)
+    if (addressParts.length > 2) invalid(endpoint, "IPv6 zone identifier is malformed")
+    if (addressParts.length == 2) validateZone(addressParts(1), endpoint)
+    if (!canParseIpv6Address(addressParts(0))) invalid(endpoint, "host is not a valid IPv6 literal")
+  }
+
+  private def isValidIpv6Literal(host: String): Boolean = {
+    val addressParts = host.split("%", -1)
+    addressParts.length <= 2 && addressParts(0).contains(":") &&
+      (addressParts.length == 1 || isValidZone(addressParts(1))) && canParseIpv6Address(addressParts(0))
+  }
+
+  private def canParseIpv6Address(address: String): Boolean = {
+    try {
+      // A colon-bearing literal is parsed locally by the JDK and never triggers a hostname lookup.
+      InetAddress.getByName(address)
+      true
+    } catch {
+      case _: UnknownHostException => false
+    }
+  }
+
+  private def validateZone(zone: String, endpoint: String): Unit = {
+    if (zone.isEmpty) invalid(endpoint, "IPv6 zone identifier is empty")
+    if (!isValidZone(zone)) {
+      invalid(endpoint, "IPv6 zone identifier contains whitespace, control characters, or a delimiter")
+    }
+  }
+
+  private def isValidZone(zone: String): Boolean = zone.nonEmpty && !zone.exists(isInvalidZoneCharacter)
+
+  private def isInvalidZoneCharacter(character: Char): Boolean = {
+    Character.isWhitespace(character) || Character.isISOControl(character) ||
+      character == ':' || character == '[' || character == ']' || character == ',' || character == '%'
+  }
+
+  private def parsePort(portText: String, endpoint: String): Int = {
+    if (portText.isEmpty) invalid(endpoint, "port is empty")
+    if (!portText.forall(character => character >= '0' && character <= '9')) {
+      invalid(endpoint, "port is not a decimal integer")
+    }
+    val port = try {
+      portText.toInt
+    } catch {
+      case _: NumberFormatException => invalid(endpoint, "port is too large")
+    }
+    if (port < MinNetworkPort || port > LightGBMConstants.MaxPort) {
+      invalid(endpoint, s"port is outside the valid range $MinNetworkPort-${LightGBMConstants.MaxPort}")
+    }
+    port
+  }
+
+  private[lightgbm] def preview(endpoint: String): String = {
+    val escaped = Option(endpoint).getOrElse("<null>").flatMap {
+      case '\r' => "\\r"
+      case '\n' => "\\n"
+      case '\t' => "\\t"
+      case character if Character.isISOControl(character) => f"\\u${character.toInt}%04x"
+      case character => character.toString
+    }
+    val preview = if (escaped.length <= EndpointPreviewLimit) escaped else escaped.take(EndpointPreviewLimit) + "..."
+    s"'$preview'"
+  }
+
+  private def invalid(endpoint: String, reason: String): Nothing = {
+    throw new IllegalArgumentException(
+      s"Invalid LightGBM worker endpoint ${preview(endpoint)}: $reason. " +
+        s"Expected hostname:port, IPv4:port, [IPv6]:port, or bare IPv6:port with a decimal port " +
+        s"between $MinNetworkPort and ${LightGBMConstants.MaxPort}")
+  }
+}

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/WorkerEndpoint.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/WorkerEndpoint.scala
@@ -3,14 +3,73 @@
 
 package com.microsoft.azure.synapse.ml.lightgbm
 
-import java.net.{InetAddress, UnknownHostException}
+import java.net.{InetAddress, NetworkInterface, SocketException, UnknownHostException}
 
-private[lightgbm] final case class WorkerEndpoint(host: String, port: Int)
+private[lightgbm] final case class WorkerEndpoint(host: String, port: Int) {
+  /** Whether the host is an IPv6 literal, which has to be bracketed before a ':' port separator. */
+  def isIpv6Literal: Boolean = WorkerEndpoint.isIpv6Host(host)
+
+  /** The zone identifier of a scoped IPv6 literal, if it carries one. */
+  def zoneId: Option[String] = {
+    val separator = host.indexOf('%')
+    if (separator < 0) None else Some(host.substring(separator + 1))
+  }
+
+  /** Whether the zone identifier is a numeric interface index, which is local to one machine. */
+  def hasNumericZone: Boolean = zoneId.exists(zone => zone.nonEmpty && zone.forall(_.isDigit))
+
+  /** The address without its zone identifier. */
+  def address: String = {
+    val separator = host.indexOf('%')
+    if (separator < 0) host else host.substring(0, separator)
+  }
+
+  /** The unambiguous wire form of this endpoint. */
+  def wireString: String = WorkerEndpoint.wireString(host, port)
+}
 
 /** Parses the worker addresses exchanged by the LightGBM network handshake. */
 private[lightgbm] object WorkerEndpoint {
   private val EndpointPreviewLimit = 200
   private val MinNetworkPort = 1
+
+  /** Whether a host is an IPv6 literal. Hostnames and IPv4 literals never contain a ':'. */
+  def isIpv6Host(host: String): Boolean = Option(host).exists(_.contains(":"))
+
+  /** Replace a numeric IPv6 scope with the interface name it stands for on this machine.
+    *
+    * A numeric scope is an interface index, which is only meaningful on the machine that produced
+    * it, so it must never be published to peers. An interface name survives the trip whenever the
+    * cluster names its interfaces consistently, which is the only case where a link-local address
+    * can work at all. Anything else is returned unchanged.
+    */
+  def normalizeHost(host: String): String = {
+    val endpoint = WorkerEndpoint(Option(host).getOrElse(""), 1)
+    endpoint.zoneId.filter(zone => zone.nonEmpty && zone.forall(_.isDigit)).flatMap { zone =>
+      try {
+        Option(NetworkInterface.getByIndex(zone.toInt)).map(named => s"${endpoint.address}%${named.getName}")
+      } catch {
+        case _: SocketException => None
+        case _: IllegalArgumentException => None
+      }
+    }.getOrElse(host)
+  }
+
+  /** Bracket an IPv6 literal so a ':' port separator stays unambiguous. Other hosts are unchanged. */
+  def wireHost(host: String): String =
+    if (isIpv6Host(host) && !host.startsWith("[")) s"[$host]" else host
+
+  /** Render an endpoint in the wire form every LightGBM component parses.
+    *
+    * The result is parsed back before it is returned, so a host carrying a control character, a
+    * delimiter, or an unbalanced bracket fails here instead of corrupting the line protocol or the
+    * comma-delimited machine list it would have been written into.
+    */
+  def wireString(host: String, port: Int): String = {
+    val endpoint = s"${wireHost(host)}:$port"
+    parse(endpoint)
+    endpoint
+  }
 
   /** Parse the first (main) address from a comma-delimited LightGBM machine list. */
   def parseFirst(nodes: String): WorkerEndpoint = {

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/WorkerMessage.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/WorkerMessage.scala
@@ -87,13 +87,10 @@ private[lightgbm] object WorkerMessage {
   }
 
   def format(message: TaskMessageInfo, stageAttemptNumber: Int): String = {
-    val host = if (message.taskHost.contains(":") && !message.taskHost.startsWith("[")) {
-      s"[${message.taskHost}]"
-    } else {
-      message.taskHost
-    }
-    s"${message.status}:$host:${message.localListenPort}:${message.partitionId}:${message.executorId}:" +
-      stageAttemptNumber
+    // Validated bracketing keeps an IPv6 host unambiguous and keeps a host that carries a control
+    // character or a delimiter out of the line protocol entirely.
+    val endpoint = WorkerEndpoint.wireString(message.taskHost, message.localListenPort)
+    s"${message.status}:$endpoint:${message.partitionId}:${message.executorId}:" + stageAttemptNumber
   }
 
   def formatFinished(stageAttemptNumber: Int, barrierTaskCount: Int): String =

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/WorkerMessage.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/WorkerMessage.scala
@@ -5,6 +5,8 @@ package com.microsoft.azure.synapse.ml.lightgbm
 
 import java.io.IOException
 
+import scala.util.Try
+
 /**
   * The line protocol tasks use to report themselves to the driver while the LightGBM network
   * topology is being assembled.
@@ -36,31 +38,70 @@ private[lightgbm] object WorkerMessage {
     if (message == null) {
       throw new IOException("Worker closed the connection before sending a status message")
     }
-    val components = message.split(":")
+    val components = message.split(":", -1)
     val status = components(0)
 
     if (status == LightGBMConstants.FinishedStatus) {
       WorkerMessage(status, "", -1, -1, "", parseIntOrDefault(components, 1, 0),
         parseOptionalInt(components, 2))
     } else {
-      if (components.length != TaskMessageFieldCount && components.length != TaskMessageFieldCountWithStageAttempt) {
-        throw new Exception(s"Unexpected message: $message")
+      val currentMessage = parseTaskMessage(components, hasStageAttempt = true)
+      val legacyMessage = parseTaskMessage(components, hasStageAttempt = false)
+      (currentMessage, legacyMessage) match {
+        case (Some(current), Some(_)) if components.length > 1 && components(1).startsWith("[") => current
+        // An unbracketed IPv6 message that fits both layouts predates the stage-attempt suffix.
+        case (Some(_), Some(legacy)) => legacy
+        case (Some(current), None) => current
+        case (None, Some(legacy)) => legacy
+        case _ => throw new IllegalArgumentException(
+          s"Unexpected worker message: expected status:host:port:partitionId:executorId[:stageAttemptNumber], " +
+            s"but received ${WorkerEndpoint.preview(message)}")
       }
-
-      WorkerMessage(status, components(1), components(2).toInt, components(3).toInt, components(4),
-        parseIntOrDefault(components, TaskMessageFieldCount, 0))
     }
   }
 
-  def format(message: TaskMessageInfo, stageAttemptNumber: Int): String =
-    s"${message.toString}:$stageAttemptNumber"
+  private def parseTaskMessage(components: Array[String], hasStageAttempt: Boolean): Option[WorkerMessage] = {
+    val suffixFieldCount = if (hasStageAttempt) {
+      TaskMessageFieldCountWithStageAttempt - 2
+    } else {
+      TaskMessageFieldCount - 2
+    }
+    val portIndex = components.length - suffixFieldCount
+    if (portIndex <= 1) {
+      None
+    } else {
+      val host = components.slice(1, portIndex).mkString(":")
+      val portText = components(portIndex)
+      val partitionText = components(portIndex + 1)
+      val executorId = components(portIndex + 2)
+      val stageAttemptText = if (hasStageAttempt) Some(components(portIndex + 3)) else None
+
+      val endpointText = if (host.contains(":") && !host.startsWith("[")) s"[$host]:$portText" else s"$host:$portText"
+      for {
+        endpoint <- Try(WorkerEndpoint.parse(endpointText)).toOption
+        partitionId <- Try(partitionText.toInt).toOption
+        stageAttemptNumber <- stageAttemptText.map(value => Try(value.toInt).toOption).getOrElse(Some(0))
+        if executorId.nonEmpty && stageAttemptNumber >= 0
+      } yield WorkerMessage(components(0), endpoint.host, endpoint.port, partitionId, executorId, stageAttemptNumber)
+    }
+  }
+
+  def format(message: TaskMessageInfo, stageAttemptNumber: Int): String = {
+    val host = if (message.taskHost.contains(":") && !message.taskHost.startsWith("[")) {
+      s"[${message.taskHost}]"
+    } else {
+      message.taskHost
+    }
+    s"${message.status}:$host:${message.localListenPort}:${message.partitionId}:${message.executorId}:" +
+      stageAttemptNumber
+  }
 
   def formatFinished(stageAttemptNumber: Int, barrierTaskCount: Int): String =
     s"${LightGBMConstants.FinishedStatus}:$stageAttemptNumber:$barrierTaskCount"
 
   private def parseIntOrDefault(components: Array[String], index: Int, default: Int): Int =
-    if (components.length > index) components(index).toInt else default
+    if (components.length > index && components(index).nonEmpty) components(index).toInt else default
 
   private def parseOptionalInt(components: Array[String], index: Int): Option[Int] =
-    if (components.length > index) Some(components(index).toInt) else None
+    if (components.length > index && components(index).nonEmpty) Some(components(index).toInt) else None
 }

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/DriverSocketRetrySuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/DriverSocketRetrySuite.scala
@@ -414,6 +414,7 @@ class DriverSocketRetrySuite extends AnyFunSuite {
 
       // This is what executeTraining now does in its finally block when partition tasks fail.
       manager.closeConnections()
+      manager.waitForNetworkCommunicationsDone()
 
       val retriedSocket = new Socket()
       try {
@@ -423,7 +424,6 @@ class DriverSocketRetrySuite extends AnyFunSuite {
       } finally {
         retriedSocket.close()
       }
-      manager.waitForNetworkCommunicationsDone()
     } finally {
       manager.closeConnections()
       closeTasks(task)

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/DriverSocketRetrySuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/DriverSocketRetrySuite.scala
@@ -3,7 +3,7 @@
 
 package com.microsoft.azure.synapse.ml.lightgbm.split1
 
-import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMConstants, NetworkManager, TaskMessageInfo}
+import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMConstants, NetworkManager, TaskMessageInfo, WorkerMessage}
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.io.{BufferedReader, BufferedWriter, IOException, InputStreamReader, OutputStreamWriter}
@@ -349,6 +349,54 @@ class DriverSocketRetrySuite extends AnyFunSuite {
     assert(constructorArities.contains(1))
     assert(constructorArities.contains(5))
     assert(!constructorArities.contains(6))
+  }
+
+  test("Worker status parsing preserves IPv6 hosts in current and legacy messages") {
+    val hosts = Seq("2001:db8::1", "2001:db8:0:1:2:3:4:5", "fe80::a%3")
+    hosts.foreach { taskHost =>
+      val message = TaskMessageInfo(
+        LightGBMConstants.EnabledTask,
+        taskHost,
+        LightGBMConstants.DefaultLocalListenPort,
+        3,
+        "executor-1")
+      assert(NetworkManager.parseWorkerMessage(s"${message.toString}:7") == message)
+    }
+
+    val legacyMessage = TaskMessageInfo(
+      LightGBMConstants.EnabledTask,
+      "2001:db8::1",
+      LightGBMConstants.DefaultLocalListenPort,
+      3,
+      "7")
+    assert(NetworkManager.parseWorkerMessage(legacyMessage.toString) == legacyMessage)
+
+    val ambiguousLegacyMessage = legacyMessage.copy(taskHost = "2001:db8::1:10")
+    assert(NetworkManager.parseWorkerMessage(ambiguousLegacyMessage.toString) == ambiguousLegacyMessage)
+
+    val lowPortCurrentMessage = legacyMessage.copy(localListenPort = 80, executorId = "executor-1")
+    assert(NetworkManager.parseWorkerMessage(WorkerMessage.format(lowPortCurrentMessage, 7)) == lowPortCurrentMessage)
+  }
+
+  test("Finished worker messages tolerate omitted trailing fields") {
+    val missingBarrierCount = WorkerMessage.parse(s"${LightGBMConstants.FinishedStatus}:7:")
+    assert(missingBarrierCount.stageAttemptNumber == 7)
+    assert(missingBarrierCount.barrierTaskCount.isEmpty)
+
+    val missingSuffix = WorkerMessage.parse(s"${LightGBMConstants.FinishedStatus}::")
+    assert(missingSuffix.stageAttemptNumber == 0)
+    assert(missingSuffix.barrierTaskCount.isEmpty)
+  }
+
+  test("Malformed worker messages escape control characters in errors") {
+    val nul = 0.toChar
+    val failure = intercept[IllegalArgumentException] {
+      NetworkManager.parseWorkerMessage(s"enabledTask:host:not-a-port:3:executor-1\r${nul}malformed")
+    }
+    assert(failure.getMessage.contains("\\r"))
+    assert(failure.getMessage.contains("\\u0000"))
+    assert(!failure.getMessage.contains("\r"))
+    assert(!failure.getMessage.contains(nul))
   }
 
   test("A worker that disconnects before sending a message reports the disconnect, not a NullPointerException") {

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMIpv6NetworkE2ESuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMIpv6NetworkE2ESuite.scala
@@ -260,6 +260,7 @@ class LightGBMIpv6NetworkE2ESuite extends AnyFunSuite with BeforeAndAfterEach {
   }
 
   test("Without a bridge the native library cannot form a network from any IPv6 machine list") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
     val selfPort = freePort(ipv6Loopback)
     val peerPort = freePort(ipv6Loopback)
     // The bracketed form is what an IPv6 aware driver publishes.

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMIpv6NetworkE2ESuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMIpv6NetworkE2ESuite.scala
@@ -1,0 +1,397 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm.split1
+
+import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMConstants, LightGBMNetworkBridge, LightGBMUtils,
+  NetworkManager, NetworkTopologyInfo}
+import com.microsoft.ml.lightgbm.{lightgbmlib, lightgbmlibConstants}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funsuite.AnyFunSuite
+import org.slf4j.LoggerFactory
+
+import java.io.DataInputStream
+import java.net.{InetAddress, InetSocketAddress, NetworkInterface, ServerSocket, Socket}
+import java.nio.{ByteBuffer, ByteOrder}
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, Executors, ThreadFactory, TimeUnit}
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+/** Drives the real native LightGBM network over IPv6.
+  *
+  * The native network state is thread local, so one JVM can hold several LightGBM ranks as long as
+  * each one stays on its own thread. These tests use that to run a real two worker training round
+  * over IPv6, and to check the single rank link behavior against simulated peers.
+  */
+class LightGBMIpv6NetworkE2ESuite extends AnyFunSuite with BeforeAndAfterEach {
+
+  private val log = LoggerFactory.getLogger(classOf[LightGBMIpv6NetworkE2ESuite])
+  private val ipv6Loopback = "::1"
+  private val ipv4Loopback = "127.0.0.1"
+  private val socketTimeoutMillis = 30000L
+  private val connectAttemptTimeoutMillis = 1000
+  private val nativeWorkTimeoutMillis = 180000L
+  private val retryIntervalMillis = 10L
+  private val rankSize = 4
+  private val trainingRows = 64
+  private val trainingCols = 2
+  private val trainingIterations = 5
+  private val peerLabelOffset = 100.0f
+  private val modelBufferLength = 1L << 20
+  private val closeables = new ConcurrentLinkedQueue[AutoCloseable]()
+
+  private val peerExecutor = Executors.newCachedThreadPool(new ThreadFactory {
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = new Thread(runnable, "lightgbm-ipv6-e2e-peer")
+      thread.setDaemon(true)
+      thread
+    }
+  })
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    LightGBMUtils.initializeNativeLibrary()
+  }
+
+  override def afterEach(): Unit = {
+    closeables.asScala.foreach(resource => Try(resource.close()))
+    closeables.clear()
+    super.afterEach()
+  }
+
+  private def register[T <: AutoCloseable](resource: T): T = {
+    closeables.add(resource)
+    resource
+  }
+
+  private def ipv6LoopbackAvailable: Boolean = Try {
+    val probe = new ServerSocket()
+    try {
+      probe.bind(new InetSocketAddress(InetAddress.getByName(ipv6Loopback), 0))
+      true
+    } finally {
+      probe.close()
+    }
+  }.getOrElse(false)
+
+  /** An address the native library also finds in its own local address list, on every platform. */
+  private def localIpv4Host: String = {
+    Try(NetworkInterface.getNetworkInterfaces.asScala
+      .filter(candidate => Try(candidate.isUp).getOrElse(false))
+      .flatMap(_.getInetAddresses.asScala)
+      .find(address => address.isSiteLocalAddress && address.getAddress.length == 4)
+      .map(_.getHostAddress)).toOption.flatten.getOrElse(ipv4Loopback)
+  }
+
+  private def freePort(host: String): Int = {
+    val probe = new ServerSocket()
+    try {
+      probe.bind(new InetSocketAddress(InetAddress.getByName(host), 0))
+      probe.getLocalPort
+    } finally {
+      probe.close()
+    }
+  }
+
+  private def listenOn(host: String): ServerSocket = {
+    val listener = new ServerSocket()
+    listener.bind(new InetSocketAddress(InetAddress.getByName(host), 0))
+    listener.setSoTimeout(socketTimeoutMillis.toInt)
+    register(listener)
+  }
+
+  private def rankBytes(rank: Int): Array[Byte] =
+    ByteBuffer.allocate(rankSize).order(ByteOrder.nativeOrder()).putInt(rank).array()
+
+  private def readRank(socket: Socket): Int = {
+    val buffer = new Array[Byte](rankSize)
+    new DataInputStream(socket.getInputStream).readFully(buffer)
+    ByteBuffer.wrap(buffer).order(ByteOrder.nativeOrder()).getInt
+  }
+
+  /** Stand in for a machine LightGBM expects to dial this task, which every lower rank does. */
+  private def startDialingPeer(host: String, port: Int, rank: Int): CountDownLatch = {
+    val linked = new CountDownLatch(1)
+    peerExecutor.execute(new Runnable {
+      override def run(): Unit = {
+        val deadline = System.currentTimeMillis() + socketTimeoutMillis
+
+        @tailrec
+        def dial(): Unit = {
+          val socket = new Socket()
+          val connected = try {
+            socket.connect(new InetSocketAddress(InetAddress.getByName(host), port), connectAttemptTimeoutMillis)
+            register(socket)
+            socket.getOutputStream.write(rankBytes(rank))
+            socket.getOutputStream.flush()
+            true
+          } catch {
+            case _: Exception =>
+              Try(socket.close())
+              false
+          }
+          if (connected) {
+            linked.countDown()
+            // Hold the link open: LightGBM keeps every peer socket for the whole training run.
+            Thread.sleep(socketTimeoutMillis)
+          } else if (System.currentTimeMillis() < deadline) {
+            Thread.sleep(retryIntervalMillis)
+            dial()
+          }
+        }
+
+        dial()
+      }
+    })
+    linked
+  }
+
+  /** Stand in for a machine LightGBM dials, which every higher rank is. */
+  private def startAcceptingPeer(listener: ServerSocket, receivedRank: AtomicInteger): CountDownLatch = {
+    val linked = new CountDownLatch(1)
+    peerExecutor.execute(new Runnable {
+      override def run(): Unit = {
+        val socket = register(listener.accept())
+        receivedRank.set(readRank(socket))
+        linked.countDown()
+        Thread.sleep(socketTimeoutMillis)
+      }
+    })
+    linked
+  }
+
+  private def nativeNetworkInit(machineList: String, localListenPort: Int, machineCount: Int): Int =
+    lightgbmlib.LGBM_NetworkInit(machineList, localListenPort, LightGBMConstants.DefaultListenTimeout, machineCount)
+
+  /** Run native work on its own thread, because LightGBM keeps its network state thread local. */
+  private def onNativeThread[T](name: String)(work: => T): () => T = {
+    val outcome = new AtomicReference[Either[Throwable, T]]()
+    val done = new CountDownLatch(1)
+    val thread = new Thread(new Runnable {
+      override def run(): Unit = {
+        try {
+          outcome.set(Right(work))
+        } catch {
+          case failure: Throwable => outcome.set(Left(failure))
+        } finally {
+          done.countDown()
+        }
+      }
+    }, name)
+    thread.setDaemon(true)
+    thread.start()
+    () => {
+      assert(done.await(nativeWorkTimeoutMillis, TimeUnit.MILLISECONDS), s"$name never finished")
+      outcome.get() match {
+        case Right(result) => result
+        case Left(failure) => throw failure
+      }
+    }
+  }
+
+  private def await[T](pending: () => T): T = pending()
+
+  /** Initialize the production network path, run the body, and always release the native network. */
+  private def withNativeNetwork[T](topology: NetworkTopologyInfo, machineCount: Int)(body: => T): T = {
+    var initialized = false
+    try {
+      NetworkManager.initNativeNetwork(topology, machineCount, log)
+      initialized = true
+      body
+    } finally {
+      if (initialized) lightgbmlib.LGBM_NetworkFree()
+      topology.releaseNetworkResources()
+    }
+  }
+
+  /** Train a tiny model on this rank's shard, which allreduces with every peer on every iteration. */
+  private def trainShard(rank: Int, numMachines: Int): String = {
+    val features = lightgbmlib.new_doubleArray((trainingRows * trainingCols).toLong)
+    val labels = lightgbmlib.new_floatArray(trainingRows.toLong)
+    (0 until trainingRows).foreach { row =>
+      lightgbmlib.doubleArray_setitem(features, (row * trainingCols).toLong, row.toDouble)
+      lightgbmlib.doubleArray_setitem(features, (row * trainingCols + 1).toLong, (row % 8).toDouble)
+      // Each rank holds a clearly different slice, so a model built from both is easy to tell apart.
+      lightgbmlib.floatArray_setitem(labels, row.toLong, row.toFloat + rank * peerLabelOffset)
+    }
+
+    val datasetParams = "max_bin=15 min_data_in_bin=1 min_data_in_leaf=1 verbosity=-1"
+    val datasetOut = lightgbmlib.voidpp_handle()
+    LightGBMUtils.validate(lightgbmlib.LGBM_DatasetCreateFromMat(
+      lightgbmlib.double_to_voidp_ptr(features),
+      lightgbmlibConstants.C_API_DTYPE_FLOAT64,
+      trainingRows,
+      trainingCols,
+      1,
+      datasetParams,
+      None.orNull,
+      datasetOut), "Dataset create")
+    val dataset = lightgbmlib.voidpp_value(datasetOut)
+    LightGBMUtils.validate(lightgbmlib.LGBM_DatasetSetField(dataset, "label",
+      lightgbmlib.float_to_voidp_ptr(labels), trainingRows, lightgbmlibConstants.C_API_DTYPE_FLOAT32),
+      "Dataset set label")
+
+    val boosterOut = lightgbmlib.voidpp_handle()
+    LightGBMUtils.validate(lightgbmlib.LGBM_BoosterCreate(dataset,
+      s"objective=regression tree_learner=data num_machines=$numMachines num_leaves=4 learning_rate=0.5 " +
+        s"$datasetParams num_threads=1", boosterOut), "Booster create")
+    val booster = lightgbmlib.voidpp_value(boosterOut)
+    val isFinished = lightgbmlib.new_intp()
+    val modelLength = lightgbmlib.new_int64_tp()
+    try {
+      (0 until trainingIterations).foreach(_ =>
+        LightGBMUtils.validate(lightgbmlib.LGBM_BoosterUpdateOneIter(booster, isFinished), "Update one iteration"))
+      lightgbmlib.LGBM_BoosterSaveModelToStringSWIG(booster, 0, -1, 0, modelBufferLength, modelLength)
+    } finally {
+      lightgbmlib.delete_intp(isFinished)
+      lightgbmlib.delete_int64_tp(modelLength)
+      lightgbmlib.LGBM_BoosterFree(booster)
+      lightgbmlib.LGBM_DatasetFree(dataset)
+      lightgbmlib.delete_doubleArray(features)
+      lightgbmlib.delete_floatArray(labels)
+    }
+  }
+
+  private def leafValues(model: String): Seq[Double] = {
+    model.split("\n").filter(_.startsWith("leaf_value=")).flatMap(line =>
+      line.stripPrefix("leaf_value=").trim.split("\\s+").filter(_.nonEmpty).map(_.toDouble)).toSeq
+  }
+
+  test("Without a bridge the native library cannot form a network from any IPv6 machine list") {
+    val selfPort = freePort(ipv6Loopback)
+    val peerPort = freePort(ipv6Loopback)
+    // The bracketed form is what an IPv6 aware driver publishes.
+    val bracketed = nativeNetworkInit(s"[$ipv6Loopback]:$selfPort,[$ipv6Loopback]:$peerPort", selfPort, 2)
+    assert(bracketed == -1, "The native library unexpectedly accepted a bracketed IPv6 machine list")
+    assert(lightgbmlib.LGBM_GetLastError().contains("Cannot find any ip and port"))
+
+    // The bare form is what the driver published before this change: the native parser splits it on
+    // ':' and keeps a meaningless host instead of rejecting the entry.
+    val bare = nativeNetworkInit(s"$ipv6Loopback:$selfPort,$ipv6Loopback:$peerPort", selfPort, 2)
+    assert(bare == -1, "The native library unexpectedly accepted a bare IPv6 machine list")
+    assert(lightgbmlib.LGBM_GetLastError().contains("doesn't contain the local machine"))
+
+    // A routable IPv6 address fares no better, so this is not a loopback quirk.
+    val routable = nativeNetworkInit(s"[2001:db8::1]:$selfPort,[2001:db8::2]:$peerPort", selfPort, 2)
+    assert(routable == -1, "The native library unexpectedly accepted a routable IPv6 machine list")
+  }
+
+  test("An IPv4 topology still initializes natively with no bridge and no rewriting") {
+    val host = localIpv4Host
+    val selfPort = freePort(ipv4Loopback)
+    val peerListener = listenOn(ipv4Loopback)
+    val receivedRank = new AtomicInteger(-1)
+    val peerLinked = startAcceptingPeer(peerListener, receivedRank)
+
+    val machineList = s"$host:$selfPort,$ipv4Loopback:${peerListener.getLocalPort}"
+    val topology = NetworkTopologyInfo(machineList, Array(0), selfPort).withAdvertisedHost(host)
+    await(onNativeThread("lightgbm-ipv4-rank") {
+      withNativeNetwork(topology, 2) {
+        assert(!topology.hasNetworkBridge, "An IPv4 topology has to reach the native library untouched")
+        assert(peerLinked.await(socketTimeoutMillis, TimeUnit.MILLISECONDS),
+          "The native library never linked to its IPv4 peer")
+        assert(receivedRank.get() == 0, "The native library announced the wrong rank to its peer")
+      }
+    })
+  }
+
+  test("A LightGBM worker links to IPv6 peers in both directions through the bridge") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    // Rank 1 of 3 is the only rank that both accepts a link (from rank 0) and dials one (to rank 2).
+    val advertisedPort = freePort(ipv6Loopback)
+    val lowerRankPort = freePort(ipv6Loopback)
+    val higherRankListener = listenOn(ipv6Loopback)
+    val receivedRank = new AtomicInteger(-1)
+    val higherRankLinked = startAcceptingPeer(higherRankListener, receivedRank)
+    val lowerRankLinked = startDialingPeer(ipv6Loopback, advertisedPort, 0)
+
+    val machineList = s"[$ipv6Loopback]:$lowerRankPort,[$ipv6Loopback]:$advertisedPort," +
+      s"[$ipv6Loopback]:${higherRankListener.getLocalPort}"
+    val topology = NetworkTopologyInfo(machineList, Array(0), advertisedPort).withAdvertisedHost(ipv6Loopback)
+    await(onNativeThread("lightgbm-ipv6-rank") {
+      withNativeNetwork(topology, 3) {
+        assert(topology.hasNetworkBridge, "An IPv6 topology has to be bridged onto the native transport")
+        assert(lowerRankLinked.await(socketTimeoutMillis, TimeUnit.MILLISECONDS),
+          "The lower rank never linked to this worker over IPv6")
+        assert(higherRankLinked.await(socketTimeoutMillis, TimeUnit.MILLISECONDS),
+          "This worker never linked to the higher rank over IPv6")
+        assert(receivedRank.get() == 1,
+          s"The higher rank received rank ${receivedRank.get()} instead of the bridged worker's rank 1")
+      }
+    })
+  }
+
+  test("The native listener stops accepting once the bridge has claimed its link slots") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    // Rank 1 of 2, so the native listener has exactly one slot, which the bridge claims from loopback.
+    val advertisedPort = freePort(ipv6Loopback)
+    val machineList = s"[$ipv6Loopback]:${freePort(ipv6Loopback)},[$ipv6Loopback]:$advertisedPort"
+    val bridge = register(LightGBMNetworkBridge.open(machineList, ipv6Loopback, advertisedPort, log))
+    val bridged = bridge.bridgedNetwork
+    val lowerRankLinked = startDialingPeer(ipv6Loopback, advertisedPort, 0)
+
+    await(onNativeThread("lightgbm-native-listener") {
+      val result = nativeNetworkInit(bridged.machineList, bridged.localListenPort, bridged.machineCount)
+      try {
+        assert(result == 0, s"Native init failed: ${lightgbmlib.LGBM_GetLastError()}")
+        assert(lowerRankLinked.await(socketTimeoutMillis, TimeUnit.MILLISECONDS),
+          "The lower rank never linked through the bridge")
+      } finally {
+        if (result == 0) lightgbmlib.LGBM_NetworkFree()
+      }
+    })
+
+    // The native library closes its listener as soon as its slots are filled, and only the bridge
+    // ever filled them, so nothing external can still reach that port.
+    val probe = new Socket()
+    val refused = try {
+      probe.connect(new InetSocketAddress(InetAddress.getByName(ipv4Loopback), bridged.localListenPort),
+        connectAttemptTimeoutMillis)
+      false
+    } catch {
+      case _: java.io.IOException => true
+    } finally {
+      Try(probe.close())
+    }
+    assert(refused, s"The native listener on port ${bridged.localListenPort} is still accepting connections")
+  }
+
+  test("Two LightGBM workers train one distributed model over IPv6") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val firstPort = freePort(ipv6Loopback)
+    val secondPort = freePort(ipv6Loopback)
+    val machineList = s"[$ipv6Loopback]:$firstPort,[$ipv6Loopback]:$secondPort"
+
+    def worker(rank: Int, advertisedPort: Int): () => String = {
+      val topology = NetworkTopologyInfo(machineList, Array(rank), advertisedPort).withAdvertisedHost(ipv6Loopback)
+      onNativeThread(s"lightgbm-ipv6-worker-$rank") {
+        withNativeNetwork(topology, 2) {
+          assert(topology.hasNetworkBridge, s"Worker $rank did not bridge its IPv6 topology")
+          trainShard(rank, 2)
+        }
+      }
+    }
+
+    // Both workers have to be running before either can link, exactly as two Spark tasks would be.
+    val pendingFirst = worker(0, firstPort)
+    val pendingSecond = worker(1, secondPort)
+    val firstModel = await(pendingFirst)
+    val secondModel = await(pendingSecond)
+
+    assert(firstModel.contains("Tree=0"), "The distributed training produced no trees")
+    assert(firstModel.contains("split_feature="), "The distributed training produced only empty trees")
+    assert(firstModel == secondModel,
+      "Data parallel LightGBM builds the same model on every rank, so the two IPv6 workers disagreeing " +
+        "means their allreduce traffic did not cross the bridge")
+
+    // A model built from only one shard cannot see the peer's labels, so its leaves sit far lower.
+    val localModel = await(onNativeThread("lightgbm-single-machine")(trainShard(0, 1)))
+    val distributedMean = leafValues(firstModel).sum / leafValues(firstModel).length
+    val localMean = leafValues(localModel).sum / leafValues(localModel).length
+    assert(math.abs(distributedMean - localMean) > 1.0,
+      s"The distributed leaves ($distributedMean) match a single machine model ($localMean), so the " +
+        "peer's data never reached this worker")
+  }
+}

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMNetworkBridgeLifecycleSuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMNetworkBridgeLifecycleSuite.scala
@@ -1,0 +1,602 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm.split1
+
+import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMNetworkBridge, LightGBMNetworkRelay, NetworkManager,
+  NetworkTopologyInfo, WorkerEndpoint}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funsuite.AnyFunSuite
+import org.slf4j.LoggerFactory
+
+import java.io.{DataInputStream, IOException}
+import java.net.{InetAddress, InetSocketAddress, ServerSocket, Socket}
+import java.nio.channels.ServerSocketChannel
+import java.nio.{ByteBuffer, ByteOrder}
+import java.util.Random
+import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
+import java.util.concurrent.{Callable, ConcurrentLinkedQueue, Executors, TimeUnit}
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+/** Covers what the IPv6 bridge does over the life of a task: admission, concurrency, and cleanup. */
+class LightGBMNetworkBridgeLifecycleSuite extends AnyFunSuite with BeforeAndAfterEach {
+
+  private val log = LoggerFactory.getLogger(classOf[LightGBMNetworkBridgeLifecycleSuite])
+  private val ipv6Loopback = "::1"
+  private val ipv4Loopback = LightGBMNetworkBridge.LoopbackHost
+  private val socketTimeoutMillis = 30000
+  private val smallPayloadSize = 64 * 1024
+  private val concurrentPeers = 8
+  private val sequentialPeers = 8
+  private val largeTopologySize = 33
+  private val stallWriteBytes = 64L * 1024 * 1024
+  private val stallObservationMillis = 2000L
+  private val maxBufferedBytes = 8L * 1024 * 1024
+  private val threadShutdownMillis = 10000L
+  private val unsolicitedConnections = 6
+  private val shortHandshakeMillis = 500L
+  private val closeables = new ConcurrentLinkedQueue[AutoCloseable]()
+  private val pool = Executors.newCachedThreadPool()
+
+  override def afterEach(): Unit = {
+    closeables.asScala.foreach(resource => Try(resource.close()))
+    closeables.clear()
+    super.afterEach()
+  }
+
+  private def register[T <: AutoCloseable](resource: T): T = {
+    closeables.add(resource)
+    resource
+  }
+
+  private def ipv6LoopbackAvailable: Boolean = Try {
+    val probe = new ServerSocket()
+    try {
+      probe.bind(new InetSocketAddress(InetAddress.getByName(ipv6Loopback), 0))
+      true
+    } finally {
+      probe.close()
+    }
+  }.getOrElse(false)
+
+  private def freePort(host: String): Int = {
+    val probe = new ServerSocket()
+    try {
+      probe.bind(new InetSocketAddress(InetAddress.getByName(host), 0))
+      probe.getLocalPort
+    } finally {
+      probe.close()
+    }
+  }
+
+  private def listenOnLoopback(port: Int): ServerSocket = {
+    val listener = new ServerSocket()
+    listener.bind(new InetSocketAddress(InetAddress.getByName(ipv4Loopback), port))
+    listener.setSoTimeout(socketTimeoutMillis)
+    register(listener)
+  }
+
+  private def connect(host: String, port: Int): Socket = {
+    val socket = new Socket()
+    socket.connect(new InetSocketAddress(InetAddress.getByName(host), port), socketTimeoutMillis)
+    socket.setSoTimeout(socketTimeoutMillis)
+    register(socket)
+  }
+
+  private def dialAsRank(port: Int, rank: Int): Socket = {
+    val socket = connect(ipv6Loopback, port)
+    socket.getOutputStream.write(LightGBMNetworkRelay.rankBuffer(rank).array())
+    socket.getOutputStream.flush()
+    socket
+  }
+
+  private def acceptNativeSlot(listener: ServerSocket): (Int, Socket) = {
+    val socket = register(listener.accept())
+    val bytes = new Array[Byte](LightGBMNetworkRelay.RankBytes)
+    new DataInputStream(socket.getInputStream).readFully(bytes)
+    (ByteBuffer.wrap(bytes).order(ByteOrder.nativeOrder()).getInt, socket)
+  }
+
+  /** A machine list where this task is the last entry, so every other machine is a lower rank. */
+  private def machineListWithSelfLast(peerCount: Int, advertisedPort: Int): String =
+    ((1 to peerCount).map(_ => s"[$ipv6Loopback]:${freePort(ipv6Loopback)}") :+
+      s"[$ipv6Loopback]:$advertisedPort").mkString(",")
+
+  private def twoMachineList(selfPort: Int, peerPort: Int): String =
+    s"[$ipv6Loopback]:$selfPort,[$ipv6Loopback]:$peerPort"
+
+  private def payload(seed: Int, size: Int): Array[Byte] = {
+    val bytes = new Array[Byte](size)
+    new Random(seed.toLong).nextBytes(bytes)
+    bytes
+  }
+
+  private def assertPayloadCrosses(sender: Socket, receiver: Socket, bytes: Array[Byte]): Unit = {
+    val received = pool.submit(new Callable[Array[Byte]] {
+      override def call(): Array[Byte] = {
+        val buffer = new Array[Byte](bytes.length)
+        new DataInputStream(receiver.getInputStream).readFully(buffer)
+        buffer
+      }
+    })
+    sender.getOutputStream.write(bytes)
+    sender.getOutputStream.flush()
+    assert(received.get(socketTimeoutMillis.toLong, TimeUnit.MILLISECONDS).sameElements(bytes),
+      "A relayed payload did not arrive intact")
+  }
+
+  private def assertEndOfStream(socket: Socket, clue: String): Unit = {
+    val ended = try {
+      socket.setSoTimeout(socketTimeoutMillis)
+      socket.getInputStream.read() == -1
+    } catch {
+      case _: IOException => true
+    }
+    assert(ended, clue)
+  }
+
+  private def relayThreads(bridge: LightGBMNetworkBridge): Seq[Thread] =
+    Thread.getAllStackTraces.keySet.asScala
+      .filter(thread => thread.isAlive && thread.getName.startsWith(bridge.threadNamePrefix)).toSeq
+
+  private def awaitNoRelayThreads(bridge: LightGBMNetworkBridge): Unit = {
+    val deadline = System.currentTimeMillis() + threadShutdownMillis
+
+    @tailrec
+    def poll(): Seq[Thread] = {
+      val alive = relayThreads(bridge)
+      if (alive.isEmpty || System.currentTimeMillis() > deadline) {
+        alive
+      } else {
+        Thread.sleep(50L)
+        poll()
+      }
+    }
+
+    assert(poll().isEmpty, s"Relay threads of ${bridge.threadNamePrefix} outlived the bridge")
+  }
+
+  private def awaitLinkCount(bridge: LightGBMNetworkBridge, expected: Int, clue: String): Unit = {
+    val deadline = System.currentTimeMillis() + threadShutdownMillis
+
+    @tailrec
+    def poll(): Int = {
+      val count = bridge.relayLinkCount
+      if (count == expected || System.currentTimeMillis() > deadline) count else {
+        Thread.sleep(25L)
+        poll()
+      }
+    }
+
+    assert(poll() == expected, clue)
+  }
+
+  private def assertPortIsFree(port: Int): Unit = {
+    val rebound = new ServerSocket()
+    try {
+      rebound.bind(new InetSocketAddress(port))
+      assert(rebound.isBound)
+    } finally {
+      rebound.close()
+    }
+  }
+
+  test("A connection that never sends its rank is dropped instead of stalling the native listener") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val advertisedPort = freePort(ipv6Loopback)
+    val bridge = register(LightGBMNetworkBridge.open(machineListWithSelfLast(1, advertisedPort),
+      ipv6Loopback, advertisedPort, log, handshakeTimeoutMillis = shortHandshakeMillis))
+    listenOnLoopback(bridge.bridgedNetwork.localListenPort)
+
+    // The native accept loop has no timeout of its own, so a silent caller has to be dropped here.
+    val silent = connect(ipv6Loopback, advertisedPort)
+    assertEndOfStream(silent, "A connection that never sent a rank was left open")
+    awaitLinkCount(bridge, 0, "A dropped handshake still holds a link slot")
+  }
+
+  test("A connection claiming a rank the topology does not have is refused") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val advertisedPort = freePort(ipv6Loopback)
+    // Rank 1 of 2, so rank 0 is the only rank allowed to open a link here.
+    val bridge = register(LightGBMNetworkBridge.open(machineListWithSelfLast(1, advertisedPort),
+      ipv6Loopback, advertisedPort, log))
+    listenOnLoopback(bridge.bridgedNetwork.localListenPort)
+
+    Seq(1, 7, -1).foreach { forged =>
+      val stray = dialAsRank(advertisedPort, forged)
+      assertEndOfStream(stray, s"A connection claiming rank $forged was relayed to the native library")
+    }
+    awaitLinkCount(bridge, 0, "A refused handshake still holds a link slot")
+  }
+
+  test("A second connection claiming an already linked rank is refused") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val advertisedPort = freePort(ipv6Loopback)
+    val bridge = register(LightGBMNetworkBridge.open(machineListWithSelfLast(1, advertisedPort),
+      ipv6Loopback, advertisedPort, log))
+    val nativeListener = listenOnLoopback(bridge.bridgedNetwork.localListenPort)
+    val (claimedRank, nativeSide) = acceptNativeSlot(nativeListener)
+    assert(claimedRank == 0)
+
+    val first = dialAsRank(advertisedPort, 0)
+    assertPayloadCrosses(first, nativeSide, payload(1, 64))
+
+    val impostor = dialAsRank(advertisedPort, 0)
+    assertEndOfStream(impostor, "A duplicate rank was allowed to take over an established link")
+    assertPayloadCrosses(first, nativeSide, payload(2, 64))
+  }
+
+  test("A mixed IPv4 and IPv6 topology relays only its IPv6 peer and still accepts both families") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val advertisedPort = freePort(ipv6Loopback)
+    val ipv4PeerPort = freePort(ipv4Loopback)
+    val ipv6PeerPort = freePort(ipv6Loopback)
+    val machineList = s"$ipv4Loopback:$ipv4PeerPort,[$ipv6Loopback]:$ipv6PeerPort,[$ipv6Loopback]:$advertisedPort"
+    val bridge = register(LightGBMNetworkBridge.open(machineList, ipv6Loopback, advertisedPort, log))
+    val bridged = bridge.bridgedNetwork
+    val entries = bridged.machineList.split(",").toSeq
+
+    // The IPv4 peer keeps its own entry, so the native library dials it with no relay in between.
+    assert(entries(1) == s"$ipv4Loopback:$ipv4PeerPort")
+    assert(WorkerEndpoint.parse(entries(2)).host == ipv4Loopback)
+
+    val nativeListener = listenOnLoopback(bridged.localListenPort)
+    val slots = (1 to 2).map(_ => acceptNativeSlot(nativeListener)).toMap
+    assert(slots.keySet == Set(0, 1))
+
+    // The advertised port is a dual stack listener, so peers of either family land on the native side.
+    val ipv4Peer = connect(ipv4Loopback, advertisedPort)
+    ipv4Peer.getOutputStream.write(LightGBMNetworkRelay.rankBuffer(0).array())
+    ipv4Peer.getOutputStream.flush()
+    assertPayloadCrosses(ipv4Peer, slots(0), payload(1, smallPayloadSize))
+
+    val ipv6Peer = dialAsRank(advertisedPort, 1)
+    assertPayloadCrosses(ipv6Peer, slots(1), payload(2, smallPayloadSize))
+    assertPayloadCrosses(slots(1), ipv6Peer, payload(3, smallPayloadSize))
+  }
+
+  test("Sequential links from every lower rank are served without accumulating threads") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val advertisedPort = freePort(ipv6Loopback)
+    val bridge = register(LightGBMNetworkBridge.open(machineListWithSelfLast(sequentialPeers, advertisedPort),
+      ipv6Loopback, advertisedPort, log))
+    val nativeListener = listenOnLoopback(bridge.bridgedNetwork.localListenPort)
+    val slots = (1 to sequentialPeers).map(_ => acceptNativeSlot(nativeListener)).toMap
+    val threadsAfterStart = relayThreads(bridge).size
+
+    (0 until sequentialPeers).foreach { rank =>
+      val peer = dialAsRank(advertisedPort, rank)
+      assertPayloadCrosses(peer, slots(rank), payload(rank, 4096))
+      peer.close()
+      slots(rank).close()
+    }
+
+    assert(relayThreads(bridge).size == threadsAfterStart,
+      s"The relay thread count changed while serving $sequentialPeers links")
+  }
+
+  test("Concurrent relayed links keep their streams separate") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val advertisedPort = freePort(ipv6Loopback)
+    val bridge = register(LightGBMNetworkBridge.open(machineListWithSelfLast(concurrentPeers, advertisedPort),
+      ipv6Loopback, advertisedPort, log))
+    val nativeListener = listenOnLoopback(bridge.bridgedNetwork.localListenPort)
+    val slots = (1 to concurrentPeers).map(_ => acceptNativeSlot(nativeListener)).toMap
+
+    val peers = (0 until concurrentPeers).map(rank => rank -> dialAsRank(advertisedPort, rank))
+    val transfers = peers.map { case (rank, peer) =>
+      pool.submit(new Runnable {
+        override def run(): Unit = assertPayloadCrosses(peer, slots(rank), payload(rank, smallPayloadSize))
+      })
+    }
+    transfers.foreach(_.get(socketTimeoutMillis.toLong, TimeUnit.MILLISECONDS))
+  }
+
+  test("One relay thread serves a bridge whatever the machine count is") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val smallPort = freePort(ipv6Loopback)
+    val small = register(LightGBMNetworkBridge.open(machineListWithSelfLast(1, smallPort),
+      ipv6Loopback, smallPort, log))
+    val largePort = freePort(ipv6Loopback)
+    val large = register(LightGBMNetworkBridge.open(machineListWithSelfLast(largeTopologySize - 1, largePort),
+      ipv6Loopback, largePort, log))
+    val nativeListener = listenOnLoopback(large.bridgedNetwork.localListenPort)
+    val slots = (1 until largeTopologySize).map(_ => acceptNativeSlot(nativeListener)).toMap
+
+    val peers = (0 until largeTopologySize - 1).map(rank => rank -> dialAsRank(largePort, rank))
+    peers.foreach { case (rank, peer) => assertPayloadCrosses(peer, slots(rank), payload(rank, 1024)) }
+
+    assert(relayThreads(small).size == 1, "A two machine bridge should run exactly one relay thread")
+    assert(relayThreads(large).size == 1,
+      s"A $largeTopologySize machine bridge with ${peers.size} live links should still run one relay thread")
+  }
+
+  test("An abrupt failure on one relay direction closes the other one too") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val advertisedPort = freePort(ipv6Loopback)
+    val bridge = register(LightGBMNetworkBridge.open(machineListWithSelfLast(1, advertisedPort),
+      ipv6Loopback, advertisedPort, log))
+    val nativeListener = listenOnLoopback(bridge.bridgedNetwork.localListenPort)
+    val (_, nativeSide) = acceptNativeSlot(nativeListener)
+    val peer = dialAsRank(advertisedPort, 0)
+    assertPayloadCrosses(peer, nativeSide, payload(1, 64))
+    awaitLinkCount(bridge, 1, "The established link was not counted")
+
+    // A reset, which is what a killed executor or a dropped route looks like to the other side.
+    nativeSide.setSoLinger(true, 0)
+    nativeSide.close()
+
+    assertEndOfStream(peer, "The peer was left waiting on a link whose other half had failed")
+    awaitLinkCount(bridge, 0, "An aborted link never released its slot")
+  }
+
+  test("A stalled reader stops the sender instead of buffering inside the bridge") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val advertisedPort = freePort(ipv6Loopback)
+    val bridge = register(LightGBMNetworkBridge.open(machineListWithSelfLast(1, advertisedPort),
+      ipv6Loopback, advertisedPort, log))
+    val nativeListener = listenOnLoopback(bridge.bridgedNetwork.localListenPort)
+    val (_, nativeSide) = acceptNativeSlot(nativeListener)  // deliberately never read from again
+    val peer = dialAsRank(advertisedPort, 0)
+
+    val accepted = new AtomicLong(0)
+    pool.submit(new Runnable {
+      override def run(): Unit = {
+        val chunk = new Array[Byte](64 * 1024)
+
+        @tailrec
+        def writeChunk(): Unit = {
+          if (accepted.get() < stallWriteBytes) {
+            peer.getOutputStream.write(chunk)
+            accepted.addAndGet(chunk.length.toLong)
+            writeChunk()
+          }
+        }
+
+        Try(writeChunk())
+      }
+    })
+    Thread.sleep(stallObservationMillis)
+
+    val buffered = accepted.get()
+    assert(buffered < maxBufferedBytes,
+      s"The bridge absorbed $buffered bytes for a reader that never read, so backpressure is not reaching the peer")
+    assert(buffered > 0, "The relay never forwarded anything to the stalled reader")
+    assert(nativeSide.isConnected)
+  }
+
+  test("Closing the bridge ends its relay thread, which is a daemon") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val advertisedPort = freePort(ipv6Loopback)
+    val bridge = LightGBMNetworkBridge.open(machineListWithSelfLast(1, advertisedPort),
+      ipv6Loopback, advertisedPort, log)
+    val nativeListener = listenOnLoopback(bridge.bridgedNetwork.localListenPort)
+    acceptNativeSlot(nativeListener)
+    val peer = dialAsRank(advertisedPort, 0)
+
+    val running = relayThreads(bridge)
+    assert(running.size == 1, "The bridge should run exactly one relay thread")
+    assert(running.forall(_.isDaemon), "A relay thread would keep the executor JVM alive after training")
+
+    bridge.close()
+    awaitNoRelayThreads(bridge)
+    assertPortIsFree(advertisedPort)
+    Try(peer.close())
+  }
+
+  test("Cleanup after a cancelled task closes the bridge and preserves the interrupt") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val advertisedPort = freePort(ipv6Loopback)
+    val topology = NetworkTopologyInfo(twoMachineList(advertisedPort, freePort(ipv6Loopback)),
+      Array(0), advertisedPort).withAdvertisedHost(ipv6Loopback)
+    NetworkManager.initNativeNetwork(topology, 2, log, (_, _, _) => ())
+    assert(topology.hasNetworkBridge)
+
+    // Spark cancels a task by interrupting its thread, and cleanup still has to finish.
+    Thread.currentThread().interrupt()
+    try {
+      topology.releaseNetworkResources()
+      assert(Thread.currentThread().isInterrupted,
+        "Bridge cleanup swallowed the interrupt that tells Spark the task was cancelled")
+    } finally {
+      Thread.interrupted()
+    }
+    assert(!topology.hasNetworkBridge)
+    assertPortIsFree(advertisedPort)
+  }
+
+  test("A failed native init closes the bridge so the advertised port is free for the retry") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val advertisedPort = freePort(ipv6Loopback)
+    val topology = NetworkTopologyInfo(twoMachineList(advertisedPort, freePort(ipv6Loopback)),
+      Array(0), advertisedPort).withAdvertisedHost(ipv6Loopback)
+
+    val failure = intercept[RuntimeException] {
+      NetworkManager.initNativeNetwork(topology, 2, log,
+        (_, _, _) => throw new RuntimeException("native init failed"))
+    }
+
+    assert(failure.getMessage.contains("native init failed"))
+    assert(!topology.hasNetworkBridge, "A bridge outlived the native failure it was opened for")
+    assertPortIsFree(advertisedPort)
+    val reservation = NetworkManager.reserveExactPort(advertisedPort, log)
+    try {
+      assert(reservation.getLocalPort == advertisedPort)
+    } finally {
+      reservation.close()
+    }
+  }
+
+  test("The native init retry rebinds the advertised port and rebuilds the bridge on every attempt") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val advertisedPort = freePort(ipv6Loopback)
+    val topology = NetworkTopologyInfo(twoMachineList(advertisedPort, freePort(ipv6Loopback)),
+      Array(0), advertisedPort).withAdvertisedHost(ipv6Loopback)
+    val attempts = new AtomicInteger(0)
+    val nativePorts = new ConcurrentLinkedQueue[Int]()
+    val machineLists = new ConcurrentLinkedQueue[String]()
+
+    NetworkManager.initLightGBMNetworkWithRetry(
+      topology,
+      log,
+      retry = 2,
+      delay = 1L,
+      networkInit = () => NetworkManager.initNativeNetwork(topology, 2, log, (machines, port, _) => {
+        machineLists.add(machines)
+        nativePorts.add(port)
+        if (attempts.incrementAndGet() < 3) throw new RuntimeException("native init failed")
+      }),
+      reservePort = port => NetworkManager.reserveExactPort(port, log),
+      sleep = _ => ())
+
+    assert(attempts.get() == 3, "The retry did not reach the attempt that succeeds")
+    assert(machineLists.asScala.forall(_.startsWith(s"${LightGBMNetworkBridge.RankPrefix}0,")),
+      "Every attempt has to pin the rank for the native library")
+    assert(nativePorts.asScala.forall(_ != advertisedPort),
+      "The native listener must never be given the port the bridge owns")
+    assert(topology.hasNetworkBridge, "The successful attempt did not keep its bridge")
+
+    topology.releaseNetworkResources()
+    assertPortIsFree(advertisedPort)
+  }
+
+  /** A connect that fails the way an address with no route does: synchronously, on the caller. */
+  private def failingConnect(failuresPerAddress: Int,
+                             matches: InetSocketAddress => Boolean,
+                             attempts: AtomicInteger): LightGBMNetworkRelay.ConnectAttempt =
+    (channel, address) => {
+      if (matches(address) && attempts.incrementAndGet() <= failuresPerAddress) {
+        throw new java.net.SocketException("Network is unreachable")
+      }
+      LightGBMNetworkRelay.DefaultConnect(channel, address)
+    }
+
+  private def isLoopbackAddress(address: InetSocketAddress): Boolean =
+    address.getAddress.isLoopbackAddress
+
+  test("A dial that fails synchronously is retried on the timer until it connects") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val advertisedPort = freePort(ipv6Loopback)
+    val attempts = new AtomicInteger(0)
+    // The native link slot is claimed over loopback, so this fails that dial three times first.
+    val bridge = register(LightGBMNetworkBridge.open(machineListWithSelfLast(1, advertisedPort),
+      ipv6Loopback, advertisedPort, log, connectAttempt = failingConnect(3, isLoopbackAddress, attempts)))
+    val nativeListener = listenOnLoopback(bridge.bridgedNetwork.localListenPort)
+
+    val (claimedRank, nativeSide) = acceptNativeSlot(nativeListener)
+    assert(claimedRank == 0, "The retried dial did not claim the slot for the lower rank")
+    assert(attempts.get() > 3, "The connect hook was not exercised")
+    assert(bridge.terminalFailure.isEmpty, "A retried failure was recorded as terminal")
+
+    val peer = dialAsRank(advertisedPort, 0)
+    assertPayloadCrosses(peer, nativeSide, payload(1, smallPayloadSize))
+  }
+
+  test("A peer that can never be reached releases its slot, keeps the listener, and is recorded") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val peerPort = freePort(ipv6Loopback)
+    val advertisedPort = freePort(ipv6Loopback)
+    val attempts = new AtomicInteger(0)
+    // Every dial to the peer fails synchronously, which is what ENETUNREACH looks like.
+    val bridge = register(LightGBMNetworkBridge.open(
+      s"[$ipv6Loopback]:$advertisedPort,[$ipv6Loopback]:$peerPort", ipv6Loopback, advertisedPort, log,
+      connectTimeoutMillis = 300L,
+      connectAttempt = failingConnect(Int.MaxValue, address => address.getPort == peerPort, attempts)))
+    val relayPort = WorkerEndpoint.parse(bridge.bridgedNetwork.machineList.split(",")(2)).port
+
+    val nativeSide = connect(ipv4Loopback, relayPort)
+    assertEndOfStream(nativeSide, "The native link was left open although its peer was unreachable")
+    awaitLinkCount(bridge, 0, "An unreachable peer never released its link slot")
+    assert(attempts.get() > 1, "The dial was not retried before giving up")
+
+    // The listener has to survive the failure of the connection it accepted.
+    val second = connect(ipv4Loopback, relayPort)
+    assertEndOfStream(second, "The outbound listener stopped serving after a failed dial")
+    awaitLinkCount(bridge, 0, "The second attempt never released its link slot")
+    assert(bridge.terminalFailure.isDefined, "An unreachable peer was not recorded as a terminal failure")
+  }
+
+  test("A terminal relay failure fails the native init path instead of leaving the task waiting") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val peerPort = freePort(ipv6Loopback)
+    val advertisedPort = freePort(ipv6Loopback)
+    val attempts = new AtomicInteger(0)
+    val bridge = register(LightGBMNetworkBridge.open(
+      s"[$ipv6Loopback]:$advertisedPort,[$ipv6Loopback]:$peerPort", ipv6Loopback, advertisedPort, log,
+      connectTimeoutMillis = 300L,
+      connectAttempt = failingConnect(Int.MaxValue, address => address.getPort == peerPort, attempts)))
+    val relayPort = WorkerEndpoint.parse(bridge.bridgedNetwork.machineList.split(",")(2)).port
+    val nativeSide = connect(ipv4Loopback, relayPort)
+    assertEndOfStream(nativeSide, "The native link was left open although its peer was unreachable")
+
+    val failure = intercept[Exception](NetworkManager.failIfBridgeIsBroken(bridge))
+    assert(failure.getMessage.contains("network bridge for this task failed"))
+    assert(failure.getMessage.contains("could not reach"))
+  }
+
+  test("A peer that disconnects mid handshake leaves the advertised listener serving") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val advertisedPort = freePort(ipv6Loopback)
+    val bridge = register(LightGBMNetworkBridge.open(machineListWithSelfLast(1, advertisedPort),
+      ipv6Loopback, advertisedPort, log))
+    val nativeListener = listenOnLoopback(bridge.bridgedNetwork.localListenPort)
+    val (_, nativeSide) = acceptNativeSlot(nativeListener)
+
+    // A half sent rank followed by a reset, which is what a killed peer looks like.
+    val aborted = connect(ipv6Loopback, advertisedPort)
+    aborted.getOutputStream.write(Array[Byte](0, 0))
+    aborted.getOutputStream.flush()
+    aborted.setSoLinger(true, 0)
+    aborted.close()
+    awaitLinkCount(bridge, 0, "An aborted handshake never released its link slot")
+
+    val peer = dialAsRank(advertisedPort, 0)
+    assertPayloadCrosses(peer, nativeSide, payload(2, smallPayloadSize))
+  }
+
+  test("Unsolicited connections to the lowest rank never consume the links its peers need") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    // Rank 0 is the only rank no machine opens a link to, so every inbound connection is unsolicited.
+    val advertisedPort = freePort(ipv6Loopback)
+    val peerListener = ServerSocketChannel.open()
+    peerListener.bind(new InetSocketAddress(InetAddress.getByName(ipv6Loopback), 0))
+    register(peerListener)
+    val peerPort = peerListener.socket().getLocalPort
+    val machineList = s"[$ipv6Loopback]:$advertisedPort,[$ipv6Loopback]:$peerPort"
+    val bridge = register(LightGBMNetworkBridge.open(machineList, ipv6Loopback, advertisedPort, log))
+    assert(bridge.bridgedNetwork.rank == 0)
+
+    // More than the two machine cap allows, so a slot leaked per refusal would exhaust it.
+    (1 to unsolicitedConnections).foreach { attempt =>
+      val stray = connect(ipv6Loopback, advertisedPort)
+      assertEndOfStream(stray, s"Unsolicited connection $attempt was not refused")
+    }
+    awaitLinkCount(bridge, 0, "Refusing an unsolicited connection consumed a link slot")
+
+    // The native library can still open its own outbound link, which draws on the same cap.
+    val relayPort = WorkerEndpoint.parse(bridge.bridgedNetwork.machineList.split(",")(2)).port
+    val nativeSide = connect(ipv4Loopback, relayPort)
+    val peerSide = register(peerListener.accept().socket())
+    peerSide.setSoTimeout(socketTimeoutMillis)
+    assertPayloadCrosses(nativeSide, peerSide, payload(7, smallPayloadSize))
+    awaitLinkCount(bridge, 1, "The native outbound link was not admitted after the refusals")
+  }
+
+  test("NetworkTopologyInfo keeps the three field shape callers and serialized forms depend on") {
+    val partitions = Array(0, 1)
+    val topology = NetworkTopologyInfo("10.0.0.4:12400", partitions, 12400)
+    assert(topology.productArity == 3)
+    assert(NetworkTopologyInfo.unapply(topology).map { case (machines, ids, port) =>
+      (machines, ids.toSeq, port)
+    }.contains(("10.0.0.4:12400", Seq(0, 1), 12400)))
+    assert(topology.copy(localListenPort = 12401).localListenPort == 12401)
+
+    // The advertised host is task local state, so it changes neither the shape nor equality.
+    val withHost = topology.withAdvertisedHost("2001:db8::1")
+    assert(withHost.taskHost == "2001:db8::1")
+    assert(withHost == NetworkTopologyInfo("10.0.0.4:12400", partitions, 12400).withAdvertisedHost("other"))
+    assert(NetworkTopologyInfo("10.0.0.4:12400", partitions, 12400).taskHost.isEmpty)
+  }
+}

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMNetworkBridgeLifecycleSuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMNetworkBridgeLifecycleSuite.scala
@@ -15,7 +15,7 @@ import java.nio.channels.ServerSocketChannel
 import java.nio.{ByteBuffer, ByteOrder}
 import java.util.Random
 import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
-import java.util.concurrent.{Callable, ConcurrentLinkedQueue, Executors, TimeUnit}
+import java.util.concurrent.{Callable, ConcurrentLinkedQueue, Executors, ThreadFactory, TimeUnit}
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.util.Try
@@ -38,7 +38,13 @@ class LightGBMNetworkBridgeLifecycleSuite extends AnyFunSuite with BeforeAndAfte
   private val unsolicitedConnections = 6
   private val shortHandshakeMillis = 500L
   private val closeables = new ConcurrentLinkedQueue[AutoCloseable]()
-  private val pool = Executors.newCachedThreadPool()
+  private val pool = Executors.newCachedThreadPool(new ThreadFactory {
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = new Thread(runnable, "lightgbm-network-bridge-lifecycle-test")
+      thread.setDaemon(true)
+      thread
+    }
+  })
 
   override def afterEach(): Unit = {
     closeables.asScala.foreach(resource => Try(resource.close()))

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMNetworkBridgeSuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMNetworkBridgeSuite.scala
@@ -1,0 +1,355 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm.split1
+
+import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMNetworkBridge, LightGBMNetworkRelay, WorkerEndpoint}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funsuite.AnyFunSuite
+import org.slf4j.LoggerFactory
+
+import java.io.{DataInputStream, IOException}
+import java.net.{InetAddress, InetSocketAddress, NetworkInterface, ServerSocket, Socket}
+import java.nio.{ByteBuffer, ByteOrder}
+import java.util.Random
+import java.util.concurrent.{Callable, ConcurrentLinkedQueue, Executors, TimeUnit}
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+/** Covers the IPv6 transport bridge that carries the LightGBM traffic the native library cannot. */
+class LightGBMNetworkBridgeSuite extends AnyFunSuite with BeforeAndAfterEach {
+
+  private val log = LoggerFactory.getLogger(classOf[LightGBMNetworkBridgeSuite])
+  private val socketTimeoutMillis = 30000
+  private val ipv6Loopback = "::1"
+  private val payloadSize = 1 << 20
+  private val closeables = new ConcurrentLinkedQueue[AutoCloseable]()
+  private val pool = Executors.newCachedThreadPool()
+
+  override def afterEach(): Unit = {
+    closeables.asScala.foreach(resource => Try(resource.close()))
+    closeables.clear()
+    super.afterEach()
+  }
+
+  private def register[T <: AutoCloseable](resource: T): T = {
+    closeables.add(resource)
+    resource
+  }
+
+  private def ipv6LoopbackAvailable: Boolean = Try {
+    val probe = new ServerSocket()
+    try {
+      probe.bind(new InetSocketAddress(InetAddress.getByName(ipv6Loopback), 0))
+      true
+    } finally {
+      probe.close()
+    }
+  }.getOrElse(false)
+
+  private def listenOnIpv6(): ServerSocket = {
+    val listener = new ServerSocket()
+    listener.bind(new InetSocketAddress(InetAddress.getByName(ipv6Loopback), 0))
+    listener.setSoTimeout(socketTimeoutMillis)
+    register(listener)
+  }
+
+  private def listenOnLoopback(port: Int): ServerSocket = {
+    val listener = new ServerSocket()
+    listener.bind(new InetSocketAddress(InetAddress.getByName(LightGBMNetworkBridge.LoopbackHost), port))
+    listener.setSoTimeout(socketTimeoutMillis)
+    register(listener)
+  }
+
+  private def freeIpv6Port(): Int = {
+    val probe = new ServerSocket()
+    try {
+      probe.bind(new InetSocketAddress(InetAddress.getByName(ipv6Loopback), 0))
+      probe.getLocalPort
+    } finally {
+      probe.close()
+    }
+  }
+
+  private def connect(host: String, port: Int): Socket = {
+    val socket = new Socket()
+    socket.connect(new InetSocketAddress(InetAddress.getByName(host), port), socketTimeoutMillis)
+    socket.setSoTimeout(socketTimeoutMillis)
+    register(socket)
+  }
+
+  /** Stand in for a peer opening a LightGBM link, which starts by sending its own rank. */
+  private def dialAsRank(port: Int, rank: Int, host: String = "::1"): Socket = {
+    val socket = connect(host, port)
+    socket.getOutputStream.write(LightGBMNetworkRelay.rankBuffer(rank).array())
+    socket.getOutputStream.flush()
+    socket
+  }
+
+  /** Stand in for the native listener, which the bridge claims a link slot on for every lower rank. */
+  private def acceptNativeSlot(listener: ServerSocket): (Int, Socket) = {
+    val socket = register(listener.accept())
+    val bytes = new Array[Byte](LightGBMNetworkRelay.RankBytes)
+    new DataInputStream(socket.getInputStream).readFully(bytes)
+    (ByteBuffer.wrap(bytes).order(ByteOrder.nativeOrder()).getInt, socket)
+  }
+
+  private def endpoint(entry: String): WorkerEndpoint = WorkerEndpoint.parse(entry)
+
+  private def bridgedEntries(machineList: String): Seq[String] = machineList.split(",").toSeq
+
+  private def randomPayload(size: Int): Array[Byte] = {
+    val payload = new Array[Byte](size)
+    new Random(size.toLong).nextBytes(payload)
+    payload
+  }
+
+  private def assertPayloadCrosses(sender: Socket, receiver: Socket, payload: Array[Byte]): Unit = {
+    val received = pool.submit(new Callable[Array[Byte]] {
+      override def call(): Array[Byte] = {
+        val buffer = new Array[Byte](payload.length)
+        new DataInputStream(receiver.getInputStream).readFully(buffer)
+        buffer
+      }
+    })
+    sender.getOutputStream.write(payload)
+    sender.getOutputStream.flush()
+    assert(received.get(socketTimeoutMillis.toLong, TimeUnit.MILLISECONDS).sameElements(payload),
+      "The relayed payload did not arrive intact")
+  }
+
+  private def assertEndOfStream(socket: Socket, clue: String): Unit = {
+    val ended = try {
+      socket.getInputStream.read() == -1
+    } catch {
+      // A reset is the other legitimate way for the far side to report that it is gone.
+      case _: IOException => true
+    }
+    assert(ended, clue)
+  }
+
+  test("An IPv4 machine list never needs the bridge") {
+    assert(!LightGBMNetworkBridge.requiresBridge("127.0.0.1:12400,10.0.0.4:12400"))
+    assert(!LightGBMNetworkBridge.requiresBridge("worker-1:12400,worker-2:12401"))
+    assert(!LightGBMNetworkBridge.requiresBridge(""))
+    assert(!LightGBMNetworkBridge.requiresBridge(None.orNull))
+  }
+
+  test("Every IPv6 machine list form needs the bridge") {
+    assert(LightGBMNetworkBridge.requiresBridge("[2001:db8::1]:12400,[2001:db8::2]:12400"))
+    assert(LightGBMNetworkBridge.requiresBridge("2001:db8::1:12400"))
+    assert(LightGBMNetworkBridge.requiresBridge("[fe80::1%eth0]:12400"))
+    // A single IPv6 machine in an otherwise IPv4 list is still unreachable for the native library.
+    assert(LightGBMNetworkBridge.requiresBridge("10.0.0.4:12400,[2001:db8::2]:12400"))
+  }
+
+  test("Machine list parsing keeps entry order and rejects malformed entries") {
+    val parsed = LightGBMNetworkBridge.parseMachineList(" [2001:db8::2]:12401 ,10.0.0.4:12400 ")
+    assert(parsed.map(_.wireString) == Seq("[2001:db8::2]:12401", "10.0.0.4:12400"))
+    assert(intercept[IllegalArgumentException](LightGBMNetworkBridge.parseMachineList("")).getMessage
+      .contains("does not contain any endpoint"))
+    assert(intercept[IllegalArgumentException](LightGBMNetworkBridge.parseMachineList("[2001:db8::2]"))
+      .getMessage.contains("missing its port"))
+  }
+
+  test("A task finds its own machine list entry even when peers share its host or port") {
+    val entries = Seq("[2001:db8::1]:12400", "[2001:db8::2]:12400", "[2001:db8::2]:12401").map(endpoint)
+    assert(LightGBMNetworkBridge.findSelf(entries, "2001:db8::2", 12400) == 1)
+    assert(LightGBMNetworkBridge.findSelf(entries, "2001:db8::1", 12400) == 0)
+    assert(LightGBMNetworkBridge.findSelf(entries, "2001:db8::2", 12401) == 2)
+    // A host written in a different but equivalent form still resolves to the same entry.
+    assert(LightGBMNetworkBridge.findSelf(entries, "2001:0db8:0000:0000:0000:0000:0000:0002", 12401) == 2)
+    // A unique port identifies the entry even when the reported host was not preserved.
+    assert(LightGBMNetworkBridge.findSelf(entries, "", 12401) == 2)
+  }
+
+  test("A machine list without this task's endpoint fails with an actionable error") {
+    val entries = Seq("[2001:db8::1]:12400", "[2001:db8::2]:12400").map(endpoint)
+    val failure = intercept[IllegalArgumentException](LightGBMNetworkBridge.findSelf(entries, "2001:db8::9", 12999))
+    assert(failure.getMessage.contains("does not contain this task's own endpoint"))
+    assert(failure.getMessage.contains("[2001:db8::9]:12999"))
+  }
+
+  test("The bridged machine list keeps entry order, pins the rank, and only relays IPv6 peers") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val advertisedPort = freeIpv6Port()
+    val peerPort = freeIpv6Port()
+    val machineList = s"[$ipv6Loopback]:$peerPort,10.0.0.4:12400,[$ipv6Loopback]:$advertisedPort"
+    val bridge = register(LightGBMNetworkBridge.open(machineList, ipv6Loopback, advertisedPort, log))
+
+    val bridged = bridge.bridgedNetwork
+    val entries = bridgedEntries(bridged.machineList)
+    assert(entries.head == s"${LightGBMNetworkBridge.RankPrefix}2", "The rank has to be pinned for the native library")
+    assert(entries.length == 4)
+    assert(bridged.machineCount == 3, "The bridge must not change the number of machines")
+    assert(bridged.rank == 2)
+    // The IPv4 peer stays a direct native connection; the IPv6 peer and this task are relayed.
+    assert(endpoint(entries(1)).host == LightGBMNetworkBridge.LoopbackHost)
+    assert(entries(2) == "10.0.0.4:12400")
+    assert(endpoint(entries(3)) ==
+      WorkerEndpoint.parse(s"${LightGBMNetworkBridge.LoopbackHost}:${bridged.localListenPort}"))
+    assert(bridged.localListenPort != advertisedPort,
+      "The native listener needs its own port, because the bridge owns the advertised one")
+  }
+
+  test("The bridge claims a native link slot for every lower rank as soon as the port is bound") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    // Rank 2 of 3, so the native listener would accept two links before closing itself.
+    val advertisedPort = freeIpv6Port()
+    val machineList = s"[$ipv6Loopback]:${freeIpv6Port()},[$ipv6Loopback]:${freeIpv6Port()}," +
+      s"[$ipv6Loopback]:$advertisedPort"
+    val bridge = register(LightGBMNetworkBridge.open(machineList, ipv6Loopback, advertisedPort, log))
+    val nativeListener = listenOnLoopback(bridge.bridgedNetwork.localListenPort)
+
+    // No peer has connected yet, so these can only be the bridge claiming the slots from loopback.
+    val claimed = (1 to 2).map(_ => acceptNativeSlot(nativeListener))
+    assert(claimed.map { case (rank, _) => rank }.toSet == Set(0, 1),
+      "The bridge has to identify each claimed slot with the rank that will use it")
+    claimed.foreach { case (_, socket) =>
+      assert(socket.getInetAddress.isLoopbackAddress, "A native link slot was claimed from off the machine")
+    }
+  }
+
+  test("Peer traffic arriving over IPv6 reaches the native listener and flows both ways") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val advertisedPort = freeIpv6Port()
+    val peerPort = freeIpv6Port()
+    val machineList = s"[$ipv6Loopback]:$peerPort,[$ipv6Loopback]:$advertisedPort"
+    val bridge = register(LightGBMNetworkBridge.open(machineList, ipv6Loopback, advertisedPort, log))
+    val bridged = bridge.bridgedNetwork
+
+    // Stand in for the native LightGBM listener, which only ever binds an IPv4 socket.
+    val nativeListener = listenOnLoopback(bridged.localListenPort)
+    val (claimedRank, nativeConnection) = acceptNativeSlot(nativeListener)
+    assert(claimedRank == 0)
+
+    val peerConnection = dialAsRank(advertisedPort, 0)
+    assertPayloadCrosses(peerConnection, nativeConnection, randomPayload(payloadSize))
+    assertPayloadCrosses(nativeConnection, peerConnection, randomPayload(payloadSize))
+
+    // LightGBM ends a link by closing it, so the half close has to reach the peer.
+    nativeConnection.shutdownOutput()
+    assertEndOfStream(peerConnection, "The peer never saw the native end of stream")
+  }
+
+  test("Native traffic to an IPv6 peer is relayed to that peer's real address") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val peerListener = listenOnIpv6()
+    val advertisedPort = freeIpv6Port()
+    val machineList = s"[$ipv6Loopback]:$advertisedPort,[$ipv6Loopback]:${peerListener.getLocalPort}"
+    val bridge = register(LightGBMNetworkBridge.open(machineList, ipv6Loopback, advertisedPort, log))
+    val bridged = bridge.bridgedNetwork
+
+    // The native library dials the loopback entry the bridge published for machine 1.
+    val relayPort = endpoint(bridgedEntries(bridged.machineList)(2)).port
+    val nativeConnection = connect(LightGBMNetworkBridge.LoopbackHost, relayPort)
+    val peerConnection = register(peerListener.accept())
+
+    assertPayloadCrosses(nativeConnection, peerConnection, randomPayload(payloadSize))
+    assertPayloadCrosses(peerConnection, nativeConnection, randomPayload(payloadSize))
+  }
+
+  test("A rank handshake in the LightGBM wire form survives the bridge") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    // An outbound link is forwarded verbatim, so the peer reads the rank the native library sent.
+    val peerListener = listenOnIpv6()
+    val advertisedPort = freeIpv6Port()
+    val machineList = s"[$ipv6Loopback]:$advertisedPort,[$ipv6Loopback]:${peerListener.getLocalPort}"
+    val bridge = register(LightGBMNetworkBridge.open(machineList, ipv6Loopback, advertisedPort, log))
+    val relayPort = endpoint(bridgedEntries(bridge.bridgedNetwork.machineList)(2)).port
+
+    val nativeConnection = connect(LightGBMNetworkBridge.LoopbackHost, relayPort)
+    nativeConnection.getOutputStream.write(LightGBMNetworkRelay.rankBuffer(0).array())
+    nativeConnection.getOutputStream.flush()
+
+    val peerConnection = register(peerListener.accept())
+    val rankBytes = new Array[Byte](LightGBMNetworkRelay.RankBytes)
+    new DataInputStream(peerConnection.getInputStream).readFully(rankBytes)
+    assert(ByteBuffer.wrap(rankBytes).order(ByteOrder.nativeOrder()).getInt == 0)
+  }
+
+  test("A relayed connection whose far side never answers is closed instead of stalling LightGBM") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val deadPeerPort = freeIpv6Port()
+    val advertisedPort = freeIpv6Port()
+    val machineList = s"[$ipv6Loopback]:$advertisedPort,[$ipv6Loopback]:$deadPeerPort"
+    val bridge = register(
+      LightGBMNetworkBridge.open(machineList, ipv6Loopback, advertisedPort, log, connectTimeoutMillis = 200L))
+    val relayPort = endpoint(bridgedEntries(bridge.bridgedNetwork.machineList)(2)).port
+
+    val nativeConnection = connect(LightGBMNetworkBridge.LoopbackHost, relayPort)
+    // Nothing is listening on the peer port, so the relay gives up and closes the native side.
+    assertEndOfStream(nativeConnection,
+      "The bridge kept a relayed connection open even though its far side was unreachable")
+  }
+
+  test("An IPv6 link-local peer is only accepted with a zone this machine can resolve") {
+    val unscoped = intercept[IllegalArgumentException](
+      LightGBMNetworkBridge.resolvePeer(endpoint("[fe80::1]:12400"), log))
+    assert(unscoped.getMessage.contains("has to advertise a zone identifier"))
+
+    val unknownZone = intercept[IllegalArgumentException](
+      LightGBMNetworkBridge.resolvePeer(endpoint("[fe80::1%no-such-interface]:12400"), log))
+    assert(unknownZone.getMessage.contains("does not name an interface on this machine"))
+
+    // A zone this machine does know keeps its scope all the way through resolution.
+    val scopedZone = NetworkInterface.getNetworkInterfaces.asScala.map(_.getName)
+      .find(name => Try(InetAddress.getByName(s"fe80::1%$name")).isSuccess)
+    scopedZone.foreach { zone =>
+      val resolved = LightGBMNetworkBridge.resolvePeer(endpoint(s"[fe80::1%$zone]:12400"), log)
+      assert(resolved.isLinkLocalAddress)
+      assert(resolved.getHostAddress.contains("%"), "The resolved link-local address lost its zone")
+    }
+  }
+
+  test("A numeric IPv6 scope is normalized before it is published and rejected when a peer sends one") {
+    // An interface index only means something on the machine that produced it.
+    val named = NetworkInterface.getNetworkInterfaces.asScala.find(_.getIndex > 0)
+    named.foreach { candidate =>
+      val normalized = WorkerEndpoint.normalizeHost(s"fe80::1%${candidate.getIndex}")
+      assert(normalized == s"fe80::1%${candidate.getName}",
+        s"A numeric scope was published as is instead of as an interface name")
+    }
+    assert(WorkerEndpoint.normalizeHost("10.0.0.4") == "10.0.0.4")
+    assert(WorkerEndpoint.normalizeHost("fe80::1%eth0") == "fe80::1%eth0")
+
+    val numericPeer = intercept[IllegalArgumentException](
+      LightGBMNetworkBridge.resolvePeer(endpoint("[fe80::1%3]:12400"), log))
+    assert(numericPeer.getMessage.contains("numeric interface index"))
+  }
+
+  test("A JVM pinned to the IPv4 stack is told why it cannot join an IPv6 network") {
+    val property = "java.net.preferIPv4Stack"
+    val previous = Option(System.getProperty(property))
+    try {
+      System.setProperty(property, "true")
+      val failure = intercept[IllegalStateException](
+        LightGBMNetworkBridge.open("[2001:db8::1]:12400,[2001:db8::2]:12400", "2001:db8::1", 12400, log))
+      assert(failure.getMessage.contains("-Djava.net.preferIPv4Stack=true"))
+    } finally {
+      previous.map(value => System.setProperty(property, value)).getOrElse(System.clearProperty(property))
+    }
+  }
+
+  test("Closing the bridge releases the advertised port and its relay ports") {
+    assume(ipv6LoopbackAvailable, "IPv6 loopback is not available on this machine")
+    val advertisedPort = freeIpv6Port()
+    val peerPort = freeIpv6Port()
+    val machineList = s"[$ipv6Loopback]:$advertisedPort,[$ipv6Loopback]:$peerPort"
+    val bridge = LightGBMNetworkBridge.open(machineList, ipv6Loopback, advertisedPort, log)
+    val relayPort = endpoint(bridgedEntries(bridge.bridgedNetwork.machineList)(2)).port
+
+    bridge.close()
+    bridge.close()  // The training path can close a bridge more than once.
+
+    Seq(advertisedPort, relayPort).foreach { port =>
+      val rebound = new ServerSocket()
+      try {
+        rebound.bind(new InetSocketAddress(port))
+        assert(rebound.isBound)
+      } finally {
+        rebound.close()
+      }
+    }
+  }
+}

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMNetworkBridgeSuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMNetworkBridgeSuite.scala
@@ -12,7 +12,7 @@ import java.io.{DataInputStream, IOException}
 import java.net.{InetAddress, InetSocketAddress, NetworkInterface, ServerSocket, Socket}
 import java.nio.{ByteBuffer, ByteOrder}
 import java.util.Random
-import java.util.concurrent.{Callable, ConcurrentLinkedQueue, Executors, TimeUnit}
+import java.util.concurrent.{Callable, ConcurrentLinkedQueue, Executors, ThreadFactory, TimeUnit}
 import scala.collection.JavaConverters._
 import scala.util.Try
 
@@ -24,7 +24,13 @@ class LightGBMNetworkBridgeSuite extends AnyFunSuite with BeforeAndAfterEach {
   private val ipv6Loopback = "::1"
   private val payloadSize = 1 << 20
   private val closeables = new ConcurrentLinkedQueue[AutoCloseable]()
-  private val pool = Executors.newCachedThreadPool()
+  private val pool = Executors.newCachedThreadPool(new ThreadFactory {
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = new Thread(runnable, "lightgbm-network-bridge-test")
+      thread.setDaemon(true)
+      thread
+    }
+  })
 
   override def afterEach(): Unit = {
     closeables.asScala.foreach(resource => Try(resource.close()))

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/TrainUtilsSuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/TrainUtilsSuite.scala
@@ -3,10 +3,13 @@
 
 package com.microsoft.azure.synapse.ml.lightgbm.split1
 
-import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMRegressor, TrainUtils}
+import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMRegressor, NetworkManager, TrainUtils}
 import org.scalatest.funsuite.AnyFunSuite
+import org.slf4j.LoggerFactory
 
 class TrainUtilsSuite extends AnyFunSuite {
+
+  private val log = LoggerFactory.getLogger(classOf[TrainUtilsSuite])
 
   private val lowerIsBetterMetrics = Seq(
     "rmse",
@@ -59,6 +62,75 @@ class TrainUtilsSuite extends AnyFunSuite {
         assert(!TrainUtils.isImprovement(metric, bestScore - margin, bestScore, tolerance))
       }
     }
+  }
+
+  test("Main worker endpoint parser keeps hostname and IPv4 behavior") {
+    val endpoints = Seq(
+      "worker.example.test:12404" -> ("worker.example.test", 12404),
+      "localhost:80" -> ("localhost", 80),
+      "192.0.2.10:65535" -> ("192.0.2.10", 65535),
+      "127.0.0.1:00080" -> ("127.0.0.1", 80))
+
+    endpoints.foreach { case (endpoint, expected) =>
+      assert(NetworkManager.parseHostAndPort(endpoint) == expected)
+      assert(NetworkManager.getMainWorkerPort(s"$endpoint,backup.example.test:12405", log) == expected._2)
+    }
+  }
+
+  test("Main worker endpoint parser supports bracketed and practical bare IPv6") {
+    val endpoints = Seq(
+      "[2001:db8::1]:12404" -> ("2001:db8::1", 12404),
+      "2001:db8::1:12404" -> ("2001:db8::1", 12404),
+      "2001:db8:0:1:2:3:4:5:12404" -> ("2001:db8:0:1:2:3:4:5", 12404),
+      "[::1]:443" -> ("::1", 443),
+      "::1:12404" -> ("::1", 12404),
+      "2001:db8:::12404" -> ("2001:db8::", 12404),
+      "[fe80::a%eth0]:12404" -> ("fe80::a%eth0", 12404),
+      "fe80::a%3:12404" -> ("fe80::a%3", 12404))
+
+    endpoints.foreach { case (endpoint, expected) =>
+      assert(NetworkManager.parseHostAndPort(endpoint) == expected)
+      assert(NetworkManager.getMainWorkerPort(endpoint, log) == expected._2)
+    }
+  }
+
+  test("Main worker endpoint parser rejects malformed hosts and ports with actionable errors") {
+    val malformedEndpoints = Seq(
+      "" -> "endpoint is empty",
+      "worker.example.test" -> "missing ':' port separator",
+      ":12404" -> "host is empty",
+      "worker.example.test:" -> "port is empty",
+      "worker.example.test:not-a-port" -> "not a decimal integer",
+      "worker.example.test:+80" -> "not a decimal integer",
+      "worker.example.test:-1" -> "not a decimal integer",
+      "worker.example.test:0" -> "outside the valid range",
+      "worker.example.test:65536" -> "outside the valid range",
+      "worker.example.test:999999999999999999999" -> "too large",
+      "[2001:db8::1]12404" -> "must be followed by a ':' port separator",
+      "[2001:db8::1" -> "missing its closing ']'",
+      "[2001:db8::1]" -> "missing its port",
+      "[worker.example.test]:12404" -> "brackets are only valid around an IPv6 literal",
+      "2001:db8::1" -> "bare IPv6 endpoint is ambiguous",
+      "2001:db8::1:10" -> "bare IPv6 endpoint is ambiguous",
+      "2001:db8:::1:12404" -> "not a valid IPv6 literal",
+      "fe80::1%:12404" -> "IPv6 zone identifier is empty",
+      "fe80::1%eth0%extra:12404" -> "IPv6 zone identifier is malformed",
+      "worker name:12404" -> "host contains whitespace, control characters, or an endpoint delimiter")
+
+    malformedEndpoints.foreach { case (endpoint, expectedMessage) =>
+      val failure = intercept[IllegalArgumentException](NetworkManager.parseHostAndPort(endpoint))
+      assert(failure.getMessage.contains(expectedMessage))
+      assert(failure.getMessage.contains("Expected hostname:port"))
+    }
+
+    val nullFailure = intercept[IllegalArgumentException] {
+      NetworkManager.parseHostAndPort(null) //scalastyle:ignore null
+    }
+    assert(nullFailure.getMessage.contains("endpoint is null"))
+    assert(intercept[IllegalArgumentException](NetworkManager.getMainWorkerPort(
+      null, log)).getMessage.contains("network node list is null")) //scalastyle:ignore null
+    assert(intercept[IllegalArgumentException](NetworkManager.getMainWorkerPort(
+      ",worker.example.test:12404", log)).getMessage.contains("endpoint is empty"))
   }
 
   test("Zero early stopping rounds disable wrapper early stopping") {

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/WorkerWireFormatSuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/WorkerWireFormatSuite.scala
@@ -1,0 +1,128 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm.split1
+
+import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMConstants, NetworkManager, TaskMessageInfo,
+  WorkerEndpoint, WorkerMessage}
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.io.{BufferedReader, BufferedWriter, InputStreamReader, OutputStreamWriter}
+import java.net.{InetSocketAddress, ServerSocket, Socket}
+import scala.collection.mutable.ListBuffer
+import scala.util.Try
+
+/** Covers the wire form of every endpoint LightGBM components exchange. */
+class WorkerWireFormatSuite extends AnyFunSuite {
+
+  private val socketTimeoutMillis = 30000
+  private val driverHost = "127.0.0.1"
+  private val timeout = 30.0
+
+  private class ReportingTask(host: String, port: Int, taskHost: String, listenPort: Int, partitionId: Int)
+    extends AutoCloseable {
+    private val socket = new Socket()
+    socket.connect(new InetSocketAddress(host, port), socketTimeoutMillis)
+    socket.setSoTimeout(socketTimeoutMillis)
+    private val reader = new BufferedReader(new InputStreamReader(socket.getInputStream))
+    private val writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream))
+
+    def report(): Unit = {
+      val message = WorkerMessage.format(
+        TaskMessageInfo(LightGBMConstants.EnabledTask, taskHost, listenPort, partitionId, partitionId.toString), 0)
+      writer.write(s"$message\n")
+      writer.flush()
+    }
+
+    def readMachineList(): String = reader.readLine()
+
+    override def close(): Unit = socket.close()
+  }
+
+  test("Only an IPv6 host is bracketed on the wire") {
+    assert(WorkerEndpoint.wireString("10.0.0.4", 12400) == "10.0.0.4:12400")
+    assert(WorkerEndpoint.wireString("worker-1", 12400) == "worker-1:12400")
+    assert(WorkerEndpoint.wireString("2001:db8::1", 12400) == "[2001:db8::1]:12400")
+    // A zone identifier belongs inside the brackets, with the address it scopes.
+    assert(WorkerEndpoint.wireString("fe80::1%eth0", 12400) == "[fe80::1%eth0]:12400")
+    // An already bracketed host is not bracketed twice.
+    assert(WorkerEndpoint.wireString("[2001:db8::1]", 12400) == "[2001:db8::1]:12400")
+  }
+
+  test("A wire endpoint round trips back to the host it was built from") {
+    Seq("10.0.0.4", "worker-1", "2001:db8::1", "fe80::1%eth0", "::1").foreach { host =>
+      val parsed = WorkerEndpoint.parse(WorkerEndpoint.wireString(host, 12400))
+      assert(parsed.host == host)
+      assert(parsed.port == 12400)
+      assert(parsed.wireString == WorkerEndpoint.wireString(host, 12400))
+    }
+  }
+
+  test("A host carrying a control character or a delimiter never reaches the wire") {
+    // The topology exchange is a line protocol over a comma delimited machine list, so any of these
+    // would either split one endpoint into two or forge an extra protocol line.
+    Seq("10.0.0.4\n", "10.0.0.4\r", "10.0.0.4\t", "10.0.0.4\u0000", "10.0.0.4 ", "10.0.0.4,10.0.0.5",
+      "10.0.0.4]", "[10.0.0.4").foreach { host =>
+      val failure = intercept[IllegalArgumentException](WorkerEndpoint.wireString(host, 12400))
+      assert(failure.getMessage.contains("Invalid LightGBM worker endpoint"), s"unexpected error for '$host'")
+    }
+  }
+
+  test("A rejected endpoint reports control characters as escapes rather than raw bytes") {
+    val failure = intercept[IllegalArgumentException](WorkerEndpoint.wireString("10.0.0.4\r\nignore:1", 12400))
+    assert(failure.getMessage.contains("\\r\\n"))
+    assert(!failure.getMessage.contains("\r"))
+    assert(!failure.getMessage.contains("\n"))
+    val nullByte = intercept[IllegalArgumentException](WorkerEndpoint.wireString("10.0.0.4\u0000", 12400))
+    assert(nullByte.getMessage.contains("\\u0000"))
+  }
+
+  test("A port outside the valid range never reaches the wire") {
+    Seq(0, -1, LightGBMConstants.MaxPort + 1).foreach { port =>
+      val failure = intercept[IllegalArgumentException](WorkerEndpoint.wireString("10.0.0.4", port))
+      assert(failure.getMessage.contains("Invalid LightGBM worker endpoint"))
+    }
+  }
+
+  test("A task message round trips for every host form, including a scoped IPv6 literal") {
+    Seq("10.0.0.4", "2001:db8::1", "fe80::1%eth0").foreach { host =>
+      val status = TaskMessageInfo(LightGBMConstants.EnabledTask, host, 12400, 3, "executor-2")
+      val message = WorkerMessage.format(status, 7)
+      val parsed = WorkerMessage.parse(message)
+      assert(parsed.taskHost == host)
+      assert(parsed.localListenPort == 12400)
+      assert(parsed.partitionId == 3)
+      assert(parsed.executorId == "executor-2")
+      assert(parsed.stageAttemptNumber == 7)
+    }
+  }
+
+  test("A task message with a forged extra line is rejected before it is sent") {
+    val status = TaskMessageInfo(LightGBMConstants.EnabledTask, "10.0.0.4\nenabledTask:10.0.0.9", 12400, 0, "e")
+    assert(intercept[IllegalArgumentException](WorkerMessage.format(status, 0))
+      .getMessage.contains("Invalid LightGBM worker endpoint"))
+  }
+
+  test("The driver publishes a machine list the LightGBM network layer can split on commas") {
+    val serverSocket = new ServerSocket(0)
+    serverSocket.setSoTimeout(socketTimeoutMillis)
+    val manager = NetworkManager(2, serverSocket, driverHost, serverSocket.getLocalPort, timeout,
+      useBarrierExecutionMode = false)
+    val tasks = ListBuffer.empty[ReportingTask]
+    try {
+      tasks += new ReportingTask(driverHost, serverSocket.getLocalPort, "2001:db8::1", 12400, 0)
+      tasks += new ReportingTask(driverHost, serverSocket.getLocalPort, "2001:db8::2", 12401, 1)
+      tasks.foreach(_.report())
+
+      val machineList = tasks.head.readMachineList()
+      assert(machineList == "[2001:db8::1]:12400,[2001:db8::2]:12401",
+        "An unbracketed IPv6 machine list cannot be split into host and port by any peer")
+      // Every consumer of the machine list has to agree on where the first endpoint ends.
+      assert(NetworkManager.getMainWorkerPort(machineList, org.slf4j.LoggerFactory.getLogger(getClass)) == 12400)
+      manager.waitForNetworkCommunicationsDone()
+    } finally {
+      manager.closeConnections()
+      tasks.foreach(task => Try(task.close()))
+    }
+  }
+}


### PR DESCRIPTION
## Related Issues/PRs

Fixes #2152

## What changes are proposed in this pull request?

- Add a focused `WorkerEndpoint` parser that preserves hostname and IPv4 behavior while supporting bracketed IPv6 and the unambiguous bare IPv6 form produced by LightGBM worker sockets.
- Preserve compressed IPv6 and zone identifiers without rewriting host text, and validate decimal ports in the range `1-65535`.
- Reject null, empty, malformed, missing-port, out-of-range, and inherently ambiguous bare IPv6 values with actionable errors that recommend `[IPv6]:port`.
- Parse IPv6-bearing current and legacy worker status messages from their fixed suffix fields without changing the native LightGBM machine-list format.
- Keep socket creation, network initialization, port reservation, retry, and cleanup behavior unchanged.
- Register the existing WorkerMessage protocol commit as a Spark 4.1 release-compatibility prerequisite so the patch replays and compiles on that branch.

## How is this patch tested?

- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

Validation used the repository JDK 11 WSL wrapper with the `SynapseMLSbtValidation` mutex held for each SBT invocation:

- `lightgbm/Compile/compile`
- `lightgbm/scalastyle`
- `lightgbm/Test/scalastyle`
- Project-wide `scalastyle` and `test:scalastyle`
- 42/42 tests across `TrainUtilsSuite`, `NetworkManagerSuite`, `DriverSocketRetrySuite`, `BarrierNetworkRecoverySuite`, and the local-only `DriverSocketRetryE2ESuite`
- Final post-review parser/protocol regression run: 18/18 tests across `TrainUtilsSuite` and `DriverSocketRetrySuite`
- `python -m pytest tools/ci/tests/test_pipeline_yaml.py -q`: 16 passed, 1 skipped

## Does this PR change any dependencies?

- [x] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.