### PR TITLE
docs: add the Spark 4 branch details the condensed skill dropped

### DIFF
--- a/.github/skills/synapseml-branches/references/branch-spark4-common.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4-common.md
@@ -46,17 +46,22 @@ against the live target branch.
   call.
 - R generation requires ANSI double-quoted identifiers, the validated sparklyr
   1.9.5 pin from the PR snapshots, `SPARK_HOME` connection behavior, and JVM
-  loading of nested stages. Both branches pair that pin with `r-base=4.4`; keep
-  the pair together, since 69/69 `RTests` was measured for the combination, not
-  for the sparklyr pin alone. Interleaved failures with successful tests between
-  them point to selection/proxy behavior, not a dead Spark session; read the
-  backtrace. Under sparklyr 1.9.3 with dbplyr 2.6 the tell is a frame chain
-  through `dbplyr:::select.tbl_lazy`, `sparklyr:::tidyselect_data_proxy.tbl_spark`
+  loading of nested stages. That pin is not yet everywhere — check
+  `environment.yml` on your branch, since a branch still on sparklyr 1.9.3 has
+  the failure below as a live concern rather than as history. Where 1.9.5 is
+  applied, keep it paired with `r-base=4.4`: 69/69 `RTests` was measured for the
+  combination, not for the sparklyr pin alone. Interleaved failures with
+  successful tests between them point to selection/proxy behavior, not a dead
+  Spark session; read the backtrace. Under sparklyr 1.9.3 with dbplyr 2.6 the
+  tell is a frame chain through `dbplyr:::select.tbl_lazy`,
+  `sparklyr:::tidyselect_data_proxy.tbl_spark`
   and `simulate_vars_spark`, which surfaces as `invoke_static`/`hive_context`
   being called on `NULL` and reads misleadingly like a dead session.
-- `RCodegenSuite` asserts the cheap R generation invariants on both Spark 4
-  branches. Run it before spending a full pipeline run on an R failure, and keep
-  its assertions in step when changing generated R.
+- `RCodegenSuite` asserts cheap R generation invariants without a full pipeline
+  run, but it is not present on every branch — `spark4.1` has it and `spark4.0`
+  does not yet. Check for it before relying on it, run it before spending a
+  pipeline run on an R failure, and keep its assertions in step when changing
+  generated R.
 
 ## Runtime and CI
 
@@ -64,15 +69,15 @@ against the live target branch.
   and use sibling-branch timing/results as a control before blaming capacity.
 - `areLibrariesInstalled == false` can mean install timeout rather than a
   failed library. Read statuses and notebook duration before classifying it.
-- `DatabricksCPUStreamingTests` is unscheduled on both Spark 4 branches: the
-  class exists in `DatabricksCPUTests.scala`, but `pipeline.yaml` names its test
-  legs explicitly and never lists it. It exists as a separate class because the
-  streaming notebook's `server.stop()` cancels concurrent SparkContext jobs, so
-  it has to run on its own cluster instead of joining an existing leg — which is
-  why scheduling it needs pool capacity as well as a notebook fix. The in-repo
-  comment is identical on both branches and attributes the behaviour to Spark
-  4.0; it has not been re-confirmed on 4.1. Treat it as a known coverage gap to
-  verify, not as an omission to accept silently.
+- `DatabricksCPUStreamingTests` exists only on the Spark 4 branches, and whether
+  it is scheduled varies by branch — read `pipeline.yaml` on the branch you are
+  working on rather than assuming. It is a separate class because the streaming
+  notebook's `server.stop()` cancels concurrent SparkContext jobs, so it needs its
+  own cluster instead of a slot on an existing leg, which is why scheduling it
+  costs pool capacity. The in-repo comment attributes that behaviour to Spark 4.0
+  and it has not been re-confirmed on 4.1. If a sync drops its leg while leaving
+  the class defined, that is lost coverage rather than a cleanup: the class is
+  still there, so nothing fails to compile and nothing reports the gap.
 - Petastorm calls pyarrow APIs the pinned pyarrow no longer ships, so Horovod's
   Spark backend needs a compatibility layer. Only `spark4.1` has one. This is a
   library-version problem, not a Python-version one, so a branch on the same

--- a/.github/skills/synapseml-branches/references/branch-spark4-common.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4-common.md
@@ -19,12 +19,14 @@ against the live target branch.
 
 - Spark 4 uses Scala 2.13 and Java 17-era tooling. Preserve branch-specific
   dependency comments, Java configuration, and removal of obsolete CMS flags.
-- The `pyarrow` and `mlflow` pins move in lockstep: `mlflow==2.21.3` declares
-  `pyarrow<20,>=4.0.0`, so a `pyarrow` bump that crosses that bound breaks the
-  environment solve unless `mlflow` moves with it. Bumps inside the bound, such
-  as 18 to 19, are fine. Trust the declared bound over the inline comments, which
-  disagree with each other — `spark4.1`'s `environment.yml` says `pyarrow<19`,
-  which is wrong, and has no comment on the `mlflow` pin at all.
+- The `pyarrow` and `mlflow` pins are coupled, and the pinned versions are not
+  the same on every branch — read both live values on the branch you are editing
+  before changing either. The bound comes from MLflow: `mlflow==2.21.3` declares
+  `pyarrow<20,>=4.0.0`, so on a branch pinning that MLflow, `pyarrow` must stay
+  under 20 or move together with `mlflow`; bumps inside the bound are fine. Older
+  MLflow pins carry different bounds, so check the pinned version's own metadata
+  rather than assuming this one. Do not trust the inline comments: they disagree
+  with each other and with the pins they sit next to.
 - Scala 2.13 collection boundaries must produce immutable `Seq` values; keep
   the central `asImmutableCollection` conversion rather than per-service fixes.
 - Preserve Spark 4 adaptations for SAR encoders/self-joins,

--- a/.github/skills/synapseml-branches/references/branch-spark4-common.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4-common.md
@@ -49,6 +49,12 @@ against the live target branch.
 - `DatabricksCPUStreamingTests` is unscheduled on both Spark 4 branches, pending
   pool capacity and notebook work. Treat it as a known coverage gap to verify,
   not as an omission to accept silently.
+- Petastorm calls pyarrow APIs the pinned pyarrow no longer ships, so Horovod's
+  Spark backend needs a compatibility layer. Only `spark4.1` has one. This is a
+  library-version problem, not a Python-version one, so a branch on the same
+  pyarrow is not exempt. Deep-learning unit tests will not reveal the gap:
+  without a usable Horovod the estimators are stubbed and the Petastorm path
+  never runs.
 - `/azp run` queues these targets. The ADO pull-request trigger filter allowed
   only `master` until 2026-08-17; it now covers `master`, `spark3.5`,
   `spark4.0` and `spark4.1`, verified by builds recording `reason=pullRequest`

