### PR TITLE
perf: run InternalCompat Scala and Python validation in parallel lanes

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1371,13 +1371,32 @@ jobs:
   # This still surfaces as its own red check run, so the signal is not lost, matching how
   # ReleaseBranchCompat above is configured.
   continueOnError: true
-  # Measured on build 230962458: conda env 6.4m + compile 1.5m + package 1.2m +
-  # Scala tests ~34m + ExcludeAIFunc. 90 min was not enough and the job was
-  # killed mid-step; 120 leaves headroom now that the live-service suites are gone.
+  # Per lane, not for the whole job. The longest lane is Scala at ~39 min measured
+  # (build 231549771), so 120 is generous; it is kept rather than tightened because
+  # spark.aifunc calls live AI services and its 22.8 min is service-latency bound.
   timeoutInMinutes: 120
   dependsOn: BuildAndCacheSbt
   pool:
     vmImage: $(UBUNTU_VERSION)
+  # Scala and Python validation are independent -- neither reads the other's output --
+  # but the job ran them back to back purely because they shared one checkout. Measured
+  # on build 231549771 (67.6 min total): the shared prefix (checkout, publish OSS to
+  # local Maven, retarget, compile) is ~12.5 min, Scala tests are 25.9 min, and the
+  # Python package+test pair is 20.2 min. Running the halves as matrix legs makes the
+  # wall clock max(~39, ~41) instead of the sum, so PR feedback arrives ~27 min sooner.
+  #
+  # Two legs, not more. Every leg re-pays the ~12.5 min prefix, so a third leg -- moving
+  # spark.aifunc, which is 22.8 of the Scala 25.9 min, away from ebm+predict -- would
+  # only take the wall clock from ~41 to ~38 min while adding a whole agent.
+  # SynapseML-Internal's own pipeline shards far further (6 Scala jobs, 8 Python jobs),
+  # but its legs have no comparable prefix to amortise: they resolve a published OSS
+  # artifact rather than building one from the PR under test.
+  strategy:
+    matrix:
+      scala:
+        COMPAT_LANE: scala
+      python:
+        COMPAT_LANE: python
   # sbt on Java 17 needs java.util.prefs opened reflectively. Setting it here
   # rather than on individual sbt commands covers every JVM the job starts,
   # including templates/sbt_cache.yml's prewarm, the Internal test loop, and any
@@ -1658,14 +1677,17 @@ jobs:
     - bash: |
         sudo chown -R $(whoami):$(id -ng) $(CONDA_CACHE_DIR)
       displayName: 'Fix conda directory permissions'
+      condition: and(succeeded(), eq(variables['COMPAT_LANE'], 'python'))
     - task: PipAuthenticate@1
       displayName: 'Private Conda Feed Authentication'
       inputs:
         artifactFeeds: 'A365/Synapse-Conda'
+      condition: and(succeeded(), eq(variables['COMPAT_LANE'], 'python'))
     - bash: |
         conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
         conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
       displayName: 'Accept Anaconda TOS'
+      condition: and(succeeded(), eq(variables['COMPAT_LANE'], 'python'))
     - bash: |
         echo "=== Disk space BEFORE cleanup ==="
         df -h / | grep -E 'Filesystem|/$'
@@ -1685,6 +1707,13 @@ jobs:
         conda clean --all -y
         pip cache purge
       displayName: 'Create Internal conda env'
+      # Python lane only. Building this env costs 7.1 min (build 231549771) and only the
+      # Python steps need it: SynapseML-Internal's own templates/scala_test_job.yml runs
+      # ScalaAIFuncTests*, ScalaEBMTests and ScalaPredictTests with useConda unset,
+      # reserving the env for its PowerBI and nbtest jobs. Those are precisely the three
+      # packages this job's Scala lane runs, and that lane already exports
+      # CREATE_SEMPY_WRITER=false, which is the non-conda path in Internal's template.
+      condition: and(succeeded(), eq(variables['COMPAT_LANE'], 'python'))
     - task: AzureKeyVault@2
       displayName: 'Fetch AI service secrets'
       retryCountOnTaskFailure: 3
@@ -1695,6 +1724,7 @@ jobs:
     - task: AzureCLI@2
       displayName: 'Run Internal Scala tests'
       timeoutInMinutes: 60
+      condition: and(succeeded(), eq(variables['COMPAT_LANE'], 'scala'))
       inputs:
         azureSubscription: 'SynapseML Build'
         scriptLocation: inlineScript
@@ -1702,8 +1732,14 @@ jobs:
         inlineScript: |
           set -e
           cd $(Agent.BuildDirectory)/s-internal
