### PR TITLE
fix: stop InternalCompat requesting an Internal version that was never published

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1572,8 +1572,19 @@ jobs:
         # dynver reads, only considers modifications to tracked files, and sbt's
         # build output lands in target/ which .gitignore already excludes. The
         # commit is local to the agent's checkout and is never pushed.
-        git -c user.email=synapseml-ci@microsoft.com -c user.name='SynapseML CI' \
-          commit --quiet --no-verify -am "CI: retarget to OSS ${OSS_VERSION}"
+        # Commit only when the edits actually changed something. 'git commit' exits
+        # non-zero when nothing is staged, which under 'set -e' would fail this step -
+        # so an unconditional commit would turn "already retargeted" into a hard error
+        # and make the step non-idempotent on retry. The greps above already proved
+        # build.sbt holds the right values, so an unchanged tree is a valid state: it
+        # just means the edits were already in place, and dynver emits a stable
+        # version either way, which is all the rest of the job needs.
+        if git diff-index --quiet HEAD --; then
+          echo "Retarget produced no changes; tree is already clean"
+        else
+          git -c user.email=synapseml-ci@microsoft.com -c user.name='SynapseML CI' \
+            commit --quiet --no-verify -am "CI: retarget to OSS ${OSS_VERSION}"
+        fi
 
         # A dirty tree here would silently reintroduce the drift, so fail loudly
         # rather than hand the next steps a version that changes under them.

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1526,7 +1526,22 @@ jobs:
           echo "##vso[task.logissue type=error]resolvers block not found in Internal build.sbt"; exit 1; }
 
         sed -i "s|val synapseMLVersion = \".*\"|val synapseMLVersion = \"${OSS_VERSION}\"|" build.sbt
-        sed -i '/^resolvers ++= Seq(/a\  Resolver.mavenLocal,' build.sbt
+        # Insert only when the resolvers block does not already carry it. 'sed a\'
+        # appends unconditionally, so running this step twice against the same tree
+        # adds a second Resolver.mavenLocal line each time. A hosted agent starts from
+        # a fresh VM and the step above re-checks out Internal, so that cannot happen
+        # today - but it also made the "tree is already clean" branch below unreachable,
+        # because the append dirtied the tree even when both edits were already applied.
+        #
+        # Scope the test to the resolvers block rather than the whole file: Internal
+        # carries an unrelated 'Resolver.mavenLocal' in usage/build.sbt and in
+        # project/BlobMavenPlugin.scala, and a file-wide test that ever matched one of
+        # those would skip the insert and leave Internal resolving against the
+        # *published* OSS build - a false green, which is the one outcome this job
+        # must never produce.
+        if ! sed -n '/^resolvers ++= Seq(/,/^)/p' build.sbt | grep -qF 'Resolver.mavenLocal'; then
+          sed -i '/^resolvers ++= Seq(/a\  Resolver.mavenLocal,' build.sbt
+        fi
 
         # A silent no-op here would compile Internal against the *published* OSS build and
         # report a false green, so verify both edits actually landed. Use fixed-string
@@ -1534,8 +1549,12 @@ jobs:
         # and could accept a line the sed above never wrote.
         grep -qF "val synapseMLVersion = \"${OSS_VERSION}\"" build.sbt || {
           echo "##vso[task.logissue type=error]Failed to retarget synapseMLVersion"; exit 1; }
-        grep -qF 'Resolver.mavenLocal,' build.sbt || {
-          echo "##vso[task.logissue type=error]Failed to add Resolver.mavenLocal"; exit 1; }
+        # Verify with the same block-scoped predicate the insert decides on, so the two
+        # can never disagree: a file-wide check here would be satisfied by the
+        # Resolver.mavenLocal in usage/build.sbt's sibling text and report success for a
+        # resolvers block that never got one.
+        sed -n '/^resolvers ++= Seq(/,/^)/p' build.sbt | grep -qF 'Resolver.mavenLocal' || {
+          echo "##vso[task.logissue type=error]Failed to add Resolver.mavenLocal to the resolvers block"; exit 1; }
 
         echo "=== Modified build.sbt ==="
         grep -n 'synapseMLVersion' build.sbt
@@ -1573,6 +1592,20 @@ jobs:
         # build output lands in target/ which .gitignore already excludes. The
         # commit is local to the agent's checkout and is never pushed.
         #
