### PR TITLE
ci: run PR validation on the spark3.5, spark4.0 and spark4.1 branches

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,11 +13,11 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master", "spark4.1" ]
+    branches: [ "master", "spark3.5", "spark4.0", "spark4.1" ]
     paths-ignore: [ "**.md" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master", "spark4.1" ]
+    branches: [ "master", "spark3.5", "spark4.0", "spark4.1" ]
     paths-ignore: [ "**.md" ]
   schedule:
     - cron: '17 7 * * 3'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [ "master", "spark4.1" ]
+    branches: [ "master", "spark3.5", "spark4.0", "spark4.1" ]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -2,7 +2,7 @@ name: PR Validation
 
 on:
   pull_request:
-    branches: [ "master", "spark4.1" ]
+    branches: [ "master", "spark3.5", "spark4.0", "spark4.1" ]
     paths-ignore: [ "**.md", "docs/**", "website/**" ]
 
 jobs:

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -13,6 +13,7 @@ trigger:
     include:
     - master
     - spark3.5
+    - spark4.0
     - spark4.1
   paths:
     exclude:
@@ -29,6 +30,7 @@ pr:
     include:
     - master
     - spark3.5
+    - spark4.0
     - spark4.1
   paths:
     exclude:


### PR DESCRIPTION
## Problem

PRs targeting **`spark4.0` run no automated checks whatsoever**, and PRs targeting **`spark3.5` run no GitHub Actions**.

Measured coverage on `master@eb76ff6bd0` before this change:

| Target branch | `pr-validation` | `dependency-review` | `codeql` | ADO `microsoft.SynapseML` |
|---|:--:|:--:|:--:|:--:|
| `master`   | ✅ | ✅ | ✅ | ✅ |
| `spark3.5` | ❌ | ❌ | ❌ | ✅ |
| `spark4.0` | ❌ | ❌ | ❌ | ❌ |
| `spark4.1` | ✅ | ✅ | ✅ | ✅ |

All three GitHub workflows were filtered to `[ "master", "spark4.1" ]`, and `pipeline.yaml` listed only `master, spark3.5, spark4.1` in both `trigger:` and `pr:`.

This is not theoretical. The `release-tag.yml` workflow added in #2540 opens rebase PRs into `spark4.0` automatically, and its own inline documentation already records the hazard:

> `spark4.0` is outside the branch filters of `pr-validation.yml` and the ADO pipeline, so this PR legitimately runs no checks at all.

So the release automation can currently open a PR into `spark4.0` that is mergeable with zero signal.

## Change

Add `spark3.5`, `spark4.0` and `spark4.1` to every branch filter:

- `.github/workflows/pr-validation.yml` — `pull_request.branches`
- `.github/workflows/dependency-review.yml` — `pull_request.branches`
- `.github/workflows/codeql.yml` — both `push.branches` and `pull_request.branches` (the file's own comment requires `pull_request` to be a subset of `push`, so both had to move together)
- `pipeline.yaml` — `trigger.branches.include` and `pr.branches.include`

Total diff: **6 insertions, 4 deletions across 4 files.** No logic changes.

## Why no change was needed in the InternalCompat job

The OSS→Internal branch pairing is an identity mapping, and the step says so explicitly:

```
# Identity mapping: OSS and Internal use the same branch names, so a branch added to
# the pr: trigger list is paired correctly without touching this step.
INTERNAL_BRANCH="$OSS_TARGET"
```

Adding `spark4.0` to `pr:` therefore pairs it with SynapseML-Internal `spark4.0` automatically. If Internal has not cut that branch, the existing guard falls back to `master` and raises a **warning** rather than failing, so this cannot introduce a new hard failure.

## Why `ReleaseBranchCompat` was deliberately *not* extended

That job replays master's changed files onto each release branch and compiles them. Its matrix stays `spark4.1`-only on purpose: `spark4.0` is currently **547 files / +48173 −18847 behind master** (last synced 2026-04-02), so adding it today would create an advisory check that is red on every master PR from the moment it merges — noise, not signal.

It should be added in a follow-up **after** the `spark4.0` sync lands. Called out here so it is a conscious deferral rather than an oversight.

## Scope note

`spark3.5` is included alongside `spark4.0` because it is the same class of gap in the same four files — it was covered by ADO but by none of the GitHub workflows. Happy to drop it to a separate PR if reviewers would rather keep this strictly Spark-4-scoped; it is a one-word revert in three files.

## Validation

- All four files re-parsed with `yaml.safe_load` after editing; each of the six filter lists asserted to equal `['master', 'spark3.5', 'spark4.0', 'spark4.1']` rather than merely "the file still parses".
- Diff reviewed line by line: no unintended edits, no unrelated files.

Note that for `pull_request` events GitHub reads workflow files from the **merge** commit, so this PR is itself validated by the filters it introduces.