-          eval "$(conda shell.bash hook)"
-          conda activate synapseml-internal
+          # The conda env is built only in the Python lane (see 'Create Internal conda
+          # env'), so activate it only when it is actually present rather than assuming
+          # it exists. sbt and the three packages tested below run on the agent's default
+          # Python, which is how SynapseML-Internal runs these same suites.
+          if conda env list 2>/dev/null | grep -q '^synapseml-internal[[:space:]]'; then
+            eval "$(conda shell.bash hook)"
+            conda activate synapseml-internal
+          fi
           export CREATE_SEMPY_WRITER=false
           export SBT_OPTS="-Xmx4G -Xss2M -Duser.timezone=GMT"
           echo "Running Internal tests against OSS $OSS_VERSION..."
@@ -1775,7 +1811,12 @@ jobs:
           # hardcoded _2.12 printed nothing there - exactly on the branches where a
           # version mismatch most needed to be visible.
           ls -d "$HOME"/.m2/repository/com/microsoft/azure/*-internal_*/*/ 2>/dev/null || true
-      condition: succeededOrFailed()
+      # This was succeededOrFailed() so Python still ran when the Scala tests failed
+      # earlier in the same job. The lanes are separate jobs now, so that decoupling is
+      # structural and the condition returns to plain succeeded(): nothing preceding it
+      # in this lane is a test, so a failure here means setup broke and packaging against
+      # a broken setup can only produce a second, more confusing error.
+      condition: and(succeeded(), eq(variables['COMPAT_LANE'], 'python'))
     # NOTE: 'Run Internal Python tests (AIFunc)' was intentionally removed. All four
     # AIFunc suites call live Azure OpenAI endpoints, so they measure service and
     # quota availability rather than OSS/Internal compatibility. They took ~23 min
@@ -1818,7 +1859,7 @@ jobs:
           fi
           echo "Running ExcludeAIFunc Python tests against OSS $OSS_VERSION..."
           sbt testPythonExcludeAIFunc
-      condition: succeededOrFailed()
+      condition: and(succeeded(), eq(variables['COMPAT_LANE'], 'python'))
     - task: PublishTestResults@2
       displayName: 'Publish Internal Scala Test Results'
       inputs:
@@ -1827,11 +1868,11 @@ jobs:
         # results, and silently publishes nothing.
         searchFolder: '$(Agent.BuildDirectory)/s-internal'
         failTaskOnFailedTests: false
-      condition: succeededOrFailed()
+      condition: and(succeededOrFailed(), eq(variables['COMPAT_LANE'], 'scala'))
     - task: PublishTestResults@2
       displayName: 'Publish Internal Python Test Results'
       inputs:
         testResultsFiles: '**/python-test-*.xml'
         searchFolder: '$(Agent.BuildDirectory)/s-internal'
         failTaskOnFailedTests: false
-      condition: succeededOrFailed()
+      condition: and(succeededOrFailed(), eq(variables['COMPAT_LANE'], 'python'))

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1716,11 +1716,23 @@ jobs:
       condition: and(succeeded(), eq(variables['COMPAT_LANE'], 'python'))
     - task: AzureKeyVault@2
       displayName: 'Fetch AI service secrets'
+      # Scala lane only. 'Run Internal Scala tests' is the sole consumer -- it maps the
+      # four sempy-integration-* values into its env block. Nothing in the Python lane
+      # reads them: ADO exposes Key Vault values as secret variables, which are never
+      # auto-exported into a script's environment, and the Python steps declare no env
+      # block. sbt's own project/Secrets.scala is inert here too (every accessor is
+      # behind SYNAPSEML_ENABLE_PUBLISH, unset in this job) and shells out to az
+      # directly rather than reading these variables. Fetching them in the Python lane
+      # would therefore materialise a certificate and this vault's secrets on an agent
+      # that never uses them.
+      condition: and(succeeded(), eq(variables['COMPAT_LANE'], 'scala'))
       retryCountOnTaskFailure: 3
       inputs:
         azureSubscription: 'SynapseML Build'
         keyVaultName: mmlspark-keys
     - template: templates/fabric_kv.yml
+      parameters:
+        condition: and(succeeded(), eq(variables['COMPAT_LANE'], 'scala'))
     - task: AzureCLI@2
       displayName: 'Run Internal Scala tests'
       timeoutInMinutes: 60

--- a/templates/fabric_kv.yml
+++ b/templates/fabric_kv.yml
@@ -1,9 +1,19 @@
+parameters:
+  # Applied to every step below. Callers that run these credentials in only some of a
+  # job's matrix legs pass a lane-scoped condition so the certificate and vault secrets
+  # are materialised only on the agents that actually consume them. The default matches
+  # the implicit step condition, so callers that omit it are unaffected.
+  - name: condition
+    type: string
+    default: succeeded()
+
 steps:
   # Fetch Fabric test credentials from Key Vault.
   # Keyvault names are resolved indirectly from mmlspark-keys
   # (loaded by kv.yml): fabric-test-kv-name, fabric-cert-kv-name
   - task: AzureKeyVault@2
     displayName: 'Get Fabric Test Credentials from Key Vault'