+        # Refresh git's stat cache before asking whether the tree changed. 'sed -i'
+        # rewrites build.sbt in place, so its mtime and inode change even when the
+        # bytes it writes are identical, and 'git diff-index' trusts stat info before
+        # comparing content - it reports a phantom modification until the index is
+        # refreshed. Without this, an already-retargeted tree takes the commit branch
+        # below, 'git commit' finds nothing staged and exits 1, and 'set -e' fails the
+        # step: exactly the non-idempotent retry the branch exists to prevent. Measured
+        # by running this step three times against a simulated Internal checkout - runs
+        # 2 and 3 exited 1 before this line was added and exit 0 after.
+        #
+        # '|| true' because --refresh deliberately exits non-zero when a file really
+        # has changed, which is the normal case on the first run.
+        git update-index -q --refresh || true
+
         # Commit only when the edits actually changed something. 'git commit' exits
         # non-zero when nothing is staged, which under 'set -e' would fail this step -
         # so an unconditional commit would turn "already retargeted" into a hard error

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1588,9 +1588,18 @@ jobs:
 
         # A dirty tree here would silently reintroduce the drift, so fail loudly
         # rather than hand the next steps a version that changes under them.
-        if [ -n "$(git diff-index --name-only HEAD --)" ]; then
-          echo "##vso[task.logissue type=error]Internal tree still dirty after commit; dynver will append a wall-clock timestamp and the published and requested versions will diverge"
-          git diff-index --name-only HEAD --
+        #
+        # Test git's exit status, not whether its output is empty. 'diff-index
+        # --name-only' prints nothing and exits 128 when git itself fails (unborn
+        # HEAD, unreadable index), which is indistinguishable from a clean tree if
+        # you only look at stdout - so an emptiness test would wave through exactly
+        # the broken state this guard exists to catch. '--quiet' exits non-zero for
+        # both "dirty" and "git failed", and neither is safe to continue from.
+        # An 'if' condition is exempt from 'set -e', and the diagnostic below is
+        # guarded so a failing git cannot abort the step before the explicit exit.
+        if ! git diff-index --quiet HEAD --; then
+          echo "##vso[task.logissue type=error]Internal tree still dirty after commit (or git could not read it); dynver will append a wall-clock timestamp and the published and requested versions will diverge"
+          git diff-index --name-only HEAD -- || true
           exit 1
         fi
         echo "=== Internal version is now stable for the rest of the job ==="

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1540,6 +1540,50 @@ jobs:
         echo "=== Modified build.sbt ==="
         grep -n 'synapseMLVersion' build.sbt
         grep -n -A4 'resolvers ++=' build.sbt
+
+        # Commit the retarget so the working tree is clean again.
+        #
+        # Internal's version comes from sbt-dynver, which appends a live
+        # "-<yyyyMMdd>-<HHmm>" suffix whenever the tree is dirty and recomputes it
+        # from the wall clock on every sbt load. The two sed edits above are what
+        # make it dirty, so without this commit each sbt session in this job picks
+        # a different version. Observed on build 231488245:
+        #
+        #   11:32  'sbt packagePython publishM2' bakes ...-1132-SNAPSHOT into the
+        #          generated Python package and publishes that same jar to ~/.m2
+        #   11:36  'sbt testPythonExcludeAIFunc' re-runs CodeGen in a new session,
+        #          rebakes the package as ...-1136-SNAPSHOT and pip-installs it
+        #   11:37  pytest fixtures read the baked coordinate out of the installed
+        #          package and ask Ivy for ...-1136-SNAPSHOT, which nobody published
+        #
+        # Ivy fails the resolve, spark-submit dies before reporting a port, and
+        # pyspark surfaces only JAVA_GATEWAY_EXITED - so every test in the step
+        # errors at fixture setup with no indication of the real cause. Note that
+        # make_mlflow_models.py runs in between and *succeeds*: it resolves the
+        # 1132 jar correctly, because the rebake has not happened yet.
+        #
+        # Pinning only the packaging step could not fix this, because the version is
+        # recomputed by a later sbt session. Making the tree clean is what makes
+        # every session agree. The OSS side already demonstrates the end state: its
+        # checkout is never edited, so its version carries no timestamp at all
+        # (1.1.3-python3.13-102-bfba9c82-SNAPSHOT in that same build).
+        #
+        # Committing is enough on its own: 'git describe --dirty', which is what
+        # dynver reads, only considers modifications to tracked files, and sbt's
+        # build output lands in target/ which .gitignore already excludes. The
+        # commit is local to the agent's checkout and is never pushed.
+        git -c user.email=synapseml-ci@microsoft.com -c user.name='SynapseML CI' \
+          commit --quiet --no-verify -am "CI: retarget to OSS ${OSS_VERSION}"
+
+        # A dirty tree here would silently reintroduce the drift, so fail loudly
+        # rather than hand the next steps a version that changes under them.
+        if [ -n "$(git diff-index --name-only HEAD --)" ]; then
+          echo "##vso[task.logissue type=error]Internal tree still dirty after commit; dynver will append a wall-clock timestamp and the published and requested versions will diverge"
+          git diff-index --name-only HEAD --
+          exit 1
+        fi
+        echo "=== Internal version is now stable for the rest of the job ==="
+        git log --oneline -1
       displayName: 'Retarget Internal to this build'
     - task: AzureCLI@2
       displayName: 'Compile Internal against OSS'
