### PR TITLE
fix: pin the JDK for InternalCompat to the branch under test

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1378,15 +1378,6 @@ jobs:
   dependsOn: BuildAndCacheSbt
   pool:
     vmImage: $(UBUNTU_VERSION)
-  # Declared with empty defaults so the `$(...)` macros below always resolve. An
-  # undefined macro is passed through to the script verbatim, and `$(COMPAT_SBT_OPTS)`
-  # reaching bash unexpanded would be read as a command substitution rather than an
-  # empty argument. 'Select matching SynapseML-Internal branch' overwrites both at
-  # runtime; these defaults only cover the case where that step did not run, since two
-  # later steps use `condition: succeededOrFailed()`.
-  variables:
-    COMPAT_JDK: ''
-    COMPAT_SBT_OPTS: ''
   steps:
     # Explicit paths: a multi-repo job otherwise nests every repo under a folder
     # named after it, which moves the OSS root off $(Build.SourcesDirectory). That
@@ -1400,6 +1391,18 @@ jobs:
       # Required by 'Select matching SynapseML-Internal branch' below: without persisted
       # credentials the follow-up fetch cannot authenticate to this private repo.
       persistCredentials: true
+    # The JDK has to match the branch under test, and the branch already declares it:
+    # templates/java_setup.yml is this repo's per-branch JDK pin, carrying 11 here and
+    # 17 on spark4.0/spark4.1. Without it this job compiled both trees on the agent's
+    # default JDK and failed with "Class java.lang.Record not found" -- on the OSS tree
+    # for spark4.1 (build 231477746) and on the Internal tree for spark4.0 (build
+    # 231456784), a type that arrived in Java 16. That was a permanent red on those
+    # branches rather than a real compatibility signal.
+    #
+    # Including the template rather than mapping the target branch to a version here
+    # keeps this line identical on every branch, so the sync never has to reconcile it,
+    # and leaves exactly one place per branch that decides the JDK.
+    - template: templates/java_setup.yml
     # Internal mirrors this repo's branch names 1:1 (master, spark3.5, spark4.0, spark4.1),
     # so the OSS branch under test decides which Internal branch is the correct comparison
     # point: master pairs with Internal master (both Spark 3.5), spark4.1 with Internal
@@ -1438,41 +1441,7 @@ jobs:
         echo "##vso[task.setvariable variable=INTERNAL_BRANCH]$INTERNAL_BRANCH"
         echo "=== SynapseML-Internal now at $INTERNAL_BRANCH ==="
         git log --oneline -1
-
-        # The JDK follows the branch under test, for the same reason the Internal branch
-        # does. Both sides of this comparison are built from $OSS_TARGET's Spark line, and
-        # the Spark 4 branches target Java 17: without this, both trees compile on the
-        # agent's default JDK and fail with "Class java.lang.Record not found" -- on the
-        # OSS tree for spark4.1 (build 231477746) and on the Internal tree for spark4.0
-        # (build 231456784). That is a permanent red on those branches rather than a real
-        # compatibility signal, which is worse than no signal for an advisory check.
-        #
-        # Only Spark 4 branches get a pin. master and spark3.5 already pass on the agent
-        # default, so pinning them would change working behaviour to fix a problem they do
-        # not have. An empty value leaves the JDK step skipped.
-        case "$OSS_TARGET" in
-          spark4.*)
-            COMPAT_JDK=17
-            # sbt on Java 17 cannot reach java.util.prefs without this; mirrors the
-            # ReleaseBranchCompat job above, which builds the same branches.
-            COMPAT_SBT_OPTS="-J--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED"
-            ;;
-          *)
-            COMPAT_JDK=""
-            COMPAT_SBT_OPTS=""
-            ;;
-        esac
-        echo "OSS target branch '$OSS_TARGET' -> JDK '${COMPAT_JDK:-<agent default>}'"
-        echo "##vso[task.setvariable variable=COMPAT_JDK]$COMPAT_JDK"
-        echo "##vso[task.setvariable variable=COMPAT_SBT_OPTS]$COMPAT_SBT_OPTS"
       displayName: 'Select matching SynapseML-Internal branch'
