### PR TITLE
fix: read and write model metadata through SparkSession instead of RDD APIs

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/logging/SynapseMLLogging.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/logging/SynapseMLLogging.scala
@@ -67,7 +67,12 @@ object SynapseMLLogging extends Logging {
 
   private[ml] def getHadoopConfEntries: Map[String, String] = {
     SparkSession.getActiveSession.map { spark =>
-      val hc = spark.sparkContext.hadoopConfiguration
+      // Session-derived rather than spark.sparkContext, which Databricks Unity Catalog standard
+      // access mode rejects by name. Matches Spark's own MLlib ReadWrite (SPARK-48909) and picks
+      // up session-level conf overrides that sparkContext.hadoopConfiguration misses.
+      // Intentionally uncached: these are session identity fields that a notebook can rebind
+      // mid-session, and the ~0.2ms cost is per fit/transform/construct call, never per row.
+      val hc = spark.sessionState.newHadoopConf()
       //noinspection ScalaStyle
       HadoopKeysToLog.flatMap { case (field, name) =>
         Option(hc.get(field)).map { v: String => (name, v) }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputePerInstanceStatistics.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/ComputePerInstanceStatistics.scala
@@ -71,7 +71,7 @@ class ComputePerInstanceStatistics(override val uid: String) extends Transformer
             if (levels.get.length > 2) levels.get.length else 2
           } else {
             // Otherwise compute unique levels
-            dataset.select(col(labelColumnName).cast(DoubleType)).rdd.distinct().count().toInt
+            dataset.select(col(labelColumnName).cast(DoubleType)).distinct().count().toInt
           }
 
         val logLossFunc = udf((scoredLabel: Double, scores: org.apache.spark.ml.linalg.Vector) =>

--- a/core/src/main/scala/org/apache/spark/ml/ComplexParamsSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/ml/ComplexParamsSerializer.scala
@@ -5,7 +5,6 @@ package org.apache.spark.ml
 
 import com.microsoft.azure.synapse.ml.core.serialize.ComplexParam
 import org.apache.hadoop.fs.Path
-import org.apache.spark.SparkContext
 import org.apache.spark.ml.param.{ParamPair, Params}
 import org.apache.spark.ml.util.DefaultParamsReader.Metadata
 import org.apache.spark.ml.util._
@@ -37,7 +36,7 @@ private[ml] class ComplexParamsWriter(instance: Params) extends MLWriter {
   override protected def saveImpl(path: String): Unit = {
     val complexParamLocs = ComplexParamsWriter.getComplexParamLocations(instance, path)
     val complexParamJson = ComplexParamsWriter.getComplexMetadata(complexParamLocs)
-    ComplexParamsWriter.saveMetadata(instance, path, sc, complexParamJson)
+    ComplexParamsWriter.saveMetadata(instance, path, sparkSession, complexParamJson)
     ComplexParamsWriter.saveComplexParams(path, complexParamLocs, shouldOverwrite)
   }
 }
@@ -90,12 +89,12 @@ private[ml] object ComplexParamsWriter {
     */
   def saveMetadata(instance: Params,
                    path: String,
-                   sc: SparkContext,
+                   spark: SparkSession,
                    extraMetadata: Option[JObject] = None,
                    paramMap: Option[JValue] = None): Unit = {
     val metadataPath = new Path(path, "metadata").toString
-    val metadataJson = getMetadataToSave(instance, sc, extraMetadata, paramMap)
-    sc.parallelize(Seq(metadataJson), 1).saveAsTextFile(metadataPath)
+    val metadataJson = getMetadataToSave(instance, spark, extraMetadata, paramMap)
+    spark.createDataFrame(Seq(Tuple1(metadataJson))).toDF("value").write.text(metadataPath)
   }
 
   /** Helper for [[saveMetadata()]] which extracts the JSON to save.
@@ -104,7 +103,7 @@ private[ml] object ComplexParamsWriter {
     * @see [[saveMetadata()]] for details on what this includes.
     */
   def getMetadataToSave(instance: Params,
-                        sc: SparkContext,
+                        spark: SparkSession,
                         extraMetadata: Option[JObject] = None,
                         paramMap: Option[JValue] = None): String = {
     val uid = instance.uid
@@ -121,7 +120,7 @@ private[ml] object ComplexParamsWriter {
     }.toList)
     val basicMetadata = ("class" -> cls) ~
       ("timestamp" -> System.currentTimeMillis()) ~
-      ("sparkVersion" -> sc.version) ~
+      ("sparkVersion" -> spark.version) ~
       ("uid" -> uid) ~
       ("paramMap" -> jsonParams) ~
       ("defaultParamMap" -> jsonDefaultParams)
@@ -147,7 +146,15 @@ private[ml] object ComplexParamsWriter {
 private[ml] class ComplexParamsReader[T] extends MLReader[T] {
 
   override def load(path: String): T = {
-    val metadata = DefaultParamsReader.loadMetadata(path, sc)
+    // Mirrors Spark 4.0's DefaultParamsReader.loadMetadata(path, spark, expectedClassName),
+    // which reads the metadata through the session rather than SparkContext.textFile. Spark 3.5
+    // only offers the SparkContext overload, so inline the same three lines here: otherwise
+    // loading a model still needs a SparkContext and remains unusable on Databricks Unity
+    // Catalog shared access mode and Spark Connect, which is the whole point of the writer
+    // change above.
+    val metadataPath = new Path(path, "metadata").toString
+    val metadataStr = sparkSession.read.text(metadataPath).first().getString(0)
+    val metadata = DefaultParamsReader.parseMetadata(metadataStr)
     val cls = Utils.classForName(metadata.className)
     val instance =
       cls.getConstructor(classOf[String]).newInstance(metadata.uid).asInstanceOf[Params]

--- a/core/src/main/scala/org/apache/spark/ml/Serializer.scala
+++ b/core/src/main/scala/org/apache/spark/ml/Serializer.scala
@@ -7,7 +7,6 @@ import com.microsoft.azure.synapse.ml.core.env.StreamUtilities._
 import com.microsoft.azure.synapse.ml.core.utils.ContextObjectInputStream
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import org.apache.spark.SparkContext
 import org.apache.spark.ml.util.MLWritable
 import org.apache.spark.sql._
 
@@ -76,10 +75,6 @@ object Serializer {
   private[ml] def sessionHadoopConf(spark: SparkSession): Configuration =
     spark.sessionState.newHadoopConf()
 
-  private final val SparkContextDeprecation =
-    "Use the SparkSession overload. SparkContext is unavailable under Spark Connect and on " +
-      "Databricks Unity Catalog standard access mode."
-
   /** Writes the object to the given path.
     *
     * @param obj        The object to write.
@@ -88,15 +83,6 @@ object Serializer {
   def writeToHDFS[O](spark: SparkSession, obj: O, outputPath: Path, overwrite: Boolean)
                     (implicit ttag: TypeTag[O]): Unit = {
     using(outputPath.getFileSystem(sessionHadoopConf(spark)).create(outputPath, overwrite)) { os =>
-      write[O](obj, os)(ttag)
-    }.get
-  }
-
-  @deprecated(SparkContextDeprecation, "1.1.0")
-  def writeToHDFS[O](sc: SparkContext, obj: O, outputPath: Path, overwrite: Boolean)
-                    (implicit ttag: TypeTag[O]): Unit = {
-    val hadoopConf = sc.hadoopConfiguration
-    using(outputPath.getFileSystem(hadoopConf).create(outputPath, overwrite)) { os =>
       write[O](obj, os)(ttag)
     }.get
   }
@@ -112,21 +98,8 @@ object Serializer {
     }.get
   }
 
-  @deprecated(SparkContextDeprecation, "1.1.0")
-  def readFromHDFS[O](sc: SparkContext, path: Path)(implicit ttag: TypeTag[O]): O = {
-    val hadoopConf = sc.hadoopConfiguration
-    using(path.getFileSystem(hadoopConf).open(path)) { in =>
-      read[O](in)(ttag)
-    }.get
-  }
-
   def makeQualifiedPath(spark: SparkSession, path: String): Path = {
     makeQualifiedPath(sessionHadoopConf(spark), path)
-  }
-
-  @deprecated(SparkContextDeprecation, "1.1.0")
-  def makeQualifiedPath(sc: SparkContext, path: String): Path = {
-    makeQualifiedPath(sc.hadoopConfiguration, path)
   }
 
   private def makeQualifiedPath(hadoopConf: Configuration, path: String): Path = {
@@ -139,11 +112,6 @@ object Serializer {
 }
 
 class ObjectSerializer[O](spark: SparkSession)(implicit ttag: TypeTag[O]) extends Serializer[O] {
-
-  @deprecated("Use the SparkSession constructor. SparkContext is unavailable under Spark Connect " +
-    "and on Databricks Unity Catalog standard access mode.", "1.1.0")
-  def this(sc: SparkContext)(implicit ttag: TypeTag[O]) =
-    this(SparkSession.builder().sparkContext(sc).getOrCreate())
 
   def write(obj: O, path: Path, overwrite: Boolean): Unit = Serializer.writeToHDFS(spark, obj, path, overwrite)
 

--- a/core/src/main/scala/org/apache/spark/ml/Serializer.scala
+++ b/core/src/main/scala/org/apache/spark/ml/Serializer.scala
@@ -70,13 +70,13 @@ object Serializer {
     * `SparkSession.sparkContext` is unavailable under Spark Connect and is explicitly unsupported
     * on Databricks Unity Catalog standard access mode, so deriving the configuration from the
     * session is what keeps model persistence working there. This mirrors Spark MLlib's own
-    * `session.sessionState.newHadoopConf()`. It also picks up `spark.hadoop.*` settings applied to
-    * the session, which `sparkContext.hadoopConfiguration` alone does not.
+    * `session.sessionState.newHadoopConf()`. It also layers in session-level conf, which
+    * `sparkContext.hadoopConfiguration` alone does not.
     */
   private[ml] def sessionHadoopConf(spark: SparkSession): Configuration =
     spark.sessionState.newHadoopConf()
 
-  private val SparkContextDeprecation =
+  private final val SparkContextDeprecation =
     "Use the SparkSession overload. SparkContext is unavailable under Spark Connect and on " +
       "Databricks Unity Catalog standard access mode."
 

--- a/core/src/main/scala/org/apache/spark/ml/Serializer.scala
+++ b/core/src/main/scala/org/apache/spark/ml/Serializer.scala
@@ -5,6 +5,7 @@ package org.apache.spark.ml
 
 import com.microsoft.azure.synapse.ml.core.env.StreamUtilities._
 import com.microsoft.azure.synapse.ml.core.utils.ContextObjectInputStream
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkContext
 import org.apache.spark.ml.util.MLWritable
@@ -42,7 +43,7 @@ object Serializer {
     (if (tpe <:< typeOf[PipelineStage])              new PipelineSerializer()
      else if (tpe <:< typeOf[Array[PipelineStage]])  new PipelineArraySerializer()
      else if (tpe <:< typeOf[Dataset[_]])            new DFSerializer(sparkSession)
-     else new ObjectSerializer(sparkSession.sparkContext)(typeToTypeTag(tpe)))
+     else new ObjectSerializer(sparkSession)(typeToTypeTag(tpe)))
       .asInstanceOf[Serializer[T]]
   }
 
@@ -64,11 +65,34 @@ object Serializer {
     }.get
   }
 
+  /** Hadoop configuration derived from the session instead of the SparkContext.
+    *
+    * `SparkSession.sparkContext` is unavailable under Spark Connect and is explicitly unsupported
+    * on Databricks Unity Catalog standard access mode, so deriving the configuration from the
+    * session is what keeps model persistence working there. This mirrors Spark MLlib's own
+    * `session.sessionState.newHadoopConf()`. It also picks up `spark.hadoop.*` settings applied to
+    * the session, which `sparkContext.hadoopConfiguration` alone does not.
+    */
+  private[ml] def sessionHadoopConf(spark: SparkSession): Configuration =
+    spark.sessionState.newHadoopConf()
+
+  private val SparkContextDeprecation =
+    "Use the SparkSession overload. SparkContext is unavailable under Spark Connect and on " +
+      "Databricks Unity Catalog standard access mode."
+
   /** Writes the object to the given path.
     *
     * @param obj        The object to write.
     * @param outputPath Where to write the object
     */
+  def writeToHDFS[O](spark: SparkSession, obj: O, outputPath: Path, overwrite: Boolean)
+                    (implicit ttag: TypeTag[O]): Unit = {
+    using(outputPath.getFileSystem(sessionHadoopConf(spark)).create(outputPath, overwrite)) { os =>
+      write[O](obj, os)(ttag)
+    }.get
+  }
+
+  @deprecated(SparkContextDeprecation, "1.1.0")
   def writeToHDFS[O](sc: SparkContext, obj: O, outputPath: Path, overwrite: Boolean)
                     (implicit ttag: TypeTag[O]): Unit = {
     val hadoopConf = sc.hadoopConfiguration
@@ -82,6 +106,13 @@ object Serializer {
     * @param path The main path for model to load the object from.
     * @return The loaded object.
     */
+  def readFromHDFS[O](spark: SparkSession, path: Path)(implicit ttag: TypeTag[O]): O = {
+    using(path.getFileSystem(sessionHadoopConf(spark)).open(path)) { in =>
+      read[O](in)(ttag)
+    }.get
+  }
+
+  @deprecated(SparkContextDeprecation, "1.1.0")
   def readFromHDFS[O](sc: SparkContext, path: Path)(implicit ttag: TypeTag[O]): O = {
     val hadoopConf = sc.hadoopConfiguration
     using(path.getFileSystem(hadoopConf).open(path)) { in =>
@@ -89,9 +120,17 @@ object Serializer {
     }.get
   }
 
+  def makeQualifiedPath(spark: SparkSession, path: String): Path = {
+    makeQualifiedPath(sessionHadoopConf(spark), path)
+  }
+
+  @deprecated(SparkContextDeprecation, "1.1.0")
   def makeQualifiedPath(sc: SparkContext, path: String): Path = {
+    makeQualifiedPath(sc.hadoopConfiguration, path)
+  }
+
+  private def makeQualifiedPath(hadoopConf: Configuration, path: String): Path = {
     val modelPath = new Path(path)
-    val hadoopConf = sc.hadoopConfiguration
     // Note: to get correct working dir, must use root path instead of root + part
     val fs = modelPath.getFileSystem(hadoopConf)
     modelPath.makeQualified(fs.getUri, fs.getWorkingDirectory)
@@ -99,10 +138,16 @@ object Serializer {
 
 }
 
-class ObjectSerializer[O](sc: SparkContext)(implicit ttag: TypeTag[O]) extends Serializer[O] {
-  def write(obj: O, path: Path, overwrite: Boolean): Unit = Serializer.writeToHDFS(sc, obj, path, overwrite)
+class ObjectSerializer[O](spark: SparkSession)(implicit ttag: TypeTag[O]) extends Serializer[O] {
 
-  def read(path: Path): O = Serializer.readFromHDFS(sc, path)
+  @deprecated("Use the SparkSession constructor. SparkContext is unavailable under Spark Connect " +
+    "and on Databricks Unity Catalog standard access mode.", "1.1.0")
+  def this(sc: SparkContext)(implicit ttag: TypeTag[O]) =
+    this(SparkSession.builder().sparkContext(sc).getOrCreate())
+
+  def write(obj: O, path: Path, overwrite: Boolean): Unit = Serializer.writeToHDFS(spark, obj, path, overwrite)
+
+  def read(path: Path): O = Serializer.readFromHDFS(spark, path)
 }
 
 class DFSerializer(spark: SparkSession) extends Serializer[DataFrame] {

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/core/serialize/ValidateComplexParamSerializer.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/core/serialize/ValidateComplexParamSerializer.scala
@@ -3,6 +3,7 @@
 
 package com.microsoft.azure.synapse.ml.core.serialize
 
+import com.microsoft.azure.synapse.ml.core.env.StreamUtilities.using
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 import com.microsoft.azure.synapse.ml.param.ByteArrayParam
 import org.apache.commons.io.FileUtils
@@ -125,22 +126,21 @@ class ValidateComplexParamSerializer extends TestBase {
     assert(mpt1.getStringParam === mpt2.getStringParam)
   }
 
-  test("Object serialization is interchangeable between the SparkSession and SparkContext paths") {
+  test("Objects written the way earlier versions wrote them still load through the session path") {
     spark
     val obj = "round-trip payload".toCharArray.map(_.toByte)
-    val sessionPath = new Path(new File(tmpDir.toFile, "session-object").toString)
     val legacyPath = new Path(new File(tmpDir.toFile, "legacy-object").toString)
 
-    val sessionSerializer = new ObjectSerializer[Array[Byte]](spark)
-    sessionSerializer.write(obj, sessionPath, true)
+    // Reproduce the previous write path byte for byte: the FileSystem resolved from the
+    // SparkContext Hadoop configuration rather than from the session, writing through the same
+    // Serializer.write. Only the configuration lookup moved, so this pins that the on-disk format
+    // is unchanged and that objects written by earlier SynapseML versions still load.
+    using(legacyPath.getFileSystem(spark.sparkContext.hadoopConfiguration).create(legacyPath, true)) { os =>
+      Serializer.write(obj, os)
+    }.get
 
-    // The deprecated SparkContext entry points stay for downstream callers, so assert they still
-    // work and stay wire compatible with the session path in both directions. A format change
-    // here would silently break models written by older SynapseML versions.
-    Serializer.writeToHDFS(spark.sparkContext, obj, legacyPath, true)
-
-    assert(sessionSerializer.read(legacyPath) === obj)
-    assert(Serializer.readFromHDFS[Array[Byte]](spark.sparkContext, sessionPath) === obj)
+    assert(new ObjectSerializer[Array[Byte]](spark).read(legacyPath) === obj)
+    assert(Serializer.readFromHDFS[Array[Byte]](spark, legacyPath) === obj)
   }
 
   override def afterAll(): Unit = {

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/core/serialize/ValidateComplexParamSerializer.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/core/serialize/ValidateComplexParamSerializer.scala
@@ -6,9 +6,10 @@ package com.microsoft.azure.synapse.ml.core.serialize
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 import com.microsoft.azure.synapse.ml.param.ByteArrayParam
 import org.apache.commons.io.FileUtils
+import org.apache.hadoop.fs.Path
 import org.apache.spark.ml.param.{Param, ParamMap, Params}
 import org.apache.spark.ml.util._
-import org.apache.spark.ml.{ComplexParamsReadable, ComplexParamsWritable, Transformer}
+import org.apache.spark.ml.{ComplexParamsReadable, ComplexParamsWritable, ObjectSerializer, Serializer, Transformer}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Dataset}
 
@@ -122,6 +123,24 @@ class ValidateComplexParamSerializer extends TestBase {
     val mpt2 = MixedParamTest.load(saveFile)
     assert(mpt1.getByteArray === mpt2.getByteArray)
     assert(mpt1.getStringParam === mpt2.getStringParam)
+  }
+
+  test("Object serialization is interchangeable between the SparkSession and SparkContext paths") {
+    spark
+    val obj = "round-trip payload".toCharArray.map(_.toByte)
+    val sessionPath = new Path(new File(tmpDir.toFile, "session-object").toString)
+    val legacyPath = new Path(new File(tmpDir.toFile, "legacy-object").toString)
+
+    val sessionSerializer = new ObjectSerializer[Array[Byte]](spark)
+    sessionSerializer.write(obj, sessionPath, true)
+
+    // The deprecated SparkContext entry points stay for downstream callers, so assert they still
+    // work and stay wire compatible with the session path in both directions. A format change
+    // here would silently break models written by older SynapseML versions.
+    Serializer.writeToHDFS(spark.sparkContext, obj, legacyPath, true)
+
+    assert(sessionSerializer.read(legacyPath) === obj)
+    assert(Serializer.readFromHDFS[Array[Byte]](spark.sparkContext, sessionPath) === obj)
   }
 
   override def afterAll(): Unit = {

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/core/serialize/ValidateComplexParamSerializer.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/core/serialize/ValidateComplexParamSerializer.scala
@@ -104,6 +104,26 @@ class ValidateComplexParamSerializer extends TestBase {
     assert(mpt1.getStringParam === mpt2.getStringParam)
   }
 
+  test("Complex Param serialization should read metadata written by the legacy SparkContext path") {
+    spark
+    val bytes = "foo".toCharArray.map(_.toByte)
+
+    val mpt1 = new MixedParamTest("foo").setByteArray(bytes).setStringParam("foo")
+    mpt1.write.overwrite().save(saveFile)
+
+    // Rewrite the metadata the way SynapseML wrote it before the reader moved off
+    // SparkContext.textFile, so this asserts that models saved by earlier versions still
+    // load rather than just round-tripping the current writer against the current reader.
+    val metadataDir = new File(saveFile, "metadata")
+    val metadataJson = spark.read.text(metadataDir.toString).first().getString(0)
+    FileUtils.deleteDirectory(metadataDir)
+    spark.sparkContext.parallelize(Seq(metadataJson), 1).saveAsTextFile(metadataDir.toString)
+
+    val mpt2 = MixedParamTest.load(saveFile)
+    assert(mpt1.getByteArray === mpt2.getByteArray)
+    assert(mpt1.getStringParam === mpt2.getStringParam)
+  }
+
   override def afterAll(): Unit = {
     new File(saveFile).delete()
     new File(saveFile2).delete()

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/logging/VerifySynapseMLLogging.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/logging/VerifySynapseMLLogging.scala
@@ -5,6 +5,7 @@ package com.microsoft.azure.synapse.ml.logging
 
 import com.microsoft.azure.synapse.ml.build.BuildInfo
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import org.apache.spark.sql.SparkSession
 
 class VerifySynapseMLLogging extends TestBase {
 
@@ -107,6 +108,45 @@ class VerifySynapseMLLogging extends TestBase {
     } finally {
       // Clean up to avoid leaking state into other tests
       SynapseMLLogging.LoggedClasses.remove("TestClass")
+    }
+  }
+
+  test("getHadoopConfEntries reads cluster-level Hadoop configuration") {
+    // Fabric sets the trident.* keys on the cluster Hadoop conf. getHadoopConfEntries now derives
+    // its conf from the session instead of spark.sparkContext, so this pins that existing
+    // telemetry still resolves.
+    SparkSession.setActiveSession(spark)
+    val hc = spark.sparkContext.hadoopConfiguration
+    try {
+      hc.set("trident.workspace.id", "ws-from-cluster")
+      assert(SynapseMLLogging.getHadoopConfEntries.get("workspaceId").contains("ws-from-cluster"))
+    } finally {
+      hc.unset("trident.workspace.id")
+    }
+  }
+
+  test("getHadoopConfEntries reads session-level overrides") {
+    SparkSession.setActiveSession(spark)
+    try {
+      spark.conf.set("trident.artifact.id", "artifact-from-session")
+      assert(SynapseMLLogging.getHadoopConfEntries.get("artifactId").contains("artifact-from-session"))
+    } finally {
+      spark.conf.unset("trident.artifact.id")
+    }
+  }
+
+  test("getHadoopConfEntries returns only known telemetry field names") {
+    SparkSession.setActiveSession(spark)
+    val known = SynapseMLLogging.HadoopKeysToLog.values.toSet
+    assert(SynapseMLLogging.getHadoopConfEntries.keySet.subsetOf(known))
+  }
+
+  test("getHadoopConfEntries is empty when no session is active") {
+    SparkSession.clearActiveSession()
+    try {
+      assert(SynapseMLLogging.getHadoopConfEntries.isEmpty)
+    } finally {
+      SparkSession.setActiveSession(spark)
     }
   }
 }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/logging/VerifySynapseMLLogging.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/logging/VerifySynapseMLLogging.scala
@@ -111,50 +111,59 @@ class VerifySynapseMLLogging extends TestBase {
     }
   }
 
-  /** Makes `spark` the active session for the current thread, and deliberately leaves it that way.
+  /** Runs `f` with `spark` as the active session, restoring a previously-active session if there
+    * was one.
     *
     * `getHadoopConfEntries` resolves its configuration through `SparkSession.getActiveSession`, so
-    * these tests need one. `TestBase` never establishes an active session — `getOrCreate` only sets
-    * one when it actually constructs the session — so it is whatever a previously-run suite happened
-    * to leave behind.
+    * these tests need one. When another suite has left a session active on this thread it is
+    * restored exactly, so nothing is overwritten.
     *
-    * Restoring the "previous" value afterwards is tempting but measurably wrong here: the previous
-    * value is usually empty, so restoring it clears the active session for every suite that later
-    * runs on this thread. `EnsembleByKey.transformSchema` falls back to `getActiveSession` and
-    * silently defaults `spark.sql.caseSensitive` to `false` when there is none, which turns three
-    * `EnsembleByKeySuite` tests red when both suites share a JVM. Leaving the shared session active
-    * is the canonical state, and is what every suite that reads `getActiveSession` expects.
+    * When there was none, the shared session is deliberately left active rather than cleared.
+    * `TestBase` never establishes one — `getOrCreate` only calls `setActiveSession` on the branch
+    * that actually constructs the session, not when it returns an existing one — so "restoring" an
+    * empty previous value would clear the active session for every suite that later runs on this
+    * thread. `EnsembleByKey.transformSchema` falls back to `getActiveSession` and silently defaults
+    * `spark.sql.caseSensitive` to `false` when there is none, which turns three `EnsembleByKeySuite`
+    * tests red when both suites share a JVM. Leaving the shared session active is the canonical
+    * state, and is what every suite reading `getActiveSession` already assumes.
     */
-  private def activateSharedSession(): Unit = SparkSession.setActiveSession(spark)
+  private def withActiveSharedSession[T](f: => T): T = {
+    val previous = SparkSession.getActiveSession
+    SparkSession.setActiveSession(spark)
+    try f finally previous.foreach(SparkSession.setActiveSession)
+  }
 
   test("getHadoopConfEntries reads cluster-level Hadoop configuration") {
     // Fabric sets the trident.* keys on the cluster Hadoop conf. getHadoopConfEntries now derives
     // its conf from the session instead of spark.sparkContext, so this pins that existing
     // telemetry still resolves.
-    activateSharedSession()
-    val hc = spark.sparkContext.hadoopConfiguration
-    try {
-      hc.set("trident.workspace.id", "ws-from-cluster")
-      assert(SynapseMLLogging.getHadoopConfEntries.get("workspaceId").contains("ws-from-cluster"))
-    } finally {
-      hc.unset("trident.workspace.id")
+    withActiveSharedSession {
+      val hc = spark.sparkContext.hadoopConfiguration
+      try {
+        hc.set("trident.workspace.id", "ws-from-cluster")
+        assert(SynapseMLLogging.getHadoopConfEntries.get("workspaceId").contains("ws-from-cluster"))
+      } finally {
+        hc.unset("trident.workspace.id")
+      }
     }
   }
 
   test("getHadoopConfEntries reads session-level overrides") {
-    activateSharedSession()
-    try {
-      spark.conf.set("trident.artifact.id", "artifact-from-session")
-      assert(SynapseMLLogging.getHadoopConfEntries.get("artifactId").contains("artifact-from-session"))
-    } finally {
-      spark.conf.unset("trident.artifact.id")
+    withActiveSharedSession {
+      try {
+        spark.conf.set("trident.artifact.id", "artifact-from-session")
+        assert(SynapseMLLogging.getHadoopConfEntries.get("artifactId").contains("artifact-from-session"))
+      } finally {
+        spark.conf.unset("trident.artifact.id")
+      }
     }
   }
 
   test("getHadoopConfEntries returns only known telemetry field names") {
-    activateSharedSession()
-    val known = SynapseMLLogging.HadoopKeysToLog.values.toSet
-    assert(SynapseMLLogging.getHadoopConfEntries.keySet.subsetOf(known))
+    withActiveSharedSession {
+      val known = SynapseMLLogging.HadoopKeysToLog.values.toSet
+      assert(SynapseMLLogging.getHadoopConfEntries.keySet.subsetOf(known))
+    }
   }
 
   test("getHadoopConfEntries is empty when no session is active") {

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/logging/VerifySynapseMLLogging.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/logging/VerifySynapseMLLogging.scala
@@ -111,11 +111,27 @@ class VerifySynapseMLLogging extends TestBase {
     }
   }
 
+  /** Makes `spark` the active session for the current thread, and deliberately leaves it that way.
+    *
+    * `getHadoopConfEntries` resolves its configuration through `SparkSession.getActiveSession`, so
+    * these tests need one. `TestBase` never establishes an active session — `getOrCreate` only sets
+    * one when it actually constructs the session — so it is whatever a previously-run suite happened
+    * to leave behind.
+    *
+    * Restoring the "previous" value afterwards is tempting but measurably wrong here: the previous
+    * value is usually empty, so restoring it clears the active session for every suite that later
+    * runs on this thread. `EnsembleByKey.transformSchema` falls back to `getActiveSession` and
+    * silently defaults `spark.sql.caseSensitive` to `false` when there is none, which turns three
+    * `EnsembleByKeySuite` tests red when both suites share a JVM. Leaving the shared session active
+    * is the canonical state, and is what every suite that reads `getActiveSession` expects.
+    */
+  private def activateSharedSession(): Unit = SparkSession.setActiveSession(spark)
+
   test("getHadoopConfEntries reads cluster-level Hadoop configuration") {
     // Fabric sets the trident.* keys on the cluster Hadoop conf. getHadoopConfEntries now derives
     // its conf from the session instead of spark.sparkContext, so this pins that existing
     // telemetry still resolves.
-    SparkSession.setActiveSession(spark)
+    activateSharedSession()
     val hc = spark.sparkContext.hadoopConfiguration
     try {
       hc.set("trident.workspace.id", "ws-from-cluster")
@@ -126,7 +142,7 @@ class VerifySynapseMLLogging extends TestBase {
   }
 
   test("getHadoopConfEntries reads session-level overrides") {
-    SparkSession.setActiveSession(spark)
+    activateSharedSession()
     try {
       spark.conf.set("trident.artifact.id", "artifact-from-session")
       assert(SynapseMLLogging.getHadoopConfEntries.get("artifactId").contains("artifact-from-session"))
@@ -136,17 +152,26 @@ class VerifySynapseMLLogging extends TestBase {
   }
 
   test("getHadoopConfEntries returns only known telemetry field names") {
-    SparkSession.setActiveSession(spark)
+    activateSharedSession()
     val known = SynapseMLLogging.HadoopKeysToLog.values.toSet
     assert(SynapseMLLogging.getHadoopConfEntries.keySet.subsetOf(known))
   }
 
   test("getHadoopConfEntries is empty when no session is active") {
-    SparkSession.clearActiveSession()
-    try {
-      assert(SynapseMLLogging.getHadoopConfEntries.isEmpty)
-    } finally {
-      SparkSession.setActiveSession(spark)
-    }
+    // Runs on its own thread so that clearing the active session cannot strand suites that share
+    // the main test thread; SparkSession's active-session slot is a thread local.
+    var failure: Option[Throwable] = None
+    val thread = new Thread(new Runnable {
+      override def run(): Unit =
+        try {
+          SparkSession.clearActiveSession()
+          assert(SynapseMLLogging.getHadoopConfEntries.isEmpty)
+        } catch {
+          case e: Throwable => failure = Some(e)
+        }
+    })
+    thread.start()
+    thread.join()
+    failure.foreach(e => throw e)
   }
 }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputePerInstanceStatistics.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyComputePerInstanceStatistics.scala
@@ -10,6 +10,7 @@ import com.microsoft.azure.synapse.ml.train.TrainClassifierTestUtilities._
 import com.microsoft.azure.synapse.ml.train.TrainRegressorTestUtilities._
 import org.apache.spark.ml.classification.LogisticRegression
 import org.apache.spark.ml.feature.FastVectorAssembler
+import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.sql._
 
 /** Tests to validate the functionality of Compute Per Instance Statistics module. */
@@ -119,6 +120,41 @@ class VerifyComputePerInstanceStatistics extends TestBase {
     val scoredDataset = TrainClassifierTestUtilities.trainScoreDataset(labelColumn, dataset, logisticRegressor)
     val evaluatedData = new ComputePerInstanceStatistics().transform(scoredDataset)
     validatePerInstanceClassificationStatistics(evaluatedData)
+  }
+
+  test("Verify log loss uses the distinct label count when levels metadata is absent") {
+    // numLevels is derived from a distinct count over the label column. Pin that here: the label
+    // has three distinct values, and the final row is scored with a label equal to that count, so
+    // it must fall into the "no label seen in training" branch instead of indexing the vector.
+    // An off-by-one in the distinct count shows up either as an index error or as a wrong loss.
+    val probs: Vector = Vectors.dense(0.7, 0.2, 0.1)
+    val scoredData = spark.createDataFrame(Seq(
+      (0.0, probs, probs, 0.0),
+      (1.0, probs, probs, 1.0),
+      (2.0, probs, probs, 2.0),
+      (0.0, probs, probs, 0.0),
+      (1.0, probs, probs, 1.0),
+      (2.0, probs, probs, 3.0)))
+      .toDF(labelColumn, "scoresCol", "probabilitiesCol", "scoredLabelsCol")
+
+    val evaluatedData = new ComputePerInstanceStatistics()
+      .setLabelCol(labelColumn)
+      .setScoredLabelsCol("scoredLabelsCol")
+      .setScoresCol("scoresCol")
+      .setScoredProbabilitiesCol("probabilitiesCol")
+      .setEvaluationMetric(MetricConstants.ClassificationMetricsName)
+      .transform(scoredData)
+
+    val penalized = -Math.log(ComputePerInstanceStatistics.Epsilon)
+    val rows = evaluatedData.select("scoredLabelsCol", MetricConstants.LogLossMetric).collect()
+    assert(rows.length === 6)
+    assert(rows.count(r => r.getDouble(1) === penalized) === 1)
+    rows.foreach { row =>
+      val scoredLabel = row.getDouble(0).toInt
+      val logLoss = row.getDouble(1)
+      val expected = if (scoredLabel < 3) -Math.log(probs(scoredLabel)) else penalized
+      assert(logLoss === expected)
+    }
   }
 
   private def validatePerInstanceRegressionStatistics(evaluatedData: DataFrame): Unit = {


### PR DESCRIPTION
Closes #2401

## What

Takes SynapseML's **model persistence path and telemetry** off `SparkContext`/RDD, in three parts:

**1. Model metadata** — read and write now go through `SparkSession`:

```scala
// write
- sc.parallelize(Seq(metadataJson), 1).saveAsTextFile(metadataPath)
+ spark.createDataFrame(Seq(Tuple1(metadataJson))).toDF("value").write.text(metadataPath)

// read
- DefaultParamsReader.loadMetadata(path, sc, className)
+ DefaultParamsReader.parseMetadata(spark.read.text(metadataPath).first().getString(0), className)
```

**2. Complex params** — the Hadoop configuration now comes from the session:

```scala
- new ObjectSerializer(sparkSession.sparkContext)(typeToTypeTag(tpe))
+ new ObjectSerializer(sparkSession)(typeToTypeTag(tpe))

- val hadoopConf = sc.hadoopConfiguration
+ val hadoopConf = spark.sessionState.newHadoopConf()
```

**3. Telemetry** — `SynapseMLLogging` reads the `trident.*` fields the same way:

```scala
- val hc = spark.sparkContext.hadoopConfiguration
+ val hc = spark.sessionState.newHadoopConf()
```

Plus one redundant `.rdd` hop dropped in `ComputePerInstanceStatistics`.

## Why

This is **not** because RDDs are removed in Spark 4.0 — they are not. `RDD` carries no `@deprecated` in 4.0/4.1, and neither the [Core](https://spark.apache.org/docs/4.0.0/core-migration-guide.html) nor the [SQL](https://spark.apache.org/docs/4.0.0/sql-migration-guide.html) 3.5→4.0 migration guide mentions RDD at all.

The reason is that these call sites **hard-fail on the runtimes SynapseML users are being moved onto**:

| Runtime | `sc.parallelize(...).saveAsTextFile` / `spark.sparkContext` | Replacement |
|---|---|---|
| Spark 4.x **classic** | works | works |
| **Spark Connect** (4.0+) | throws `UNSUPPORTED_CONNECT_FEATURE.SESSION_SPARK_CONTEXT` | works |
| Databricks **UC standard** access mode (Scala, DBR 13.3+) | unsupported | works |
| Databricks **serverless** | unsupported | works |

- Spark 4.0 moved `SparkSession`/`Dataset` into the shared `sql-api` module and annotated every RDD member `@ClassicOnly` ([SPARK-48918](https://issues.apache.org/jira/browse/SPARK-48918)). The Connect implementation throws: `sql/connect/.../SparkSession.scala` → `ConnectClientUnsupportedErrors.sparkContext()`, `sql/connect/.../Dataset.scala` → `ConnectClientUnsupportedErrors.rdd()`.
- Databricks [standard compute limitations](https://learn.microsoft.com/en-us/azure/databricks/compute/standard-limitations) states *"RDD APIs are not supported"* and *"`spark.sparkContext` ... not supported for Scala"*, naming `parallelize` and `textFile` explicitly — exactly the APIs removed here.

**Direct precedent: Apache Spark made this identical change in its own MLlib.** [SPARK-48909](https://issues.apache.org/jira/browse/SPARK-48909) *"Uses SparkSession over SparkContext when writing metadata"* shipped in **4.0.0** (commit `0e8d403`) and rewrote `mllib/.../util/ReadWrite.scala` with the same substitution in both directions. Spark's MLlib likewise derives its Hadoop configuration via `session.sessionState.newHadoopConf()` (`ReadWrite.scala:831`, v4.1.0).

## Why the complex-param half matters

Fixing metadata alone would leave persistence half migrated. `Serializer.typeToSerializer` falls back to `ObjectSerializer` for every param whose type is not a `PipelineStage` or `Dataset` — that is **`UDFParam`, `EvaluatorParam` and `ArrayParamMapParam`**. So saving or loading a `UDFTransformer`, `TuneHyperparameters` or `FindBestModel` would still have called `spark.sparkContext` and still failed on UC standard mode.

Using `sessionState.newHadoopConf()` is also a small correctness win independent of Spark 4: it layers session-level conf on top of the cluster Hadoop conf, which `sparkContext.hadoopConfiguration` does not — so per-session storage credentials are now honoured when writing complex params.

**`Serializer`'s `SparkContext` entry points are removed outright.** `writeToHDFS`, `readFromHDFS`, `makeQualifiedPath` and the `ObjectSerializer` constructor previously had `SparkContext` forms. An earlier revision of this PR kept them `@deprecated` alongside new `SparkSession` overloads; they are now deleted instead. A repository-wide search found **no callers anywhere** — core, cognitive, lightgbm, vw, deep-learning, opencv — the only references were in this PR's own test. Keeping a second path that cannot work under Spark Connect or UC standard mode would only invite new callers onto it, so there is now a single session-based path. `compile` and `Test/compile` pass across all six modules. This is a source break only for an external caller of `org.apache.spark.ml.Serializer`, which is an internal utility with no callers in-tree.

## Why the telemetry change matters

`SynapseMLLogging.getHadoopConfEntries` is reached from `logClass` — which runs in **every SynapseML stage constructor** — as well as from `logFit`/`logTransform`. On UC standard mode the old `spark.sparkContext.hadoopConfiguration` read meant simply *constructing* a stage could raise before any user code ran: the earliest and least debuggable failure point in the library.

It is deliberately **not** cached. The eight `trident.*` keys are session identity fields (workspace, lakehouse, artifact, capacity, tenant) that a notebook can rebind mid-session, so memoizing them risks emitting stale telemetry. Measured cost of the swap is **15.7 µs → 247 µs**, incurred once per `fit`/`transform`/constructor call — never per row, per partition or per task. The cheapest possible Spark job in the same harness took **304 ms**, so this is ≈0.08% of one trivial action.

Same free correctness win as above: session-level conf is now layered in, so `spark.conf.set("trident.workspace.id", ...)` is reflected in telemetry where previously it was invisible. Pinned by a test.

## Spark 3.5 / Spark 4.1 compatibility

Every API used exists with an **identical signature** in both, verified against Apache Spark source:

| API used | Spark 3.5.0 | Spark 4.1.0 |
|---|---|---|
| `DefaultParamsReader.parseMetadata(str, expectedClassName = "")` | `ReadWrite.scala:599` | `ReadWrite.scala:736` |
| `spark.createDataFrame(Seq(Tuple1(x))).write.text(p)` | supported | **used by MLlib itself**, `ReadWrite.scala:1050` |
| `spark.read.text(p).first().getString(0)` | supported | **used by MLlib itself**, `ReadWrite.scala:1058` |
| `spark.sessionState.newHadoopConf()` | supported | **used by MLlib itself**, `ReadWrite.scala:831` |
| `MLReader.sparkSession`, `spark.version` | supported | supported |

Two notes on why the metadata read is written the way it is:

- Spark **3.5.0 only ships `loadMetadata(path, sc, expectedClassName)`** — there is no `SparkSession` overload (added in 4.0; 4.1 has all three at `ReadWrite.scala:713/719/725`). Calling the 4.0 overload directly would not compile against 3.5, so the same three lines are inlined, which works on **both**.
- Forward-compatible by construction: when `master` moves to Spark 4.x those lines collapse to `DefaultParamsReader.loadMetadata(path, spark, className)` with no behaviour change.

## Scope boundary

This PR takes the **model persistence path and the telemetry path** off `SparkContext` end to end. It deliberately does not attempt the whole library — 66 `SparkContext`/RDD call sites remain across 31 files (`ClusterUtil`, `LightGBMBase`, `ONNXModel`, `VowpalWabbitBase`, `StratifiedRepartition`, `ComputeModelStatistics`, ...). Those need separate, individually validated changes; several are not mechanical.

## On-disk format and backward compatibility

Byte-identical output, both halves.

- **Metadata**: Spark's text writer emits raw UTF-8 with no quoting or escaping, the reader does no unescaping, and `createDataFrame(Seq(Tuple1(...)))` produces a `LocalRelation` → exactly one part file (`_SUCCESS` is skipped by `hiddenFileFilter`).
- **Complex params**: only the *source* of the Hadoop `Configuration` changed; the bytes written are produced by the same `ObjectOutputStream` path as before.

Models written by older SynapseML load with this change, and vice versa — asserted by two dedicated tests rather than by inspection.

## Validation

Run locally on Spark 3.5.0 / Scala 2.12.17 / Java 17:

- `core/testOnly *ValidateComplexParamSerializer` → **4 succeeded, 0 failed**, including a test that rewrites metadata via the legacy `saveAsTextFile` path and loads it with the new reader, and a test that reproduces the previous object write byte for byte — FileSystem resolved from `sc.hadoopConfiguration`, same `Serializer.write` — then reads it back through the session path. That is the property that actually matters: models written by earlier SynapseML versions must still load.
- `core/testOnly *VerifyComputePerInstanceStatistics` → **5 succeeded, 0 failed**. The new test pins the `numLevels` distinct count that the dropped `.rdd` hop feeds. It was verified three ways: it passes with the new `DataFrame.distinct`, passes unchanged with the previous `.rdd.distinct` (so the two are equivalent on this path), and **fails** when `numLevels` is deliberately mutated by `+1`, so it is not a vacuous test.
- `core/testOnly ...core.serialize.* ...train.VerifyComputePerInstanceStatistics ...stages.* ...automl.* ...logging.*` → **397 succeeded, 0 failed** — this is the meaningful one: `stages` covers `UDFParam`, `automl` covers `EvaluatorParam`/`ArrayParamMapParam` (the params that route through `ObjectSerializer`), and re-running it after the logging change exercises the full transform path.
- `core/testOnly ...logging.*` → **38 succeeded, 0 failed**, including four new tests covering the cluster-level conf path (what Fabric populates today), session-level overrides, the known-key contract, and the no-active-session case.
- `core/testOnly com.microsoft.azure.synapse.ml.train.*` → **45 succeeded, 1 failed**; `VerifyComputePerInstanceStatistics` **4/4**.
  - The single failure (`VerifyTrainClassifier` → *"train on a dataset that contains a vector column"*, `Vector values MUST NOT be NaN`) **reproduces identically on unmodified `master`** — pre-existing and unrelated.
- `core/scalastyle` + `core/test:scalastyle` → **0 errors**, main and test.

## Related

- Closes #2401, which names this exact file and line and cites SPARK-48909 as the precedent.
- Supersedes the serialization portion of #2517; see [this comment](https://github.com/microsoft/SynapseML/pull/2517#issuecomment-5301842286) for why the remaining hunks there were excluded.
- **The `spark4.1` branch needs the same fix.** `ComplexParamsSerializer.scala` there still calls `sc.parallelize(...).saveAsTextFile(...)`, `DefaultParamsReader.loadMetadata(path, sc)` and `sc.version`, so Connect / UC standard mode is still broken on that branch. This change applies cleanly and is Scala 2.13 safe.
  - This is why **`Release Branch Compatibility Check spark4.1` is red on this PR, and that is the correct signal** — the check rebases these commits onto `spark4.1`, which still carries the pre-fix code in the same hunks, so it conflicts. The job is `continueOnError: true` (`pipeline.yaml:921`) and is not one of the three required contexts (`license/cla`, `WIP`, `microsoft.SynapseML`), so it is advisory only. Every other check is green.
