### PR TITLE
feat: add Fabric LLM traffic metadata

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -508,6 +508,8 @@ abstract class OpenAIServicesBase(override val uid: String) extends CognitiveSer
 trait HasOpenAIFabricHeaders extends HasCognitiveServiceInput {
   self: OpenAIServicesBase =>
 
+  private val extendedPropertiesHeader = "X-Taxonomy-ExtendedProperties"
+
   private def usingImplicitFabricEndpoint: Boolean = {
     val hasCustomUrlRoot = get(customUrlRoot).orElse(getDefault(customUrlRoot))
       .exists(value => Option(value).exists(_.trim.nonEmpty))
@@ -517,9 +519,11 @@ trait HasOpenAIFabricHeaders extends HasCognitiveServiceInput {
   abstract override protected def getCustomHeaders(row: Row): Option[Map[String, String]] = {
     val headers = super.getCustomHeaders(row)
     if (usingImplicitFabricEndpoint) {
+      val serviceOwnedHeaders = headers.getOrElse(Map.empty)
+        .filterNot { case (name, _) => name.equalsIgnoreCase(extendedPropertiesHeader) }
       Some(
-        headers.getOrElse(Map.empty).updated(
-          "X-Taxonomy-ExtendedProperties",
+        serviceOwnedHeaders.updated(
+          extendedPropertiesHeader,
           Map(
             "feature" -> "synapseml",
             "runtime" -> fabricRuntime

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -530,9 +530,9 @@ trait HasOpenAIFabricHeaders extends HasCognitiveServiceInput {
             "runtime" -> fabricRuntime
           ).toJson.compactPrint
       )
-      val serviceOwnedHeaders = headers.map(ServiceAuthHeaders.sanitizeHeaderMap).getOrElse(Map.empty)
+      val remainingHeaders = headers.map(ServiceAuthHeaders.sanitizeHeaderMap).getOrElse(Map.empty)
         .filterNot { case (name, _) => fabricHeaders.keys.exists(_.equalsIgnoreCase(name)) }
-      Some(serviceOwnedHeaders ++ fabricHeaders)
+      Some(remainingHeaders ++ fabricHeaders)
     } else {
       headers
     }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -13,6 +13,7 @@ import org.apache.spark.ml.param.{Param, Params}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 import spray.json.DefaultJsonProtocol._
+import spray.json._
 
 import java.util.Locale
 import scala.language.existentials
@@ -488,14 +489,45 @@ abstract class OpenAIServicesBase(override val uid: String) extends CognitiveSer
     }
   }
 
-  private def usingDefaultOpenAIEndpoint(): Boolean = {
+  protected[openai] def usingDefaultOpenAIEndpoint: Boolean = {
     getUrl == FabricClient.MLWorkloadEndpointML + "/cognitive/openai/"
   }
 
+  protected[openai] def runningOnFabric: Boolean = PlatformDetails.runningOnFabric()
+
+  protected[openai] def fabricRuntime: String = PlatformDetails.CurrentPlatform
+
   override protected def getInternalTransformer(schema: StructType): PipelineModel = {
-    if (PlatformDetails.runningOnFabric() && usingDefaultOpenAIEndpoint) {
+    if (runningOnFabric && usingDefaultOpenAIEndpoint) {
       assertModelStatus(getDeploymentName)
     }
     super.getInternalTransformer(schema)
+  }
+}
+
+trait HasOpenAIFabricHeaders extends HasCognitiveServiceInput {
+  self: OpenAIServicesBase =>
+
+  private def usingImplicitFabricEndpoint: Boolean = {
+    val hasCustomUrlRoot = get(customUrlRoot).orElse(getDefault(customUrlRoot))
+      .exists(value => Option(value).exists(_.trim.nonEmpty))
+    runningOnFabric && usingDefaultOpenAIEndpoint && !hasCustomUrlRoot
+  }
+
+  abstract override protected def getCustomHeaders(row: Row): Option[Map[String, String]] = {
+    val headers = super.getCustomHeaders(row)
+    if (usingImplicitFabricEndpoint) {
+      Some(
+        headers.getOrElse(Map.empty).updated(
+          "X-Taxonomy-ExtendedProperties",
+          Map(
+            "feature" -> "synapseml",
+            "runtime" -> fabricRuntime
+          ).toJson.compactPrint
+        )
+      )
+    } else {
+      headers
+    }
   }
 }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -509,6 +509,8 @@ trait HasOpenAIFabricHeaders extends HasCognitiveServiceInput {
   self: OpenAIServicesBase =>
 
   private val extendedPropertiesHeader = "X-Taxonomy-ExtendedProperties"
+  private val trafficTypeHeader = "X-Taxonomy-TrafficType"
+  private val serviceTierHeader = "x-llm-service-tier"
 
   private def usingImplicitFabricEndpoint: Boolean = {
     val hasCustomUrlRoot = get(customUrlRoot).nonEmpty
@@ -518,17 +520,19 @@ trait HasOpenAIFabricHeaders extends HasCognitiveServiceInput {
   abstract override protected def getCustomHeaders(row: Row): Option[Map[String, String]] = {
     val headers = super.getCustomHeaders(row)
     if (usingImplicitFabricEndpoint) {
-      val serviceOwnedHeaders = headers.map(ServiceAuthHeaders.sanitizeHeaderMap).getOrElse(Map.empty)
-        .filterNot { case (name, _) => name.equalsIgnoreCase(extendedPropertiesHeader) }
-      Some(
-        serviceOwnedHeaders.updated(
-          extendedPropertiesHeader,
+      // SynapseML owns the complete workload classification on its implicit Fabric endpoint.
+      val fabricHeaders = Map(
+        trafficTypeHeader -> "Background",
+        serviceTierHeader -> "flex",
+        extendedPropertiesHeader ->
           Map(
             "feature" -> "synapseml",
             "runtime" -> fabricRuntime
           ).toJson.compactPrint
-        )
       )
+      val serviceOwnedHeaders = headers.map(ServiceAuthHeaders.sanitizeHeaderMap).getOrElse(Map.empty)
+        .filterNot { case (name, _) => fabricHeaders.keys.exists(_.equalsIgnoreCase(name)) }
+      Some(serviceOwnedHeaders ++ fabricHeaders)
     } else {
       headers
     }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -511,15 +511,14 @@ trait HasOpenAIFabricHeaders extends HasCognitiveServiceInput {
   private val extendedPropertiesHeader = "X-Taxonomy-ExtendedProperties"
 
   private def usingImplicitFabricEndpoint: Boolean = {
-    val hasCustomUrlRoot = get(customUrlRoot).orElse(getDefault(customUrlRoot))
-      .exists(value => Option(value).exists(_.trim.nonEmpty))
+    val hasCustomUrlRoot = get(customUrlRoot).nonEmpty
     runningOnFabric && usingDefaultOpenAIEndpoint && !hasCustomUrlRoot
   }
 
   abstract override protected def getCustomHeaders(row: Row): Option[Map[String, String]] = {
     val headers = super.getCustomHeaders(row)
     if (usingImplicitFabricEndpoint) {
-      val serviceOwnedHeaders = headers.getOrElse(Map.empty)
+      val serviceOwnedHeaders = headers.map(ServiceAuthHeaders.sanitizeHeaderMap).getOrElse(Map.empty)
         .filterNot { case (name, _) => name.equalsIgnoreCase(extendedPropertiesHeader) }
       Some(
         serviceOwnedHeaders.updated(

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIChatCompletion.scala
@@ -97,7 +97,8 @@ object OpenAIChatCompletion extends ComplexParamsReadable[OpenAIChatCompletion]
 
 class OpenAIChatCompletion(override val uid: String) extends OpenAIServicesBase(uid)
   with HasOpenAITextParamsExtended with HasMessagesInput with HasCognitiveServiceInput
-  with HasInternalJsonOutputParser with SynapseMLLogging with HasRAIContentFilter with HasTextOutput {
+  with HasOpenAIFabricHeaders with HasInternalJsonOutputParser
+  with SynapseMLLogging with HasRAIContentFilter with HasTextOutput {
   logClass(FeatureNames.AiServices.OpenAI)
 
   def this() = this(Identifiable.randomUID("OpenAIChatCompletion"))

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIEmbedding.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIEmbedding.scala
@@ -25,7 +25,8 @@ import org.apache.spark.ml.param.Param
 object OpenAIEmbedding extends ComplexParamsReadable[OpenAIEmbedding]
 
 class OpenAIEmbedding (override val uid: String) extends OpenAIServicesBase(uid)
-  with HasOpenAIEmbeddingParams with HasCognitiveServiceInput with SynapseMLLogging {
+  with HasOpenAIEmbeddingParams with HasCognitiveServiceInput
+  with HasOpenAIFabricHeaders with SynapseMLLogging {
   logClass(FeatureNames.AiServices.OpenAI)
 
   def this() = this(Identifiable.randomUID("OpenAIEmbedding"))

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIResponses.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIResponses.scala
@@ -122,7 +122,7 @@ object OpenAIResponses extends ComplexParamsReadable[OpenAIResponses]
 
 class OpenAIResponses(override val uid: String) extends OpenAIServicesBase(uid)
   with HasOpenAITextParamsResponses with HasMessagesInput with HasCognitiveServiceInput
-  with HasInternalJsonOutputParser with SynapseMLLogging with HasCustomHeaders
+  with HasOpenAIFabricHeaders with HasInternalJsonOutputParser with SynapseMLLogging with HasCustomHeaders
   with HasRAIContentFilter with HasTextOutput {
   logClass(FeatureNames.AiServices.OpenAI)
 

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
@@ -10,6 +10,12 @@ import spray.json._
 
 class OpenAIFabricHeadersSuite extends TestBase {
 
+  private val fabricHeaderNames = Seq(
+    "X-Taxonomy-TrafficType",
+    "x-llm-service-tier",
+    "X-Taxonomy-ExtendedProperties"
+  )
+
   private trait InspectableFabricHeaders {
     self: OpenAIServicesBase with HasCognitiveServiceInput =>
 
@@ -63,15 +69,9 @@ class OpenAIFabricHeadersSuite extends TestBase {
     )
   }
 
-  test("default Fabric OpenAI requests include SynapseML extended properties") {
-    val transformer = new InspectableOpenAIChatCompletion(
-      isFabric = true,
-      usesDefaultEndpoint = true
-    ).setCustomHeaders(Map(
-      "x-taxonomy-extendedproperties" -> """{"feature":"caller"}"""
-    ))
-    val headers = transformer.requestHeaders
-
+  private def assertFabricHeaders(headers: Map[String, String]): Unit = {
+    assert(headers("X-Taxonomy-TrafficType") == "Background")
+    assert(headers("x-llm-service-tier") == "flex")
     assert(
       headers("X-Taxonomy-ExtendedProperties").parseJson ==
         JsObject(
@@ -79,38 +79,53 @@ class OpenAIFabricHeadersSuite extends TestBase {
           "runtime" -> JsString("synapse_internal")
         )
     )
-    assert(headers.keys.count(_.equalsIgnoreCase("X-Taxonomy-ExtendedProperties")) == 1)
+    fabricHeaderNames.foreach { headerName =>
+      assert(headers.keys.count(_.equalsIgnoreCase(headerName)) == 1)
+    }
   }
 
-  test("all OpenAI stages include SynapseML extended properties") {
+  private def assertNoFabricHeaders(headers: Map[String, String]): Unit = {
+    fabricHeaderNames.foreach { headerName =>
+      assert(!headers.keys.exists(_.equalsIgnoreCase(headerName)))
+    }
+  }
+
+  test("default Fabric OpenAI requests include SynapseML classification headers") {
+    val transformer = new InspectableOpenAIChatCompletion(
+      isFabric = true,
+      usesDefaultEndpoint = true
+    ).setCustomHeaders(Map(
+      "x-taxonomy-traffictype" -> "caller",
+      "X-LLM-SERVICE-TIER" -> "caller",
+      "x-taxonomy-extendedproperties" -> """{"feature":"caller"}"""
+    ))
+
+    assertFabricHeaders(transformer.requestHeaders)
+  }
+
+  test("all OpenAI stages include SynapseML classification headers") {
     transformers(isFabric = true, usesDefaultEndpoint = true).foreach { transformer =>
-      assert(
-        transformer.requestHeaders("X-Taxonomy-ExtendedProperties").parseJson ==
-          JsObject(
-            "feature" -> JsString("synapseml"),
-            "runtime" -> JsString("synapse_internal")
-          )
-      )
+      assertFabricHeaders(transformer.requestHeaders)
     }
   }
 
-  test("non-Fabric OpenAI requests omit SynapseML extended properties") {
+  test("non-Fabric OpenAI requests omit SynapseML classification headers") {
     transformers(isFabric = false, usesDefaultEndpoint = true).foreach { transformer =>
-      assert(!transformer.requestHeaders.contains("X-Taxonomy-ExtendedProperties"))
+      assertNoFabricHeaders(transformer.requestHeaders)
     }
   }
 
-  test("explicit OpenAI endpoints omit SynapseML extended properties") {
+  test("explicit OpenAI endpoints omit SynapseML classification headers") {
     transformers(isFabric = true, usesDefaultEndpoint = false).foreach { transformer =>
-      assert(!transformer.requestHeaders.contains("X-Taxonomy-ExtendedProperties"))
+      assertNoFabricHeaders(transformer.requestHeaders)
     }
   }
 
-  test("custom OpenAI URL roots omit SynapseML extended properties") {
+  test("custom OpenAI URL roots omit SynapseML classification headers") {
     Seq("https://example.openai.azure.com/", " ").foreach { customUrlRoot =>
       transformers(isFabric = true, usesDefaultEndpoint = true).foreach { transformer =>
         transformer.withCustomUrlRoot(customUrlRoot)
-        assert(!transformer.requestHeaders.contains("X-Taxonomy-ExtendedProperties"))
+        assertNoFabricHeaders(transformer.requestHeaders)
       }
     }
   }
@@ -123,11 +138,13 @@ class OpenAIFabricHeadersSuite extends TestBase {
     ).withRawCustomHeaders(Map(
       nullString -> "value",
       "Other" -> nullString,
+      "x-taxonomy-traffictype" -> "caller",
+      "X-LLM-SERVICE-TIER" -> "caller",
       "x-taxonomy-extendedproperties" -> """{"feature":"caller"}"""
     ))
     val headers = transformer.requestHeaders
 
-    assert(headers.keys.count(_.equalsIgnoreCase("X-Taxonomy-ExtendedProperties")) == 1)
+    assertFabricHeaders(headers)
     assert(headers.keys.forall(_ != null))
     assert(headers.values.forall(_ != null))
     assert(!headers.contains("Other"))

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
@@ -1,0 +1,75 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.services.openai
+
+import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import org.apache.spark.sql.Row
+import spray.json._
+
+class OpenAIFabricHeadersSuite extends TestBase {
+
+  private class InspectableOpenAIChatCompletion(
+      isFabric: Boolean,
+      usesDefaultEndpoint: Boolean) extends OpenAIChatCompletion {
+
+    override protected[openai] def runningOnFabric: Boolean = isFabric
+
+    override protected[openai] def usingDefaultOpenAIEndpoint: Boolean = usesDefaultEndpoint
+
+    override protected[openai] def fabricRuntime: String = "synapse_internal"
+
+    def requestHeaders: Map[String, String] = {
+      buildServiceAuthHeaders(
+        Row.empty,
+        addContentType = false,
+        fabricFallbackAuthHeader = None
+      )
+    }
+  }
+
+  test("default Fabric OpenAI requests include SynapseML extended properties") {
+    val transformer = new InspectableOpenAIChatCompletion(
+      isFabric = true,
+      usesDefaultEndpoint = true
+    ).setCustomHeaders(Map(
+      "X-Taxonomy-ExtendedProperties" -> """{"feature":"caller"}"""
+    ))
+    val headers = transformer.requestHeaders
+
+    assert(
+      headers("X-Taxonomy-ExtendedProperties").parseJson ==
+        JsObject(
+          "feature" -> JsString("synapseml"),
+          "runtime" -> JsString("synapse_internal")
+        )
+    )
+  }
+
+  test("non-Fabric OpenAI requests omit SynapseML extended properties") {
+    val headers = new InspectableOpenAIChatCompletion(
+      isFabric = false,
+      usesDefaultEndpoint = true
+    ).requestHeaders
+
+    assert(!headers.contains("X-Taxonomy-ExtendedProperties"))
+  }
+
+  test("explicit OpenAI endpoints omit SynapseML extended properties") {
+    val headers = new InspectableOpenAIChatCompletion(
+      isFabric = true,
+      usesDefaultEndpoint = false
+    ).requestHeaders
+
+    assert(!headers.contains("X-Taxonomy-ExtendedProperties"))
+  }
+
+  test("custom OpenAI URL roots omit SynapseML extended properties") {
+    val transformer = new InspectableOpenAIChatCompletion(
+      isFabric = true,
+      usesDefaultEndpoint = true
+    ).setCustomUrlRoot("https://example.openai.azure.com/")
+
+    assert(!transformer.requestHeaders.contains("X-Taxonomy-ExtendedProperties"))
+  }
+}

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
@@ -4,14 +4,18 @@
 package com.microsoft.azure.synapse.ml.services.openai
 
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import com.microsoft.azure.synapse.ml.services.HasCognitiveServiceInput
 import org.apache.spark.sql.Row
 import spray.json._
 
 class OpenAIFabricHeadersSuite extends TestBase {
 
-  private class InspectableOpenAIChatCompletion(
-      isFabric: Boolean,
-      usesDefaultEndpoint: Boolean) extends OpenAIChatCompletion {
+  private trait InspectableFabricHeaders {
+    self: OpenAIServicesBase with HasCognitiveServiceInput =>
+
+    protected def isFabric: Boolean
+
+    protected def usesDefaultEndpoint: Boolean
 
     override protected[openai] def runningOnFabric: Boolean = isFabric
 
@@ -28,12 +32,27 @@ class OpenAIFabricHeadersSuite extends TestBase {
     }
   }
 
+  private class InspectableOpenAIChatCompletion(
+      override protected val isFabric: Boolean,
+      override protected val usesDefaultEndpoint: Boolean)
+    extends OpenAIChatCompletion with InspectableFabricHeaders
+
+  private class InspectableOpenAIEmbedding(
+      override protected val isFabric: Boolean,
+      override protected val usesDefaultEndpoint: Boolean)
+    extends OpenAIEmbedding with InspectableFabricHeaders
+
+  private class InspectableOpenAIResponses(
+      override protected val isFabric: Boolean,
+      override protected val usesDefaultEndpoint: Boolean)
+    extends OpenAIResponses with InspectableFabricHeaders
+
   test("default Fabric OpenAI requests include SynapseML extended properties") {
     val transformer = new InspectableOpenAIChatCompletion(
       isFabric = true,
       usesDefaultEndpoint = true
     ).setCustomHeaders(Map(
-      "X-Taxonomy-ExtendedProperties" -> """{"feature":"caller"}"""
+      "x-taxonomy-extendedproperties" -> """{"feature":"caller"}"""
     ))
     val headers = transformer.requestHeaders
 
@@ -44,6 +63,25 @@ class OpenAIFabricHeadersSuite extends TestBase {
           "runtime" -> JsString("synapse_internal")
         )
     )
+    assert(headers.keys.count(_.equalsIgnoreCase("X-Taxonomy-ExtendedProperties")) == 1)
+  }
+
+  test("all OpenAI stages include SynapseML extended properties") {
+    val transformers = Seq(
+      new InspectableOpenAIChatCompletion(isFabric = true, usesDefaultEndpoint = true),
+      new InspectableOpenAIEmbedding(isFabric = true, usesDefaultEndpoint = true),
+      new InspectableOpenAIResponses(isFabric = true, usesDefaultEndpoint = true)
+    )
+
+    transformers.foreach { transformer =>
+      assert(
+        transformer.requestHeaders("X-Taxonomy-ExtendedProperties").parseJson ==
+          JsObject(
+            "feature" -> JsString("synapseml"),
+            "runtime" -> JsString("synapse_internal")
+          )
+      )
+    }
   }
 
   test("non-Fabric OpenAI requests omit SynapseML extended properties") {

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
@@ -30,6 +30,12 @@ class OpenAIFabricHeadersSuite extends TestBase {
         fabricFallbackAuthHeader = None
       )
     }
+
+    def withCustomUrlRoot(value: String): this.type = setCustomUrlRoot(value)
+
+    def withRawCustomHeaders(value: Map[String, String]): this.type = {
+      set(customHeaders, Left(value))
+    }
   }
 
   private class InspectableOpenAIChatCompletion(
@@ -46,6 +52,16 @@ class OpenAIFabricHeadersSuite extends TestBase {
       override protected val isFabric: Boolean,
       override protected val usesDefaultEndpoint: Boolean)
     extends OpenAIResponses with InspectableFabricHeaders
+
+  private def transformers(
+      isFabric: Boolean,
+      usesDefaultEndpoint: Boolean): Seq[InspectableFabricHeaders] = {
+    Seq(
+      new InspectableOpenAIChatCompletion(isFabric, usesDefaultEndpoint),
+      new InspectableOpenAIEmbedding(isFabric, usesDefaultEndpoint),
+      new InspectableOpenAIResponses(isFabric, usesDefaultEndpoint)
+    )
+  }
 
   test("default Fabric OpenAI requests include SynapseML extended properties") {
     val transformer = new InspectableOpenAIChatCompletion(
@@ -67,13 +83,7 @@ class OpenAIFabricHeadersSuite extends TestBase {
   }
 
   test("all OpenAI stages include SynapseML extended properties") {
-    val transformers = Seq(
-      new InspectableOpenAIChatCompletion(isFabric = true, usesDefaultEndpoint = true),
-      new InspectableOpenAIEmbedding(isFabric = true, usesDefaultEndpoint = true),
-      new InspectableOpenAIResponses(isFabric = true, usesDefaultEndpoint = true)
-    )
-
-    transformers.foreach { transformer =>
+    transformers(isFabric = true, usesDefaultEndpoint = true).foreach { transformer =>
       assert(
         transformer.requestHeaders("X-Taxonomy-ExtendedProperties").parseJson ==
           JsObject(
@@ -85,29 +95,41 @@ class OpenAIFabricHeadersSuite extends TestBase {
   }
 
   test("non-Fabric OpenAI requests omit SynapseML extended properties") {
-    val headers = new InspectableOpenAIChatCompletion(
-      isFabric = false,
-      usesDefaultEndpoint = true
-    ).requestHeaders
-
-    assert(!headers.contains("X-Taxonomy-ExtendedProperties"))
+    transformers(isFabric = false, usesDefaultEndpoint = true).foreach { transformer =>
+      assert(!transformer.requestHeaders.contains("X-Taxonomy-ExtendedProperties"))
+    }
   }
 
   test("explicit OpenAI endpoints omit SynapseML extended properties") {
-    val headers = new InspectableOpenAIChatCompletion(
-      isFabric = true,
-      usesDefaultEndpoint = false
-    ).requestHeaders
-
-    assert(!headers.contains("X-Taxonomy-ExtendedProperties"))
+    transformers(isFabric = true, usesDefaultEndpoint = false).foreach { transformer =>
+      assert(!transformer.requestHeaders.contains("X-Taxonomy-ExtendedProperties"))
+    }
   }
 
   test("custom OpenAI URL roots omit SynapseML extended properties") {
+    Seq("https://example.openai.azure.com/", " ").foreach { customUrlRoot =>
+      transformers(isFabric = true, usesDefaultEndpoint = true).foreach { transformer =>
+        transformer.withCustomUrlRoot(customUrlRoot)
+        assert(!transformer.requestHeaders.contains("X-Taxonomy-ExtendedProperties"))
+      }
+    }
+  }
+
+  test("raw null custom headers are sanitized before Fabric attribution") {
+    val nullString = Option.empty[String].orNull
     val transformer = new InspectableOpenAIChatCompletion(
       isFabric = true,
       usesDefaultEndpoint = true
-    ).setCustomUrlRoot("https://example.openai.azure.com/")
+    ).withRawCustomHeaders(Map(
+      nullString -> "value",
+      "Other" -> nullString,
+      "x-taxonomy-extendedproperties" -> """{"feature":"caller"}"""
+    ))
+    val headers = transformer.requestHeaders
 
-    assert(!transformer.requestHeaders.contains("X-Taxonomy-ExtendedProperties"))
+    assert(headers.keys.count(_.equalsIgnoreCase("X-Taxonomy-ExtendedProperties")) == 1)
+    assert(headers.keys.forall(_ != null))
+    assert(headers.values.forall(_ != null))
+    assert(!headers.contains("Other"))
   }
 }


### PR DESCRIPTION
## Summary

Attribute implicit Fabric OpenAI traffic from SynapseML so the Fabric LLM endpoint receives the complete workload classification without requiring callers to configure headers:

```http
X-Taxonomy-TrafficType: Background
x-llm-service-tier: flex
X-Taxonomy-ExtendedProperties: {"feature":"synapseml","runtime":"<detected platform>"}
```

The header is added only when SynapseML uses the implicit Fabric OpenAI endpoint. Non-Fabric execution, explicit OpenAI endpoints, and custom URL roots remain caller-controlled and receive no SynapseML-owned extended properties.

## Compatibility

* Existing public APIs, Spark params, serialized models, and generated Python wrappers are unchanged.
* Existing custom headers are preserved.
* On the implicit Fabric path, SynapseML owns all three headers and replaces caller-provided casing variants with one canonical value each.

## Implementation

* Adds a stackable `HasOpenAIFabricHeaders` request-header trait that sends traffic type, service tier, and extended properties together across all three OpenAI request surfaces.
* Uses `PlatformDetails.CurrentPlatform` for runtime attribution.
* Removes caller-provided variants of all three headers case-insensitively before adding the service-owned values.
* Preserves all existing custom headers and authentication behavior.
* Adds targeted tests for chat completion, embedding, Responses, non-Fabric execution, explicit endpoints, custom URL roots, runtime, and caller-override behavior.

## Validation

* Rebased onto `master` at `7fd1a0b86762ca54c0a4ef7306e1d0f8827fb613`.
* `OpenAIFabricHeadersSuite`: 6 passed, including blank custom URL roots and raw null header entries.
* Scala style, main compilation, test compilation, and code generation: passed with JDK 11.
* Repository-pinned Black 22.3.0 check: passed.
* `git diff --check`: passed.

## References

* [AB#5520317 - Fabric LLM Endpoint contract compliance](https://dev.azure.com/msdata/A365/_workitems/edit/5520317)
* [Fabric LLM Endpoint taxonomy and class-of-service guidance](https://eng.ms/docs/synapse-data-science-fabric-product-synapse-data-science/llmendpoint/partnerdocs/taxonomyandclassofservice.html)
* [AI Functions draft PR #2253680](https://dev.azure.com/msdata/A365/_git/SynapseML-Internal/pullrequest/2253680)

* [AB#5533937 - Add Fabric LLM taxonomy headers to SynapseML](https://dev.azure.com/msdata/A365/_workitems/edit/5533937)

