### PR TITLE
feat(featurize): support preserving missing numeric rows

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/featurize/Featurize.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/featurize/Featurize.scala
@@ -78,6 +78,45 @@ class Featurize(override val uid: String) extends Estimator[PipelineModel]
   /** @group setParam */
   def setImputeMissing(value: Boolean): this.type = set(imputeMissing, value)
 
+  /** How the final internal VectorAssembler stage handles null input values and Double.NaN
+    * scalar numeric values when assembling the output feature vector.
+    *
+    * This only affects that last assembly step; it does not change text featurization,
+    * categorical one-hot encoding, or the imputeMissing mean/median imputation performed earlier
+    * in the pipeline. Supported values mirror the VectorAssembler handleInvalid parameter in
+    * Spark 3.5:
+    *  - "skip" (default): drop rows containing an invalid value, preserving the
+    *    historical Featurize behavior.
+    *  - "error": fail transform if an invalid value is encountered.
+    *  - "keep": preserve every row and encode invalid values as Double.NaN in the assembled
+    *    feature vector, e.g. so LightGBM native missing-value handling can use them. A null
+    *    vector input becomes one Double.NaN per vector element.
+    *    Set imputeMissing to false as well if raw missing values (rather than imputed ones)
+    *    should reach the assembler.
+    *
+    * Note: input columns that are already vectors need size metadata (for example added via
+    * VectorSizeHint) to use "keep"; otherwise Spark cannot infer their length and will throw.
+    *
+    * @group param
+    */
+  val vectorAssemblerHandleInvalid: Param[String] = new Param[String](this,
+    "vectorAssemblerHandleInvalid",
+    "How the final VectorAssembler stage handles null inputs and scalar numeric NaN values: " +
+      "skip (default, drops rows, matches prior behavior), error (fails on invalid values), " +
+      "or keep (preserves rows and encodes invalid values as Double.NaN, e.g. " +
+      "for LightGBM missing-value handling). Only affects the final VectorAssembler; does not " +
+      "change text, categorical, or imputeMissing behavior. Vector-typed input columns without " +
+      "size metadata (see VectorSizeHint) can fail to infer lengths when set to keep.",
+    ParamValidators.inArray(Array("skip", "error", "keep")))
+
+  setDefault(vectorAssemblerHandleInvalid -> "skip")
+
+  /** @group getParam */
+  final def getVectorAssemblerHandleInvalid: String = $(vectorAssemblerHandleInvalid)
+
+  /** @group setParam */
+  def setVectorAssemblerHandleInvalid(value: String): this.type = set(vectorAssemblerHandleInvalid, value)
+
   private case class ColumnInfo(originalName: String, dataType: DataType, version: Int = 0) {
     def currentName: String = {
       if (version == 0) {
@@ -220,7 +259,7 @@ class Featurize(override val uid: String) extends Estimator[PipelineModel]
         new VectorAssembler()
           .setInputCols(columnState.getCurrentCols.toArray)
           .setOutputCol(getOutputCol)
-          .setHandleInvalid("skip"),
+          .setHandleInvalid(getVectorAssemblerHandleInvalid),
         new DropColumns().setCols(columnState.getColsToDrop.toArray)
       )
 
@@ -230,9 +269,7 @@ class Featurize(override val uid: String) extends Estimator[PipelineModel]
   //scalastyle:on cyclomatic.complexity
   //scalastyle:on method.length
 
-  override def copy(extra: ParamMap): Estimator[PipelineModel] = {
-    new Featurize()
-  }
+  override def copy(extra: ParamMap): Estimator[PipelineModel] = defaultCopy(extra)
 
   override def transformSchema(schema: StructType): StructType =
     schema.add(getOutputCol, VectorType)

--- a/core/src/test/python/synapsemltest/featurize/__init__.py
+++ b/core/src/test/python/synapsemltest/featurize/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.

--- a/core/src/test/python/synapsemltest/featurize/test_featurize.py
+++ b/core/src/test/python/synapsemltest/featurize/test_featurize.py
@@ -1,0 +1,50 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+import math
+import unittest
+
+from pyspark.ml import Pipeline
+from pyspark.sql import types as t
+
+from synapse.ml.core.init_spark import init_spark
+from synapse.ml.featurize import Featurize
+
+spark = init_spark()
+
+
+class FeaturizeSpec(unittest.TestCase):
+    def test_keep_preserves_missing_numeric_rows_in_pipeline(self):
+        schema = t.StructType(
+            [
+                t.StructField("id", t.IntegerType(), nullable=False),
+                t.StructField("value", t.DoubleType(), nullable=True),
+            ],
+        )
+        dataset = spark.createDataFrame(
+            [(0, 1.0), (1, None), (2, float("nan")), (3, 4.0)],
+            schema,
+        )
+        featurize = (
+            Featurize()
+            .setInputCols(["value"])
+            .setOutputCol("features")
+            .setImputeMissing(False)
+            .setVectorAssemblerHandleInvalid("keep")
+        )
+
+        self.assertEqual(featurize.getVectorAssemblerHandleInvalid(), "keep")
+        result = Pipeline(stages=[featurize]).fit(dataset).transform(dataset)
+        by_id = {
+            row.id: row.features[0] for row in result.select("id", "features").collect()
+        }
+
+        self.assertEqual(set(by_id), {0, 1, 2, 3})
+        self.assertEqual(by_id[0], 1.0)
+        self.assertTrue(math.isnan(by_id[1]))
+        self.assertTrue(math.isnan(by_id[2]))
+        self.assertEqual(by_id[3], 4.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/featurize/VerifyFeaturize.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/featurize/VerifyFeaturize.scala
@@ -6,13 +6,17 @@ package com.microsoft.azure.synapse.ml.featurize
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 import com.microsoft.azure.synapse.ml.core.test.fuzzing.{EstimatorFuzzing, TestObject}
 import org.apache.commons.io.FileUtils
-import org.apache.spark.ml.PipelineModel
-import org.apache.spark.ml.feature.StringIndexer
+import org.apache.spark.SparkException
+import org.apache.spark.ml.attribute.AttributeGroup
+import org.apache.spark.ml.feature.{StringIndexer, VectorSizeHint, VectorSlicer}
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
+import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.util.MLReadable
+import org.apache.spark.ml.{Pipeline, PipelineModel}
 import org.apache.spark.sql._
 
 import java.io.File
+import java.lang.{Double => JDouble}
 import java.nio.file.Files
 import java.sql.{Date, Timestamp}
 import java.util.GregorianCalendar
@@ -261,6 +265,172 @@ class VerifyFeaturize extends TestBase with EstimatorFuzzing[Featurize] {
     val resultNoOneHot: DataFrame = featurizeAndVerifyResult(catDataset, historicNoOneHotMissingsFile)
     // Verify that features column has the correct number of slots
     assert(resultNoOneHot.first().getAs[DenseVector](featuresColumn).size == 4)
+  }
+
+  val missingValueLabelColumn = "missingLabel"
+  val missingValueInputCol = "missingCol"
+
+  lazy val missingValueDataset: DataFrame = spark.createDataFrame(Seq[(Int, JDouble)](
+    (0, 1.0),
+    (1, null),
+    (2, Double.NaN),
+    (3, 4.0)))
+    .toDF(missingValueLabelColumn, missingValueInputCol)
+
+  private def missingValueFeaturize: Featurize =
+    new Featurize()
+      .setInputCols(Array(missingValueInputCol))
+      .setOutputCol(featuresColumn)
+      .setImputeMissing(false)
+
+  private def firstSlotByLabel(result: DataFrame): Map[Int, Double] = {
+    result.select(missingValueLabelColumn, featuresColumn).collect().map { row =>
+      row.getAs[Int](missingValueLabelColumn) -> row.getAs[Vector](featuresColumn)(0)
+    }.toMap
+  }
+
+  test("Featurize vectorAssemblerHandleInvalid defaults to skip and preserves prior row-dropping behavior") {
+    val feat = missingValueFeaturize
+    assert(feat.getVectorAssemblerHandleInvalid == "skip")
+    val result = feat.fit(missingValueDataset).transform(missingValueDataset)
+    assert(result.count() == 2)
+    val byLabel = firstSlotByLabel(result)
+    assert(byLabel.keySet == Set(0, 3))
+    assert(byLabel(0) == 1.0)
+    assert(byLabel(3) == 4.0)
+  }
+
+  test("Featurize vectorAssemblerHandleInvalid=keep preserves all rows and encodes missing values as NaN") {
+    val feat = missingValueFeaturize.setVectorAssemblerHandleInvalid("keep")
+    val result = feat.fit(missingValueDataset).transform(missingValueDataset)
+    assert(result.count() == 4)
+    val byLabel = firstSlotByLabel(result)
+    assert(byLabel(0) == 1.0)
+    assert(byLabel(1).isNaN)
+    assert(byLabel(2).isNaN)
+    assert(byLabel(3) == 4.0)
+  }
+
+  test("Featurize vectorAssemblerHandleInvalid=error throws on missing scalar values") {
+    val feat = missingValueFeaturize.setVectorAssemblerHandleInvalid("error")
+    assertSparkException[SparkException](feat, missingValueDataset)
+  }
+
+  test("Featurize setVectorAssemblerHandleInvalid rejects unsupported values") {
+    val ex = intercept[IllegalArgumentException] {
+      missingValueFeaturize.setVectorAssemblerHandleInvalid("bogus")
+    }
+    assert(ex.getMessage.contains("vectorAssemblerHandleInvalid"))
+  }
+
+  test("Featurize copy retains vectorAssemblerHandleInvalid and other configured params") {
+    val feat = missingValueFeaturize.setVectorAssemblerHandleInvalid("keep")
+    val copied = feat.copy(new ParamMap()).asInstanceOf[Featurize]
+    assert(copied.uid == feat.uid)
+    assert(copied.getVectorAssemblerHandleInvalid == "keep")
+    assert(!copied.getImputeMissing)
+    assert(copied.getInputCols.toSeq == feat.getInputCols.toSeq)
+    assert(copied.getOutputCol == feat.getOutputCol)
+    val result = copied.fit(missingValueDataset).transform(missingValueDataset)
+    assert(result.count() == 4)
+
+    val overridden = feat.copy(new ParamMap()
+      .put(feat.vectorAssemblerHandleInvalid, "error")
+      .put(feat.imputeMissing, true))
+      .asInstanceOf[Featurize]
+    assert(overridden.getVectorAssemblerHandleInvalid == "error")
+    assert(overridden.getImputeMissing)
+  }
+
+  test("Featurize keep supports sparse, dense, and null vectors and preserves feature metadata") {
+    val vectorInputCol = "vectorInput"
+    val scalarInputCol = "scalarInput"
+    val rawDataset = spark.createDataFrame(Seq[(Int, Vector, JDouble)](
+      (0, Vectors.sparse(3, Seq(0 -> 1.0)), 0.0),
+      (1, Vectors.dense(0.0, Double.NaN, 2.0), 3.0),
+      (2, null, 4.0)))
+      .toDF(missingValueLabelColumn, vectorInputCol, scalarInputCol)
+    val dataset = new VectorSizeHint()
+      .setInputCol(vectorInputCol)
+      .setSize(3)
+      .setHandleInvalid("optimistic")
+      .transform(rawDataset)
+
+    val feat = new Featurize()
+      .setInputCols(Array(vectorInputCol, scalarInputCol))
+      .setOutputCol(featuresColumn)
+      .setImputeMissing(false)
+      .setVectorAssemblerHandleInvalid("keep")
+    val result = feat.fit(dataset).transform(dataset)
+    assert(result.count() == 3)
+
+    val attributeGroup = AttributeGroup.fromStructField(result.schema(featuresColumn))
+    val attributes = attributeGroup.attributes.get
+    assert(attributeGroup.size == 4)
+    assert(attributes.flatMap(_.name).toSet ==
+      Set(s"${vectorInputCol}_0", s"${vectorInputCol}_1", s"${vectorInputCol}_2", scalarInputCol))
+
+    val byLabel = result.select(missingValueLabelColumn, featuresColumn).collect().map { row =>
+      val namedValues = attributes.zip(row.getAs[Vector](featuresColumn).toArray).map {
+        case (attribute, value) => attribute.name.get -> value
+      }.toMap
+      row.getAs[Int](missingValueLabelColumn) -> (row.getAs[Vector](featuresColumn), namedValues)
+    }.toMap
+
+    assert(byLabel(0)._1.isInstanceOf[SparseVector])
+    assert(byLabel(0)._2(s"${vectorInputCol}_0") == 1.0)
+    assert(byLabel(0)._2(s"${vectorInputCol}_1") == 0.0)
+    assert(byLabel(0)._2(s"${vectorInputCol}_2") == 0.0)
+    assert(byLabel(0)._2(scalarInputCol) == 0.0)
+
+    assert(byLabel(1)._1.isInstanceOf[DenseVector])
+    assert(byLabel(1)._2(s"${vectorInputCol}_0") == 0.0)
+    assert(byLabel(1)._2(s"${vectorInputCol}_1").isNaN)
+    assert(byLabel(1)._2(s"${vectorInputCol}_2") == 2.0)
+    assert(byLabel(1)._2(scalarInputCol) == 3.0)
+
+    assert(byLabel(2)._2(s"${vectorInputCol}_0").isNaN)
+    assert(byLabel(2)._2(s"${vectorInputCol}_1").isNaN)
+    assert(byLabel(2)._2(s"${vectorInputCol}_2").isNaN)
+    assert(byLabel(2)._2(scalarInputCol) == 4.0)
+  }
+
+  test("Featurize estimator save/load retains vectorAssemblerHandleInvalid") {
+    val feat = missingValueFeaturize.setVectorAssemblerHandleInvalid("keep")
+    val path = new File(tmpDir.toFile, "featurize-estimator-keep").toString
+    feat.write.overwrite().save(path)
+    val loaded = Featurize.load(path)
+    assert(loaded.getVectorAssemblerHandleInvalid == "keep")
+    val result = loaded.fit(missingValueDataset).transform(missingValueDataset)
+    assert(result.count() == 4)
+    val byLabel = firstSlotByLabel(result)
+    assert(byLabel(1).isNaN)
+    assert(byLabel(2).isNaN)
+  }
+
+  test("Featurize keep works in a persisted Pipeline with a downstream transformer") {
+    val feat = missingValueFeaturize.setVectorAssemblerHandleInvalid("keep")
+    val selectedFeaturesColumn = "selectedFeatures"
+    val pipeline = new Pipeline().setStages(Array(
+      feat,
+      new VectorSlicer()
+        .setInputCol(featuresColumn)
+        .setOutputCol(selectedFeaturesColumn)
+        .setIndices(Array(0))))
+    val model = pipeline.fit(missingValueDataset)
+    val path = new File(tmpDir.toFile, "featurize-pipeline-model-keep").toString
+    model.write.overwrite().save(path)
+    val loadedModel = PipelineModel.load(path)
+    val result = loadedModel.transform(missingValueDataset)
+    assert(result.count() == 4)
+    val byLabel = firstSlotByLabel(result)
+    assert(byLabel(0) == 1.0)
+    assert(byLabel(1).isNaN)
+    assert(byLabel(2).isNaN)
+    assert(byLabel(3) == 4.0)
+    assert(result.select(selectedFeaturesColumn).collect().forall {
+      _.getAs[Vector](selectedFeaturesColumn).size == 1
+    })
   }
 
   private def featurize(dataset: DataFrame,

--- a/docs/Quick Examples/estimators/core/_Featurize.md
+++ b/docs/Quick Examples/estimators/core/_Featurize.md
@@ -205,6 +205,56 @@ feat.fit(dataset).transform(dataset).show()
 </TabItem>
 </Tabs>
 
+#### Handling rows with missing numeric values
+
+By default, `Featurize`'s final `VectorAssembler` uses `"skip"`, so rows are dropped when
+null values or numeric scalar `NaN` values reach that assembler (for example when missing-value
+imputation is disabled). To instead preserve those rows as `NaN`, set
+`vectorAssemblerHandleInvalid` to `"keep"`:
+
+<Tabs
+defaultValue="py"
+values={[
+{label: `Python`, value: `py`},
+{label: `Scala`, value: `scala`},
+]}>
+<TabItem value="py">
+
+```python
+from synapse.ml.featurize import Featurize
+
+feat = (Featurize()
+      .setInputCols(["col1", "col2", "col3"])
+      .setOutputCol("testColumn")
+      .setImputeMissing(False)
+      .setVectorAssemblerHandleInvalid("keep"))
+```
+
+</TabItem>
+<TabItem value="scala">
+
+```scala
+val feat = (new Featurize()
+      .setInputCols(featureColumns)
+      .setOutputCol("testColumn")
+      .setImputeMissing(false)
+      .setVectorAssemblerHandleInvalid("keep"))
+```
+
+</TabItem>
+</Tabs>
+
+Supported values are `"skip"` (default, drops rows, unchanged prior behavior), `"error"`
+(fails transform on invalid values), and `"keep"` (preserves rows, encoding nulls and numeric
+scalar `NaN` values as `NaN`). A null vector becomes one `NaN` per vector element; `NaN` values
+already stored inside sparse or dense vectors are preserved. The param only affects the final
+`VectorAssembler` step; it doesn't change text featurization, one-hot encoding, or
+`imputeMissing` mean/median imputation, which runs earlier in the pipeline and can hide missing
+values from the assembler unless disabled. Vector-typed input columns need size metadata (for
+example added via Spark's `VectorSizeHint`) to use `"keep"`; otherwise Spark cannot infer their
+length. If null vectors must also be preserved, configure `VectorSizeHint` with
+`handleInvalid="optimistic"` so it adds metadata without filtering or rejecting them.
+
 <DocTable className="Featurize"
 py="synapse.ml.featurize.html#module-synapse.ml.featurize.Featurize"
 scala="com/microsoft/azure/synapse/ml/featurize/Featurize.html"

--- a/docs/Quick Examples/estimators/core/_Featurize.md
+++ b/docs/Quick Examples/estimators/core/_Featurize.md
@@ -220,6 +220,8 @@ values={[
 ]}>
 <TabItem value="py">
 
+<!--pytest-codeblocks:cont-->
+
 ```python
 from synapse.ml.featurize import Featurize
 


### PR DESCRIPTION
Fixes #304

## Behavior

- Adds validated `vectorAssemblerHandleInvalid` modes `skip`, `error`, and `keep` to `Featurize`'s final internal `VectorAssembler`.
- Keeps `skip` as the default, preserving historical row-dropping behavior.
- With `imputeMissing=false`, `keep` preserves null/NaN scalar rows; null vector inputs become NaNs when vector-size metadata is available.
- Preserves sparse/dense vector behavior and output feature metadata.
- Uses `defaultCopy(extra)` so configuration and UID semantics survive Spark pipeline copies.

## Compatibility and generated APIs

- Existing constructors, companion object, JVM signatures, and serialized parameter shapes remain compatible; the parameter/accessors are additive.
- Existing and previously persisted callers retain the `skip` default.
- Generated Python and R APIs expose the parameter with default `skip`; no hand-written generated export was added.
- Rebased onto `master` target `ac50e8a3d1ba928fea1a6a8d4853ffcf667b0561`; validated head is `0927181ce6d553cd2afc36879185c9544f0f2728`.

## Validation

Validated with JDK 11 and Spark 3.5:

- `core/compile`: passed.
- `core/Test/compile`: passed.
- `core/scalastyle` and `core/Test/scalastyle`: passed with 0 findings.
- `core/testOnly com.microsoft.azure.synapse.ml.featurize.VerifyFeaturize`: 18 passed, 1 pre-existing ignored.
- `core/codegen`: passed; generated Python AST/`py_compile`, package export, setter/getter/default, and generated R surface verified.
- Exact-head generated-Python pipeline pytest: 1 passed.
- Exact-head isolated `_Featurize.md` website codeblocks: 6 passed.
- Black 22.3.0 repository check: 191 files unchanged.
- `git diff --check`: passed.

The final rebase preserved the intended patch exactly (`git patch-id` `36ab047ef9be83054a2bbc366ec69fe5ff576ccb`).

## Integration note

PR #2629 also edits `Featurize.scala` and `VerifyFeaturize.scala`. The Scala implementation changes are conceptually compatible and currently merge automatically, but `VerifyFeaturize.scala` has a real content conflict. Whichever PR lands second must rebase and resolve that test-file conflict; this PR intentionally does not incorporate #2629.

## Final CI and review

- Azure Pipelines build [231492858](https://msdata.visualstudio.com/b9b2accc-2d1c-45b3-9d24-0eb5d78cc47f/_build/results?buildId=231492858) ran with `reason=pullRequest` against merge commit `60f73965caeb3d20361b47da16a02a0c268201ed` and succeeded.
- All current-head check runs completed with 0 failures and 0 pending checks.
- Copilot review covers exact head `0927181ce6d553cd2afc36879185c9544f0f2728` (5/5 files, 0 new comments).
- All historical review bodies and threads were audited. No minimized or suppressed findings remain; the sole prior thread is resolved and outdated.
- Final `Get-PrReadiness.ps1 -PullRequest 2638 -WaitForReview -RunPipeline` reported `complete=true`.

Only the requested human approval from `BrendanWalsh` remains.