@@ -1666,15 +1710,16 @@ jobs:
           export CREATE_SEMPY_WRITER=false
           export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
           echo "Packaging Internal Python against OSS $OSS_VERSION..."
-          # packagePython and publishM2 MUST share one sbt session. Internal's version
-          # embeds an HHmm timestamp, so separate invocations can differ by a minute:
-          # packagePython bakes the jar coordinate into the generated Python package,
-          # publishM2 then publishes a *different* version, and the Spark launch inside
-          # make_mlflow_models.py fails to resolve it - surfacing only as an opaque
-          # JAVA_GATEWAY_EXITED. Observed: packaged 1022, published 1023.
+          # packagePython and publishM2 share one sbt session so the version is
+          # computed once. The retarget step now commits its edits, so dynver no
+          # longer appends a wall-clock timestamp and every sbt session in this job
+          # agrees; keeping these together is cheap defence in depth.
           sbt packagePython publishM2
           echo "=== published Internal versions in ~/.m2 ==="
-          ls -d "$HOME"/.m2/repository/com/microsoft/azure/*-internal_2.12/*/ 2>/dev/null || true
+          # Glob the Scala suffix: this branch builds _2.13, and hardcoding _2.12
+          # made this diagnostic print nothing here - exactly on the branch where a
+          # version mismatch most needed to be visible.
+          ls -d "$HOME"/.m2/repository/com/microsoft/azure/*-internal_*/*/ 2>/dev/null || true
       condition: succeededOrFailed()
     # NOTE: 'Run Internal Python tests (AIFunc)' was intentionally removed. All four
     # AIFunc suites call live Azure OpenAI endpoints, so they measure service and

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1727,8 +1727,9 @@ jobs:
           # agrees; keeping these together is cheap defence in depth.
           sbt packagePython publishM2
           echo "=== published Internal versions in ~/.m2 ==="
-          # Glob the Scala suffix: this branch builds _2.13, and hardcoding _2.12
-          # made this diagnostic print nothing here - exactly on the branch where a
+          # Glob the Scala suffix so this diagnostic is correct on every branch:
+          # master builds _2.12 while the Spark 4 branches build _2.13, and the
+          # hardcoded _2.12 printed nothing there - exactly on the branches where a
           # version mismatch most needed to be visible.
           ls -d "$HOME"/.m2/repository/com/microsoft/azure/*-internal_*/*/ 2>/dev/null || true
       condition: succeededOrFailed()

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1572,6 +1572,7 @@ jobs:
         # dynver reads, only considers modifications to tracked files, and sbt's
         # build output lands in target/ which .gitignore already excludes. The
         # commit is local to the agent's checkout and is never pushed.
+        #
         # Commit only when the edits actually changed something. 'git commit' exits
         # non-zero when nothing is staged, which under 'set -e' would fail this step -
         # so an unconditional commit would turn "already retargeted" into a hard error


### PR DESCRIPTION
> **Retargeted to `master`.** Per `.github/skills/synapseml-branches` — *"Spark 4 branches are maintained ports, not feature branches. Land ordinary work on `master`, then merge it into the port branch."* This was developed and proven on `spark4.1` first (evidence in the comments below); it now lands on `master` and will be ported to `spark4.1` and `spark4.0`.
>
> This is not a master-only concern: the `InternalCompat` job is scoped to PR builds (`eq(variables.isPR, true)`), and it fails the same way on master-targeting PRs — e.g. #2630, build 231505494, `Run Internal Python tests` = failed. Master's own post-merge builds simply never run the job, which is why the breakage was invisible there.
>
> The port is mechanical: the `Retarget Internal to this build` step region is **byte-identical** on `master`, `spark4.1` and `spark4.0` (verified with `git show <branch>:pipeline.yaml`), so the merge is conflict-free.
>
> One branch-sensitive detail: the `ls` diagnostic hardcoded `*-internal_2.12`. That is *correct* on `master` (`scalaVersion 2.12.17`) but wrong on `spark4.1` (2.13.17) and `spark4.0` (2.13.16), where it printed nothing — exactly where a version mismatch most needed to be visible. The glob fixes it everywhere and keeps `pipeline.yaml` identical across branches.

---
Fixes #2653. Follow-up to #2645, which merged with this check red.

**Targeted at `spark4.1` rather than `master` so the fix is validated where the failure actually reproduces** — and against SynapseML-Internal's own `spark4.1` branch (confirmed to exist, so the job's branch-matching does not silently fall back to Internal `master`).