--- a/.github/skills/synapseml-branches/references/branch-spark4-common.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4-common.md
@@ -2,8 +2,19 @@
 
 Condensed from the branch guides developed in
 [#2645](https://github.com/microsoft/SynapseML/pull/2645) and
-[#2646](https://github.com/microsoft/SynapseML/pull/2646). Verify every item
-against the live target branch.
+[#2646](https://github.com/microsoft/SynapseML/pull/2646).
+
+**Read this as describing the branches as of those two sync PRs, not as a
+snapshot of the live branches.** Both guides were written on the sync branches,
+so they describe the merged result. Until those PRs land, a live branch can lack
+things described here — at the time of writing, live `spark4.0` has no
+`OpenAIPromptPythonOverrides.scala`, no `test_http_package.py` /
+`test_package_exports.py`, no `new_ml_pipeline_stage` in generated R, and a
+different GPU pool. Verify every item against the live target branch with
+`git show <branch>:<path>` or `git grep <pattern> <branch>`; do not read it out
+of a local sync worktree, which is a PR result rather than branch state. That
+specific mistake produced several wrong claims in earlier revisions of this
+file.
 
 ## Purpose and sync
 
@@ -60,7 +71,8 @@ against the live target branch.
   `class _OpenAIPrompt` and a hand-written `OpenAIPrompt.py` supplies the public
   name. Python emitted into that class must use zero-argument `super()`; a
   hardcoded `super(OpenAIPrompt, self)` raises `NameError` because that name does
-  not exist inside the generated module. See `OpenAIPromptPythonOverrides.scala`.
+  not exist inside the generated module. See `OpenAIPromptPythonOverrides.scala`,
+  which is on `spark4.1` and reaches `spark4.0` with #2646.
 - `PythonInitMerger` makes hand-written `__init__.py` files live package code by
   splicing them *after* the generated imports; before it, codegen overwrote them
   and their contents were inert, so a stale one is now a real bug. Keep the HTTP
@@ -69,7 +81,9 @@ against the live target branch.
   `PythonTests core` plus seven website samples. Remove initializers that only
   duplicate generated exports, and do not narrow `import *` by redefining
   `__all__` as a hand-maintained list. Keep the ones that add exports codegen
-  does not emit. `test_http_package.py` and `test_package_exports.py` guard this.
+  does not emit. `test_http_package.py` and `test_package_exports.py` guard this
+  where they exist; they are not on live `spark4.0` yet and arrive there with
+  #2646, so on that branch the policy is currently unenforced.
 - `cyber/utils/spark_utils.py` differs between the branches without either form
   being version-specific: `spark4.0` builds its indexed frame with
   `rdd.toDF(schema)` and `spark4.1` uses `spark.createDataFrame(rdd, schema)`.
@@ -96,7 +110,8 @@ against the live target branch.
   does not yet. Check for it before relying on it, run it before spending a
   pipeline run on an R failure, and keep its assertions in step when changing
   generated R.
-- Nested stages load off the JVM: `PipelineStageWrappable.rLoadLine` emits
+- Nested stages load off the JVM on branches that have adopted it — `spark4.1`
+  has, live `spark4.0` has not yet. `PipelineStageWrappable.rLoadLine` emits
   `sparklyr:::new_ml_pipeline_stage(invoke(spark_jobj(x), "getStages")[[1]])`
   rather than `ml_stages(x)[[1]]`. `new_ml_pipeline_stage` is sparklyr-internal
   but has an identical signature in every release from v1.8.0 to v1.9.5.
@@ -110,13 +125,15 @@ against the live target branch.
 
 ## Runtime and CI
 
-- Spark 4 Databricks builds share scarce GPU capacity: the GPU pool
-  `synapseml-build-14.3-gpu` is shared with `master` and both Spark 4 branches
-  (instance pools are runtime-agnostic, so sharing avoids duplicating scarce GPU
-  quota). It holds three workers (`GpuWorkersPerRun` 1 x `GpuConcurrentRuns` 3),
-  so two concurrent builds can exhaust it. Queue them sequentially, and use the
-  sibling branch as a free control: because the pool is shared, an outcome that
-  tracks the branch rather than the timing is a code difference, not contention.
+- Spark 4 Databricks builds contend for scarce GPU capacity, and the pool names
+  differ by branch — read them from `pipeline.yaml`/the Databricks test config on
+  your branch rather than assuming. Instance pools are runtime-agnostic, so a
+  GPU pool is often deliberately shared across branches to avoid duplicating
+  scarce quota; where it is shared it holds three workers
+  (`GpuWorkersPerRun` 1 x `GpuConcurrentRuns` 3), so two concurrent builds can
+  exhaust it. Queue Spark 4 builds sequentially. Where the pool *is* shared, the
+  sibling branch is a free control: an outcome that tracks the branch rather
+  than the timing is a code difference, not contention.
 - `areLibrariesInstalled == false` is a timeout, not a capacity verdict, and the
   logic inverts the way people expect. The check *throws* `Library Installation
   Failure` with the offending statuses if any library reports `FAILED`, so

--- a/.github/skills/synapseml-branches/references/branch-spark4-common.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4-common.md
@@ -9,12 +9,17 @@ snapshot of the live branches.** Both guides were written on the sync branches,
 so they describe the merged result. Until those PRs land, a live branch can lack
 things described here — at the time of writing, live `spark4.0` has no
 `OpenAIPromptPythonOverrides.scala`, no `test_http_package.py` /
-`test_package_exports.py`, no `new_ml_pipeline_stage` in generated R, and a
-different GPU pool. Verify every item against the live target branch with
-`git show <branch>:<path>` or `git grep <pattern> <branch>`; do not read it out
-of a local sync worktree, which is a PR result rather than branch state. That
-specific mistake produced several wrong claims in earlier revisions of this
-file.
+`test_package_exports.py`, no `new_ml_pipeline_stage` in generated R, and its
+own GPU pool (`DatabricksUtilities.scala` sets
+`GpuPoolName = "synapseml-build-17.3-gpu"` there, not master's
+`synapseml-build-14.3-gpu`). Verify every item against the live target branch
+with `git show <branch>:<path>` or `git grep <pattern> <branch>`; do not read it
+out of a local sync worktree, which is a PR result rather than branch state.
+That specific mistake produced several wrong claims in earlier revisions of this
+file, and an automated reviewer then made it against this very paragraph —
+reporting the GPU pool sentence as stale after reading the sync branch. Quote
+the file and value you checked, so the next reader can repeat the check instead
+of re-deriving it from whatever tree they happen to have open.
 
 ## Purpose and sync
 

--- a/.github/skills/synapseml-branches/references/branch-spark4-common.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4-common.md
@@ -19,6 +19,9 @@ against the live target branch.
 
 - Spark 4 uses Scala 2.13 and Java 17-era tooling. Preserve branch-specific
   dependency comments, Java configuration, and removal of obsolete CMS flags.
+- The `pyarrow` and `mlflow` pins move in lockstep: the pinned MLflow requires
+  `pyarrow<20`, so raising `pyarrow` alone breaks the environment solve. Read
+  both comments in `environment.yml` before changing either.
 - Scala 2.13 collection boundaries must produce immutable `Seq` values; keep
   the central `asImmutableCollection` conversion rather than per-service fixes.
 - Preserve Spark 4 adaptations for SAR encoders/self-joins,
@@ -33,6 +36,9 @@ against the live target branch.
   loading of nested stages. Interleaved failures with successful tests between
   them point to selection/proxy behavior, not a dead Spark session; read the
   backtrace.
+- `RCodegenSuite` asserts the cheap R generation invariants on both Spark 4
+  branches. Run it before spending a full pipeline run on an R failure, and keep
+  its assertions in step when changing generated R.
 
 ## Runtime and CI
 
@@ -40,6 +46,9 @@ against the live target branch.
   and use sibling-branch timing/results as a control before blaming capacity.
 - `areLibrariesInstalled == false` can mean install timeout rather than a
   failed library. Read statuses and notebook duration before classifying it.
+- `DatabricksCPUStreamingTests` is unscheduled on both Spark 4 branches, pending
+  pool capacity and notebook work. Treat it as a known coverage gap to verify,
+  not as an omission to accept silently.
 - `/azp run` queues these targets. The ADO pull-request trigger filter allowed
   only `master` until 2026-08-17; it now covers `master`, `spark3.5`,
   `spark4.0` and `spark4.1`, verified by builds recording `reason=pullRequest`

--- a/.github/skills/synapseml-branches/references/branch-spark4-common.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4-common.md
@@ -20,10 +20,11 @@ against the live target branch.
 - Spark 4 uses Scala 2.13 and Java 17-era tooling. Preserve branch-specific
   dependency comments, Java configuration, and removal of obsolete CMS flags.
 - The `pyarrow` and `mlflow` pins move in lockstep: `mlflow==2.21.3` declares
-  `pyarrow<20,>=4.0.0`, so raising `pyarrow` alone breaks the environment solve.
-  Trust that bound over the inline comments, which disagree with each other —
-  `spark4.1`'s `environment.yml` says `pyarrow<19`, which is wrong, and has no
-  comment on the `mlflow` pin at all.
+  `pyarrow<20,>=4.0.0`, so a `pyarrow` bump that crosses that bound breaks the
+  environment solve unless `mlflow` moves with it. Bumps inside the bound, such
+  as 18 to 19, are fine. Trust the declared bound over the inline comments, which
+  disagree with each other — `spark4.1`'s `environment.yml` says `pyarrow<19`,
+  which is wrong, and has no comment on the `mlflow` pin at all.
 - Scala 2.13 collection boundaries must produce immutable `Seq` values; keep
   the central `asImmutableCollection` conversion rather than per-service fixes.
 - Preserve Spark 4 adaptations for SAR encoders/self-joins,
@@ -33,11 +34,24 @@ against the live target branch.
 - `PythonInitMerger` makes hand-written `__init__.py` files live package code.
   Keep the HTTP initializer empty, remove duplicate generated exports, and do
   not narrow `__all__` with hand-maintained class lists.
+- `cyber/utils/spark_utils.py` differs between the branches without either form
+  being version-specific: `spark4.0` builds its indexed frame with
+  `rdd.toDF(schema)` and `spark4.1` uses `spark.createDataFrame(rdd, schema)`.
+  `toDF` was measured working on both 4.0.1 and 4.1.1, so this is a portable
+  choice rather than a hazard. Adopting 4.1's form only reduces reliance on the
+  monkey-patched RDD API, which does not exist under Spark Connect, and buys
+  little on its own while the surrounding `df.rdd.zipWithIndex()` remains an RDD
+  call.
 - R generation requires ANSI double-quoted identifiers, the validated sparklyr
   1.9.5 pin from the PR snapshots, `SPARK_HOME` connection behavior, and JVM
-  loading of nested stages. Interleaved failures with successful tests between
+  loading of nested stages. Both branches pair that pin with `r-base=4.4`; keep
+  the pair together, since 69/69 `RTests` was measured for the combination, not
+  for the sparklyr pin alone. Interleaved failures with successful tests between
   them point to selection/proxy behavior, not a dead Spark session; read the
-  backtrace.
+  backtrace. Under sparklyr 1.9.3 with dbplyr 2.6 the tell is a frame chain
+  through `dbplyr:::select.tbl_lazy`, `sparklyr:::tidyselect_data_proxy.tbl_spark`
+  and `simulate_vars_spark`, which surfaces as `invoke_static`/`hive_context`
+  being called on `NULL` and reads misleadingly like a dead session.
 - `RCodegenSuite` asserts the cheap R generation invariants on both Spark 4
   branches. Run it before spending a full pipeline run on an R failure, and keep
   its assertions in step when changing generated R.

--- a/.github/skills/synapseml-branches/references/branch-spark4-common.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4-common.md
@@ -11,14 +11,32 @@ against the live target branch.
   work on `master`, then merge it into the port branch.
 - Resolve conflicts per hunk and compare content with the merge base and
   `master`; blanket `ours`/`theirs` and reachability are insufficient.
-- Diff `spark4.0` and `spark4.1` before debugging or merging. Shared fixes often
-  already exist on the sibling branch, but version-specific changes must not be
-  copied blindly.
+- Diff `spark4.0` and `spark4.1` before debugging or merging
+  (`git diff spark4.0 spark4.1 -- <path>`). `spark4.1` descends from `spark4.0`'s
+  upgrade commit and is maintained more actively, so it has usually already hit
+  and solved the same problem — it has directly supplied the fixes for R parsing,
+  the R Spark connection, nested-stage loading in R, the generated-wrapper
+  `super()` bug, the stale `__init__.py` shims, the local setup skill, the
+  notebook runtime, and a failing training test. This is the single
+  highest-value habit on these branches. Two cautions when porting: substitute
+  the target branch's version strings, and confirm the fix is not specific to
+  the source branch's Spark/Python version.
 
 ## Common deliberate differences from master
 
-- Spark 4 uses Scala 2.13 and Java 17-era tooling. Preserve branch-specific
-  dependency comments, Java configuration, and removal of obsolete CMS flags.
+- Spark 4 uses Scala 2.13 and Java 17-era tooling, so generated Python lands in
+  `target/scala-2.13/generated/src/python/` rather than master's `scala-2.12`
+  path. `tools/docker/*/Dockerfile` set `JAVA_HOME` to Java 17 and
+  `.github/workflows/pr-validation.yml` uses JDK 17. `pipeline.yaml` drops
+  master's `-XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled` from
+  `SBT_OPTS`: CMS was removed in Java 17 and the JVM refuses to start with those
+  flags, so a sync that restores them fails before any test runs.
+- `environment.yml` moves pins forward for the branch's Python, and each pin
+  carries a comment saying why. Those comments are the mechanism that stops a
+  later sync from "restoring" master's value, so preserve them through conflict
+  resolution. The recurring reasons: master's `pip` is too old to install for
+  these interpreters, `torch`/`torchvision` need their first releases supporting
+  the version, and `pandas`/`horovod` come from interpreter-specific wheel URLs.
 - The `pyarrow` and `mlflow` pins are coupled, and the pinned versions are not
   the same on every branch — read both live values on the branch you are editing
   before changing either. The bound comes from MLflow: `mlflow==2.21.3` declares
@@ -29,13 +47,29 @@ against the live target branch.
   with each other and with the pins they sit next to.
 - Scala 2.13 collection boundaries must produce immutable `Seq` values; keep
   the central `asImmutableCollection` conversion rather than per-service fixes.
-- Preserve Spark 4 adaptations for SAR encoders/self-joins,
-  `Wrappable.safeGetDefault`, and the non-NaN classifier fixture.
-- `OpenAIPrompt` is an internal generated wrapper. Generated overrides use
-  zero-argument `super()` because the public class name is not in that module.
-- `PythonInitMerger` makes hand-written `__init__.py` files live package code.
-  Keep the HTTP initializer empty, remove duplicate generated exports, and do
-  not narrow `__all__` with hand-maintained class lists.
+- Preserve the Spark 4 adaptations. In `SAR.scala`/`SARModel.scala` the affinity
+  pairs use a named `case class` with explicit struct fields because Spark 4
+  rejects the old `Seq[Row]` UDF shape with `UnboundRowEncoder`, and the join
+  column is qualified (`col("sarUserFactors.flatList")`) because a self-join now
+  trips `DetectAmbiguousSelfJoin`. `Wrappable.safeGetDefault` guards
+  `getDefault`, which throws on Spark 4 where Spark 3 returned a default.
+  `VerifyTrainClassifier`'s vector fixture no longer feeds `Double.NaN` to the
+  trainer: that test is about training on a vector column, not about NaN, so the
+  value was replaced rather than the assertion weakened.
+- `OpenAIPrompt` sets `pyInternalWrapper = true`, so codegen emits
+  `class _OpenAIPrompt` and a hand-written `OpenAIPrompt.py` supplies the public
+  name. Python emitted into that class must use zero-argument `super()`; a
+  hardcoded `super(OpenAIPrompt, self)` raises `NameError` because that name does
+  not exist inside the generated module. See `OpenAIPromptPythonOverrides.scala`.
+- `PythonInitMerger` makes hand-written `__init__.py` files live package code by
+  splicing them *after* the generated imports; before it, codegen overwrote them
+  and their contents were inert, so a stale one is now a real bug. Keep the HTTP
+  initializer empty — it listed `HTTPFunctions` and `ServingFunctions`, which are
+  modules of free functions with no same-named class, and the failed import broke
+  `PythonTests core` plus seven website samples. Remove initializers that only
+  duplicate generated exports, and do not narrow `import *` by redefining
+  `__all__` as a hand-maintained list. Keep the ones that add exports codegen
+  does not emit. `test_http_package.py` and `test_package_exports.py` guard this.
 - `cyber/utils/spark_utils.py` differs between the branches without either form
   being version-specific: `spark4.0` builds its indexed frame with
   `rdd.toDF(schema)` and `spark4.1` uses `spark.createDataFrame(rdd, schema)`.
@@ -62,13 +96,34 @@ against the live target branch.
   does not yet. Check for it before relying on it, run it before spending a
   pipeline run on an R failure, and keep its assertions in step when changing
   generated R.
+- Nested stages load off the JVM: `PipelineStageWrappable.rLoadLine` emits
+  `sparklyr:::new_ml_pipeline_stage(invoke(spark_jobj(x), "getStages")[[1]])`
+  rather than `ml_stages(x)[[1]]`. `new_ml_pipeline_stage` is sparklyr-internal
+  but has an identical signature in every release from v1.8.0 to v1.9.5.
+  `EstimatorParam`, `ModelParam`, `PipelineStageParam` and `TransformerParam` all
+  inherit this single implementation — do not reintroduce per-class overrides,
+  and keep the three `rLoadLine` assertions in
+  `VerifyModelParam`/`VerifyPipelineStageParams` in step with it. Be accurate
+  about its status: on a branch whose R tests died earlier on `ml_load`, this
+  line was never reached, so it is alignment with the working branch rather than
+  a proven fix.
 
 ## Runtime and CI
 
-- Spark 4 Databricks builds share scarce GPU capacity. Queue them sequentially
-  and use sibling-branch timing/results as a control before blaming capacity.
-- `areLibrariesInstalled == false` can mean install timeout rather than a
-  failed library. Read statuses and notebook duration before classifying it.
+- Spark 4 Databricks builds share scarce GPU capacity: the GPU pool
+  `synapseml-build-14.3-gpu` is shared with `master` and both Spark 4 branches
+  (instance pools are runtime-agnostic, so sharing avoids duplicating scarce GPU
+  quota). It holds three workers (`GpuWorkersPerRun` 1 x `GpuConcurrentRuns` 3),
+  so two concurrent builds can exhaust it. Queue them sequentially, and use the
+  sibling branch as a free control: because the pool is shared, an outcome that
+  tracks the branch rather than the timing is a code difference, not contention.
+- `areLibrariesInstalled == false` is a timeout, not a capacity verdict, and the
+  logic inverts the way people expect. The check *throws* `Library Installation
+  Failure` with the offending statuses if any library reports `FAILED`, so
+  returning `false` means the opposite: nothing failed, the libraries simply had
+  not all reached `INSTALLED` before the retry budget ran out (`60 * 10` attempts
+  at 1s, about 10 minutes). A slow install reads exactly like a starved pool.
+  Read statuses and notebook duration before classifying it.
 - `DatabricksCPUStreamingTests` exists only on the Spark 4 branches, and whether
   it is scheduled varies by branch — read `pipeline.yaml` on the branch you are
   working on rather than assuming. It is a separate class because the streaming

--- a/.github/skills/synapseml-branches/references/branch-spark4-common.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4-common.md
@@ -19,9 +19,11 @@ against the live target branch.
 
 - Spark 4 uses Scala 2.13 and Java 17-era tooling. Preserve branch-specific
   dependency comments, Java configuration, and removal of obsolete CMS flags.
-- The `pyarrow` and `mlflow` pins move in lockstep: the pinned MLflow requires
-  `pyarrow<20`, so raising `pyarrow` alone breaks the environment solve. Read
-  both comments in `environment.yml` before changing either.
+- The `pyarrow` and `mlflow` pins move in lockstep: `mlflow==2.21.3` declares
+  `pyarrow<20,>=4.0.0`, so raising `pyarrow` alone breaks the environment solve.
+  Trust that bound over the inline comments, which disagree with each other —
+  `spark4.1`'s `environment.yml` says `pyarrow<19`, which is wrong, and has no
+  comment on the `mlflow` pin at all.
 - Scala 2.13 collection boundaries must produce immutable `Seq` values; keep
   the central `asImmutableCollection` conversion rather than per-service fixes.
 - Preserve Spark 4 adaptations for SAR encoders/self-joins,
@@ -46,9 +48,15 @@ against the live target branch.
   and use sibling-branch timing/results as a control before blaming capacity.
 - `areLibrariesInstalled == false` can mean install timeout rather than a
   failed library. Read statuses and notebook duration before classifying it.
-- `DatabricksCPUStreamingTests` is unscheduled on both Spark 4 branches, pending
-  pool capacity and notebook work. Treat it as a known coverage gap to verify,
-  not as an omission to accept silently.
+- `DatabricksCPUStreamingTests` is unscheduled on both Spark 4 branches: the
+  class exists in `DatabricksCPUTests.scala`, but `pipeline.yaml` names its test
+  legs explicitly and never lists it. It exists as a separate class because the
+  streaming notebook's `server.stop()` cancels concurrent SparkContext jobs, so
+  it has to run on its own cluster instead of joining an existing leg — which is
+  why scheduling it needs pool capacity as well as a notebook fix. The in-repo
+  comment is identical on both branches and attributes the behaviour to Spark
+  4.0; it has not been re-confirmed on 4.1. Treat it as a known coverage gap to
+  verify, not as an omission to accept silently.
 - Petastorm calls pyarrow APIs the pinned pyarrow no longer ships, so Horovod's
   Spark backend needs a compatibility layer. Only `spark4.1` has one. This is a
   library-version problem, not a Python-version one, so a branch on the same

--- a/.github/skills/synapseml-branches/references/branch-spark4-common.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4-common.md
@@ -92,7 +92,11 @@ file.
   monkey-patched RDD API, which does not exist under Spark Connect, and buys
   little on its own while the surrounding `df.rdd.zipWithIndex()` remains an RDD
   call.
-- R generation requires ANSI double-quoted identifiers, the validated sparklyr
+- R generation requires ANSI double-quoted identifiers — `RTestGen.scala` sets
+  `spark.sql.ansi.enabled=true` and `spark.sql.ansi.doubleQuotedIdentifiers=true`,
+  because sparklyr emits `SELECT 0L AS "class", ...` and without the second flag
+  Spark 4 reads `"class"` as a string literal and fails with
+  `PARSE_SYNTAX_ERROR`. It also requires the validated sparklyr
   1.9.5 pin from the PR snapshots, `SPARK_HOME` connection behavior, and JVM
   loading of nested stages. That pin is not yet everywhere — check
   `environment.yml` on your branch, since a branch still on sparklyr 1.9.3 has
@@ -161,11 +165,13 @@ file.
   `spark4.0` and `spark4.1`, verified by builds recording `reason=pullRequest`
   rather than `reason=manual`. If a comment produces no build, re-read the
   definition's trigger filter before assuming flakiness, and fall back to
-  queueing the PR merge ref, never `refs/heads/<branch>`.
+  queueing the PR merge ref (`refs/pull/<N>/merge`), never
+  `refs/heads/<branch>`, which fails service-connection authorization.
 - GitHub checks compile/lint but do not replace full Azure, Databricks, native,
   R, or service validation.
-- Intermittent ONNX OOM and R package HTTP failures require log evidence and a
-  controlled rerun; they are not automatic product regressions or exemptions.
+- Intermittent ONNX OOM (`ImageFeaturizerSuite`) and R package HTTP failures
+  (a conda `HTTP 403` in `RTests vw`) require log evidence and a controlled
+  rerun; they are not automatic product regressions or exemptions.
 
 ## Before merging a sync
 

--- a/.github/skills/synapseml-branches/references/branch-spark4p0.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4p0.md
@@ -43,8 +43,10 @@ templatized version of the branch context from
   4.0-capable Fabric runtime exists, which may never happen; the more likely
   resolution is that this branch is superseded by `spark4.1`.
 - At #2646, two GPU fine-tune notebooks failed because no Horovod wheel matched
-  DBR 17.3's PyTorch. Do not switch to DBR 18 merely to turn them green; that
-  would test Spark 4.1 instead of this branch. Revalidate this known gap.
+  DBR 17.3's PyTorch. Do not switch `AdbGpuRuntime` to DBR 18 merely to turn
+  them green; DBR 17.3 LTS ML ships Spark 4.0 and 18.0 ML ships Spark 4.1, so
+  bumping it would test Spark 4.1 instead of this branch and make the suite
+  green by no longer testing what it exists to test. Revalidate this known gap.
 - Two of four GPU notebooks failing is that gap's expected shape. Check the
   failing count and which notebooks, not the job's red/green, before calling it
   a regression. The Horovod wheel is the first blocker and it masks the missing

--- a/.github/skills/synapseml-branches/references/branch-spark4p0.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4p0.md
@@ -15,7 +15,11 @@ templatized version of the branch context from
 
 - Keep NumPy 1.26.4 pinned: Python 3.12 has wheels and pandas 2.0.3 is not
   compatible with the NumPy 2 ABI.
-- Do not copy Python 3.13 petastorm/cloudpickle shims without branch evidence.
+- This branch has `_horovod.py` but not `_petastorm_compat.py`, so it uses the
+  plain Horovod `SparkBackend` rather than 4.1's Petastorm-compatible subclass.
+  That gap is real rather than version-driven: the shim restores pyarrow APIs
+  Petastorm still calls, and both branches pin the same pyarrow. See
+  branch-spark4-common.md.
 - `LongOffset` remains under `...execution.streaming`, not `.runtime`.
 - Spark 4.0 returns `bytearray` for Python `BinaryType`; it does not require the
   4.1 `np.frombuffer` workaround.
@@ -30,9 +34,10 @@ templatized version of the branch context from
   would test Spark 4.1 instead of this branch. Revalidate this known gap.
 - Two of four GPU notebooks failing is that gap's expected shape. Check the
   failing count and which notebooks, not the job's red/green, before calling it
-  a regression. `spark4.1`'s petastorm/cloudpickle shims are a plausible second
-  contributor, but that is unproven; do not quote it as the cause without
-  notebook stderr.
+  a regression. The Horovod wheel is the first blocker and it masks the missing
+  Petastorm layer noted above, so fixing the wheel alone should not be expected
+  to turn these notebooks green. Confirm each step from the notebook's stderr
+  output rather than inferring it.
 - Avoid pinning runtime-provided torch/torchvision without a demonstrated need;
   incompatible pins can trigger multi-gigabyte CUDA downgrades and timeouts.
 - A sub-minute GPU notebook failure occurs during dependency setup, before
@@ -44,6 +49,9 @@ templatized version of the branch context from
 ## Do not port from `spark4.1`
 
 - 4.1 `LongOffset` import, BinaryType `np.frombuffer` workaround, Python 3.13
-  shims, unpinned NumPy, or version strings.
+  wheels, unpinned NumPy, or version strings.
 - Fabric Runtime 2.0 enablement.
 - Any runtime/dependency change whose only evidence is a green 4.1 build.
+- The Petastorm compatibility layer is not on this list. It is a back-port
+  candidate, not a 4.1-only change, but it needs validation on real 4.0 rather
+  than adoption on suspicion.

--- a/.github/skills/synapseml-branches/references/branch-spark4p0.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4p0.md
@@ -10,6 +10,11 @@ templatized version of the branch context from
   Scala 2.13.16, Java 17, Python 3.12, and Databricks 17.3; verify live files.
 - Check `spark4.1` before debugging from scratch because it is the more actively
   maintained descendant, then prove any candidate fix is not 4.1-specific.
+- Live state lags the #2646 description. The live branch currently has its own
+  GPU pool (`synapseml-build-17.3-gpu`) rather than the shared `14.3-gpu` one,
+  and does not yet carry `OpenAIPromptPythonOverrides.scala`, the
+  `__init__.py` guard tests, or the `new_ml_pipeline_stage` R loading. #2646
+  brings all of those. Check the live branch before assuming any of them.
 
 ## Core differences
 

--- a/.github/skills/synapseml-branches/references/branch-spark4p0.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4p0.md
@@ -28,12 +28,18 @@ templatized version of the branch context from
 - At #2646, two GPU fine-tune notebooks failed because no Horovod wheel matched
   DBR 17.3's PyTorch. Do not switch to DBR 18 merely to turn them green; that
   would test Spark 4.1 instead of this branch. Revalidate this known gap.
+- Two of four GPU notebooks failing is that gap's expected shape. Check the
+  failing count and which notebooks, not the job's red/green, before calling it
+  a regression. `spark4.1`'s petastorm/cloudpickle shims are a plausible second
+  contributor, but that is unproven; do not quote it as the cause without
+  notebook stderr.
 - Avoid pinning runtime-provided torch/torchvision without a demonstrated need;
   incompatible pins can trigger multi-gigabyte CUDA downgrades and timeouts.
 - A sub-minute GPU notebook failure occurs during dependency setup, before
   training. Use run timing and stderr rather than attributing it to the model.
-- Confirm target-branch automation actually queued; this branch historically
-  had no PR checks even when `master` contained corrected filters.
+- Confirm target-branch automation actually queued rather than assuming the
+  comment was enough; see branch-spark4-common.md for how to tell a
+  trigger-driven build from a hand-queued one.
 
 ## Do not port from `spark4.1`
 

--- a/.github/skills/synapseml-branches/references/branch-spark4p0.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4p0.md
@@ -19,7 +19,7 @@ templatized version of the branch context from
   plain Horovod `SparkBackend` rather than 4.1's Petastorm-compatible subclass.
   That gap is real rather than version-driven: the shim restores pyarrow APIs
   Petastorm still calls, and both branches pin the same pyarrow. See
-  branch-spark4-common.md.
+  [branch-spark4-common.md](branch-spark4-common.md).
 - `LongOffset` remains under `...execution.streaming`, not `.runtime`.
 - Spark 4.0 returns `bytearray` for Python `BinaryType`; it does not require the
   4.1 `np.frombuffer` workaround.
@@ -43,7 +43,8 @@ templatized version of the branch context from
 - A sub-minute GPU notebook failure occurs during dependency setup, before
   training. Use run timing and stderr rather than attributing it to the model.
 - Confirm target-branch automation actually queued rather than assuming the
-  comment was enough; see branch-spark4-common.md for how to tell a
+  comment was enough; see
+  [branch-spark4-common.md](branch-spark4-common.md) for how to tell a
   trigger-driven build from a hand-queued one.
 
 ## Do not port from `spark4.1`

--- a/.github/skills/synapseml-branches/references/branch-spark4p0.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4p0.md
@@ -32,7 +32,11 @@ templatized version of the branch context from
 
 ## Runtime and CI
 
-- Fabric E2E remains disabled because Fabric has no managed Spark 4.0 runtime.
+- Fabric E2E remains disabled because Fabric has no managed Spark 4.0 runtime —
+  Fabric Runtime 2.0 went GA on Spark 4.1. This is real lost coverage rather
+  than a cosmetic skip, and it should stay disabled here until a Spark
+  4.0-capable Fabric runtime exists, which may never happen; the more likely
+  resolution is that this branch is superseded by `spark4.1`.
 - At #2646, two GPU fine-tune notebooks failed because no Horovod wheel matched
   DBR 17.3's PyTorch. Do not switch to DBR 18 merely to turn them green; that
   would test Spark 4.1 instead of this branch. Revalidate this known gap.
@@ -43,7 +47,17 @@ templatized version of the branch context from
   to turn these notebooks green. Confirm each step from the notebook's stderr
   output rather than inferring it.
 - Avoid pinning runtime-provided torch/torchvision without a demonstrated need;
-  incompatible pins can trigger multi-gigabyte CUDA downgrades and timeouts.
+  incompatible pins can trigger multi-gigabyte CUDA downgrades and timeouts. The
+  recorded instance was `torchvision==0.17.0` in `GPULibraries`, which
+  hard-requires `torch==2.2.0`: pip had to *downgrade* the runtime's much newer
+  torch and pull large CUDA wheels, slow enough to exhaust the install budget but
+  never reporting `FAILED`. The GPU ML runtime already ships both, so the pin
+  bought nothing.
+- When the fine-tune notebooks were investigated, the notebooks and
+  `GPULibraries` were byte-identical to `spark4.1` and still failed here while
+  passing there, and swapping in `spark4.1`'s sha256-pinned wheel changed nothing
+  measurable (71.6s to 60.6s, 56.2s to 47.0s — the same failure in the same
+  window). Treat that swap as alignment with the working branch, not a fix.
 - A sub-minute GPU notebook failure occurs during dependency setup, before
   training. Use run timing and stderr rather than attributing it to the model.
 - Confirm target-branch automation actually queued rather than assuming the

--- a/.github/skills/synapseml-branches/references/branch-spark4p0.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4p0.md
@@ -10,11 +10,19 @@ templatized version of the branch context from
   Scala 2.13.16, Java 17, Python 3.12, and Databricks 17.3; verify live files.
 - Check `spark4.1` before debugging from scratch because it is the more actively
   maintained descendant, then prove any candidate fix is not 4.1-specific.
-- Live state lags the #2646 description. The live branch currently has its own
-  GPU pool (`synapseml-build-17.3-gpu`) rather than the shared `14.3-gpu` one,
-  and does not yet carry `OpenAIPromptPythonOverrides.scala`, the
-  `__init__.py` guard tests, or the `new_ml_pipeline_stage` R loading. #2646
-  brings all of those. Check the live branch before assuming any of them.
+- Live state lags the #2646 description. In `DatabricksUtilities.scala` the live
+  branch pairs its own GPU pool with a matching runtime --
+  `GpuPoolName = "synapseml-build-17.3-gpu"` with
+  `AdbGpuRuntime = "17.3.x-gpu-ml-scala2.13"`, resolved by `getPoolIdByName` --
+  and does not yet carry `OpenAIPromptPythonOverrides.scala`, the `__init__.py`
+  guard tests, or the `new_ml_pipeline_stage` R loading. #2646 brings those, and
+  also moves the GPU pool to master's shared `synapseml-build-14.3-gpu`
+  (resolved by `getPoolIdByNameAndNodeType`, which takes a node type and minimum
+  capacity) while keeping the 17.3 CPU pool and the 17.3.x GPU runtime. That
+  mixed pairing is not an oversight: `spark4.1` already runs master's
+  `14.3-gpu` pool against an `18.0.x-gpu-ml-scala2.13` runtime, so the pool name
+  identifies a warm node pool rather than a DBR version. Check the live branch
+  before assuming any of it.
 
 ## Core differences
 

--- a/.github/skills/synapseml-branches/references/branch-spark4p0.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4p0.md
@@ -13,12 +13,16 @@ templatized version of the branch context from
 
 ## Core differences
 
-- Keep NumPy 1.26.4 pinned: Python 3.12 has wheels and pandas 2.0.3 is not
-  compatible with the NumPy 2 ABI.
+- NumPy is currently unpinned here, as it is on 4.1. If you reintroduce a pin,
+  pin for a reason you can state: Python 3.12 has NumPy 1.26.4 wheels, and
+  pandas 2.0.3 is not compatible with the NumPy 2 ABI, so a pin is warranted
+  only while something in the resolved set actually requires it.
 - This branch has `_horovod.py` but not `_petastorm_compat.py`, so it uses the
   plain Horovod `SparkBackend` rather than 4.1's Petastorm-compatible subclass.
   That gap is real rather than version-driven: the shim restores pyarrow APIs
-  Petastorm still calls, and both branches pin the same pyarrow. See
+  Petastorm still calls, and this branch currently resolves to a *newer* pyarrow
+  than 4.1 does, so those APIs are at least as absent here. Confirm both pins
+  from `environment.yml` on each branch before reasoning about it. See
   [branch-spark4-common.md](branch-spark4-common.md).
 - `LongOffset` remains under `...execution.streaming`, not `.runtime`.
 - Spark 4.0 returns `bytearray` for Python `BinaryType`; it does not require the
@@ -50,7 +54,7 @@ templatized version of the branch context from
 ## Do not port from `spark4.1`
 
 - 4.1 `LongOffset` import, BinaryType `np.frombuffer` workaround, Python 3.13
-  wheels, unpinned NumPy, or version strings.
+  wheels, or version strings.
 - Fabric Runtime 2.0 enablement.
 - Any runtime/dependency change whose only evidence is a green 4.1 build.
 - The Petastorm compatibility layer is not on this list. It is a back-port

--- a/.github/skills/synapseml-branches/references/branch-spark4p1.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4p1.md
@@ -31,7 +31,13 @@ templatized version of the branch context from
 - Fabric Runtime 2.0 supports Spark 4.1, so the old "unsupported runtime"
   reason for disabling Fabric E2E is stale. Re-enable only in a dedicated PR:
   request Spark 4.1 in workspace creation, restore the pipeline condition, and
-  validate with real Fabric capacity/service connection.
+  validate with real Fabric capacity/service connection. The workspace-creation
+  payload lives in the Fabric test package's `FabricOperations.scala`, which
+  hardcodes `'SparkVersion': '3.5'` and must request `'4.1'`. That value is
+  hardcoded identically on `master`, `spark4.0` and `spark4.1`, so changing it
+  here does not alter master's behaviour. It also needs a Fabric capacity in the
+  `sempy-integration-region` that can provision Runtime 2.0 workspaces, which is
+  the one prerequisite not discoverable from the code.
 - Databricks CPU/GPU validation uses 18.x-era runtimes. Run Spark 4 builds
   sequentially because the GPU pool is shared.
 - `DatabricksCPUStreamingTests` was unscheduled pending capacity and notebook

--- a/.github/skills/synapseml-branches/references/branch-spark4p1.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4p1.md
@@ -17,8 +17,9 @@ templatized version of the branch context from
   Preserve explanatory pin comments through syncs.
 - The Petastorm/Horovod compatibility layer is separate from that: it restores
   pyarrow APIs Petastorm still calls, which the pinned pyarrow no longer
-  provides. Do not describe it as a Python 3.13 workaround, or `spark4.0` looks
-  exempt when it pins the same pyarrow version.
+  provides. Do not describe it as a Python 3.13 workaround — that framing makes
+  `spark4.0` look exempt when it is not. `spark4.0` pins a different, newer
+  pyarrow, so those APIs are missing there too.
 - `LongOffset` moved to `...execution.streaming.runtime`; the 4.0 import does
   not compile here.
 - Spark 4.1 returns Python `bytes` for `BinaryType`; `ImageTransformer` uses
@@ -38,8 +39,9 @@ templatized version of the branch context from
   here does not alter master's behaviour. It also needs a Fabric capacity in the
   `sempy-integration-region` that can provision Runtime 2.0 workspaces, which is
   the one prerequisite not discoverable from the code.
-- Databricks CPU/GPU validation uses 18.x-era runtimes. Run Spark 4 builds
-  sequentially because the GPU pool is shared.
+- Databricks CPU/GPU validation uses 18.x-era runtimes: CPU pool
+  `synapseml-build-18.0`, GPU pool `synapseml-build-14.3-gpu`. Run Spark 4 builds
+  sequentially because the GPU pool is shared with `master` and `spark4.0`.
 - `DatabricksCPUStreamingTests` was unscheduled pending capacity and notebook
   work; verify rather than silently accepting the omission.
 - Master compatibility replay commonly applies release-relevant patches here

--- a/.github/skills/synapseml-branches/references/branch-spark4p1.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4p1.md
@@ -13,9 +13,12 @@ templatized version of the branch context from
 
 ## Core differences
 
-- Python 3.13 requires newer wheels, an intentionally unpinned NumPy, and the
-  petastorm/cloudpickle/Horovod compatibility shims. Preserve explanatory pin
-  comments through syncs.
+- Python 3.13 requires newer wheels and an intentionally unpinned NumPy.
+  Preserve explanatory pin comments through syncs.
+- The Petastorm/Horovod compatibility layer is separate from that: it restores
+  pyarrow APIs Petastorm still calls, which the pinned pyarrow no longer
+  provides. Do not describe it as a Python 3.13 workaround, or `spark4.0` looks
+  exempt when it runs the same pyarrow.
 - `LongOffset` moved to `...execution.streaming.runtime`; the 4.0 import does
   not compile here.
 - Spark 4.1 returns Python `bytes` for `BinaryType`; `ImageTransformer` uses

--- a/.github/skills/synapseml-branches/references/branch-spark4p1.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4p1.md
@@ -18,7 +18,7 @@ templatized version of the branch context from
 - The Petastorm/Horovod compatibility layer is separate from that: it restores
   pyarrow APIs Petastorm still calls, which the pinned pyarrow no longer
   provides. Do not describe it as a Python 3.13 workaround, or `spark4.0` looks
-  exempt when it runs the same pyarrow.
+  exempt when it pins the same pyarrow version.
 - `LongOffset` moved to `...execution.streaming.runtime`; the 4.0 import does
   not compile here.
 - Spark 4.1 returns Python `bytes` for `BinaryType`; `ImageTransformer` uses

--- a/.github/skills/synapseml-pr-loop/SKILL.md
+++ b/.github/skills/synapseml-pr-loop/SKILL.md
@@ -75,7 +75,16 @@ is complete and green.
 - Follow the Spark and performance gates in
   [references/spark-performance.md](references/spark-performance.md).
 - Reply in the existing thread with the fix and evidence, then resolve it.
-  Re-audit after every push because new Copilot comments may appear.
+- Re-audit after every push. Automated review is asynchronous and re-runs per
+  commit, so auditing immediately after pushing reads the *previous* review and
+  reports a false all-clear. Wait until the newest automated review's commit
+  equals the pushed head, then audit; poll rather than checking once.
+- Suppressed comments are not review threads. They appear only inside a
+  collapsed section of the review body, so a `reviewThreads` query returns zero
+  while they exist, and they have no thread to reply to or resolve. Read every
+  automated review body for the current head, and address them in the follow-up
+  commit message or a PR comment. Treat them as ordinary findings: they are
+  suppressed for confidence, not for correctness.
 
 ### 5. Add proof-oriented tests
 

--- a/.github/skills/synapseml-pr-loop/SKILL.md
+++ b/.github/skills/synapseml-pr-loop/SKILL.md
@@ -116,6 +116,14 @@ is complete and green.
   ID. A trigger-driven build records `reason=pullRequest`; one you queued
   yourself records `reason=manual`, which is the quickest way to tell whether
   the trigger really fired or you merely re-ran it by hand.
+- Do this after **every** push, not once per pull request. The build does not
+  re-queue itself when the head moves, so the previous run's result belongs to
+  code that no longer exists. The GitHub Actions checks do re-run on each push
+  and go green within a couple of minutes, which makes a head with no Azure
+  Pipelines build on it look fully checked; an absent check is neither failed
+  nor pending, so nothing reports it. Verify the build against the head SHA by
+  name, or run `Get-PrReadiness.ps1 -RunPipeline` to post the comment
+  automatically when it is missing.
 - If no build appears, check the pipeline definition's own pull-request trigger
   rather than assuming a transient failure. That trigger can be defined in the
   pipeline UI, in which case it overrides the `pr:` block in `pipeline.yaml`
@@ -134,8 +142,13 @@ is complete and green.
 
 ### 8. Final readiness loop
 
-Run `Get-PrReadiness.ps1` again and confirm every gate in
-[references/readiness-gates.md](references/readiness-gates.md).
+Run `Get-PrReadiness.ps1 -PullRequest <numbers> -WaitForReview -RunPipeline`
+after the final push and confirm every gate in
+[references/readiness-gates.md](references/readiness-gates.md). Those two
+switches cover the asynchronous gaps that a bare snapshot reports as clean: the
+automated review has not arrived yet, and the Azure Pipelines build has not been
+asked to start. Both leave the same signature -- nothing failed, nothing
+pending, nothing there.
 
 For multiple PRs, after each merge:
 

--- a/.github/skills/synapseml-pr-loop/references/readiness-gates.md
+++ b/.github/skills/synapseml-pr-loop/references/readiness-gates.md
@@ -80,13 +80,19 @@ by current-head evidence.
   port-branch compatibility pass as applicable.
 - Full Azure Pipelines and required GitHub checks are complete with zero
   unexplained failures or pending jobs.
+- The Azure Pipelines build is present on the current head at all. It does not
+  queue itself on a push here, so every push needs its own `/azp run`; a head
+  that never got one carries only the GitHub Actions checks, and those going
+  green is not CI passing. An absent check is neither failed nor pending, so it
+  is invisible to both of those gates -- confirm the build by name against the
+  head SHA, not by the absence of red.
 - Skips are expected and documented; a skipped required scenario is a blocker.
 - `Get-PrReadiness.ps1` reports these as `completeness.complete`, which is true
   only when comment pagination was not truncated, an automated review covers the
-  head, and unresolved threads, suppressed-for-head items, failed checks and
-  pending checks are all zero. Treat a pending check as unknown rather than
-  passing. Trust the individual fields over the summary when they disagree: that
-  flag has been wrong before, in both directions.
+  head, and unresolved threads, suppressed-for-head items, missing required
+  checks, failed checks and pending checks are all zero. Treat a pending check as
+  unknown rather than passing. Trust the individual fields over the summary when
+  they disagree: that flag has been wrong before, in both directions.
 
 ## Honest confidence language
 

--- a/.github/skills/synapseml-pr-loop/references/readiness-gates.md
+++ b/.github/skills/synapseml-pr-loop/references/readiness-gates.md
@@ -81,6 +81,12 @@ by current-head evidence.
 - Full Azure Pipelines and required GitHub checks are complete with zero
   unexplained failures or pending jobs.
 - Skips are expected and documented; a skipped required scenario is a blocker.
+- `Get-PrReadiness.ps1` reports these as `completeness.complete`, which is true
+  only when comment pagination was not truncated, an automated review covers the
+  head, and unresolved threads, suppressed-for-head items, failed checks and
+  pending checks are all zero. Treat a pending check as unknown rather than
+  passing. Trust the individual fields over the summary when they disagree: that
+  flag has been wrong before, in both directions.
 
 ## Honest confidence language
 

--- a/.github/skills/synapseml-pr-loop/references/readiness-gates.md
+++ b/.github/skills/synapseml-pr-loop/references/readiness-gates.md
@@ -71,8 +71,11 @@ by current-head evidence.
 - No blocking review decision, requested-change vote, ownership gate, or
   required coverage failure remains.
 - Suppressed/minimized Copilot feedback was read and either fixed or rebutted
-  with evidence.
-- Latest review covers the final head.
+  with evidence. Read it from the review body for the current head; it never
+  appears as a review thread, so a zero-thread query does not clear this gate.
+- Latest automated review covers the final head, compared by commit rather than
+  by recency. A review produced before the last push does not clear the two
+  gates above, because it never saw that code.
 - Targeted tests, compile, test compile, style, Black, codegen, Python, and
   port-branch compatibility pass as applicable.
 - Full Azure Pipelines and required GitHub checks are complete with zero

--- a/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
+++ b/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
@@ -81,10 +81,11 @@ $owner = $repoParts[0]
 $name = $repoParts[1]
 
 $automatedLogins = @($AutomatedReviewer |
-    Where-Object { $_ } |
-    ForEach-Object { ($_ -replace '\[bot\]$', '').ToLowerInvariant() })
+    Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+    ForEach-Object { ($_.Trim() -replace '\[bot\]$', '').ToLowerInvariant() } |
+    Where-Object { $_ })
 if (-not $automatedLogins) {
-    throw "AutomatedReviewer must contain at least one login."
+    throw "AutomatedReviewer must contain at least one non-blank login."
 }
 
 $threadQuery = @'

--- a/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
+++ b/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
@@ -6,9 +6,18 @@
     and review bodies containing suppressed comments. Review threads and reviews
     are fully paginated, and the emitted `completeness` object reports page
     counts plus any thread whose comments were truncated, so an incomplete
-    snapshot is visible rather than silent. It does not make the readiness
-    decision; use the skill's evidence gates for that judgment. Output can
-    contain review content; keep it local or redact it before sharing.
+    snapshot is visible rather than silent.
+
+    Automated review is asynchronous, so a snapshot taken right after a push
+    describes the previous head and can report zero findings for code nobody has
+    reviewed yet. `automatedReviewCoversHead` compares the newest automated
+    review's commit with the current head and gates `complete`, and
+    `suppressedReviewBodiesForHead` narrows suppressed feedback to that head.
+    Poll until it is true rather than trusting a single clean snapshot.
+
+    It does not make the readiness decision; use the skill's evidence gates for
+    that judgment. Output can contain review content; keep it local or redact it
+    before sharing.
 #>
 param(
     [Parameter(Mandatory)]
@@ -179,6 +188,18 @@ $results = @(foreach ($number in $PullRequest) {
         }
     })
 
+    $automatedReviews = @($reviewPage.nodes | Where-Object {
+        $_.author.login -and $_.author.login -imatch 'copilot'
+    })
+    $latestAutomated = $automatedReviews |
+        Where-Object { $_.submittedAt } |
+        Sort-Object { [datetime]$_.submittedAt } |
+        Select-Object -Last 1
+    $automatedReviewCoversHead =
+        [bool]($latestAutomated -and $latestAutomated.commit.oid -eq $view.headRefOid)
+    $suppressedForHead = @($suppressed |
+        Where-Object { $_.commit -eq $view.headRefOid })
+
     [pscustomobject]@{
         number = $view.number
         title = $view.title
@@ -197,13 +218,17 @@ $results = @(foreach ($number in $PullRequest) {
         pendingChecks = $pendingChecks
         unresolvedThreads = $unresolved
         suppressedReviewBodies = $suppressed
+        suppressedReviewBodiesForHead = $suppressedForHead
         completeness = [pscustomobject]@{
             reviewThreadPages = $threadPage.pages
             reviewThreadCount = $threads.Count
             reviewPages = $reviewPage.pages
             reviewCount = @($reviewPage.nodes).Count
             threadsWithUnreadComments = $truncatedThreadComments
-            complete = ($truncatedThreadComments.Count -eq 0)
+            latestAutomatedReviewCommit = $latestAutomated.commit.oid
+            latestAutomatedReviewAt = $latestAutomated.submittedAt
+            automatedReviewCoversHead = $automatedReviewCoversHead
+            complete = ($truncatedThreadComments.Count -eq 0 -and $automatedReviewCoversHead)
         }
     }
 })

--- a/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
+++ b/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
@@ -33,6 +33,13 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# GraphQL responses are sparse: absent fields are simply missing rather than null,
+# and this script reads them positionally. Under StrictMode that is a terminating
+# error, so a caller with StrictMode enabled would get no snapshot at all instead
+# of a snapshot reporting what is missing. Pin the mode off for this scope so the
+# script's behaviour does not depend on the caller's session state.
+Set-StrictMode -Off
+
 if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
     throw "GitHub CLI 'gh' is required."
 }
@@ -122,7 +129,7 @@ function Invoke-PagedQuery {
         }
 
         $response = $text | ConvertFrom-Json
-        if ($response.errors) {
+        if ($response.PSObject.Properties['errors'] -and $response.errors) {
             $messages = @($response.errors | ForEach-Object { $_.message }) -join "; "
             throw "$Description returned GraphQL errors for PR #${Number}: $messages"
         }
@@ -238,9 +245,9 @@ $results = @(foreach ($number in $PullRequest) {
             reviewPages = $reviewPage.pages
             reviewCount = @($reviewPage.nodes).Count
             threadsWithUnreadComments = $truncatedThreadComments
-            latestAutomatedReviewCommit = $latestAutomated.commit.oid
-            latestAutomatedReviewAt = $latestAutomated.submittedAt
-            latestAutomatedReviewAuthor = $latestAutomated.author.login
+            latestAutomatedReviewCommit = if ($latestAutomated) { $latestAutomated.commit.oid } else { $null }
+            latestAutomatedReviewAt = if ($latestAutomated) { $latestAutomated.submittedAt } else { $null }
+            latestAutomatedReviewAuthor = if ($latestAutomated) { $latestAutomated.author.login } else { $null }
             automatedReviewCoversHead = $automatedReviewCoversHead
             complete = ($truncatedThreadComments.Count -eq 0 -and $automatedReviewCoversHead)
         }

--- a/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
+++ b/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
@@ -15,6 +15,14 @@
     `suppressedReviewBodiesForHead` narrows suppressed feedback to that head.
     Poll until it is true rather than trusting a single clean snapshot.
 
+    A pull request that was never reviewed at all reports the same zero findings,
+    so `-RequestReview` asks for one as a fallback. Review is normally triggered
+    automatically, so the usual need is not to ask but to wait: `-WaitForReview`
+    blocks until the review of the current head arrives, instead of returning a
+    premature all-clear and leaving a human to notice the comments later.
+    Suppressed comments are reported too: they live inside the review body rather
+    than as review threads, so a thread query alone never surfaces them.
+
     It does not make the readiness decision; use the skill's evidence gates for
     that judgment. Output can contain review content; keep it local or redact it
     before sharing.
@@ -28,7 +36,28 @@ param(
     # Logins whose reviews count as automated coverage of the head commit. Matched
     # exactly, with an optional "[bot]" suffix, so a human account that merely
     # contains one of these words is never mistaken for the reviewer.
-    [string[]]$AutomatedReviewer = @("copilot-pull-request-reviewer", "github-copilot", "copilot")
+    [string[]]$AutomatedReviewer = @("copilot-pull-request-reviewer", "github-copilot", "copilot"),
+
+    # Block until the automated review of the current head arrives. Review is
+    # triggered automatically on push but lands afterwards, so a snapshot taken
+    # immediately reports zero findings for code nobody has reviewed yet. Waiting
+    # here keeps that from being mistaken for a clean result.
+    [switch]$WaitForReview,
+
+    [ValidateRange(1, 240)]
+    [int]$TimeoutMinutes = 20,
+
+    [ValidateRange(5, 600)]
+    [int]$PollSeconds = 60,
+
+    # Fallback only. Review is normally triggered automatically; use this when a
+    # pull request has somehow never been reviewed at all, which reports the same
+    # zero findings as a clean review.
+    [switch]$RequestReview,
+
+    # Handle used when requesting that review. This is the requestable handle, not
+    # the login the submitted review is attributed to.
+    [string]$ReviewerHandle = "Copilot"
 )
 
 $ErrorActionPreference = "Stop"
@@ -155,7 +184,9 @@ function Invoke-PagedQuery {
     [pscustomobject]@{ nodes = $nodes; pages = $pages }
 }
 
-$results = @(foreach ($number in $PullRequest) {
+function Get-PrSnapshot {
+    param([int]$number)
+
     $jsonFields = "number,title,state,isDraft,mergeable,mergeStateStatus,reviewDecision," +
         "headRefOid,baseRefName,statusCheckRollup,url"
     $viewText = & gh pr view $number --repo $Repo --json $jsonFields
@@ -220,6 +251,23 @@ $results = @(foreach ($number in $PullRequest) {
     $suppressedForHead = @($suppressed |
         Where-Object { $_.commit -eq $view.headRefOid })
 
+    $reviewRequested = $false
+    if ($RequestReview -and -not $automatedReviewCoversHead) {
+        # Requesting by handle through the REST endpoint is the only path that works.
+        # The GraphQL requestReviews mutation rejects the reviewer's Bot node id
+        # ("Could not resolve to User node"), and `gh pr edit --add-reviewer` cannot
+        # resolve the bot login at all. The reviewer also never shows up in
+        # requested_reviewers afterwards, so a successful request cannot be confirmed
+        # by reading that list back; confirm it by polling until
+        # automatedReviewCoversHead turns true.
+        gh api "repos/$owner/$name/pulls/$number/requested_reviewers" `
+            -X POST -f "reviewers[]=$ReviewerHandle" *> $null
+        $reviewRequested = ($LASTEXITCODE -eq 0)
+        if (-not $reviewRequested) {
+            Write-Warning "PR #${number}: could not request a review from '$ReviewerHandle'."
+        }
+    }
+
     [pscustomobject]@{
         number = $view.number
         title = $view.title
@@ -249,9 +297,36 @@ $results = @(foreach ($number in $PullRequest) {
             latestAutomatedReviewAt = if ($latestAutomated) { $latestAutomated.submittedAt } else { $null }
             latestAutomatedReviewAuthor = if ($latestAutomated) { $latestAutomated.author.login } else { $null }
             automatedReviewCoversHead = $automatedReviewCoversHead
+            automatedReviewRequested = $reviewRequested
             complete = ($truncatedThreadComments.Count -eq 0 -and $automatedReviewCoversHead)
         }
     }
+}
+
+$results = @(foreach ($number in $PullRequest) {
+    $snapshot = Get-PrSnapshot -number $number
+
+    # Automated review lands some time after a push, so a single snapshot taken
+    # straight after one reports zero findings for code that has not been looked
+    # at yet. Wait for the review of this exact head rather than leaving a human
+    # to notice that the comments arrived later.
+    if ($WaitForReview -and -not $snapshot.completeness.automatedReviewCoversHead) {
+        $deadline = (Get-Date).AddMinutes($TimeoutMinutes)
+        while ((Get-Date) -lt $deadline) {
+            Write-Verbose ("PR #{0}: waiting for automated review of {1}" -f
+                $number, $snapshot.headSha)
+            Start-Sleep -Seconds $PollSeconds
+            $snapshot = Get-PrSnapshot -number $number
+            if ($snapshot.completeness.automatedReviewCoversHead) { break }
+        }
+        if (-not $snapshot.completeness.automatedReviewCoversHead) {
+            Write-Warning ("PR #{0}: no automated review covered {1} within {2} minute(s). " +
+                "Findings for this head may still be pending; do not read this as clean." -f
+                $number, $snapshot.headSha, $TimeoutMinutes)
+        }
+    }
+
+    $snapshot
 })
 
 ConvertTo-Json -InputObject $results -Depth 12

--- a/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
+++ b/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
@@ -84,6 +84,10 @@ if (-not $automatedLogins) {
     throw "AutomatedReviewer must contain at least one non-blank login."
 }
 
+# Review requests are attempted at most once per PR per invocation; see the
+# -RequestReview block in Get-PrSnapshot.
+$script:reviewRequestOutcome = @{}
+
 $threadQuery = @'
 query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
   repository(owner: $owner, name: $name) {
@@ -276,7 +280,15 @@ function Get-PrSnapshot {
         Where-Object { $_.commit -eq $view.headRefOid })
 
     $reviewRequested = $false
-    if ($RequestReview -and -not $automatedReviewCoversHead) {
+    if ($script:reviewRequestOutcome.ContainsKey($number)) {
+        $reviewRequested = $script:reviewRequestOutcome[$number]
+    }
+    # Under -WaitForReview this function runs once per poll, so requesting
+    # unconditionally would re-POST the request every cycle until coverage
+    # arrived - notification spam and a rate-limit risk. Attempt it at most once
+    # per PR per invocation and reuse the recorded outcome afterwards.
+    if ($RequestReview -and -not $automatedReviewCoversHead -and
+        -not $script:reviewRequestOutcome.ContainsKey($number)) {
         # Requesting by handle through the REST endpoint is the only path that works.
         # The GraphQL requestReviews mutation rejects the reviewer's Bot node id
         # ("Could not resolve to User node"), and `gh pr edit --add-reviewer` cannot
@@ -287,6 +299,7 @@ function Get-PrSnapshot {
         gh api "repos/$owner/$name/pulls/$number/requested_reviewers" `
             -X POST -f "reviewers[]=$ReviewerHandle" *> $null
         $reviewRequested = ($LASTEXITCODE -eq 0)
+        $script:reviewRequestOutcome[$number] = $reviewRequested
         if (-not $reviewRequested) {
             Write-Warning "PR #${number}: could not request a review from '$ReviewerHandle'."
         }
@@ -322,7 +335,18 @@ function Get-PrSnapshot {
             latestAutomatedReviewAuthor = if ($latestAutomated) { $latestAutomated.author.login } else { $null }
             automatedReviewCoversHead = $automatedReviewCoversHead
             automatedReviewRequested = $reviewRequested
-            complete = ($truncatedThreadComments.Count -eq 0 -and $automatedReviewCoversHead)
+            # Everything verifiable must be clear. This previously tested only
+            # $truncatedThreadComments, which counts comment-pagination truncation
+            # rather than unresolved review threads, so it reported complete=true
+            # with review feedback still outstanding.
+            complete = (
+                @($truncatedThreadComments).Count -eq 0 -and
+                $automatedReviewCoversHead -and
+                @($unresolved).Count -eq 0 -and
+                @($suppressedForHead).Count -eq 0 -and
+                @($failedChecks).Count -eq 0 -and
+                @($pendingChecks).Count -eq 0
+            )
         }
     }
 }

--- a/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
+++ b/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
@@ -35,8 +35,11 @@ param(
 
     # Logins whose reviews count as automated coverage of the head commit. Matched
     # exactly, with an optional "[bot]" suffix, so a human account that merely
-    # contains one of these words is never mistaken for the reviewer.
-    [string[]]$AutomatedReviewer = @("copilot-pull-request-reviewer", "github-copilot", "copilot"),
+    # contains one of these words is never mistaken for the reviewer. Defaults to
+    # this repo's reviewer bot only: shorter generic logins such as "copilot" are
+    # registerable by humans, and an exact match on one of those would count a
+    # human review as automated coverage. Pass -AutomatedReviewer to extend.
+    [string[]]$AutomatedReviewer = @("copilot-pull-request-reviewer"),
 
     # Block until the automated review of the current head arrives. Review is
     # triggered automatically on push but lands afterwards, so a snapshot taken
@@ -61,13 +64,6 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-
-# GraphQL responses are sparse: absent fields are simply missing rather than null,
-# and this script reads them positionally. Under StrictMode that is a terminating
-# error, so a caller with StrictMode enabled would get no snapshot at all instead
-# of a snapshot reporting what is missing. Pin the mode off for this scope so the
-# script's behaviour does not depend on the caller's session state.
-Set-StrictMode -Off
 
 if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
     throw "GitHub CLI 'gh' is required."
@@ -143,6 +139,13 @@ function Invoke-PagedQuery {
         [Parameter(Mandatory)][string]$Description
     )
 
+    # GraphQL responses are sparse: absent fields are simply missing rather than
+    # null, and this function reads them positionally. Under StrictMode that is a
+    # terminating error, so a caller with StrictMode enabled would get no snapshot
+    # at all instead of a snapshot reporting what is missing. Scoped to this
+    # function so dot-sourcing the script cannot disable StrictMode session-wide.
+    Set-StrictMode -Off
+
     $nodes = @()
     $cursor = $null
     $pages = 0
@@ -187,6 +190,11 @@ function Invoke-PagedQuery {
 
 function Get-PrSnapshot {
     param([int]$number)
+
+    # Same reason as Invoke-PagedQuery: sparse GraphQL fields are read
+    # positionally here, and StrictMode is scoped to this function so
+    # dot-sourcing cannot change the caller's session.
+    Set-StrictMode -Off
 
     $jsonFields = "number,title,state,isDraft,mergeable,mergeStateStatus,reviewDecision," +
         "headRefOid,baseRefName,statusCheckRollup,url"

--- a/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
+++ b/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
@@ -23,7 +23,12 @@ param(
     [Parameter(Mandatory)]
     [int[]]$PullRequest,
 
-    [string]$Repo = "microsoft/SynapseML"
+    [string]$Repo = "microsoft/SynapseML",
+
+    # Logins whose reviews count as automated coverage of the head commit. Matched
+    # exactly, with an optional "[bot]" suffix, so a human account that merely
+    # contains one of these words is never mistaken for the reviewer.
+    [string[]]$AutomatedReviewer = @("copilot-pull-request-reviewer", "github-copilot", "copilot")
 )
 
 $ErrorActionPreference = "Stop"
@@ -38,6 +43,13 @@ if ($repoParts.Count -ne 2 -or -not $repoParts[0] -or -not $repoParts[1]) {
 }
 $owner = $repoParts[0]
 $name = $repoParts[1]
+
+$automatedLogins = @($AutomatedReviewer |
+    Where-Object { $_ } |
+    ForEach-Object { ($_ -replace '\[bot\]$', '').ToLowerInvariant() })
+if (-not $automatedLogins) {
+    throw "AutomatedReviewer must contain at least one login."
+}
 
 $threadQuery = @'
 query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
@@ -189,7 +201,8 @@ $results = @(foreach ($number in $PullRequest) {
     })
 
     $automatedReviews = @($reviewPage.nodes | Where-Object {
-        $_.author.login -and $_.author.login -imatch 'copilot'
+        $_.author.login -and
+        ($automatedLogins -contains ($_.author.login -replace '\[bot\]$', '').ToLowerInvariant())
     })
     $latestAutomated = $automatedReviews |
         Where-Object { $_.submittedAt } |
@@ -227,6 +240,7 @@ $results = @(foreach ($number in $PullRequest) {
             threadsWithUnreadComments = $truncatedThreadComments
             latestAutomatedReviewCommit = $latestAutomated.commit.oid
             latestAutomatedReviewAt = $latestAutomated.submittedAt
+            latestAutomatedReviewAuthor = $latestAutomated.author.login
             automatedReviewCoversHead = $automatedReviewCoversHead
             complete = ($truncatedThreadComments.Count -eq 0 -and $automatedReviewCoversHead)
         }

--- a/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
+++ b/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
@@ -243,12 +243,24 @@ function Get-PrSnapshot {
         $_.author.login -and
         ($automatedLogins -contains ($_.author.login -replace '\[bot\]$', '').ToLowerInvariant())
     })
-    $latestAutomated = $automatedReviews |
-        Where-Object { $_.submittedAt } |
-        Sort-Object { [datetime]$_.submittedAt } |
-        Select-Object -Last 1
-    $automatedReviewCoversHead =
-        [bool]($latestAutomated -and $latestAutomated.commit.oid -eq $view.headRefOid)
+    # Coverage must be decided by commit, not recency. A force-push back to an
+    # already-reviewed commit leaves the newest review pointing at a commit that
+    # is no longer head, which would report a reviewed head as uncovered and
+    # send -WaitForReview into a pointless wait.
+    $reviewsForHead = @($automatedReviews |
+        Where-Object { $_.commit.oid -eq $view.headRefOid })
+    $latestAutomated = if ($reviewsForHead) {
+        $reviewsForHead |
+            Where-Object { $_.submittedAt } |
+            Sort-Object { [datetime]$_.submittedAt } |
+            Select-Object -Last 1
+    } else {
+        $automatedReviews |
+            Where-Object { $_.submittedAt } |
+            Sort-Object { [datetime]$_.submittedAt } |
+            Select-Object -Last 1
+    }
+    $automatedReviewCoversHead = [bool]$reviewsForHead
     $suppressedForHead = @($suppressed |
         Where-Object { $_.commit -eq $view.headRefOid })
 

--- a/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
+++ b/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
@@ -255,11 +255,14 @@ function Get-PrSnapshot {
     # already-reviewed commit leaves the newest review pointing at a commit that
     # is no longer head, which would report a reviewed head as uncovered and
     # send -WaitForReview into a pointless wait.
+    # Only submitted reviews count. A pending review already carries a commit oid
+    # but has a null submittedAt, so matching on the oid alone would report the
+    # head as covered while the review is still being written - the exact
+    # premature all-clear this gate exists to prevent.
     $reviewsForHead = @($automatedReviews |
-        Where-Object { $_.commit.oid -eq $view.headRefOid })
+        Where-Object { $_.submittedAt -and $_.commit.oid -eq $view.headRefOid })
     $latestAutomated = if ($reviewsForHead) {
         $reviewsForHead |
-            Where-Object { $_.submittedAt } |
             Sort-Object { [datetime]$_.submittedAt } |
             Select-Object -Last 1
     } else {

--- a/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
+++ b/.github/skills/synapseml-pr-loop/scripts/Get-PrReadiness.ps1
@@ -23,6 +23,13 @@
     Suppressed comments are reported too: they live inside the review body rather
     than as review threads, so a thread query alone never surfaces them.
 
+    Checks are reported by absence as well as outcome. `failedChecks` and
+    `pendingChecks` can only describe checks that exist, so a head whose build
+    never started scores zero in both and reads as finished;
+    `missingRequiredChecks` catches that and gates `complete`. The Azure DevOps
+    build is the usual casualty because it does not queue itself on a push -- it
+    waits for an `/azp run` comment -- so `-RunPipeline` posts one.
+
     It does not make the readiness decision; use the skill's evidence gates for
     that judgment. Output can contain review content; keep it local or redact it
     before sharing.
@@ -60,7 +67,19 @@ param(
 
     # Handle used when requesting that review. This is the requestable handle, not
     # the login the submitted review is attributed to.
-    [string]$ReviewerHandle = "Copilot"
+    [string]$ReviewerHandle = "Copilot",
+
+    # Checks that must be PRESENT on the head commit, matched as a name prefix so
+    # one entry covers a pipeline's several legs. Absence is the point: the
+    # failed/pending sets can only describe checks that exist, so a head whose CI
+    # never started scores zero failures and zero pending and looks finished. The
+    # Azure DevOps build does not queue itself on every push here -- it needs an
+    # `/azp run` comment -- which is exactly the check most likely to be missing.
+    [string[]]$RequiredCheck = @("microsoft.SynapseML"),
+
+    # Post `/azp run` when a required check is missing from the head, instead of
+    # leaving a human to notice that full CI never started.
+    [switch]$RunPipeline
 )
 
 $ErrorActionPreference = "Stop"
@@ -87,6 +106,9 @@ if (-not $automatedLogins) {
 # Review requests are attempted at most once per PR per invocation; see the
 # -RequestReview block in Get-PrSnapshot.
 $script:reviewRequestOutcome = @{}
+
+# Likewise for `/azp run` comments; see the -RunPipeline block in Get-PrSnapshot.
+$script:pipelineRunOutcome = @{}
 
 $threadQuery = @'
 query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
@@ -235,6 +257,19 @@ function Get-PrSnapshot {
         $_.state -in @("EXPECTED", "PENDING")
     } | ForEach-Object { if ($_.name) { $_.name } else { $_.context } })
 
+    # A check that never started cannot fail and cannot be pending, so it leaves
+    # no trace in either set above. Test presence separately, by prefix, so one
+    # required name covers every leg the pipeline reports.
+    $checkNames = @($view.statusCheckRollup |
+        ForEach-Object { if ($_.name) { $_.name } else { $_.context } } |
+        Where-Object { $_ })
+    $missingRequiredChecks = @($RequiredCheck | Where-Object {
+        $required = $_
+        -not ($checkNames | Where-Object {
+            $_.StartsWith($required, [StringComparison]::OrdinalIgnoreCase)
+        })
+    })
+
     $threads = @($threadPage.nodes)
     $unresolved = @($threads | Where-Object { -not $_.isResolved })
     $truncatedThreadComments = @($threads |
@@ -305,6 +340,25 @@ function Get-PrSnapshot {
         }
     }
 
+    $pipelineRunRequested = $false
+    if ($script:pipelineRunOutcome.ContainsKey($number)) {
+        $pipelineRunRequested = $script:pipelineRunOutcome[$number]
+    }
+    # Same once-per-invocation guard as the review request above: under
+    # -WaitForReview this runs every poll, and each `/azp run` comment queues
+    # another build and notifies every subscriber.
+    if ($RunPipeline -and @($missingRequiredChecks).Count -gt 0 -and
+        -not $script:pipelineRunOutcome.ContainsKey($number)) {
+        # A comment is the only trigger the pipeline honours from here; queueing
+        # through the ADO API needs credentials this script does not assume.
+        gh pr comment $number --repo $Repo --body "/azp run" *> $null
+        $pipelineRunRequested = ($LASTEXITCODE -eq 0)
+        $script:pipelineRunOutcome[$number] = $pipelineRunRequested
+        if (-not $pipelineRunRequested) {
+            Write-Warning "PR #${number}: could not comment '/azp run'."
+        }
+    }
+
     [pscustomobject]@{
         number = $view.number
         title = $view.title
@@ -321,6 +375,7 @@ function Get-PrSnapshot {
         behindBy = $compare.behind_by
         failedChecks = $failedChecks
         pendingChecks = $pendingChecks
+        missingRequiredChecks = $missingRequiredChecks
         unresolvedThreads = $unresolved
         suppressedReviewBodies = $suppressed
         suppressedReviewBodiesForHead = $suppressedForHead
@@ -335,15 +390,19 @@ function Get-PrSnapshot {
             latestAutomatedReviewAuthor = if ($latestAutomated) { $latestAutomated.author.login } else { $null }
             automatedReviewCoversHead = $automatedReviewCoversHead
             automatedReviewRequested = $reviewRequested
+            pipelineRunRequested = $pipelineRunRequested
             # Everything verifiable must be clear. This previously tested only
             # $truncatedThreadComments, which counts comment-pagination truncation
             # rather than unresolved review threads, so it reported complete=true
-            # with review feedback still outstanding.
+            # with review feedback still outstanding. It also read a head whose
+            # required build had never queued as clean, because an absent check
+            # is neither failed nor pending.
             complete = (
                 @($truncatedThreadComments).Count -eq 0 -and
                 $automatedReviewCoversHead -and
                 @($unresolved).Count -eq 0 -and
                 @($suppressedForHead).Count -eq 0 -and
+                @($missingRequiredChecks).Count -eq 0 -and
                 @($failedChecks).Count -eq 0 -and
                 @($pendingChecks).Count -eq 0
             )
@@ -356,21 +415,30 @@ $results = @(foreach ($number in $PullRequest) {
 
     # Automated review lands some time after a push, so a single snapshot taken
     # straight after one reports zero findings for code that has not been looked
-    # at yet. Wait for the review of this exact head rather than leaving a human
-    # to notice that the comments arrived later.
-    if ($WaitForReview -and -not $snapshot.completeness.automatedReviewCoversHead) {
+    # at yet. The required build is worse: it does not start at all until someone
+    # comments, so waiting only on the review would still return a head with no
+    # CI on it. Wait for both, for this exact head.
+    if ($WaitForReview) {
         $deadline = (Get-Date).AddMinutes($TimeoutMinutes)
-        while ((Get-Date) -lt $deadline) {
-            Write-Verbose ("PR #{0}: waiting for automated review of {1}" -f
+        while (-not ($snapshot.completeness.automatedReviewCoversHead -and
+                @($snapshot.missingRequiredChecks).Count -eq 0) -and
+            (Get-Date) -lt $deadline) {
+            Write-Verbose ("PR #{0}: waiting for automated review and required checks of {1}" -f
                 $number, $snapshot.headSha)
             Start-Sleep -Seconds $PollSeconds
             $snapshot = Get-PrSnapshot -number $number
-            if ($snapshot.completeness.automatedReviewCoversHead) { break }
         }
         if (-not $snapshot.completeness.automatedReviewCoversHead) {
             Write-Warning ("PR #{0}: no automated review covered {1} within {2} minute(s). " +
                 "Findings for this head may still be pending; do not read this as clean." -f
                 $number, $snapshot.headSha, $TimeoutMinutes)
+        }
+        if (@($snapshot.missingRequiredChecks).Count -gt 0) {
+            Write-Warning ("PR #{0}: required check(s) '{1}' never appeared on {2} within " +
+                "{3} minute(s). Full CI has not run on this head; comment '/azp run' " +
+                "(or pass -RunPipeline)." -f
+                $number, ($snapshot.missingRequiredChecks -join ", "),
+                $snapshot.headSha, $TimeoutMinutes)
         }
     }
 


### PR DESCRIPTION
Recovers the Spark 4 branch operating knowledge that the condensed skill
dropped, corrects the claims in it that turned out to be wrong, and fixes the
PR-review loop that kept failing to catch either.

**Scope: 6 files, +411/-51, across two skills**, regenerated from
`git diff --stat ms/master...HEAD`.

### Why this matters more than a docs tidy-up

`AGENTS_spark4.0.md` and `AGENTS_spark4.1.md` exist **only on the two sync
branches** (#2646, #2645). Neither live `spark4.0` nor live `spark4.1` carries
any branch documentation at all. Those files are deleted as part of the sync, so
whatever they record and this skill does not is simply lost — including the
reasons behind pins, the failures that look like something else, and the fixes
that must not be ported.

So transfer fidelity was **measured, not assumed**: 40 distinctive terms from
both guides were tested against the skill. Six were absent; five were restored
(`spark.sql.ansi.doubleQuotedIdentifiers` and `PARSE_SYNTAX_ERROR`,
`AdbGpuRuntime`, `refs/pull/<N>/merge`, `ImageFeaturizerSuite`, the `RTests vw`
conda 403). Coverage is 39/40.

The one deliberate omission is `cloudpickle`. Both guides describe
`_petastorm_compat.py` as working around "cloudpickle/petastorm breakage under
Python 3.13". Reading the file disproved that — it has no Python-version gating
anywhere and reimplements pyarrow APIs Petastorm still calls
(`pq.ParquetDataset`, `pyarrow.filesystem`, `pyarrow.hdfs`, the legacy partition
classes). It is a **pyarrow** compatibility layer. Restoring the term would
restore the error.

### Every branch claim is verified against live refs

Earlier revisions of this PR were wrong in a consistent way: claims were read
out of local **sync worktrees** — which are the *results* of #2646/#2645 — and
written down as current branch state. Everything is now checked with
`git show ms/<branch>:<path>` and `git grep <pattern> ms/<branch>`.

| Earlier claim | Live reality |
| --- | --- |
| pyarrow/mlflow "pinned in lockstep on both" | `spark4.0` 22.0.0 / 1.26.1; `spark4.1` 18.0.0 / 2.21.3 |
| `RCodegenSuite` "on both branches" | `spark4.1` only |
| `DatabricksCPUStreamingTests` "unscheduled on both" | **scheduled** on live `spark4.0`; class absent on `master` |
| sparklyr 1.9.5 "on both" | `spark4.0` still on 1.9.3, so its documented backtrace is live, not history |
| "Keep NumPy 1.26.4 pinned" | unpinned on both |
| GPU pool `synapseml-build-14.3-gpu`, shared | live `spark4.0` uses its own `synapseml-build-17.3-gpu` |

That last one has teeth: "the pool is shared, so the sibling branch is a free
control" is the *diagnostic method* the guide recommends, and it is a
post-merge property. Applied to live `spark4.0` today it would draw conclusions
from a pool nobody else is using.

Live `spark4.0` also lacks `OpenAIPromptPythonOverrides.scala`, the
`__init__.py` guard tests (`test_http_package.py`, `test_package_exports.py`, so
that policy is currently unenforced there), and `new_ml_pipeline_stage` in
generated R. All arrive with #2646.

Rather than patch these bullet by bullet, the header now states that the guides
describe the branches **as of** #2645/#2646, lists what live `spark4.0` lacks,
and names the worktree-vs-live trap explicitly so the next reader does not
repeat it. Where a pin was quoted only to illustrate a rule, the text states the
rule and points at `environment.yml` on the reader's own branch.

Also retracts an unverified suspicion raised during review: `LongOffset` **is**
present on live `spark4.0` (`DistributedHTTPSource.scala`, `HTTPSource.scala`).
The empty grep behind it was a case-sensitivity error.

### Recovered operating detail

Generated Python under `target/scala-2.13` (not master's `scala-2.12`); the
Java 17 surface and the exact CMS flags whose restoration stops the JVM booting;
why `environment.yml` pins move and why their comments are load-bearing through
a sync; the Spark 4 adaptations by name (`UnboundRowEncoder` and the SAR case
class, `DetectAmbiguousSelfJoin` and the qualified join column,
`safeGetDefault`, and why the classifier fixture dropped NaN rather than
weakening the assertion); the `__init__.py` rationale and its guard tests;
`rLoadLine`/`new_ml_pipeline_stage` (signature stable v1.8.0–v1.9.5, four param
types share one implementation, keep the three assertions in step); the
sibling-diff habit and its track record; `areLibrariesInstalled == false` as a
~10 minute timeout that **inverts** expectations, since a genuine `FAILED`
throws instead; the `torchvision 0.17.0` → `torch 2.2.0` downgrade; and the
fine-tune timings showing the wheel swap was alignment, not a fix.

### `synapseml-pr-loop` — why the loop kept missing all of this

Suppressed Copilot comments are **not review threads**. They live in a collapsed
section of the review *body*, so a `reviewThreads` query returns zero while they
exist, and an agent following the skill exactly gets a clean result and stops.
They also have no thread, so they cannot be replied to or resolved. Both facts
are now written down.

Automated review is asynchronous and per-commit, so auditing right after a push
reads the *previous* head's review and reports zero findings for code nobody has
looked at. The discriminator is the review's commit, not its recency.
`Get-PrReadiness.ps1` now gates on that and can block on it with
`-WaitForReview`, so waiting is the tool's job rather than a human's.

That immediately showed **#2646 had never been reviewed at all**, which its
"zero unresolved threads" had been concealing.

Review then found four separate false all-clears in that gate:

| Defect | Effect |
| --- | --- |
| `-imatch 'copilot'` substring matching | `not-copilot` counted as coverage |
| coverage decided by recency, not commit | force-push to a reviewed commit misreported |
| unsubmitted reviews counted | all-clear before the review existed |
| `complete` tested pagination truncation, not unresolved threads | **reported `complete=true` on this PR with a thread open** |

All four failed in the same direction — toward declaring readiness that had not
been established — so `readiness-gates.md` now documents what `complete` means
and says to trust the individual fields over the summary flag. `-RequestReview`
is also attempted at most once per PR instead of on every poll.

### Validation

- 7/7 matcher cases pass; the three impostor logins that matched before do not
- caller with `Set-StrictMode -Version 3.0` still gets a snapshot; after
  dot-sourcing, a missing-property access in the caller still throws
  (StrictMode is scoped to the two functions that read sparse GraphQL fields)
- a simulated pending review carrying the head oid with a null `submittedAt`
  yields `coversHead=false`
- the same live input that produced `complete=true` with a thread open now
  produces `complete=false`
- knowledge transfer measured at 39/40 terms, with the omission reasoned above
- docs plus one skill script: nothing in `.github/workflows`, `pipeline.yaml`,
  `build.sbt`, or any `.scala`/`.py`/`.sh` references either skill, so the blast
  radius on `master`, `spark4.0` and `spark4.1` is zero

One caveat worth stating plainly: a `param()` block placed after a statement
parses cleanly and fails only at runtime, so this script was briefly broken
while passing a parse check. Every fix here was verified by running it.