-    - task: JavaToolInstaller@0
-      displayName: 'Set up JDK $(COMPAT_JDK)'
-      condition: and(succeeded(), ne(variables['COMPAT_JDK'], ''))
-      inputs:
-        versionSpec: $(COMPAT_JDK)
-        jdkArchitectureOption: x64
-        jdkSourceOption: PreInstalled
     - template: templates/sbt_cache.yml
     - task: AzureCLI@2
       displayName: 'Publish OSS to local Maven'
@@ -1489,7 +1458,7 @@ jobs:
           # timestamp whenever the tree is dirty, so querying the version and publishing in
           # two separate invocations can yield two different versions when they straddle a
           # minute boundary. Run both in ONE sbt session so the version is computed once.
-          if ! SBT_OUT="$(sbt -no-colors $(COMPAT_SBT_OPTS) "core/version" publishM2 2>&1)"; then
+          if ! SBT_OUT="$(sbt -no-colors -J--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED "core/version" publishM2 2>&1)"; then
             echo "$SBT_OUT"
             echo "##vso[task.logissue type=error]sbt core/version publishM2 failed"
             exit 1
@@ -1567,7 +1536,7 @@ jobs:
           cd $(Agent.BuildDirectory)/s-internal
           export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
           echo "Compiling SynapseML-Internal against OSS $OSS_VERSION..."
-          sbt $(COMPAT_SBT_OPTS) compile Test/compile
+          sbt -J--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED compile Test/compile
     - bash: |
         echo "##vso[task.prependpath]$CONDA/bin"
       displayName: 'Add conda to PATH'
@@ -1686,7 +1655,7 @@ jobs:
           # publishM2 then publishes a *different* version, and the Spark launch inside
           # make_mlflow_models.py fails to resolve it - surfacing only as an opaque
           # JAVA_GATEWAY_EXITED. Observed: packaged 1022, published 1023.
-          sbt $(COMPAT_SBT_OPTS) packagePython publishM2
+          sbt -J--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED packagePython publishM2
           echo "=== published Internal versions in ~/.m2 ==="
           ls -d "$HOME"/.m2/repository/com/microsoft/azure/*-internal_2.12/*/ 2>/dev/null || true
       condition: succeededOrFailed()
@@ -1731,7 +1700,7 @@ jobs:
             python ./src/test/python/make_mlflow_models.py
           fi
           echo "Running ExcludeAIFunc Python tests against OSS $OSS_VERSION..."
-          sbt $(COMPAT_SBT_OPTS) testPythonExcludeAIFunc
+          sbt -J--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED testPythonExcludeAIFunc
       condition: succeededOrFailed()
     - task: PublishTestResults@2
       displayName: 'Publish Internal Scala Test Results'

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1384,9 +1384,11 @@ jobs:
   # JVM the tests fork -- per-command flags reach none of those. spark4.0's
   # pipeline already uses JAVA_TOOL_OPTIONS this way for the same reason.
   #
-  # Set unconditionally rather than only for Spark 4: --add-opens has existed
-  # since Java 9 and an unknown module is a warning, not an error, so this is
-  # inert on master's Java 11. That keeps the value out of a branch conditional.
+  # Set unconditionally rather than only for Spark 4. `java.prefs` has existed
+  # since Java 9, so on master's Java 11 the option is genuinely applied rather
+  # than ignored -- it just opens a package nothing on that path reflects into,
+  # which is harmless. Setting it for every target keeps a branch conditional
+  # out of this file.
   #
   # The one place JVM stderr is parsed is the OSS version read below, and its
   # grep is anchored to '^\[info\] ', which the "Picked up JAVA_TOOL_OPTIONS"

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1378,6 +1378,21 @@ jobs:
   dependsOn: BuildAndCacheSbt
   pool:
     vmImage: $(UBUNTU_VERSION)