+    condition: ${{ parameters.condition }}
     inputs:
       azureSubscription: 'SynapseMLFabricTestCreds'
       KeyVaultName: '$(fabric-test-kv-name)'
@@ -23,10 +33,12 @@ steps:
       echo "Computed certificate secret name: ${cert_name}"
       echo "##vso[task.setvariable variable=cert-adminuser-bami]${cert_name}"
     displayName: 'Compute certificate secret name from account'
+    condition: ${{ parameters.condition }}
 
   # Download the account certificate
   - task: AzureCLI@2
     displayName: 'Get certificate from Key Vault'
+    condition: ${{ parameters.condition }}
     inputs:
       azureSubscription: 'SynapseMLFabricTestCreds'
       scriptType: 'bash'


### PR DESCRIPTION
## What

Splits the `SynapseML-Internal Compatibility Check` (`InternalCompat`) job into two parallel matrix legs — `scala` and `python`.

**Measured: 67.6 min → 39.2 min (−28.4 min, −42%)**, with identical test counts on both sides.

Rebased onto `master` after #2655 merged. **Two commits, two files, +74 / −9.**

> [!NOTE]
> Replaces #2657, which was opened from a fork. `InternalCompat` is guarded by `ne(variables['System.PullRequest.IsFork'], 'True')` — because SynapseML-Internal is private and fork PRs cannot authenticate to it — so on that PR the job was **skipped entirely** and the change went unexercised. This branch lives on `microsoft/SynapseML` so the job actually runs.

## Results

Two full runs of this branch, against the serial baseline:

| | baseline<br>[231549771](https://msdata.visualstudio.com/A365/_build/results?buildId=231549771) | run 1<br>[231589470](https://msdata.visualstudio.com/A365/_build/results?buildId=231589470) | run 2 (+ KV gating)<br>[231600597](https://msdata.visualstudio.com/A365/_build/results?buildId=231600597) |
|---|---:|---:|---:|
| `scala` leg | — | 38.2 min | 39.2 min |
| `python` leg | — | 38.7 min | 37.2 min |
| **Job wall clock** | **67.6 min** | **38.7 min** | **39.2 min** |
| Agent-minutes | 67.6 | 76.9 | 76.4 |

**Test counts are unchanged** — this buys latency, it does not skip work:

| | baseline | run 1 | run 2 |
|---|---:|---:|---:|
| `spark.aifunc` | 129 / 12 suites | 129 / 12 | 129 / 12 |
| `ebm` | 71 / 9 | 71 / 9 | 71 / 9 |
| `predict` | 11 / 2 | 11 / 2 | 11 / 2 |
| **Scala total** | **211** | **211** | **211** |
| Python `ExcludeAIFunc` | 26 passed, 2 skipped | 26 passed, 2 skipped | 26 passed, 2 skipped |

### Measured step breakdown (run 2)

```
=== scala : succeeded  TOTAL 39.2m ===        === python : succeeded  TOTAL 37.2m ===
   Publish OSS to local Maven      8.3m          Publish OSS to local Maven      8.2m
   Compile Internal against OSS    1.6m          Compile Internal against OSS    1.5m
   Free disk space                 0.6m          Free disk space                 0.6m
   Fetch AI service secrets        0.1m          Create Internal conda env       6.3m
   Get certificate from Key Vault  0.1m          Package Internal Python         0.9m
   Run Internal Scala tests       26.6m          Run Internal Python tests      17.8m
   (no conda env)                                (no Key Vault steps)
```

### Scope of the win — this is not 28 min off every PR

`InternalCompat` was the critical path in the baseline; it no longer is:

| | baseline `231549771` | run 1 `231589470` |
|---|---:|---:|
| `InternalCompat` finishes at | **72.1 min** — critical path | **47.7 min** |
| `Databricks GPU E2E` finishes at | 61.9 min | **79.4 min** — critical path |
| Build total | 72.4 min | 79.6 min |

The `InternalCompat` answer now arrives ~24 min earlier and the job is off the critical path. Total build time in run 1 was *higher*, because `Databricks GPU E2E` independently went 58.7 → 71.5 min and every job in that run started 5–10 min later under heavier agent-queue contention. Neither is related to this diff, which touches only `InternalCompat`. **`Databricks GPU E2E` is the next bottleneck worth attacking.**

## Why

Its Scala and Python halves are independent — neither reads the other's output — and only ran back to back because they happened to share one checkout.

| Segment | Baseline time | Needed by |
|---|---:|---|
| Shared prefix — checkout, publish OSS to local Maven, retarget, compile | 12.5 min | both legs |
| `Create Internal conda env` | 7.1 min | python only |
| Scala — `spark.aifunc` 22.8m + `ebm` 2.5m + `predict` 0.4m | 25.9 min | scala only |
| Python — package 1.0m + `testPythonExcludeAIFunc` 19.2m | 20.2 min | python only |

## How

This mirrors what SynapseML-Internal's own pipeline already does — it shards into 6 Scala jobs and 8 Python jobs via `templates/scala_test_job.yml` and `templates/python_test_job.yml`.

```yaml
strategy:
  matrix:
    scala:
      COMPAT_LANE: scala
    python:
      COMPAT_LANE: python
```

Shared steps stay ungated; lane-specific steps get `eq(variables['COMPAT_LANE'], ...)`.

**The Scala leg skips conda env creation (−6.3 min, measured).** This was not a guess: SynapseML-Internal runs `ScalaAIFuncTests*`, `ScalaEBMTests` and `ScalaPredictTests` with `useConda` unset, reserving that env for its PowerBI and nbtest jobs — exactly the three packages this leg runs. Both runs confirm it: the `scala` leg has no conda step and still executes all 211 tests. Activation is guarded on the env actually existing, so the step still works unchanged if the env is ever reintroduced.

**Key Vault secrets are fetched only in the Scala leg** (second commit, in response to review). `Run Internal Scala tests` is the sole consumer — it maps the four `sempy-integration-*` values into its `env:` block. Nothing in the Python lane reads them: ADO exposes Key Vault values as *secret* variables, which are never auto-exported into a script environment, and the Python steps declare no `env:` block; sbt's `project/Secrets.scala` is inert here too (every accessor is behind `SYNAPSEML_ENABLE_PUBLISH`, unset in this job) and shells out to `az` directly. Left as-is, the split would have materialised a downloaded **certificate** and the `mmlspark-keys` secrets on an agent that never used them — an exposure the serial job did not have, since it had only one agent.

`templates/fabric_kv.yml` gains a `condition` parameter defaulting to `succeeded()` — the implicit step condition — because a `- template:` reference cannot carry a `condition:`, and gating only the `mmlspark-keys` task would have *broken* the Python leg, which resolves `KeyVaultName: '$(fabric-test-kv-name)'` from it. The **Fabric E2E** job includes the template without parameters and is therefore unchanged.

### Why two legs and not more

Every leg re-pays the ~12.5 min shared prefix, so sharding has sharply diminishing returns:

| Legs | Wall clock | Cost |
|---|---:|---|
| 1 (before) | 67.6 min | 1 agent |
| **2 (this PR)** | **39.2 min (measured)** | 2 agents |
| 3 (split `spark.aifunc` from `ebm`+`predict`) | ~38 min | 3 agents |

The trade is **+9 agent-minutes (+13%)** — the duplicated prefix — for **−28 min of latency**. A third leg would buy ~1 min for another full prefix. Internal can shard 6-and-8 ways because its legs resolve a *published* OSS artifact rather than building one from the change under test, so they have no comparable prefix to amortise.

## Validation

Executed, not just reviewed:

- **Two green runs** of the job on this branch (68/68 jobs, 0 failures), with test counts matching the baseline exactly.
- **YAML parses**; all **12** inline scripts pass `bash -n`.
- **Lane simulation** over the parsed job confirms shared steps run in both legs and each lane-specific step runs in exactly one — `lane=scala` runs 14 / skips 7, `lane=python` runs 18 / skips 3.
- **Template regression check** asserts `fabric_kv.yml` has exactly two includes — one gated to `scala` (InternalCompat), one with `parameters=None` (Fabric E2E, default `succeeded()`), proving Fabric E2E is unaffected.
- **The conda-presence predicate was executed** against 5 realistic `conda env list` shapes — env present, present-and-active (`*`), absent, conda missing entirely, and a similar-but-different name (`synapseml-internal-old`) — plus a `set -e` safety check. All 5 correct.

## Risk

- `InternalCompat` keeps `continueOnError: true` and is **not** a required status check, so the new per-leg check names (`... Compatibility Check scala` / `... python`) do not affect branch protection.
- Both legs compute the OSS version from the same pinned build commit, so the retarget is identical in each — and #2655 already made that step idempotent.
- One behavioural change beyond the split: the two Python steps go from `succeededOrFailed()` back to `succeeded()`. That condition existed only to keep Python running when the Scala tests failed *in the same job*; the split now guarantees that structurally.

## Not done here

The ~12.5 min shared prefix is now the floor, and `Databricks GPU E2E` is the build's new critical path. Caching the Internal conda env, or publishing the OSS M2 artifacts once and fanning out, would attack the prefix — but both add serialisation and belong in their own change with their own measurements.