### Symptom

`Run Internal Python tests (ExcludeAIFunc)` fails on essentially every PR. All ~21 tests error at *setup*, and the only visible cause is:

```
pyspark.errors.exceptions.base.PySparkRuntimeError: [JAVA_GATEWAY_EXITED]
  Java gateway process exited before sending its port number
```

which hides the real error in the JVM that never reported a port:

```
java.lang.RuntimeException: [unresolved dependency:
  com.microsoft.azure#...-internal_2.13;1.1.3.0-python3.13-5-<sha>-20260817-1136-SNAPSHOT: not found]
	at org.apache.spark.util.MavenUtils$.resolveMavenCoordinates(MavenUtils.scala:539)
```

### Root cause

Internal's version comes from **sbt-dynver**, which appends a live `-<yyyyMMdd>-<HHmm>` suffix **whenever the working tree is dirty**, recomputed from the wall clock on *every sbt load*. Internal's `build.sbt` sets `dynverSonatypeSnapshots := true` and `dynverSeparator := "-"`, which is where the `-SNAPSHOT` suffix and the `-` separators come from.

`Retarget Internal to this build` runs two `sed -i` commands against `build.sbt`. **That is what makes the tree dirty** — for the rest of the job. Every subsequent sbt session then picks a different version.

Timeline from build `231488245` (step start times from the ADO timeline, versions from its log):

| time | what runs | version |
|---|---|---|
| 11:32 | `sbt packagePython publishM2` | bakes **1132** into the generated package **and publishes that same jar** ✅ |
| 11:33–11:36 | `make_mlflow_models.py` | uses baked **1132**, resolves it fine (`found … in local-m2-cache`) ✅ |
| **11:36** | **`sbt testPythonExcludeAIFunc` re-runs `CodeGen` in a new session** | **rebakes as 1136 and pip-installs it** |
| 11:37+ | pytest fixtures | read the baked coordinate and request **1136** — never published ❌ |

The fixtures read the coordinate from the *installed* package:

```python
# SynapseML-Internal/src/test/python/setup_spark.py
from synapse.ml.ebm import __spark_package_version__ as __spark_internal_package_version__
...
f"com.microsoft.azure:synapseml-internal_2.12:{__spark_internal_package_version__}"
```

Two consequences worth calling out:

- `make_mlflow_models.py` **succeeds** — it is not the culprit, contrary to what the existing comment in this file says. It runs before the rebake.
- The existing "packagePython and publishM2 MUST share one sbt session" mitigation is **necessary but not sufficient**: it makes those two agree, but a *later* sbt session recomputes the version regardless.

### Fix

Commit the retarget edits, so the tree is clean and dynver emits **one stable version** for the whole job.

The OSS side already demonstrates the target end state — its checkout is never edited, so its version carries **no timestamp at all**: `1.1.3-python3.13-102-bfba9c82-SNAPSHOT`, in that very same build.

### What the version becomes

No timestamp. Internal's version changes shape from

```
1.1.3.0-python3.13-5-<sha>-20260817-1132-SNAPSHOT   (dirty)
1.1.3.0-python3.13-6-<sha>-SNAPSHOT                 (clean, after this change)
```

`-SNAPSHOT` is retained because `dynverSonatypeSnapshots := true` and the distance is non-zero. This is the same shape SynapseML-Internal's own CI produces for its branches, since those checkouts are clean.

### Verification

The fix rests on two properties of `git describe --dirty` (what dynver reads). Both checked against git directly rather than assumed:

| state | `git describe --long --tags --dirty` |
|---|---|
| clean tree | `v1.1.3.0-1-g0a826a4f` |
| tracked file modified (the `sed`) | `v1.1.3.0-1-g0a826a4f**+DIRTY**` |
| after commit | `v1.1.3.0-2-gdc0c4fca` |
| **+ gitignored `target/` + untracked files** | `v1.1.3.0-2-gdc0c4fca` |

The last row is the one that matters: `--dirty` considers only **modifications to tracked files**, so sbt's own build output (`.gitignore` already excludes `**/target/*`) cannot reintroduce the drift mid-job. A `git diff-index` guard fails the step loudly if the tree is somehow dirty anyway.

The commit is local to the agent's checkout and is never pushed.

### Also fixed

The diagnostic listing published versions hardcoded `*-internal_2.12`. On this branch, which builds `_2.13`, it printed **nothing** — exactly where a version mismatch most needed to be visible.

### Scope

Internal **Scala** tests were never affected: sbt resolves through its own classpath and never goes through Ivy for the Internal artifact. That is why they pass in the same builds where the Python step fails.

The job stays `continueOnError: true` and is not a required status check. This restores a signal that has been permanently red; it does not change what gates merges.