+  # sbt on Java 17 needs java.util.prefs opened reflectively. Setting it here
+  # rather than on individual sbt commands covers every JVM the job starts,
+  # including templates/sbt_cache.yml's prewarm, the Internal test loop, and any
+  # JVM the tests fork -- per-command flags reach none of those. spark4.0's
+  # pipeline already uses JAVA_TOOL_OPTIONS this way for the same reason.
+  #
+  # Set unconditionally rather than only for Spark 4: --add-opens has existed
+  # since Java 9 and an unknown module is a warning, not an error, so this is
+  # inert on master's Java 11. That keeps the value out of a branch conditional.
+  #
+  # The one place JVM stderr is parsed is the OSS version read below, and its
+  # grep is anchored to '^\[info\] ', which the "Picked up JAVA_TOOL_OPTIONS"
+  # line cannot match.
+  variables:
+    JAVA_TOOL_OPTIONS: '--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED'
   steps:
     # Explicit paths: a multi-repo job otherwise nests every repo under a folder
     # named after it, which moves the OSS root off $(Build.SourcesDirectory). That
@@ -1458,7 +1473,7 @@ jobs:
           # timestamp whenever the tree is dirty, so querying the version and publishing in
           # two separate invocations can yield two different versions when they straddle a
           # minute boundary. Run both in ONE sbt session so the version is computed once.
-          if ! SBT_OUT="$(sbt -no-colors -J--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED "core/version" publishM2 2>&1)"; then
+          if ! SBT_OUT="$(sbt -no-colors "core/version" publishM2 2>&1)"; then
             echo "$SBT_OUT"
             echo "##vso[task.logissue type=error]sbt core/version publishM2 failed"
             exit 1
@@ -1536,7 +1551,7 @@ jobs:
           cd $(Agent.BuildDirectory)/s-internal
           export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
           echo "Compiling SynapseML-Internal against OSS $OSS_VERSION..."
-          sbt -J--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED compile Test/compile
+          sbt compile Test/compile
     - bash: |
         echo "##vso[task.prependpath]$CONDA/bin"
       displayName: 'Add conda to PATH'
@@ -1655,7 +1670,7 @@ jobs:
           # publishM2 then publishes a *different* version, and the Spark launch inside
           # make_mlflow_models.py fails to resolve it - surfacing only as an opaque
           # JAVA_GATEWAY_EXITED. Observed: packaged 1022, published 1023.
-          sbt -J--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED packagePython publishM2
+          sbt packagePython publishM2
           echo "=== published Internal versions in ~/.m2 ==="
           ls -d "$HOME"/.m2/repository/com/microsoft/azure/*-internal_2.12/*/ 2>/dev/null || true
       condition: succeededOrFailed()
@@ -1700,7 +1715,7 @@ jobs:
             python ./src/test/python/make_mlflow_models.py
           fi
           echo "Running ExcludeAIFunc Python tests against OSS $OSS_VERSION..."
-          sbt -J--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED testPythonExcludeAIFunc
+          sbt testPythonExcludeAIFunc
       condition: succeededOrFailed()
     - task: PublishTestResults@2
       displayName: 'Publish Internal Scala Test Results'

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1378,6 +1378,15 @@ jobs:
   dependsOn: BuildAndCacheSbt
   pool:
     vmImage: $(UBUNTU_VERSION)
+  # Declared with empty defaults so the `$(...)` macros below always resolve. An
+  # undefined macro is passed through to the script verbatim, and `$(COMPAT_SBT_OPTS)`
+  # reaching bash unexpanded would be read as a command substitution rather than an
+  # empty argument. 'Select matching SynapseML-Internal branch' overwrites both at
+  # runtime; these defaults only cover the case where that step did not run, since two
+  # later steps use `condition: succeededOrFailed()`.
+  variables:
+    COMPAT_JDK: ''
+    COMPAT_SBT_OPTS: ''
   steps:
     # Explicit paths: a multi-repo job otherwise nests every repo under a folder
     # named after it, which moves the OSS root off $(Build.SourcesDirectory). That
