### PR TITLE
docs: preserve Spark 4 branch operating knowledge in the branches skill

### DIFF
--- a/.github/skills/synapseml-branches/references/branch-spark4-common.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4-common.md
@@ -242,8 +242,16 @@ This is why the Spark 4 branches had to audit them.
 | `vw/`, `services/openai/` | removed | Duplicated what codegen already emits, and redefined `__all__`, narrowing `import *` to a hand-maintained list. |
 | `recommendation/`, `dl/`, `hf/`, `cognitive/`, `mmlspark/` | kept | These add exports codegen does not emit. |
 
-Do not add new `__init__.py` files that re-list generated classes.
-`test_http_package.py` and `test_package_exports.py` guard this.
+Do not add new `__init__.py` files that re-list generated classes. On the Spark 4
+branches this is guarded by two tests,
+`core/src/test/python/synapsemltest/io/http/test_http_package.py` and
+`core/src/test/python/synapsemltest/recommendation/test_package_exports.py`. Note
+where they are and are not: both are on `spark4.1`, both reach `spark4.0` through
+[#2646](https://github.com/microsoft/SynapseML/pull/2646), and **neither is on
+`master`**, which carries `PythonInitMerger` without them. So a change to these
+files on `master` is unguarded, and the guards cannot be assumed from the merger's
+presence. Verify with
+`git ls-tree -r --name-only ms/<branch> | grep -E 'test_http_package|test_package_exports'`.
 
 ## Before merging a sync
 

--- a/.github/skills/synapseml-branches/references/branch-spark4-common.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4-common.md
@@ -52,6 +52,23 @@ of re-deriving it from whatever tree they happen to have open.
   resolution. The recurring reasons: master's `pip` is too old to install for
   these interpreters, `torch`/`torchvision` need their first releases supporting
   the version, and `pandas`/`horovod` come from interpreter-specific wheel URLs.
+
+  Measured, since these are easy to get backwards:
+
+  | | master | spark4.0 | spark4.1 |
+  | --- | --- | --- | --- |
+  | `python` | 3.11.8 | 3.12.11 | 3.13 |
+  | `pyarrow` | 10.0.1 | 22.0.0 | 18.0.0 |
+  | `mlflow` | 2.21.3 | 1.26.1 | 2.21.3 |
+
+  Each branch reached its `pyarrow` by a different route, so do not carry the
+  reasoning across: `spark4.0` needs a release with cp312 wheels (older ones
+  such as 11.0.0 have none and would build from source), `spark4.1` needs cp313
+  wheels under an `mlflow` 2.x `pyarrow<19` bound, and master is held *down* at
+  10.0.1 because Petastorm uses legacy Parquet and fsspec APIs removed after
+  PyArrow 10. Note also that `spark4.0` carries `mlflow==1.26.1`, a downgrade
+  from master's 2.21.3, which is not explained by the Python version and has not
+  been validated.
 - The `pyarrow` and `mlflow` pins are coupled, and the pinned versions are not
   the same on every branch — read both live values on the branch you are editing
   before changing either. The bound comes from MLflow: `mlflow==2.21.3` declares
@@ -83,8 +100,12 @@ of re-deriving it from whatever tree they happen to have open.
   trips `DetectAmbiguousSelfJoin`. `Wrappable.safeGetDefault` guards
   `getDefault`, which throws on Spark 4 where Spark 3 returned a default.
   `VerifyTrainClassifier`'s vector fixture no longer feeds `Double.NaN` to the
-  trainer: that test is about training on a vector column, not about NaN, so the
-  value was replaced rather than the assertion weakened.
+  trainer, because Spark 4 does not tolerate a NaN feature reaching logistic
+  regression the way 3.5 did. That test is about training on a vector column,
+  not about NaN, so the value was replaced rather than the assertion weakened.
+  Master still has the `Double.NaN` at `VerifyTrainClassifier.scala:121`, so a
+  sync will try to restore it; do not let it, and do not weaken the assertion
+  instead.
 - `OpenAIPrompt` sets `pyInternalWrapper = true`, so codegen emits
   `class _OpenAIPrompt` and a hand-written `OpenAIPrompt.py` supplies the public
   name. Python emitted into that class must use zero-argument `super()`; a
@@ -220,6 +241,22 @@ of re-deriving it from whatever tree they happen to have open.
   definition's trigger filter before assuming flakiness, and fall back to
   queueing the PR merge ref (`refs/pull/<N>/merge`), never
   `refs/heads/<branch>`, which fails service-connection authorization.
+- **The trigger filter lives on the ADO definition, not in `pipeline.yaml`.**
+  The `pr:` block in `pipeline.yaml` is a red herring: a UI-defined trigger
+  overrides it silently, so editing the YAML changes nothing. The proof is on
+  the branch itself — `spark4.0`'s own `pipeline.yaml` `pr:` block lists
+  `master`, `spark3.3` and `spark3.5` and does **not** list `spark4.0`, yet PRs
+  targeting `spark4.0` build. Read the real value from the definition instead:
+
+  ```
+  GET .../_apis/build/definitions/17563?api-version=7.0
+  ```
+
+  `triggers[].branchFilters` is currently `+master, +spark3.5, +spark4.0,
+  +spark4.1`, and the `continuousIntegration` trigger reports
+  `settingsSourceType: 2`, which means UI-defined rather than YAML-defined.
+  Consequence for a future release branch: adding it to `pipeline.yaml` does not
+  give it PR builds. Someone has to add it to the definition's filter.
 - GitHub checks compile/lint but do not replace full Azure, Databricks, native,
   R, or service validation.
 - Intermittent ONNX OOM (`OutOfMemoryError` in `ImageFeaturizerSuite`, under the

--- a/.github/skills/synapseml-branches/references/branch-spark4-common.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4-common.md
@@ -42,9 +42,8 @@ of re-deriving it from whatever tree they happen to have open.
 
 - Spark 4 uses Scala 2.13 and Java 17-era tooling, so generated Python lands in
   `target/scala-2.13/generated/src/python/` rather than master's `scala-2.12`
-  path. `tools/docker/*/Dockerfile` set `JAVA_HOME` to Java 17 and
-  `.github/workflows/pr-validation.yml` uses JDK 17. `pipeline.yaml` drops
-  master's `-XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled` from
+  path. `tools/docker/*/Dockerfile` set `JAVA_HOME` to Java 17. `pipeline.yaml`
+  drops master's `-XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled` from
   `SBT_OPTS`: CMS was removed in Java 17 and the JVM refuses to start with those
   flags, so a sync that restores them fails before any test runs.
 - `environment.yml` moves pins forward for the branch's Python, and each pin
@@ -227,6 +226,45 @@ of re-deriving it from whatever tree they happen to have open.
   `UnitTests onnx` leg) and R package HTTP failures
   (a conda `HTTP 403` in `RTests vw`) require log evidence and a controlled
   rerun; they are not automatic product regressions or exemptions.
+
+## Where the Java version is declared
+
+There is no single source of truth for the JDK. Each branch declares it in
+several files, and a sync can silently disagree with itself if only some are
+updated. Measured values:
+
+| File | master | spark4.0 | spark4.1 |
+| --- | --- | --- | --- |
+| `.github/workflows/pr-validation.yml` | 11 | **11** | 17 |
+| `environment.yml` (`openjdk`) | absent | 17 | 17 |
+| `environment.dev.yml` (`openjdk`) | no file | 17 | 17 |
+| `templates/java_setup.yml` (`versionSpec`) | no file | 17 | 17 |
+| `pipeline.yaml` (`JAVA_VERSION`, ReleaseBranchCompat) | 17 | absent | 17 |
+
+Two things in that table are not typos. `spark4.0`'s GitHub workflow pins JDK
+11 while the rest of the branch is on 17, so do not assume the workflow proves
+the branch's Java version; check `environment.yml` or `java_setup.yml` instead.
+And `spark4.0` has no `JAVA_VERSION` because it is not yet in the
+ReleaseBranchCompat matrix, which is a separate follow-up.
+
+`templates/java_setup.yml` is the pin that CI jobs consume. On `spark4.0` it is
+included by the `Style` job; on `spark4.1` the file exists but nothing includes
+it yet. Master gained the file only via
+[#2652](https://github.com/microsoft/SynapseML/pull/2652), which set it to 11 —
+master's already-effective JDK, measured from a build that echoes
+`java -version` — and included it from the InternalCompat job so that job stops
+compiling Spark 4 code on master's JDK.
+
+**Conflict rule: on the first sync after #2652, `templates/java_setup.yml`
+conflicts add/add and git leaves markers. Always keep the branch's own 17.**
+Taking master's side is the intuitive resolution and the wrong one: it silently
+drops the branch to Java 11 and reintroduces `Class java.lang.Record not found`.
+The conflict is one-time — once resolved, the file histories are connected and
+later syncs merge it cleanly. Verify with:
+
+```
+git show <branch>:templates/java_setup.yml | grep versionSpec
+```
 
 ## Hand-written `__init__.py` files
 

--- a/.github/skills/synapseml-branches/references/branch-spark4-common.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4-common.md
@@ -63,6 +63,12 @@ of re-deriving it from whatever tree they happen to have open.
   with each other and with the pins they sit next to.
 - Scala 2.13 collection boundaries must produce immutable `Seq` values; keep
   the central `asImmutableCollection` conversion rather than per-service fixes.
+  The failure mode is why this matters: code that yields a `mutable.ArraySeq`
+  where an `immutable.Seq` is expected throws `ClassCastException` **at runtime,
+  not at compile time**, so a green compile proves nothing and the break surfaces
+  one or two layers away from its cause. `CognitiveServiceBase.getValueOpt`
+  converts once, centrally, using `toIndexedSeq` — chosen over `toList` because
+  it preserves O(1) indexing.
 - Preserve the Spark 4 adaptations. In `SAR.scala`/`SARModel.scala` the affinity
   pairs use a named `case class` with explicit struct fields because Spark 4
   rejects the old `Seq[Row]` UDF shape with `UnboundRowEncoder`, and the join
@@ -152,13 +158,46 @@ of re-deriving it from whatever tree they happen to have open.
   Read statuses and notebook duration before classifying it.
 - `DatabricksCPUStreamingTests` exists only on the Spark 4 branches, and whether
   it is scheduled varies by branch — read `pipeline.yaml` on the branch you are
-  working on rather than assuming. It is a separate class because the streaming
-  notebook's `server.stop()` cancels concurrent SparkContext jobs, so it needs its
-  own cluster instead of a slot on an existing leg, which is why scheduling it
-  costs pool capacity. The in-repo comment attributes that behaviour to Spark 4.0
-  and it has not been re-confirmed on 4.1. If a sync drops its leg while leaving
-  the class defined, that is lost coverage rather than a cleanup: the class is
-  still there, so nothing fails to compile and nothing reports the gap.
+  working on rather than assuming. As measured on 2026-08-17, only live
+  `spark4.0` gives it a leg, and it got one in the original port commit
+  `b76c391be4`; `master` and `spark4.1` leave the class defined but unscheduled
+  pending pool capacity and a notebook fix. A sync from master therefore drops
+  that leg on `spark4.0`, which converges the three branches rather than
+  regressing one — but record it as a decision, because nothing reports it. It
+  is a separate class because the streaming notebook's `server.stop()` cancels
+  concurrent SparkContext jobs, so it needs its own cluster instead of a slot on
+  an existing leg, which is why scheduling it costs pool capacity. The in-repo
+  comment attributes that behaviour to Spark 4.0 and it has not been
+  re-confirmed on 4.1. If a sync drops the leg while leaving the class defined,
+  nothing fails to compile and nothing reports the gap, so check deliberately.
+- The Databricks GPU suite was split and then deliberately re-merged, and the
+  history matters because `spark4.0` still carries the abandoned shape. #2538
+  split it into `DatabricksGPUTests1/2/3`, each building its own cluster with two
+  workers and running exactly one notebook via `gpuNotebook(0)`, `(1)`, `(2)`.
+  #2573 (`fix: restore SynapseML Azure pipeline`) reverted that to a single
+  `DatabricksGPUTests` because the split could not fit: three clusters times two
+  workers needs six GPU nodes, against a pool holding
+  `GpuWorkersPerRun` 1 x `GpuConcurrentRuns` 3 = three. Master's current form
+  runs the whole `GPUNotebooks` set on one cluster sized at `GpuWorkersPerRun`
+  (one worker, so concurrent builds can share the pool), pins the driver to the
+  **CPU** pool (`driverInstancePoolId = Some(PoolId)`) so it does not consume a
+  GPU node, and rather than failing on a starved pool waits for one through
+  `createActiveCluster` with `maxAttempts = Int.MaxValue` and
+  `maxRetryDurationMs` of three hours. `SYNAPSEML_GPU_SMOKE_TESTS` passes
+  `synapseml_ci_smoke` through to the notebooks, and the job takes a 300-minute
+  timeout to absorb the sequential run. Read the file rather than this paragraph
+  for the mechanism: it changed between #2573 and now, and an earlier draft of
+  this bullet described the #2573 snapshot as if it were current.
+- Prefer the consolidated form on every branch, and never restore the split
+  during a sync. Its indices are hardcoded, so it tests exactly three notebooks
+  no matter how many exist: at the time of writing `master` and `spark4.1` have
+  four GPU notebooks (`Fine-tune`/`Phi Model` matches) while live `spark4.0` has
+  three, so the split covers `spark4.0` today and would silently skip index 3 —
+  `Quickstart - End-to-end Local RAG with Phi Model` — the moment a sync brings
+  master's fourth notebook in. `DatabricksGPUTests` reads `GPUNotebooks` whole
+  and cannot drift that way. #2646 already lands exactly this: the merged
+  `DatabricksGPUTests.scala` is byte-identical to master's and the branch picks
+  up the fourth notebook, so `spark4.0` needs no separate change.
 - Petastorm calls pyarrow APIs the pinned pyarrow no longer ships, so Horovod's
   Spark backend needs a compatibility layer. Only `spark4.1` has one. This is a
   library-version problem, not a Python-version one, so a branch on the same
@@ -168,15 +207,35 @@ of re-deriving it from whatever tree they happen to have open.
 - `/azp run` queues these targets. The ADO pull-request trigger filter allowed
   only `master` until 2026-08-17; it now covers `master`, `spark3.5`,
   `spark4.0` and `spark4.1`, verified by builds recording `reason=pullRequest`
-  rather than `reason=manual`. If a comment produces no build, re-read the
+  and `requestedFor=GitHub` rather than `reason=manual`. Those two fields are
+  the reliable way to tell a trigger-driven run from one you queued by hand. If
+  a comment produces no build, re-read the
   definition's trigger filter before assuming flakiness, and fall back to
   queueing the PR merge ref (`refs/pull/<N>/merge`), never
   `refs/heads/<branch>`, which fails service-connection authorization.
 - GitHub checks compile/lint but do not replace full Azure, Databricks, native,
   R, or service validation.
-- Intermittent ONNX OOM (`ImageFeaturizerSuite`) and R package HTTP failures
+- Intermittent ONNX OOM (`OutOfMemoryError` in `ImageFeaturizerSuite`, under the
+  `UnitTests onnx` leg) and R package HTTP failures
   (a conda `HTTP 403` in `RTests vw`) require log evidence and a controlled
   rerun; they are not automatic product regressions or exemptions.
+
+## Hand-written `__init__.py` files
+
+`PythonInitMerger` came from master and **preserves** hand-written `__init__.py`
+content by splicing it after the generated imports. Codegen previously
+overwrote these files, so their contents were inert; they are now live code in
+the shipped package, which makes a stale one a real bug rather than dead text.
+This is why the Spark 4 branches had to audit them.
+
+| Path | State | Why |
+| --- | --- | --- |
+| `core/.../io/http/__init__.py` | must stay empty | It listed `HTTPFunctions` and `ServingFunctions`, which are modules of free functions with no same-named class, so the import failed and broke `PythonTests core` plus seven website-sample docs. |
+| `vw/`, `services/openai/` | removed | Duplicated what codegen already emits, and redefined `__all__`, narrowing `import *` to a hand-maintained list. |
+| `recommendation/`, `dl/`, `hf/`, `cognitive/`, `mmlspark/` | kept | These add exports codegen does not emit. |
+
+Do not add new `__init__.py` files that re-list generated classes.
+`test_http_package.py` and `test_package_exports.py` guard this.
 
 ## Before merging a sync
 

--- a/.github/skills/synapseml-branches/references/branch-spark4-common.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4-common.md
@@ -238,9 +238,15 @@ This is why the Spark 4 branches had to audit them.
 
 | Path | State | Why |
 | --- | --- | --- |
-| `core/.../io/http/__init__.py` | must stay empty | It listed `HTTPFunctions` and `ServingFunctions`, which are modules of free functions with no same-named class, so the import failed and broke `PythonTests core` plus seven website-sample docs. |
-| `vw/`, `services/openai/` | removed | Duplicated what codegen already emits, and redefined `__all__`, narrowing `import *` to a hand-maintained list. |
-| `recommendation/`, `dl/`, `hf/`, `cognitive/`, `mmlspark/` | kept | These add exports codegen does not emit. |
+| `core/.../io/http/__init__.py` | must stay empty | Listed free-function modules; see below |
+| `vw/`, `services/openai/` | removed | Duplicated codegen output |
+| `recommendation/`, `dl/`, `hf/`, `cognitive/`, `mmlspark/` | kept | Add exports codegen omits |
+
+`core/.../io/http/__init__.py` listed `HTTPFunctions` and `ServingFunctions`,
+which are modules of free functions with no same-named class, so the import
+failed and broke `PythonTests core` plus seven website-sample docs. The `vw/`
+and `services/openai/` files also redefined `__all__`, which narrowed
+`import *` to a hand-maintained list.
 
 Do not add new `__init__.py` files that re-list generated classes. On the Spark 4
 branches this is guarded by two tests,

--- a/.github/skills/synapseml-branches/references/branch-spark4-common.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4-common.md
@@ -61,14 +61,22 @@ of re-deriving it from whatever tree they happen to have open.
   MLflow pins carry different bounds, so check the pinned version's own metadata
   rather than assuming this one. Do not trust the inline comments: they disagree
   with each other and with the pins they sit next to.
-- Scala 2.13 collection boundaries must produce immutable `Seq` values; keep
-  the central `asImmutableCollection` conversion rather than per-service fixes.
-  The failure mode is why this matters: code that yields a `mutable.ArraySeq`
-  where an `immutable.Seq` is expected throws `ClassCastException` **at runtime,
-  not at compile time**, so a green compile proves nothing and the break surfaces
-  one or two layers away from its cause. `CognitiveServiceBase.getValueOpt`
-  converts once, centrally, using `toIndexedSeq` — chosen over `toList` because
-  it preserves O(1) indexing.
+- Scala 2.13 collection boundaries must produce immutable `Seq` values. The
+  failure mode is why this matters: code that yields a `mutable.ArraySeq` where
+  an `immutable.Seq` is expected throws `ClassCastException` **at runtime, not
+  at compile time**, so a green compile proves nothing and the break surfaces
+  one or two layers away from its cause. Prefer `toIndexedSeq` over `toList`
+  when converting, because it preserves O(1) indexing. Be careful what you
+  believe about *where* this is handled: the branch-local notes claimed
+  `CognitiveServiceBase.getValueOpt` converted centrally through a helper called
+  `asImmutableCollection`, and neither is true — `getValueOpt` returns the row
+  or default value with no conversion, and `asImmutableCollection` appears in no
+  branch, only in two abandoned commits (`745b342b48`, `6cab133efd`) that are
+  contained in no tip. Verify with
+  `git grep asImmutableCollection ms/master ms/spark4.0 ms/spark4.1`. If the
+  `ClassCastException` resurfaces, one conversion in `CognitiveServiceBase` is
+  the right shape of fix, but treat it as a change to make rather than one
+  already in place.
 - Preserve the Spark 4 adaptations. In `SAR.scala`/`SARModel.scala` the affinity
   pairs use a named `case class` with explicit struct fields because Spark 4
   rejects the old `Seq[Row]` UDF shape with `UnboundRowEncoder`, and the join

--- a/.github/skills/synapseml-branches/references/branch-spark4-common.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4-common.md
@@ -42,7 +42,9 @@ of re-deriving it from whatever tree they happen to have open.
 
 - Spark 4 uses Scala 2.13 and Java 17-era tooling, so generated Python lands in
   `target/scala-2.13/generated/src/python/` rather than master's `scala-2.12`
-  path. `tools/docker/*/Dockerfile` set `JAVA_HOME` to Java 17. `pipeline.yaml`
+  path. The `tools/docker/*/Dockerfile` files set `JAVA_HOME` to Java 17 on
+  both Spark 4 branches, where master sets Java 11 — check the branch, not
+  master, if you are verifying this. `pipeline.yaml`
   drops master's `-XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled` from
   `SBT_OPTS`: CMS was removed in Java 17 and the JVM refuses to start with those
   flags, so a sync that restores them fails before any test runs.
@@ -277,6 +279,7 @@ updated. Measured values:
 | `environment.dev.yml` (`openjdk`) | no file | 17 | 17 |
 | `templates/java_setup.yml` (`versionSpec`) | no file | 17 | 17 |
 | `pipeline.yaml` (`JAVA_VERSION`, ReleaseBranchCompat) | 17 | absent | 17 |
+| `tools/docker/*/Dockerfile` (`JAVA_HOME`) | 11 | 17 | 17 |
 
 Two things in that table are not typos. `spark4.0`'s GitHub workflow pins JDK
 11 while the rest of the branch is on 17, so do not assume the workflow proves
@@ -286,13 +289,15 @@ ReleaseBranchCompat matrix, which is a separate follow-up.
 
 `templates/java_setup.yml` is the pin that CI jobs consume. On `spark4.0` it is
 included by the `Style` job; on `spark4.1` the file exists but nothing includes
-it yet. Master gained the file only via
-[#2652](https://github.com/microsoft/SynapseML/pull/2652), which set it to 11 —
-master's already-effective JDK, measured from a build that echoes
-`java -version` — and included it from the InternalCompat job so that job stops
-compiling Spark 4 code on master's JDK.
+it yet. Master does **not** have the file at the time of writing: it arrives
+with [#2652](https://github.com/microsoft/SynapseML/pull/2652), which sets it to
+11 — master's already-effective JDK, measured from a build that echoes
+`java -version` — and includes it from the InternalCompat job so that job stops
+compiling Spark 4 code on master's JDK. If that PR has not merged yet, expect
+the file to be absent on master and the table row above to read "no file";
+confirm with `git show ms/master:templates/java_setup.yml`.
 
-**Conflict rule: on the first sync after #2652, `templates/java_setup.yml`
+**Conflict rule: on the first sync after #2652 merges, `templates/java_setup.yml`
 conflicts add/add and git leaves markers. Always keep the branch's own 17.**
 Taking master's side is the intuitive resolution and the wrong one: it silently
 drops the branch to Java 11 and reintroduces `Class java.lang.Record not found`.

--- a/.github/skills/synapseml-branches/references/branch-spark4p0.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4p0.md
@@ -8,6 +8,9 @@ templatized version of the branch context from
 
 - Shared Spark 4.0 port. At the #2646 snapshot it used Spark 4.0.1,
   Scala 2.13.16, Java 17, Python 3.12, and Databricks 17.3; verify live files.
+  The Databricks runtime strings are `17.3.x-scala2.13` and GPU
+  `17.3.x-gpu-ml-scala2.13`. DBR 17.3 LTS ML ships Spark 4.0 and 18.0 ML ships
+  Spark 4.1, which is why the runtime version is not a free knob here.
 - Check `spark4.1` before debugging from scratch because it is the more actively
   maintained descendant, then prove any candidate fix is not 4.1-specific.
 - Live state lags the #2646 description. In `DatabricksUtilities.scala` the live
@@ -42,6 +45,27 @@ templatized version of the branch context from
   4.1 `np.frombuffer` workaround.
 - Preserve the Spark 4 R fixes shared with 4.1. The branch-local `JAVA_HOME`
   fallback is extra; nested-stage loading was alignment, not proven root cause.
+- **sparklyr must be 1.9.5, not 1.9.3** (`r-sparklyr=1.9.5` in `environment.yml`),
+  and on the live branch it is still
+  1.9.3 — so this is a current failure, not history. Under dbplyr 2.6, sparklyr
+  1.9.3's `tidyselect_data_proxy.tbl_spark` returns a proxy carrying no Spark
+  connection, so anything routed through `dplyr::select` on a `tbl_spark` loses
+  `sc`. It broke `RTests core` (21 of 69) and `RTests deep-learning` (3 of 3),
+  and it surfaces one or two layers away as `invoke_static` or `hive_context`
+  applied to `NULL`, which reads like a dead Spark session. Interleaving is the
+  tell: a dead session fails everything after a point, whereas this failed 21
+  tests scattered among 48 passes, with `sar` passing while `sar_model` failed.
+  Read the backtrace, not the surface error. `spark4.1` pairs the same
+  `r-base=4.4` with 1.9.5 and passes 69/69.
+- R connects through `SPARK_HOME`: `RTestGen.scala` generates
+  `spark_connect(master = "local", spark_home = Sys.getenv("SPARK_HOME"), ...)`,
+  byte-identical to `spark4.1`. The pipeline exports `SPARK_HOME`, so
+  `run_r_tests.R` only unsets it and installs the tarball when it is absent,
+  which is the local-developer path. Be accurate about what that bought: the
+  previous `version = "4.0"` form also worked, because `run_r_tests.R` had
+  already installed the tarball and sparklyr resolves an install it made itself.
+  Measured R results were identical before and after. It is kept for
+  byte-identical alignment with 4.1, not because it fixed anything.
 
 ## Runtime and CI
 
@@ -51,16 +75,26 @@ templatized version of the branch context from
   4.0-capable Fabric runtime exists, which may never happen; the more likely
   resolution is that this branch is superseded by `spark4.1`.
 - At #2646, two GPU fine-tune notebooks failed because no Horovod wheel matched
-  DBR 17.3's PyTorch. Do not switch `AdbGpuRuntime` to DBR 18 merely to turn
-  them green; DBR 17.3 LTS ML ships Spark 4.0 and 18.0 ML ships Spark 4.1, so
-  bumping it would test Spark 4.1 instead of this branch and make the suite
-  green by no longer testing what it exists to test. Revalidate this known gap.
+  DBR 17.3's PyTorch. The wheel this branch needs is one built against DBR 17.3
+  ML's PyTorch, and no such wheel is published — the `synapse-extension` wheel is
+  built for 18.0 ML. Producing it is a build-artifact task rather than a code
+  change, which is why this is recorded rather than patched around. `spark4.1`
+  additionally calls `ensure_petastorm_compatibility()` *before* `import horovod`
+  in `_horovod.py`; that is a plausible second contributor but it is unproven, so
+  do not quote it as the cause without the notebook's stderr from the Databricks
+  run API. Do not switch `AdbGpuRuntime` to DBR 18 merely to turn them green;
+  that would test Spark 4.1 instead of this branch and make the suite green by no
+  longer testing what it exists to test. Revalidate this known gap.
 - Two of four GPU notebooks failing is that gap's expected shape. Check the
   failing count and which notebooks, not the job's red/green, before calling it
-  a regression. The Horovod wheel is the first blocker and it masks the missing
-  Petastorm layer noted above, so fixing the wheel alone should not be expected
-  to turn these notebooks green. Confirm each step from the notebook's stderr
-  output rather than inferring it.
+  a regression. Note the denominator moves: live `spark4.0` has three GPU
+  notebooks and #2646 brings master's fourth
+  (`Quickstart - End-to-end Local RAG with Phi Model`), because the sync also
+  adopts master's consolidated `DatabricksGPUTests`, which runs the whole
+  `GPUNotebooks` set instead of three hardcoded indices. The Horovod wheel is
+  the first blocker and it masks the missing Petastorm layer noted above, so
+  fixing the wheel alone should not be expected to turn these notebooks green.
+  Confirm each step from the notebook's stderr output rather than inferring it.
 - Avoid pinning runtime-provided torch/torchvision without a demonstrated need;
   incompatible pins can trigger multi-gigabyte CUDA downgrades and timeouts. The
   recorded instance was `torchvision==0.17.0` in `GPULibraries`, which

--- a/.github/skills/synapseml-branches/references/branch-spark4p1.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4p1.md
@@ -8,7 +8,8 @@ templatized version of the branch context from
 
 - Shared Spark 4.1 port and the more actively maintained Spark 4 reference. At
   the #2645 snapshot it used Spark 4.1.1, Scala 2.13.17, Java 17, Python 3.13,
-  and Databricks 18.0; verify live files.
+  and Databricks 18.0; verify live files. The Databricks runtime strings are
+  `18.0.x-scala2.13` and GPU `18.0.x-gpu-ml-scala2.13`.
 - Ask whether every non-4.1-specific fix should be back-ported to `spark4.0`.
 
 ## Core differences
@@ -19,26 +20,35 @@ templatized version of the branch context from
   pyarrow APIs Petastorm still calls, which the pinned pyarrow no longer
   provides. Do not describe it as a Python 3.13 workaround — that framing makes
   `spark4.0` look exempt when it is not. `spark4.0` pins a different, newer
-  pyarrow, so those APIs are missing there too.
+  pyarrow, so those APIs are missing there too. The layer has two halves:
+  `_petastorm_compat.py` and the `_serialize_petastorm_compatibility()` path in
+  `_horovod.py`. A back-port needs both.
 - `LongOffset` moved to `...execution.streaming.runtime`; the 4.0 import does
-  not compile here.
-- Spark 4.1 returns Python `bytes` for `BinaryType`; `ImageTransformer` uses
-  `np.frombuffer` because `np.asarray` treats `bytes` as a scalar string.
+  not compile here. `HTTPSource.scala` and `DistributedHTTPSource.scala` are the
+  files that import it, and they are the whole surface of this difference.
+- Spark 4.1 returns Python `bytes` for `BinaryType` where 4.0 returns
+  `bytearray`; `np.asarray(value, dtype=np.uint8)` raises `ValueError` on `bytes`
+  because it treats them as a scalar string, so `ImageTransformer.toNDArray`
+  uses `np.frombuffer`, which accepts both.
 - `RCodegenSuite` directly guards generated R behavior, including nested-stage
   loading and the Spark 4 ANSI settings.
 
 ## Runtime and CI
 
 - Fabric Runtime 2.0 supports Spark 4.1, so the old "unsupported runtime"
-  reason for disabling Fabric E2E is stale. Re-enable only in a dedicated PR:
-  request Spark 4.1 in workspace creation, restore the pipeline condition, and
-  validate with real Fabric capacity/service connection. The workspace-creation
+  reason for disabling Fabric E2E is stale. The job is switched off with a bare
+  `condition: false` on the `FabricE2E` job in `pipeline.yaml`, so it is skipped
+  rather than reported. Re-enable only in a dedicated PR: restore
+  `condition: and(succeeded(), eq('${{ parameters.testFabricE2E }}', true))`,
+  drop the stale comment, request Spark 4.1 in workspace creation, and validate
+  with real Fabric capacity/service connection. The workspace-creation
   payload lives in the Fabric test package's `FabricOperations.scala`, which
   hardcodes `'SparkVersion': '3.5'` and must request `'4.1'`. That value is
   hardcoded identically on `master`, `spark4.0` and `spark4.1`, so changing it
   here does not alter master's behaviour. It also needs a Fabric capacity in the
-  `sempy-integration-region` that can provision Runtime 2.0 workspaces, which is
-  the one prerequisite not discoverable from the code.
+  `sempy-integration-region` that can provision Runtime 2.0 workspaces, and the
+  `SynapseML Build` service connection, which are the prerequisites not
+  discoverable from the code.
 - Databricks CPU/GPU validation uses 18.x-era runtimes: CPU pool
   `synapseml-build-18.0`, GPU pool `synapseml-build-14.3-gpu`. Run Spark 4 builds
   sequentially because the GPU pool is shared with `master` and `spark4.0`.

--- a/.github/skills/synapseml-branches/references/branch-spark4p1.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4p1.md
@@ -38,7 +38,7 @@ templatized version of the branch context from
 - Fabric Runtime 2.0 supports Spark 4.1, so the old "unsupported runtime"
   reason for disabling Fabric E2E is stale. On this branch's `pipeline.yaml` the
   job is switched off with a bare `condition: false`, so it is skipped rather
-  than reported -- do not check `master` to confirm that, because `master` has
+  than reported. Do not check `master` to confirm that, because `master` has
   the normal `and(succeeded(), eq('${{ parameters.testFabricE2E }}', true))` and
   `spark4.0` a third form, `eq('${{ parameters.testFabricE2E }}', true)` with no
   `succeeded()`. Re-enable only in a dedicated PR: restore `master`'s form,

--- a/.github/skills/synapseml-branches/references/branch-spark4p1.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4p1.md
@@ -41,14 +41,14 @@ templatized version of the branch context from
   than reported. Do not check `master` to confirm that, because `master` has
   the normal `and(succeeded(), eq('${{ parameters.testFabricE2E }}', true))` and
   `spark4.0` a third form, `eq('${{ parameters.testFabricE2E }}', true)` with no
-  `succeeded()`. Re-enable only in a dedicated PR: restore `master`'s form,
-  drop the stale comment, request Spark 4.1 in workspace creation, and validate
-  with real Fabric capacity/service connection. Do it as its own PR, where the
-  pipeline run *is* the test, rather than folding it into a sync: a Fabric
-  provisioning failure would otherwise block an unrelated merge. The
-  workspace-creation
-  payload lives in the Fabric test package's `FabricOperations.scala`, which
-  hardcodes `'SparkVersion': '3.5'` and must request `'4.1'`. That value is
+  `succeeded()`. Re-enable only in a dedicated PR, where the pipeline run *is*
+  the test, rather than folding it into a sync: a Fabric provisioning failure
+  would otherwise block an unrelated merge. That PR should restore `master`'s
+  form, drop the stale comment, request Spark 4.1 in workspace creation, and
+  validate against real Fabric capacity and service connection. The
+  workspace-creation payload lives in the Fabric test package's
+  `FabricOperations.scala`, which hardcodes `'SparkVersion': '3.5'` and must
+  request `'4.1'`. That value is
   hardcoded identically on `master`, `spark4.0` and `spark4.1`, so changing it
   here does not alter master's behaviour. It also needs a Fabric capacity in the
   `sempy-integration-region` that can provision Runtime 2.0 workspaces, and the

--- a/.github/skills/synapseml-branches/references/branch-spark4p1.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4p1.md
@@ -43,7 +43,10 @@ templatized version of the branch context from
   `spark4.0` a third form, `eq('${{ parameters.testFabricE2E }}', true)` with no
   `succeeded()`. Re-enable only in a dedicated PR: restore `master`'s form,
   drop the stale comment, request Spark 4.1 in workspace creation, and validate
-  with real Fabric capacity/service connection. The workspace-creation
+  with real Fabric capacity/service connection. Do it as its own PR, where the
+  pipeline run *is* the test, rather than folding it into a sync: a Fabric
+  provisioning failure would otherwise block an unrelated merge. The
+  workspace-creation
   payload lives in the Fabric test package's `FabricOperations.scala`, which
   hardcodes `'SparkVersion': '3.5'` and must request `'4.1'`. That value is
   hardcoded identically on `master`, `spark4.0` and `spark4.1`, so changing it

--- a/.github/skills/synapseml-branches/references/branch-spark4p1.md
+++ b/.github/skills/synapseml-branches/references/branch-spark4p1.md
@@ -36,10 +36,12 @@ templatized version of the branch context from
 ## Runtime and CI
 
 - Fabric Runtime 2.0 supports Spark 4.1, so the old "unsupported runtime"
-  reason for disabling Fabric E2E is stale. The job is switched off with a bare
-  `condition: false` on the `FabricE2E` job in `pipeline.yaml`, so it is skipped
-  rather than reported. Re-enable only in a dedicated PR: restore
-  `condition: and(succeeded(), eq('${{ parameters.testFabricE2E }}', true))`,
+  reason for disabling Fabric E2E is stale. On this branch's `pipeline.yaml` the
+  job is switched off with a bare `condition: false`, so it is skipped rather
+  than reported -- do not check `master` to confirm that, because `master` has
+  the normal `and(succeeded(), eq('${{ parameters.testFabricE2E }}', true))` and
+  `spark4.0` a third form, `eq('${{ parameters.testFabricE2E }}', true)` with no
+  `succeeded()`. Re-enable only in a dedicated PR: restore `master`'s form,
   drop the stale comment, request Spark 4.1 in workspace creation, and validate
   with real Fabric capacity/service connection. The workspace-creation
   payload lives in the Fabric test package's `FabricOperations.scala`, which


### PR DESCRIPTION
## Why

[#2645](https://github.com/microsoft/SynapseML/pull/2645) and [#2646](https://github.com/microsoft/SynapseML/pull/2646) each carry a branch-local `AGENTS_spark4.1.md` / `AGENTS_spark4.0.md`. Those files are being deleted. [#2650](https://github.com/microsoft/SynapseML/pull/2650) moved most of that content into `.github/skills/synapseml-branches/`, but a measured re-check found real gaps — the `spark4.1` document had never been measured against the skill at all.

This PR closes those gaps on `master` so the knowledge outlives the sync branches. Once it merges, the two `AGENTS_spark4.*.md` files can be deleted with nothing lost.

Documentation only. No product code, no build files.

## What moved

Into the shared reference:

- **The hand-written `__init__.py` policy.** `PythonInitMerger` splices these files after the generated imports instead of overwriting them, so they went from inert text to live code in the shipped package — a stale one is now a real bug. The per-path table records which must stay empty, which were removed, which are kept, and why. `core/.../io/http/__init__.py` listing `HTTPFunctions` broke `PythonTests core` and seven website samples.
- **Scala 2.13's `ClassCastException` on `ArraySeq`**, which fails at *runtime*, not compile time, and `toIndexedSeq` as the O(1) fix.
- **The GPU suite split and re-merge.** #2538 split it into three clusters of two workers; #2573 reverted it because that needs six GPU nodes against a pool sized for three. The split also hardcodes `gpuNotebook(0/1/2)`, so it silently skips any fourth notebook. Recorded so it does not get reintroduced as a "restore lost coverage" change.
- **`DatabricksCPUStreamingTests` is scheduled only on live `spark4.0`.** `master` and `spark4.1` define the class but never schedule it, so the sync converging is a decision, not a regression.
- **`requestedFor=GitHub`** alongside `reason=pullRequest` for distinguishing a trigger-driven build from a hand-queued one.

Into `branch-spark4p0.md`: runtime strings and why the DBR version is not a free knob (17.3 LTS ML ships Spark 4.0, 18.0 ML ships Spark 4.1, so bumping it stops testing the branch); the sparklyr 1.9.3 failure, which is **live on the branch today**; the `SPARK_HOME` connect form; the Horovod wheel gap; and the GPU notebook denominator moving from three to four after the sync.

Into `branch-spark4p1.md`: runtime strings, the two halves of the Petastorm layer, the `LongOffset` importers, the `np.asarray` `ValueError` on `bytes`, and the exact line needed to re-enable Fabric E2E.

## Two claims deliberately dropped

Both are in the branch-local files and both are contradicted by measurement, so carrying them over would have preserved errors:

- The Petastorm shim is described there as a Python 3.13 / `cloudpickle` workaround. It has no version gating of any kind and is a **pyarrow** compatibility layer.
- NumPy is described as pinned to `1.26.4` on `spark4.0`. It is **unpinned** on both live branches.

## Validation

- Transfer measured mechanically: every backticked identifier in both `AGENTS_spark4.*.md` files checked against the skill. Unmatched identifiers went 42 → 7 (`spark4.0`) and 40 → 8 (`spark4.1`); every remainder is a build ID, an elided path (`core/.../io/http/...`), or a case variant of a covered term.
- One round of that measurement was itself wrong — `-like` treats `Seq[Row]` as a character class, so several "missing" tokens were false. Re-run with a literal comparison; the numbers above are from the corrected run.
- Line length ≤ 120 and all relative links resolve.
- Every branch-specific claim was verified against the live ref with `git show ms/<branch>:<path>` rather than a worktree, since reading a sync worktree as live branch state is the single most common error on this work — a Copilot review on #2650 made exactly that mistake.

## Follow-up

Not in this PR: deleting `AGENTS_spark4.0.md` / `AGENTS_spark4.1.md`. Those live on the sync branches and get removed there after this merges.
