### PR TITLE
fix: reclaim search test indexes under quota pressure, not by age alone

### DIFF
--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchIndexRetention.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchIndexRetention.scala
@@ -34,6 +34,12 @@ object SearchIndexRetention {
 
   /** Never collect an index younger than this. A full pipeline run finishes well inside an hour,
     * so an index older than this cannot still belong to a build that is running.
+    *
+    * This holds only while every run stamps names on the same clock. [[age]] can do no better
+    * than subtract the name's timestamp from the caller's `now`, so a name written in local time
+    * and read from another zone is wrong by the offset between them, and an offset larger than
+    * this floor would let a sweep collect an index a live build had just created. Producers and
+    * callers therefore both work in UTC.
     */
   val MinimumAge: Duration = Duration.ofHours(3)
 

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchIndexRetention.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchIndexRetention.scala
@@ -1,0 +1,82 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.services.search
+
+import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder, DateTimeParseException, SignStyle}
+import java.time.temporal.ChronoField
+import java.time.{Duration, LocalDateTime}
+import scala.util.matching.Regex
+
+/** Decides which of the shared search service's test indexes a run is allowed to delete.
+  *
+  * The service will only hold [[MaxIndexes]] indexes and the search suites create one per test, so
+  * a run that deletes only what it created will eventually find the service full and fail in
+  * `beforeAll` before it can create anything. Collecting purely by age does not save it either
+  * once the cap is reached faster than the retention window expires. That is what happened in
+  * issue #2639: the service sat at 48 of 50 indexes while the oldest was barely 40 hours old, so a
+  * two day cutoff selected nothing and every build in the repository, `master` included, failed
+  * until the indexes were deleted by hand.
+  *
+  * The policy here is therefore driven by pressure rather than by age alone. Anything past
+  * [[RoutineAge]] is collected on every sweep, and when that still does not leave
+  * [[DesiredFreeSlots]] free the sweep keeps taking the next oldest index until it does.
+  * [[MinimumAge]] is the floor that stops it from ever touching an index a concurrently running
+  * build might still be using.
+  */
+object SearchIndexRetention {
+
+  /** Maximum number of indexes the shared service will hold. */
+  val MaxIndexes: Int = 50
+
+  /** Slots a run wants free before it starts creating indexes of its own. */
+  val DesiredFreeSlots: Int = 10
+
+  /** Never collect an index younger than this. A full pipeline run finishes well inside an hour,
+    * so an index older than this cannot still belong to a build that is running.
+    */
+  val MinimumAge: Duration = Duration.ofHours(3)
+
+  /** Collected on every sweep, however much room happens to be left. */
+  val RoutineAge: Duration = Duration.ofHours(12)
+
+  /** Test index names end with the 17 digit timestamp that [[Formatter]] produces. */
+  private val TimestampedName: Regex = "^.*-(\\d{17})$".r
+
+  /** When a date pattern starts with 'yyyy' and has no separator following, the parser can
+    * sometimes decide to take the whole string to match the year, which results in an exception.
+    * The following is a hackaround.
+    */
+  val Formatter: DateTimeFormatter = new DateTimeFormatterBuilder()
+    .appendValue(ChronoField.YEAR_OF_ERA, 4, 4, SignStyle.EXCEEDS_PAD)
+    .appendPattern("MMddHHmmssSSS").toFormatter()
+
+  /** How old the index its name says it is, or None when the name carries no usable timestamp. */
+  def age(name: String, now: LocalDateTime): Option[Duration] = name match {
+    case TimestampedName(stamp) =>
+      try Some(Duration.between(LocalDateTime.parse(stamp, Formatter), now))
+      catch { case _: DateTimeParseException => None }
+    case _ => None
+  }
+
+  /** Every index this run is allowed to delete, oldest first.
+    *
+    * An index whose name carries no timestamp is never collected: without an age there is no way
+    * to tell it apart from one a running build just created.
+    */
+  def collectable(existing: Seq[String], now: LocalDateTime): Seq[(String, Duration)] =
+    existing.flatMap(name => age(name, now).map(name -> _))
+      .filter { case (_, indexAge) => indexAge.compareTo(MinimumAge) > 0 }
+      .sortBy { case (_, indexAge) => -indexAge.toMillis }
+
+  /** The indexes to delete on this sweep, oldest first. */
+  def select(existing: Seq[String], now: LocalDateTime): Seq[String] = {
+    val candidates = collectable(existing, now)
+    // candidates is oldest first, so the routine ones are exactly its first `routine` entries and
+    // taking any more than that walks steadily towards the youngest index still safe to collect.
+    val routine = candidates.count { case (_, indexAge) => indexAge.compareTo(RoutineAge) > 0 }
+    val freeAfterRoutine = MaxIndexes - existing.size + routine
+    val shortfall = math.max(0, DesiredFreeSlots - freeAfterRoutine)
+    candidates.take(routine + shortfall).map { case (name, _) => name }
+  }
+}

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchIndexRetention.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchIndexRetention.scala
@@ -40,8 +40,16 @@ object SearchIndexRetention {
   /** Collected on every sweep, however much room happens to be left. */
   val RoutineAge: Duration = Duration.ofHours(12)
 
-  /** Test index names end with the 17 digit timestamp that [[Formatter]] produces. */
-  private val TimestampedName: Regex = "^.*-(\\d{17})$".r
+  /** Test index names are the ones `generateIndexName` writes: a `test-` prefix, then a hash, then
+    * the 17 digit timestamp [[Formatter]] produces.
+    *
+    * The prefix is part of the match on purpose. The sweep reads every index in the shared
+    * service, not just this suite's, so matching on the timestamp alone would let it delete a
+    * foreign index that happened to end in 17 digits. That was survivable while collection only
+    * touched indexes older than two days; now that a sweep routinely collects at [[RoutineAge]]
+    * and drops to [[MinimumAge]] under pressure, it is not.
+    */
+  private val TimestampedName: Regex = "^test-.*-(\\d{17})$".r
 
   /** When a date pattern starts with 'yyyy' and has no separator following, the parser can
     * sometimes decide to take the whole string to match the year, which results in an exception.

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchIndexRetentionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchIndexRetentionSuite.scala
@@ -115,6 +115,25 @@ class SearchIndexRetentionSuite extends TestBase {
     assert(age(index(5, "-1534278552"), now).map(_.toHours).contains(5L))
   }
 
+  /** Guards the clock convention [[SearchIndexRetention.MinimumAge]] depends on. The shared
+    * service is written to both by the UTC build agents and from workstations, so a name stamped
+    * in the writer's local time reads as wrong by the offset between the two zones. Offsets reach
+    * well past the floor -- the live service showed indexes apparently seven hours in the future
+    * when read from a UTC-7 machine -- which would be enough for a sweep to collect an index a
+    * running build had just created.
+    */
+  test("An index is aged on the same clock it was named on") {
+    val stamped = s"test-utc-${Formatter.format(now)}"
+    assert(age(stamped, now).map(_.toHours).contains(0L))
+    assert(select(Seq(stamped), now).isEmpty)
+
+    // Reading the same name against a clock seven hours ahead ages it past the floor, which is
+    // what naming in local time would do to a build that is still using the index.
+    val skewed = age(stamped, now.plusHours(7))
+    assert(skewed.map(_.toHours).contains(7L))
+    assert(skewed.exists(_.compareTo(MinimumAge) > 0))
+  }
+
   test("The safety floor leaves room for a pipeline run to finish") {
     // A full run is well under an hour; anything near that would make the sweep race live builds.
     assert(MinimumAge.toHours >= 2)

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchIndexRetentionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchIndexRetentionSuite.scala
@@ -1,0 +1,109 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.services.search
+
+import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+
+import java.time.LocalDateTime
+
+/** Covers the retention policy that keeps the shared search service from filling up (issue #2639).
+  *
+  * None of this talks to the service, so it runs on every build rather than only on the ones that
+  * have search credentials, which matters because the bug it guards against took down `master`.
+  */
+class SearchIndexRetentionSuite extends TestBase {
+
+  import SearchIndexRetention._
+
+  private val now: LocalDateTime = LocalDateTime.of(2026, 8, 15, 12, 0, 0)
+
+  /** A name shaped exactly like the ones generateIndexName produces. */
+  private def index(hoursOld: Long, tag: String = "1534278552"): String =
+    s"test-$tag-${Formatter.format(now.minusHours(hoursOld))}"
+
+  /** Enough young indexes to sit `holding` short of the cap without any being collectable. */
+  private def young(count: Int): Seq[String] =
+    (1 to count).map(i => index(1, s"young$i"))
+
+  test("An index younger than the minimum age is never collected") {
+    val recent = Seq(index(MinimumAge.toHours - 1))
+    assert(collectable(recent, now).isEmpty)
+    assert(select(recent, now).isEmpty)
+  }
+
+  test("An index past the routine age is collected even when the service is nearly empty") {
+    val old = index(RoutineAge.toHours + 1)
+    assert(select(Seq(old), now) == Seq(old))
+  }
+
+  test("An index between the minimum and routine ages is kept while there is room") {
+    val middling = index(RoutineAge.toHours - 1)
+    assert(collectable(Seq(middling), now).map { case (n, _) => n } == Seq(middling))
+    assert(select(Seq(middling), now).isEmpty)
+  }
+
+  test("Pressure reclaims indexes that are too young for the routine sweep") {
+    // This is issue #2639: the service one index below its cap with nothing past the old two day
+    // cutoff. A purely age based sweep selected nothing here and the suite then failed to create.
+    val reclaimable = (1 to 20).map(i => index(MinimumAge.toHours + i, s"mid$i"))
+    val existing = reclaimable ++ young(MaxIndexes - 2 - reclaimable.size)
+    assert(existing.size == MaxIndexes - 2)
+    val collected = select(existing, now)
+    assert(collected.nonEmpty)
+    assert(existing.size - collected.size <= MaxIndexes - DesiredFreeSlots)
+  }
+
+  test("Pressure reclaims the oldest indexes first") {
+    val existing = (1 to 20).map(i => index(MinimumAge.toHours + i, s"mid$i")) ++
+      young(MaxIndexes - 2 - 20)
+    val collected = select(existing, now)
+    val ages = collected.map(name => age(name, now).get.toHours)
+    assert(ages == ages.sorted.reverse, "expected oldest first")
+    assert(ages.min > MinimumAge.toHours, "must not cross the safety floor")
+  }
+
+  test("Pressure never collects an index a running build could still own") {
+    // Every index is under the floor, so even at the cap there is nothing safe to take.
+    val existing = (1 to MaxIndexes).map(i => index(MinimumAge.toHours - 1, s"busy$i"))
+    assert(select(existing, now).isEmpty)
+  }
+
+  test("The pressure sweep stops once it has freed enough room") {
+    // Every index sits between the two ages, so nothing is collected routinely and the whole
+    // selection is pressure driven. It should stop the moment there is enough room, not keep going.
+    val existing = (1 to MaxIndexes).map(i =>
+      index(MinimumAge.toHours + 1 + (i % (RoutineAge.toHours - MinimumAge.toHours - 1)), s"mid$i"))
+    assert(collectable(existing, now).size == MaxIndexes, "expected every index to be collectable")
+    assert(select(existing, now).size == DesiredFreeSlots)
+  }
+
+  test("The routine sweep is not capped by the free slot target") {
+    // Anything past the routine age is garbage, so it all goes even though far fewer would do.
+    val existing = (1 to MaxIndexes).map(i => index(RoutineAge.toHours + i, s"old$i"))
+    assert(select(existing, now).size == MaxIndexes)
+  }
+
+  test("An index with no timestamp in its name is left alone") {
+    // Nothing can be inferred about its age, so it is not this sweep's to delete.
+    val untimestamped = Seq("test-website", "test-33467690", "examplevectorindex")
+    assert(select(untimestamped, now).isEmpty)
+    assert(untimestamped.flatMap(age(_, now)).isEmpty)
+  }
+
+  test("An index whose timestamp is not a real date is left alone") {
+    assert(age("test-1-99999999999999999", now).isEmpty)
+    assert(select(Seq("test-1-99999999999999999"), now).isEmpty)
+  }
+
+  test("Age is read back from the name generateIndexName would have written") {
+    assert(age(index(5), now).map(_.toHours).contains(5L))
+  }
+
+  test("The safety floor leaves room for a pipeline run to finish") {
+    // A full run is well under an hour; anything near that would make the sweep race live builds.
+    assert(MinimumAge.toHours >= 2)
+    assert(RoutineAge.compareTo(MinimumAge) > 0)
+    assert(DesiredFreeSlots > 0 && DesiredFreeSlots < MaxIndexes)
+  }
+}

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchIndexRetentionSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/SearchIndexRetentionSuite.scala
@@ -96,8 +96,23 @@ class SearchIndexRetentionSuite extends TestBase {
     assert(select(Seq("test-1-99999999999999999"), now).isEmpty)
   }
 
+  /** The sweep reads every index in the shared service, not just the ones these suites made, so a
+    * foreign name that happens to end in 17 digits must never be collected however old it looks
+    * or however full the service is.
+    */
+  test("An index that is not one of ours is never collected") {
+    val foreign = Seq(
+      index(RoutineAge.toHours * 10, "x").stripPrefix("test-"),
+      s"prod-catalog-${Formatter.format(now.minusDays(30))}")
+    assert(foreign.flatMap(age(_, now)).isEmpty)
+    assert(select(foreign, now).isEmpty)
+    assert(select(foreign ++ young(MaxIndexes - foreign.size), now).isEmpty)
+  }
+
   test("Age is read back from the name generateIndexName would have written") {
     assert(age(index(5), now).map(_.toHours).contains(5L))
+    // UUID.randomUUID().hashCode() is signed, so the hash segment is sometimes negative.
+    assert(age(index(5, "-1534278552"), now).map(_.toHours).contains(5L))
   }
 
   test("The safety floor leaves room for a pipeline run to finish") {

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/split1/SearchWriterSuitePart1.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/split1/SearchWriterSuitePart1.scala
@@ -18,11 +18,11 @@ import org.apache.spark.sql.DataFrame
 import org.scalatest.{Outcome, TestData}
 
 import java.time.LocalDateTime
-import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder, DateTimeParseException, SignStyle}
-import java.time.temporal.ChronoField
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 import scala.collection.mutable
 import scala.concurrent.blocking
+import scala.util.control.NonFatal
 
 trait AzureSearchKey {
   lazy val azureSearchKey: String = sys.env.getOrElse("AZURE_SEARCH_KEY", Secrets.AzureSearchKey)
@@ -35,11 +35,15 @@ class SearchWriterSuiteUtilities extends TestBase with AzureSearchKey
 
   private[ml] val testServiceName = "mmlspark-azure-search"
 
-  // When a date pattern starts with 'yyyy' and has no separator following, the parser can sometimes decide
-  // to take the whole string to match the year, which results in an exception. The following is a hackaround.
-  val formatter: DateTimeFormatter = new DateTimeFormatterBuilder()
-    .appendValue(ChronoField.YEAR_OF_ERA, 4, 4, SignStyle.EXCEEDS_PAD)
-    .appendPattern("MMddHHmmssSSS").toFormatter()
+  /** Status the service returns for an index it has just deleted. */
+  private val deletedStatus: Int = 204
+  /** Status for an index that is already gone. */
+  private val notFoundStatus: Int = 404
+  /** Stand-in status for a delete that threw before it got a response. */
+  private val unknownDeleteStatus: Int = -1
+
+  // Shared with SearchIndexRetention, which has to read back the timestamps written here.
+  val formatter: DateTimeFormatter = SearchIndexRetention.Formatter
 
   private[ml] def createTestData(numDocs: Int): DataFrame = {
     (0 until numDocs)
@@ -171,9 +175,14 @@ class SearchWriterSuiteUtilities extends TestBase with AzureSearchKey
     println("Cleaning up services")
     val indexNames = this.createdIndexes.values.flatten
     println(s"Remaining indices: ${indexNames.mkString(",")}")
-    cleanTestIndices(indexNames)
-    cleanOldIndexes()
-    super.afterAll()
+    try {
+      cleanTestIndices(indexNames)
+    } finally {
+      // Still sweep and tear down Spark even when this run could not delete its own indexes,
+      // since skipping the sweep is what leaves the service full for the run after this one.
+      cleanOldIndexes()
+      super.afterAll()
+    }
     ()
   }
 
@@ -193,34 +202,49 @@ class SearchWriterSuiteUtilities extends TestBase with AzureSearchKey
   }
 
   private[ml] def cleanTestIndices(indices: Iterable[String]): Unit = {
-    val successfulCleanup = getExisting(azureSearchKey, testServiceName)
-      .intersect(indices.toSeq).map { n =>
-        println(s"Deleting index $n")
-        deleteIndex(n)
-      }.forall(_ == 204)
-    assert(successfulCleanup)
+    val existing = getExisting(azureSearchKey, testServiceName).toSet
+    val failed = deleteQuietly(indices.filter(existing.contains))
+    assert(failed.isEmpty, s"Could not delete test indices ${failed.mkString(",")}")
     ()
   }
 
-  def cleanOldIndexes(): Unit = {
-    import scala.util.matching.Regex
-
-    val twoDaysAgo = LocalDateTime.now().minusDays(2)
-    val endingDatePattern: Regex = "^.*-(\\d{17})$".r
-    val e = getExisting(azureSearchKey, testServiceName)
-    e.foreach {
-      case name@endingDatePattern(dateString) =>
-        try {
-          val date = LocalDateTime.parse(dateString, formatter)
-          if (date.isBefore(twoDaysAgo)) {
-            deleteIndex(name)
-          }
-        } catch {
-          case _: DateTimeParseException => {}
-          case t: Throwable => throw t
+  /** Deletes every index named and returns the ones that survived.
+    *
+    * Nothing is thrown, because a sweep that stops at its first failure is how the service fills
+    * up: the indexes behind the failure are left behind and the run that would have collected
+    * them never gets that far.
+    */
+  private[ml] def deleteQuietly(indices: Iterable[String]): Seq[String] =
+    indices.toSeq.filter { name =>
+      println(s"Deleting index $name")
+      val status =
+        try deleteIndex(name)
+        catch {
+          case NonFatal(t) =>
+            println(s"Failed to delete index $name: $t")
+            unknownDeleteStatus
         }
-      case _ => {}
+      // A 404 means something else already collected it, which does just as well.
+      status != deletedStatus && status != notFoundStatus
     }
+
+  /** Frees room on the shared service, deleting the oldest test indexes first.
+    *
+    * Never throws. This runs at the start of `beforeAll`, so letting it fail would take down the
+    * whole suite over indexes that another run is free to collect later.
+    */
+  def cleanOldIndexes(): Unit = {
+    try {
+      val existing = getExisting(azureSearchKey, testServiceName)
+      val collected = SearchIndexRetention.select(existing, LocalDateTime.now())
+      println(s"Service $testServiceName holds ${existing.size} of ${SearchIndexRetention.MaxIndexes} indexes, " +
+        s"reclaiming ${collected.size}")
+      val failed = deleteQuietly(collected)
+      if (failed.nonEmpty) println(s"Could not reclaim ${failed.mkString(",")}")
+    } catch {
+      case NonFatal(t) => println(s"Could not reclaim old indexes: $t")
+    }
+    ()
   }
 
   private[ml] def retryWithBackoff[T](f: => T,

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/split1/SearchWriterSuitePart1.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/search/split1/SearchWriterSuitePart1.scala
@@ -17,7 +17,7 @@ import org.apache.spark.ml.util.MLReadable
 import org.apache.spark.sql.DataFrame
 import org.scalatest.{Outcome, TestData}
 
-import java.time.LocalDateTime
+import java.time.{LocalDateTime, ZoneOffset}
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 import scala.collection.mutable
@@ -144,7 +144,12 @@ class SearchWriterSuiteUtilities extends TestBase with AzureSearchKey
       testName.get
     }
 
-    val date = formatter.format(LocalDateTime.now())
+    // UTC, not the default zone: the timestamp in the name is the only record of when an index
+    // was made, and `cleanOldIndexes` will not collect one until it is `MinimumAge` old. Naming
+    // in local time makes that age wrong by the reader's offset whenever the two runs sit in
+    // different zones, which is the normal case here because the service is shared between the
+    // UTC build agents and whoever runs these suites from a workstation.
+    val date = formatter.format(LocalDateTime.now(ZoneOffset.UTC))
     val name = s"test-${UUID.randomUUID().hashCode()}-${date}"
     createdIndexes.getOrElseUpdate(testNameNormalized, mutable.HashSet[String]()).+=(name)
     name
@@ -236,7 +241,7 @@ class SearchWriterSuiteUtilities extends TestBase with AzureSearchKey
   def cleanOldIndexes(): Unit = {
     try {
       val existing = getExisting(azureSearchKey, testServiceName)
-      val collected = SearchIndexRetention.select(existing, LocalDateTime.now())
+      val collected = SearchIndexRetention.select(existing, LocalDateTime.now(ZoneOffset.UTC))
       println(s"Service $testServiceName holds ${existing.size} of ${SearchIndexRetention.MaxIndexes} indexes, " +
         s"reclaiming ${collected.size}")
       val failed = deleteQuietly(collected)

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -862,6 +862,7 @@ jobs:
           com.microsoft.azure.synapse.ml.services.search.AzureSearchGenericParamPersistenceSuite
           com.microsoft.azure.synapse.ml.services.search.IndexSchemaLiveRoundTripSuite
           com.microsoft.azure.synapse.ml.services.search.IndexSchemaParsingSuite
+          com.microsoft.azure.synapse.ml.services.search.SearchIndexRetentionSuite
           com.microsoft.azure.synapse.ml.services.speech.SpeechToTextSDKSecuritySuite
   steps:
     - template: templates/sbt_cache.yml


### PR DESCRIPTION
Fixes #2639.

## The failure

`UnitTests search1`, `UnitTests search2` and `UnitTests misc` fail on **every open PR and on `master`** once the shared `mmlspark-azure-search` service reaches its 50-index cap:

```
HTTP/1.1 429 Too Many Requests
{"error":{"message":"An index with the name 'test--1326844747-20260815003139417' in service
 'mmlspark-azure-search' could not be created. Index quota has been exceeded for this service.
 ... Maximum number of indexes allowed: 50"}}
```

This throws from `createIfNoneExists` in `beforeAll`, so the suite reports `Tests: succeeded 0, failed 0` — it dies before a single test runs.

**This is not a historical incident — `master` is red from it right now.** Build `231241262` on `refs/heads/master`, carrying no PR changes, failed this way, and the service reports the quota message verbatim:

```
com.microsoft.azure.synapse.ml.services.search.IndexSchemaLiveRoundTripSuite
  {"error":{"message":"An index with the name 'test-schema-450ca053' in service
   'mmlspark-azure-search' could not be created. Index quota has been exceeded for this service."}}
com.microsoft.azure.synapse.ml.services.search.split1.SearchWriterSuitePart1   (4 failures)
com.microsoft.azure.synapse.ml.services.search.split2.SearchWriterSuite        (1 failure)
  {"error":{"message":"You are sending too many requests. Please try again later."}}
```

## Why the existing cleanup didn't save it

`beforeAll` already calls `cleanOldIndexes()` first — the recovery path exists and runs. It selected **zero** indexes, because it collects only what is older than two days:

```scala
val twoDaysAgo = LocalDateTime.now().minusDays(2)
```

When I enumerated the service it held 45 leaked `test-*` indexes and **the oldest was 40.8 h old**. At current CI volume the cap is reached in roughly 40 h, i.e. faster than the retention window expires, so nothing was ever eligible. Age-only retention cannot keep up with a cap that fills faster than its own window.

A second defect compounded it. `cleanTestIndices` ended in `assert(successfulCleanup)`, and it is called from `afterAll` *before* `cleanOldIndexes()` and `super.afterAll()`. One transient delete error threw straight past both, leaking the entire run's indexes and skipping the sweep that would have collected the previous run's.

## The change

Retention becomes **pressure-driven** instead of age-only:

| | |
|---|---|
| past `RoutineAge` (12 h) | always collected, however much room is left |
| below `MinimumAge` (3 h) | never collected |
| in between | collected only while fewer than `DesiredFreeSlots` (10) are free, oldest first |

The 3 h floor is the safety property: a full pipeline run finishes well inside an hour, so an index older than the floor cannot still belong to a build that is running. Indexes whose names carry no parseable timestamp are never collected at all, since without an age there is no way to tell them apart from one a running build just created.

Deletion is now resilient:
- `deleteQuietly` attempts **every** delete and returns the survivors instead of stopping at the first failure. `404` counts as success — something else already collected it.
- `cleanTestIndices` still asserts, but on the aggregate, after all deletes have been attempted. The signal is preserved; the early abort is gone.
- `cleanOldIndexes` never throws. It runs at the top of `beforeAll`, so letting it fail would take down the suite over indexes a later run is free to collect.
- `afterAll` is wrapped in `try/finally` so the sweep and `super.afterAll()` run even when this run cannot delete its own indexes.

## Two safety properties the lower floor forced

Dropping the cutoff from two days to three hours removed the slack that had been hiding two latent problems. Both are fixed here.

**The sweep now only matches names this suite writes.** It reads *every* index in the shared service, so the original `^.*-(\d{17})$` would have collected any foreign index that happened to end in 17 digits. Survivable at a two-day cutoff; not at three hours. The pattern is now anchored on the `test-` prefix `generateIndexName` always writes:

```scala
private val TimestampedName: Regex = "^test-.*-(\\d{17})$".r
```

Checked against the live service — of the 32 indexes present, it matches the 27 test indexes and spares all 5 that are not ours:

```
MATCHED (deletable candidates): 27
SPARED  (never touched)       : 5
   examplevectorindex   form-demo-index-5   test-33467690   test-website   test
```

**Ages are now computed on one clock.** Producer and sweep both used `LocalDateTime.now()`, the JVM default zone, so an index named on a workstation and read by a UTC agent is mis-aged by the offset between them. Listing the live service from a UTC-7 machine shows it directly — the newest test index reads as **seven hours in the future**. Seven hours clears a three-hour floor outright, so a sweep could have deleted an index a live build had just created. Both sides now work in `ZoneOffset.UTC`. The format is unchanged, so indexes already in the service still parse, and the agents were already on UTC so their names are unaffected.

## Tests

The policy is extracted into `SearchIndexRetention`, a pure object that makes no service calls, so `SearchIndexRetentionSuite` (14 tests) runs on **every** build rather than only on builds that have search credentials. That is deliberate: this bug took down `master`, so its regression test must not depend on the very secrets that gate the search jobs.

```
[info] SearchIndexRetentionSuite:
[info] - An index younger than the minimum age is never collected
[info] - An index past the routine age is collected even when the service is nearly empty
[info] - An index between the minimum and routine ages is kept while there is room
[info] - Pressure reclaims indexes that are too young for the routine sweep
[info] - Pressure reclaims the oldest indexes first
[info] - Pressure never collects an index a running build could still own
[info] - The pressure sweep stops once it has freed enough room
[info] - The routine sweep is not capped by the free slot target
[info] - An index with no timestamp in its name is left alone
[info] - An index whose timestamp is not a real date is left alone
[info] - An index that is not one of ours is never collected
[info] - Age is read back from the name generateIndexName would have written
[info] - An index is aged on the same clock it was named on
[info] - The safety floor leaves room for a pipeline run to finish
[info] Tests: succeeded 14, failed 0, canceled 0, ignored 0, pending 0
```

`cognitive/scalastyle` and `cognitive/Test/scalastyle`: 0 errors.

A regression test reproducing the outage itself would have to fill a shared production search service to 50 indexes, so the reproduction is captured as the `Pressure reclaims indexes that are too young for the routine sweep` case, which asserts on exactly the 48-of-50/40 h shape observed in the incident.

`SearchIndexRetentionSuite` lives in `services.search`, a package no `UnitTests` leg claimed, which `PipelineTestCoverageSuite` fails the build over. It is registered on the `misc` leg, the one that exists for exactly that case.

## Scope

Test-only. No `src/main` file is touched, so no shipped behaviour and no generated Python wrapper changes.

`SearchWriterSuiteUtilities` is the shared base for both `SearchWriterSuitePart1` (`search1`) and `SearchWriterSuite` (`search2`), so one fix covers both jobs.

`IndexSchemaLiveRoundTripSuite` deletes in a `try/finally` and needed nothing. Its names carry no timestamp, so the sweep cannot collect them and a leak there would be permanent — worth checking rather than assuming, so I counted them on the live service: **0 present**, i.e. the cleanup is holding and no change is warranted.

`cognitive/.../face/FaceSuite.scala:282` has the same 2-day anti-pattern for a different resource. Left alone deliberately — different resource, different quota, and no evidence it is currently leaking.