@@ -1429,7 +1438,41 @@ jobs:
         echo "##vso[task.setvariable variable=INTERNAL_BRANCH]$INTERNAL_BRANCH"
         echo "=== SynapseML-Internal now at $INTERNAL_BRANCH ==="
         git log --oneline -1
+
+        # The JDK follows the branch under test, for the same reason the Internal branch
+        # does. Both sides of this comparison are built from $OSS_TARGET's Spark line, and
+        # the Spark 4 branches target Java 17: without this, both trees compile on the
+        # agent's default JDK and fail with "Class java.lang.Record not found" -- on the
+        # OSS tree for spark4.1 (build 231477746) and on the Internal tree for spark4.0
+        # (build 231456784). That is a permanent red on those branches rather than a real
+        # compatibility signal, which is worse than no signal for an advisory check.
+        #
+        # Only Spark 4 branches get a pin. master and spark3.5 already pass on the agent
+        # default, so pinning them would change working behaviour to fix a problem they do
+        # not have. An empty value leaves the JDK step skipped.
+        case "$OSS_TARGET" in
+          spark4.*)
+            COMPAT_JDK=17
+            # sbt on Java 17 cannot reach java.util.prefs without this; mirrors the
+            # ReleaseBranchCompat job above, which builds the same branches.
+            COMPAT_SBT_OPTS="-J--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED"
+            ;;
+          *)
+            COMPAT_JDK=""
+            COMPAT_SBT_OPTS=""
+            ;;
+        esac
+        echo "OSS target branch '$OSS_TARGET' -> JDK '${COMPAT_JDK:-<agent default>}'"
+        echo "##vso[task.setvariable variable=COMPAT_JDK]$COMPAT_JDK"
+        echo "##vso[task.setvariable variable=COMPAT_SBT_OPTS]$COMPAT_SBT_OPTS"
       displayName: 'Select matching SynapseML-Internal branch'
+    - task: JavaToolInstaller@0
+      displayName: 'Set up JDK $(COMPAT_JDK)'
+      condition: and(succeeded(), ne(variables['COMPAT_JDK'], ''))
+      inputs:
+        versionSpec: $(COMPAT_JDK)
+        jdkArchitectureOption: x64
+        jdkSourceOption: PreInstalled
     - template: templates/sbt_cache.yml
     - task: AzureCLI@2
       displayName: 'Publish OSS to local Maven'
@@ -1446,7 +1489,7 @@ jobs:
           # timestamp whenever the tree is dirty, so querying the version and publishing in
           # two separate invocations can yield two different versions when they straddle a
           # minute boundary. Run both in ONE sbt session so the version is computed once.
-          if ! SBT_OUT="$(sbt -no-colors "core/version" publishM2 2>&1)"; then
+          if ! SBT_OUT="$(sbt -no-colors $(COMPAT_SBT_OPTS) "core/version" publishM2 2>&1)"; then
             echo "$SBT_OUT"
             echo "##vso[task.logissue type=error]sbt core/version publishM2 failed"
             exit 1
@@ -1524,7 +1567,7 @@ jobs:
           cd $(Agent.BuildDirectory)/s-internal
           export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
           echo "Compiling SynapseML-Internal against OSS $OSS_VERSION..."
-          sbt compile Test/compile
+          sbt $(COMPAT_SBT_OPTS) compile Test/compile
     - bash: |
         echo "##vso[task.prependpath]$CONDA/bin"
       displayName: 'Add conda to PATH'
@@ -1643,7 +1686,7 @@ jobs:
           # publishM2 then publishes a *different* version, and the Spark launch inside
           # make_mlflow_models.py fails to resolve it - surfacing only as an opaque
           # JAVA_GATEWAY_EXITED. Observed: packaged 1022, published 1023.
-          sbt packagePython publishM2
+          sbt $(COMPAT_SBT_OPTS) packagePython publishM2
           echo "=== published Internal versions in ~/.m2 ==="
           ls -d "$HOME"/.m2/repository/com/microsoft/azure/*-internal_2.12/*/ 2>/dev/null || true
       condition: succeededOrFailed()
