### PR TITLE
ci: allow the two unfixable image-size advisories in dependency review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,9 +21,20 @@ jobs:
         with:
           fail-on-severity: high
           comment-summary-in-pr: always
-          # Docusaurus invokes serve-handler without any glob-based rewrites,
-          # redirects, headers, or directory-listing patterns, so untrusted
-          # input cannot reach brace-expansion. The first patched major is
-          # incompatible with serve-handler's minimatch 3 API. Track removal
-          # of this exception in AB#5469322 when upstream releases a safe path.
-          allow-ghsas: GHSA-mh99-v99m-4gvg
+          # GHSA-mh99-v99m-4gvg (minimatch): Docusaurus invokes serve-handler
+          # without any glob-based rewrites, redirects, headers, or
+          # directory-listing patterns, so untrusted input cannot reach
+          # brace-expansion. The first patched major is incompatible with
+          # serve-handler's minimatch 3 API. Track removal of this exception in
+          # AB#5469322 when upstream releases a safe path.
+          #
+          # GHSA-5p2g-fcmc-qvqq and GHSA-w3rx-r6r6-pgpr (image-size): infinite
+          # loops in the JXL/HEIF and ICNS parsers. image-size is a transitive
+          # dependency of @docusaurus/mdx-loader, which only runs at docs build
+          # time to measure images committed to this repository -- it is not
+          # part of the published static site and never parses user-supplied
+          # uploads. A malformed image could therefore only hang our own build.
+          # Both advisories cover "<= 2.0.2" and 2.0.2 is the latest release, so
+          # no patched version exists to upgrade to. Drop these entries once
+          # upstream ships a fix and Docusaurus picks it up.
+          allow-ghsas: GHSA-mh99-v99m-4gvg, GHSA-5p2g-fcmc-qvqq, GHSA-w3rx-r6r6-pgpr


### PR DESCRIPTION
### Problem

`Dependency Review` fails on the spark4.0 sync PR #2646 with two high-severity advisories:

| Advisory | Package | Issue |
|---|---|---|
| [GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq) | `image-size@2.0.2` | JXL/HEIF parsers allow DoS through infinite loops |
| [GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr) | `image-size@2.0.2` | ICNS parser allows DoS through an infinite loop |

### Why this is not new risk

`image-size@2.0.2` is **already present in this branch's** `website/package-lock.json`, with the same `sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==` integrity hash. master and spark4.1 are green today only because the package sits in their diff *base* rather than their diff.

spark4.0 still had `website/yarn.lock` and no `package-lock.json`, so its sync PR adds the entire lockfile and every entry in it reads as a newly added dependency — which is what surfaces these two.

### Why it cannot simply be fixed

Both advisories cover `<= 2.0.2`, and 2.0.2 is the latest published release — `first_patched_version` is `null` for both. There is nothing to upgrade to, and no `overrides` entry can help.

### Why the exception is safe

`image-size` is a transitive dependency of a single package:

```
node_modules/@docusaurus/mdx-loader  [dependencies] -> image-size ^2.0.2
```

`@docusaurus/mdx-loader` runs only at **docs build time**, to measure the dimensions of images committed to this repository. It is not part of the generated static site and never parses user-supplied uploads. The impact of a malformed image would therefore be limited to hanging our own docs build, which we would notice immediately.

### Why on master rather than only on the sync branch

`.github/workflows/dependency-review.yml` is currently byte-identical across master, spark3.5, spark4.0 and spark4.1. Landing the exception here keeps it that way, instead of leaving a branch-only edit that every future sync has to preserve by hand.

The comment block follows the existing `GHSA-mh99-v99m-4gvg` precedent and records the removal condition so the exception can be dropped once upstream ships a fix.