@@ -1688,7 +1731,7 @@ jobs:
             python ./src/test/python/make_mlflow_models.py
           fi
           echo "Running ExcludeAIFunc Python tests against OSS $OSS_VERSION..."
-          sbt testPythonExcludeAIFunc
+          sbt $(COMPAT_SBT_OPTS) testPythonExcludeAIFunc
       condition: succeededOrFailed()
     - task: PublishTestResults@2
       displayName: 'Publish Internal Scala Test Results'

--- a/templates/java_setup.yml
+++ b/templates/java_setup.yml
@@ -1,0 +1,7 @@
+steps:
+  - task: JavaToolInstaller@0
+    displayName: 'Use Java 11'
+    inputs:
+      versionSpec: '11'
+      jdkArchitectureOption: 'x64'
+      jdkSourceOption: 'PreInstalled'


### PR DESCRIPTION
## Problem

The `SynapseML-Internal Compatibility Check` added in #2542 never pins a JDK. It runs on the agent's default JDK, which is fine for `master` and `spark3.5` (Spark 3.5) but cannot compile the Spark 4 branches, which target Java 17.

Measured on the two open sync PRs:

| Build | PR | Target | Failing step | Error |
|---|---|---|---|---|
| `231477746` | #2645 | `spark4.1` | `Publish OSS to local Maven` | `CastUtilities.scala:14: Class java.lang.Record not found` |
| `231456784` | #2646 | `spark4.0` | `Compile Internal against OSS` | `PBIMeasureTable.scala:127: Class java.lang.Record not found` |

`java.lang.Record` arrived in Java 16, so this is a JDK-version failure on both sides of the comparison — the OSS tree on one branch, the Internal tree on the other.

It is not intermittent and it is not Internal drifting. Scanning recent builds of definition 17563, `InternalCompat` **succeeds on every `master`-targeting PR** (#2627 ×3, #2643 ×2, #2542) and **fails on both Spark 4 PRs**. Left alone it is a permanent red on `spark4.0` and `spark4.1`.

That is worse than no check. This job is advisory (`continueOnError: true`) precisely so a transient Internal problem cannot block an OSS merge, and an advisory check that is always red is one people learn to scroll past — which is how the real signal it exists to carry gets missed.

## Fix

Two lines of behaviour change, using mechanisms the repo already has.

**1. The JDK comes from the branch's own pin.** `templates/java_setup.yml` is this repo's per-branch JDK pin. It exists on `spark4.0` and `spark4.1` with `versionSpec: '17'`, and `spark4.0`'s `Style` job already includes it. This PR adds master's copy at `versionSpec: '11'` and includes the template from `InternalCompat`:

```yaml
- template: templates/java_setup.yml
```

That line is **identical on every branch**, so the sync never has to reconcile `pipeline.yaml` for the JDK, and the per-branch value lives in one file that already carries the right value where it matters. A future release branch is correct by construction — it gets its JDK from its own `java_setup.yml`, not from a glob in master's pipeline.

`versionSpec: '11'` is master's current effective JDK, not a change: build `231341458` echoes `JAVA_HOME` and `java -version` and reports Temurin 11.0.32. So master's behaviour is unchanged.

**2. `--add-opens` is set once, job-level, as `JAVA_TOOL_OPTIONS`.** Every JVM the job starts picks it up — including `templates/sbt_cache.yml`'s `sbt_retry.sh update` prewarm, the `Run Internal Scala tests` loop, and any JVM the tests fork. Per-command `-J` flags reach none of those. This is not a new mechanism here: `spark4.0`'s `pipeline.yaml` already does `export JAVA_TOOL_OPTIONS="--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED"` in two places for the same reason.

It is set unconditionally rather than behind a Spark 4 condition. `java.prefs` has existed since Java 9, so on master's Java 11 the option is genuinely applied rather than ignored — it just opens a package nothing on that path reflects into, which is harmless. Setting it for every target keeps a branch conditional out of the file.

### Why not map the target branch at runtime

The first commit on this PR did that — it read `System.PullRequest.TargetBranch` and mapped `spark4.*` to JDK 17 inside `pipeline.yaml`. It worked, but it was the wrong shape, and I replaced it:

- The Java version is already declared in up to **five** places per branch (`.github/workflows/pr-validation.yml`, `environment.yml`, `environment.dev.yml`, `templates/java_setup.yml`, and `pipeline.yaml`'s `JAVA_VERSION`). Adding a sixth, in a different style, is the wrong direction.
- It hardcoded a `spark4.*` glob that a future `spark5.0` would silently fall through, defaulting it to master's JDK.
- It needed two job-level variables purely to stop an undefined ADO macro reaching bash as a command substitution.
- `build.sbt` declares nothing about Java on any branch, so sbt cannot make this choice either — it runs on whatever JDK is on `PATH`.

## ⚠️ One-time sync conflict — read before the next Spark 4 sync

Master gains `templates/java_setup.yml` here; both Spark 4 branches already have that file. Verified with `git merge-tree` that this is an **add/add conflict**, so git stops with markers rather than silently overwriting:

```
CONFLICT (add/add): Merge conflict in templates/java_setup.yml
```

**Always keep the branch's own `17`.** Taking master's side is the intuitive resolution and the wrong one — it drops the branch to Java 11 and reintroduces the exact `Class java.lang.Record not found` failure this PR removes. The conflict is one-time; once resolved the file histories are connected and later syncs merge cleanly.

This is documented in #2651 (`branch-spark4-common.md`, "Where the Java version is declared") so it survives past this PR.

## Validation

- YAML parses. `InternalCompat`'s steps are ordered `checkout`, `checkout`, `java_setup.yml`, branch select, `sbt_cache.yml`, build.
- **Every JVM in the job is covered**, not just the sbt commands written in `pipeline.yaml`. The review on this PR correctly caught that `templates/sbt_cache.yml`'s prewarm and the Internal test loop were missed by per-command flags — see the thread; I verified both and switched mechanism rather than adding two more flags.
- **Checked the hazard `JAVA_TOOL_OPTIONS` introduces.** It makes every JVM print `Picked up JAVA_TOOL_OPTIONS: ...` to stderr, and this job does `SBT_OUT="$(sbt ... 2>&1)"` and parses a version out of that capture. The parse greps `'^\[info\] ([0-9]+\.[0-9]+|HEAD-)'`, anchored to the line start, which the `Picked up` line cannot match. The only other parses in the job are `df -h` output and test-report XML files, neither of which is JVM stderr.
- `templates/java_setup.yml` is identical to `spark4.1`'s copy apart from the two version tokens (`Compare-Object` reports only `displayName` and `versionSpec`).
- No double-include: `spark4.0`'s existing include is in the `Style` job, not `InternalCompat`. Neither Spark 4 branch has an `InternalCompat` job today — it reaches them through the sync.
- Net change against master is **34 insertions, zero deletions**, of which 25 are comment — so 10 functional lines: the new 7-line template, one template include, and one variable.
- `master` behaviour is unchanged by measurement (11 → 11), and this PR's own `InternalCompat` run exercises that path.
- The Spark 4 path cannot be exercised from a `master` PR. It gets its real validation on #2645 / #2646, where the job is red for this exact reason; I will confirm both go green there rather than assume it.

## Side observation

`spark4.0`'s `Style` job runs `sbt scalastyle test:scalastyle` on Java 17 with **no** `--add-opens` and passes, so the flag is not required for sbt startup — only for particular tasks. That is why the original failure surfaced at `publishM2` rather than immediately.

## Note on #2542's branch mapping

Unrelated to this defect, the mapping itself is confirmed working on real pipeline runs — the selection step logged `OSS target branch 'spark4.1' -> SynapseML-Internal 'spark4.1'` and `'spark4.0' -> 'spark4.0'`, with no fallback warning, so Internal has both counterpart branches and each PR is compared against the right Spark line.
