### PR TITLE
docs: document Spark 4 install coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,30 +78,39 @@ JVM artifacts. A Python wrapper can import successfully while its JVM class is
 missing; using a `_2.12` artifact with Spark 4 can produce errors such as
 `LightGBMClassifier does not exist in the JVM`.
 
-The examples below use the current base release:
+Choose one complete published build from the Spark runtime. `master` is the
+canonical Spark 3.5 development line; Spark 4.0 and Spark 4.1 are maintained on
+their corresponding branches.
 
-```bash
-SYNAPSEML_VERSION="1.1.3"
-```
+| Code line | Spark runtime | Scala | Python baseline | Release tag | Python package | Maven coordinate |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`master`](https://github.com/microsoft/SynapseML/tree/master) | Spark 3.5.x | 2.12 | Python 3.11 | [`v1.1.3`](https://github.com/microsoft/SynapseML/tree/v1.1.3) | `synapseml==1.1.3` | `com.microsoft.azure:synapseml_2.12:1.1.3` |
+| [`spark4.0`](https://github.com/microsoft/SynapseML/tree/spark4.0) | Spark 4.0.1+ (`<4.1`) | 2.13 | Python 3.12 | [`v1.1.3-spark4.0`](https://github.com/microsoft/SynapseML/tree/v1.1.3-spark4.0) | `synapseml==1.1.3` | `com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0` |
+| [`spark4.1`](https://github.com/microsoft/SynapseML/tree/spark4.1) | Spark 4.1.x | 2.13 | Python 3.13 | [`v1.1.3-spark4.1`](https://github.com/microsoft/SynapseML/tree/v1.1.3-spark4.1) | `synapseml==1.1.3` | `com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1` |
 
-Choose the Maven coordinate from the Spark runtime, not from the Python
-version:
-
-| Spark runtime | Scala binary version | Port Python baseline | Release tag | Maven coordinate |
-| --- | --- | --- | --- | --- |
-| Spark 3.5.x | 2.12 | Python 3.11 | `v${SYNAPSEML_VERSION}` | `com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}` |
-| Spark 4.0.x | 2.13 | Python 3.12 | `v${SYNAPSEML_VERSION}-spark4.0` | `com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.0` |
-| Spark 4.1.x | 2.13 | Python 3.13 | `v${SYNAPSEML_VERSION}-spark4.1` | `com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1` |
-
-In a UI that does not expand shell variables, replace
-`${SYNAPSEML_VERSION}` with the value assigned above.
-The Spark 4 rows correspond to the explicit published tags shown; documentation
-tests lock their artifact versions so a base-version bump cannot silently
-advertise an unpublished port. The same `synapseml==${SYNAPSEML_VERSION}`
-Python wheel is
-used with both Spark 4 ports. Always configure
+Always configure
 `https://mmlspark.blob.core.windows.net/maven`, where the Spark 4 artifacts are
 published. See the [full installation guide] for platform-specific details.
+
+### Latest master snapshot
+
+The latest successful `master` build targets Spark 3.5 and Scala 2.12. This
+copy-ready command reads the current snapshot version published by CI and starts
+Spark with that exact JVM build:
+
+```bash
+MASTER_VERSION="$(
+  curl -fsSL https://mmlspark.blob.core.windows.net/icons/badges/master_version3.svg |
+    sed -n 's/.*aria-label="master version: \([^"]*\)".*/\1/p'
+)"
+test -n "$MASTER_VERSION"
+spark-shell \
+  --repositories "https://mmlspark.blob.core.windows.net/maven" \
+  --packages "com.microsoft.azure:synapseml_2.12:${MASTER_VERSION}"
+```
+
+The PyPI package contains released Python wrappers. If you need Python APIs
+that are new on `master`, [build the matching wheel from source].
 
 First select the correct platform that you are installing SynapseML into:
 <!--ts-->
@@ -109,6 +118,7 @@ First select the correct platform that you are installing SynapseML into:
   - [Features](#features)
   - [Documentation and Examples](#documentation-and-examples)
   - [Setup and installation](#setup-and-installation)
+    - [Latest master snapshot](#latest-master-snapshot)
     - [Microsoft Fabric](#microsoft-fabric)
     - [Synapse Analytics](#synapse-analytics)
     - [Databricks](#databricks)
@@ -129,9 +139,8 @@ First select the correct platform that you are installing SynapseML into:
 
 ### Microsoft Fabric
 
-In Microsoft Fabric notebooks SynapseML is already installed. To override it,
-check the runtime's Spark and Scala versions, then substitute the matching full
-coordinate and Scala binary version from the matrix above:
+In Microsoft Fabric notebooks SynapseML is already installed. The following
+copy-ready override targets a Spark 4.1 / Scala 2.13 runtime:
 
 
 ```bash
@@ -139,9 +148,9 @@ coordinate and Scala binary version from the matrix above:
 {
   "name": "synapseml",
   "conf": {
-      "spark.jars.packages": "<COORDINATE_FROM_THE_MATRIX_ABOVE>",
+      "spark.jars.packages": "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1",
       "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
-      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_<SCALA_BINARY_VERSION>,org.scalactic:scalactic_<SCALA_BINARY_VERSION>,org.scalatest:scalatest_<SCALA_BINARY_VERSION>,com.fasterxml.jackson.core:jackson-databind",
+      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.13,org.scalactic:scalactic_2.13,org.scalatest:scalatest_2.13,com.fasterxml.jackson.core:jackson-databind",
       "spark.yarn.user.classpath.first": "true",
       "spark.sql.parquet.enableVectorizedReader": "false"
   }
@@ -153,9 +162,8 @@ coordinate and Scala binary version from the matrix above:
 
 ### Synapse Analytics
 
-In Azure Synapse notebooks please place the following in the first cell of your notebook. 
-
-- For Spark 3.5 Pools:
+Current Azure Synapse pools use Spark 3.5. Place the following in the first cell
+of your notebook:
 
 ```bash
 %%configure -f
@@ -163,38 +171,6 @@ In Azure Synapse notebooks please place the following in the first cell of your 
   "name": "synapseml",
   "conf": {
       "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:1.1.3",
-      "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
-      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
-      "spark.yarn.user.classpath.first": "true",
-      "spark.sql.parquet.enableVectorizedReader": "false"
-  }
-}
-```
-
-- For Spark 3.4 Pools:
-
-```bash
-%%configure -f
-{
-  "name": "synapseml",
-  "conf": {
-      "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:1.0.15",
-      "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
-      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
-      "spark.yarn.user.classpath.first": "true",
-      "spark.sql.parquet.enableVectorizedReader": "false"
-  }
-}
-```
-
-- For Spark 3.3 Pools:
-
-```bash
-%%configure -f
-{
-  "name": "synapseml",
-  "conf": {
-      "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:0.11.4-spark3.3",
       "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
       "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
       "spark.yarn.user.classpath.first": "true",
@@ -214,13 +190,17 @@ cloud](http://community.cloud.databricks.com), create a new [library from Maven
 coordinates](https://docs.databricks.com/user-guide/libraries.html#libraries-from-maven-pypi-or-spark-packages)
 in your workspace.
 
-Use the coordinate matching the cluster's Spark and Scala versions from the
-matrix above. For example, Spark 4.1 / Scala 2.13 uses
-`com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1`, while Spark
-3.5 / Scala 2.12 uses
-`com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}`. Add the resolver
-`https://mmlspark.blob.core.windows.net/maven`, attach the library to the target
-cluster, and restart it before importing `synapse.ml`.
+Use one of these exact Maven coordinates:
+
+- Spark 4.1 / Scala 2.13:
+  `com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1`
+- Spark 4.0 / Scala 2.13:
+  `com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0`
+- Spark 3.5 / Scala 2.12:
+  `com.microsoft.azure:synapseml_2.12:1.1.3`
+
+Add the resolver `https://mmlspark.blob.core.windows.net/maven`, attach the
+library to the target cluster, and restart it before importing `synapse.ml`.
 
 You can use SynapseML in both your Scala and PySpark notebooks. To get started with our example notebooks import the following databricks archive:
 
@@ -228,48 +208,40 @@ You can use SynapseML in both your Scala and PySpark notebooks. To get started w
 
 ### Python Standalone
 
-Using the `SYNAPSEML_VERSION` assigned above, choose exactly one complete
-runtime variant below, then start Spark with that variant's JVM artifact.
+Choose exactly one complete runtime variant below, then start Spark with that
+variant's JVM artifact.
 
 **Spark 4.1 / Python 3.13**
 
 ```bash
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.1,<4.2"
+python -m pip install "synapseml==1.1.3" "pyspark>=4.1,<4.2"
 ```
 
 **Spark 4.0 / Python 3.12**
 
 ```bash
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.0.1,<4.1"
+python -m pip install "synapseml==1.1.3" "pyspark>=4.0.1,<4.1"
 ```
 
 **Spark 3.5 / Python 3.11**
 
 ```bash
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=3.5,<3.6"
+python -m pip install "synapseml==1.1.3" "pyspark>=3.5,<3.6"
 ```
 
 ```python
 from pyspark.sql import SparkSession
 
-SYNAPSEML_VERSION="1.1.3"
-
-# Select the coordinate matching the PySpark command used above.
-SYNAPSEML_COORDINATE=(
-    f"com.microsoft.azure:synapseml_2.13:{SYNAPSEML_VERSION}-spark4.1"
-)
+# Spark 4.1. Select the coordinate matching the PySpark command used above.
+synapseml_coordinate = "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1"
 # Spark 4.0:
-# SYNAPSEML_COORDINATE=(
-#     f"com.microsoft.azure:synapseml_2.13:{SYNAPSEML_VERSION}-spark4.0"
-# )
+# synapseml_coordinate = "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0"
 # Spark 3.5:
-# SYNAPSEML_COORDINATE=(
-#     f"com.microsoft.azure:synapseml_2.12:{SYNAPSEML_VERSION}"
-# )
+# synapseml_coordinate = "com.microsoft.azure:synapseml_2.12:1.1.3"
 
 spark = (
     SparkSession.builder.appName("MyApp")
-    .config("spark.jars.packages", SYNAPSEML_COORDINATE)
+    .config("spark.jars.packages", synapseml_coordinate)
     .config(
         "spark.jars.repositories",
         "https://mmlspark.blob.core.windows.net/maven",
@@ -282,40 +254,53 @@ import synapse.ml
 ### Spark Submit
 
 SynapseML can be conveniently installed on existing Spark clusters via the
-`--packages` option. Include `--repositories` for the Spark 4 ports:
+`--packages` option. Each example below is independently copyable.
 
 ```bash
-SYNAPSEML_VERSION=1.1.3
-SYNAPSEML_REPOSITORY=https://mmlspark.blob.core.windows.net/maven
-
-# Spark 4.0
-pyspark --repositories "$SYNAPSEML_REPOSITORY" \
-  --packages "com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.0"
-
 # Spark 4.1
-pyspark --repositories "$SYNAPSEML_REPOSITORY" \
-  --packages "com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1"
+pyspark --repositories "https://mmlspark.blob.core.windows.net/maven" \
+  --packages "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1"
+```
 
+```bash
+# Spark 4.0
+pyspark --repositories "https://mmlspark.blob.core.windows.net/maven" \
+  --packages "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0"
+```
+
+```bash
 # Spark 3.5
-pyspark --repositories "$SYNAPSEML_REPOSITORY" \
-  --packages "com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}"
+pyspark --repositories "https://mmlspark.blob.core.windows.net/maven" \
+  --packages "com.microsoft.azure:synapseml_2.12:1.1.3"
 ```
 
 ### SBT
 
-For Spark 4.1 (use `SPARK_LINE="4.0"` for Spark 4.0), add:
+Choose the dependency matching your Spark runtime.
+
+**Spark 4.1**
 
 ```scala
-val SYNAPSEML_VERSION="1.1.3"
-val SPARK_LINE="4.1"
 resolvers += "SynapseML" at "https://mmlspark.blob.core.windows.net/maven"
 libraryDependencies +=
-  "com.microsoft.azure" % "synapseml_2.13" %
-    s"$SYNAPSEML_VERSION-spark$SPARK_LINE"
+  "com.microsoft.azure" % "synapseml_2.13" % "1.1.3-spark4.1"
 ```
 
-For Spark 3.5, use
-`"com.microsoft.azure" % "synapseml_2.12" % SYNAPSEML_VERSION`.
+**Spark 4.0**
+
+```scala
+resolvers += "SynapseML" at "https://mmlspark.blob.core.windows.net/maven"
+libraryDependencies +=
+  "com.microsoft.azure" % "synapseml_2.13" % "1.1.3-spark4.0"
+```
+
+**Spark 3.5**
+
+```scala
+resolvers += "SynapseML" at "https://mmlspark.blob.core.windows.net/maven"
+libraryDependencies +=
+  "com.microsoft.azure" % "synapseml_2.12" % "1.1.3"
+```
 
 ### Apache Livy and HDInsight
 
@@ -394,6 +379,8 @@ better integrate with intellij and SBT.
 [website]: https://microsoft.github.io/SynapseML/ "aka.ms/spark"
 
 [full installation guide]: https://microsoft.github.io/SynapseML/docs/Get%20Started/Install%20SynapseML/
+
+[build the matching wheel from source]: docs/Reference/Developer%20Setup.md
 
 [the Spark+AI Summit 2018]: https://databricks.com/sparkaisummit/north-america/spark-summit-2018-keynotes#Intelligent-cloud "Developing for the Intelligent Cloud and Intelligent Edge"
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ version:
 In a UI that does not expand shell variables, replace
 `${SYNAPSEML_VERSION}` with the value assigned above.
 The Spark 4 rows correspond to the explicit published tags shown; documentation
-tests lock those tags so a base-version bump cannot silently advertise an
-unpublished port. The same `synapseml==${SYNAPSEML_VERSION}` Python wheel is
+tests lock their artifact versions so a base-version bump cannot silently
+advertise an unpublished port. The same `synapseml==${SYNAPSEML_VERSION}`
+Python wheel is
 used with both Spark 4 ports. Always configure
 `https://mmlspark.blob.core.windows.net/maven`, where the Spark 4 artifacts are
 published. See the [full installation guide] for platform-specific details.
@@ -227,25 +228,25 @@ You can use SynapseML in both your Scala and PySpark notebooks. To get started w
 
 ### Python Standalone
 
-Choose exactly one complete runtime variant below, then start Spark with that
-variant's JVM artifact.
+Using the `SYNAPSEML_VERSION` assigned above, choose exactly one complete
+runtime variant below, then start Spark with that variant's JVM artifact.
 
 **Spark 4.1 / Python 3.13**
 
 ```bash
-python -m pip install "synapseml==1.1.3" "pyspark>=4.1,<4.2"
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.1,<4.2"
 ```
 
 **Spark 4.0 / Python 3.12**
 
 ```bash
-python -m pip install "synapseml==1.1.3" "pyspark>=4.0,<4.1"
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.0,<4.1"
 ```
 
 **Spark 3.5 / Python 3.11**
 
 ```bash
-python -m pip install "synapseml==1.1.3" "pyspark>=3.5,<3.6"
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=3.5,<3.6"
 ```
 
 ```python

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.1,<4.2"
 **Spark 4.0 / Python 3.12**
 
 ```bash
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.0,<4.1"
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.0.1,<4.1"
 ```
 
 **Spark 3.5 / Python 3.11**

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ SynapseML (previously known as MMLSpark), is an open-source library that simplif
 
 With SynapseML, you can build scalable and intelligent systems to solve challenges in domains such as anomaly detection, computer vision, deep learning, text analytics, and others. SynapseML can train and evaluate models on single-node, multi-node, and elastically resizable clusters of computers. This lets you scale your work without wasting resources. SynapseML is usable across Python, R, Scala, Java, and .NET. Furthermore, its API abstracts over a wide variety of databases, file systems, and cloud data stores to simplify experiments no matter where data is located.
 
-SynapseML requires Scala 2.12, Spark 3.4+, and Python 3.8+.  
+SynapseML publishes runtime-specific JVM artifacts: Spark 3.5 uses Scala 2.12,
+while Spark 4.0 and 4.1 use Scala 2.13. See the
+[installation matrix](#setup-and-installation) before selecting a Maven
+coordinate.
 
 | Topics  | Links                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -69,6 +72,34 @@ For quickstarts, documentation, demos, and examples please see our [website](htt
 
 ## Setup and installation
 
+SynapseML installation has two parts: the language wrapper and the JVM
+artifacts loaded by Spark. Installing `synapseml` from PyPI does **not** add the
+JVM artifacts. A Python wrapper can import successfully while its JVM class is
+missing; using a `_2.12` artifact with Spark 4 can produce errors such as
+`LightGBMClassifier does not exist in the JVM`.
+
+The examples below use the current base release:
+
+```bash
+SYNAPSEML_VERSION="1.1.3"
+```
+
+Choose the Maven coordinate from the Spark runtime, not from the Python
+version:
+
+| Spark runtime | Scala binary version | Port Python baseline | Release tag | Maven coordinate |
+| --- | --- | --- | --- | --- |
+| Spark 3.5.x | 2.12 | Python 3.11 | `v${SYNAPSEML_VERSION}` | `com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}` |
+| Spark 4.0.x | 2.13 | Python 3.12 | `v${SYNAPSEML_VERSION}-spark4.0` | `com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.0` |
+| Spark 4.1.x | 2.13 | Python 3.13 | `v${SYNAPSEML_VERSION}-spark4.1` | `com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1` |
+
+In a UI that does not expand shell variables, replace
+`${SYNAPSEML_VERSION}` with the value assigned above.
+The same `synapseml==${SYNAPSEML_VERSION}` Python wheel is used with both Spark
+4 ports. Always configure
+`https://mmlspark.blob.core.windows.net/maven`, where the Spark 4 artifacts are
+published. See the [full installation guide] for platform-specific details.
+
 First select the correct platform that you are installing SynapseML into:
 <!--ts-->
 - [Synapse Machine Learning](#synapse-machine-learning)
@@ -95,7 +126,9 @@ First select the correct platform that you are installing SynapseML into:
 
 ### Microsoft Fabric
 
-In Microsoft Fabric notebooks SynapseML is already installed. To change the version please place the following in the first cell of your notebook.
+In Microsoft Fabric notebooks SynapseML is already installed. To override it,
+check the runtime's Spark and Scala versions, then substitute the matching full
+coordinate and Scala binary version from the matrix above:
 
 
 ```bash
@@ -103,9 +136,9 @@ In Microsoft Fabric notebooks SynapseML is already installed. To change the vers
 {
   "name": "synapseml",
   "conf": {
-      "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:<THE_SYNAPSEML_VERSION_YOU_WANT>",
+      "spark.jars.packages": "<COORDINATE_FROM_THE_MATRIX_ABOVE>",
       "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
-      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
+      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_<SCALA_BINARY_VERSION>,org.scalactic:scalactic_<SCALA_BINARY_VERSION>,org.scalatest:scalatest_<SCALA_BINARY_VERSION>,com.fasterxml.jackson.core:jackson-databind",
       "spark.yarn.user.classpath.first": "true",
       "spark.sql.parquet.enableVectorizedReader": "false"
   }
@@ -178,11 +211,13 @@ cloud](http://community.cloud.databricks.com), create a new [library from Maven
 coordinates](https://docs.databricks.com/user-guide/libraries.html#libraries-from-maven-pypi-or-spark-packages)
 in your workspace.
 
-For the coordinates use: `com.microsoft.azure:synapseml_2.12:1.1.3`
-with the resolver: `https://mmlspark.blob.core.windows.net/maven`. Ensure this library is
-attached to your target cluster(s).
-
-Finally, ensure that your Spark cluster has at least Spark 3.2 and Scala 2.12. If you encounter Netty dependency issues please use DBR 10.1.
+Use the coordinate matching the cluster's Spark and Scala versions from the
+matrix above. For example, Spark 4.1 / Scala 2.13 uses
+`com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1`, while Spark
+3.5 / Scala 2.12 uses
+`com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}`. Add the resolver
+`https://mmlspark.blob.core.windows.net/maven`, attach the library to the target
+cluster, and restart it before importing `synapse.ml`.
 
 You can use SynapseML in both your Scala and PySpark notebooks. To get started with our example notebooks import the following databricks archive:
 
@@ -190,41 +225,80 @@ You can use SynapseML in both your Scala and PySpark notebooks. To get started w
 
 ### Python Standalone
 
-To try out SynapseML on a Python (or Conda) installation you can get Spark
-installed via pip with `pip install pyspark`.  You can then use `pyspark` as in
-the above example, or from python:
+Install the Python wrapper, then start Spark with the matching JVM artifact.
+This copy-paste example is for Spark 4.1 and Python 3.13. For Spark 4.0, install
+`pyspark>=4.0,<4.1` instead and set `SPARK_LINE="4.0"`:
+
+```bash
+SYNAPSEML_VERSION=1.1.3
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.1,<4.2"
+```
 
 ```python
-import pyspark
-spark = pyspark.sql.SparkSession.builder.appName("MyApp") \
-            .config("spark.jars.packages", "com.microsoft.azure:synapseml_2.12:1.1.3") \
-            .getOrCreate()
+from pyspark.sql import SparkSession
+
+SYNAPSEML_VERSION="1.1.3"
+SPARK_LINE="4.1"
+SYNAPSEML_COORDINATE=(
+    f"com.microsoft.azure:synapseml_2.13:"
+    f"{SYNAPSEML_VERSION}-spark{SPARK_LINE}"
+)
+
+spark = (
+    SparkSession.builder.appName("MyApp")
+    .config("spark.jars.packages", SYNAPSEML_COORDINATE)
+    .config(
+        "spark.jars.repositories",
+        "https://mmlspark.blob.core.windows.net/maven",
+    )
+    .getOrCreate()
+)
 import synapse.ml
 ```
 
 ### Spark Submit
 
 SynapseML can be conveniently installed on existing Spark clusters via the
-`--packages` option, examples:
+`--packages` option. Include `--repositories` for the Spark 4 ports:
 
 ```bash
-spark-shell --packages com.microsoft.azure:synapseml_2.12:1.1.3
-pyspark --packages com.microsoft.azure:synapseml_2.12:1.1.3
-spark-submit --packages com.microsoft.azure:synapseml_2.12:1.1.3 MyApp.jar
+SYNAPSEML_VERSION=1.1.3
+SYNAPSEML_REPOSITORY=https://mmlspark.blob.core.windows.net/maven
+
+# Spark 4.0
+pyspark --repositories "$SYNAPSEML_REPOSITORY" \
+  --packages "com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.0"
+
+# Spark 4.1
+pyspark --repositories "$SYNAPSEML_REPOSITORY" \
+  --packages "com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1"
+
+# Spark 3.5
+pyspark --repositories "$SYNAPSEML_REPOSITORY" \
+  --packages "com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}"
 ```
 
 ### SBT
 
-If you are building a Spark application in Scala, add the following lines to
-your `build.sbt`:
+For Spark 4.1 (use `SPARK_LINE="4.0"` for Spark 4.0), add:
 
 ```scala
-libraryDependencies += "com.microsoft.azure" % "synapseml_2.12" % "1.1.3"
+val SYNAPSEML_VERSION="1.1.3"
+val SPARK_LINE="4.1"
+resolvers += "SynapseML" at "https://mmlspark.blob.core.windows.net/maven"
+libraryDependencies +=
+  "com.microsoft.azure" % "synapseml_2.13" %
+    s"$SYNAPSEML_VERSION-spark$SPARK_LINE"
 ```
+
+For Spark 3.5, use
+`"com.microsoft.azure" % "synapseml_2.12" % SYNAPSEML_VERSION`.
 
 ### Apache Livy and HDInsight
 
-To install SynapseML from within a Jupyter notebook served by Apache Livy the following configure magic can be used. You will need to start a new session after this configure cell is executed.
+To install SynapseML from within a Jupyter notebook served by Apache Livy, the
+following Spark 3.5 / Scala 2.12 configure magic can be used. You will need to
+start a new session after this configure cell is executed.
 
 Excluding certain packages from the library may be necessary due to current issues with Livy 0.5.
 
@@ -234,6 +308,7 @@ Excluding certain packages from the library may be necessary due to current issu
     "name": "synapseml",
     "conf": {
         "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:1.1.3",
+        "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
         "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind"
     }
 }
@@ -294,6 +369,8 @@ better integrate with intellij and SBT.
 - Explore [our collaboration with Apache Spark] on image analysis.
 
 [website]: https://microsoft.github.io/SynapseML/ "aka.ms/spark"
+
+[full installation guide]: https://microsoft.github.io/SynapseML/docs/Get%20Started/Install%20SynapseML/
 
 [the Spark+AI Summit 2018]: https://databricks.com/sparkaisummit/north-america/spark-summit-2018-keynotes#Intelligent-cloud "Developing for the Intelligent Cloud and Intelligent Edge"
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ version:
 
 In a UI that does not expand shell variables, replace
 `${SYNAPSEML_VERSION}` with the value assigned above.
-The same `synapseml==${SYNAPSEML_VERSION}` Python wheel is used with both Spark
-4 ports. Always configure
+The Spark 4 rows correspond to the explicit published tags shown; documentation
+tests lock those tags so a base-version bump cannot silently advertise an
+unpublished port. The same `synapseml==${SYNAPSEML_VERSION}` Python wheel is
+used with both Spark 4 ports. Always configure
 `https://mmlspark.blob.core.windows.net/maven`, where the Spark 4 artifacts are
 published. See the [full installation guide] for platform-specific details.
 
@@ -225,24 +227,39 @@ You can use SynapseML in both your Scala and PySpark notebooks. To get started w
 
 ### Python Standalone
 
-Install the Python wrapper, then start Spark with the matching JVM artifact.
-This copy-paste example is for Spark 4.1 and Python 3.13. For Spark 4.0, install
-`pyspark>=4.0,<4.1` instead and set `SPARK_LINE="4.0"`:
+Install the Python wrapper and PySpark version for one complete runtime variant,
+then start Spark with that variant's JVM artifact:
 
 ```bash
 SYNAPSEML_VERSION=1.1.3
+
+# Spark 4.1 / Python 3.13
 python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.1,<4.2"
+
+# Spark 4.0 / Python 3.12
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.0,<4.1"
+
+# Spark 3.5 / Python 3.11
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=3.5,<3.6"
 ```
 
 ```python
 from pyspark.sql import SparkSession
 
 SYNAPSEML_VERSION="1.1.3"
-SPARK_LINE="4.1"
+
+# Select the coordinate matching the PySpark command used above.
 SYNAPSEML_COORDINATE=(
-    f"com.microsoft.azure:synapseml_2.13:"
-    f"{SYNAPSEML_VERSION}-spark{SPARK_LINE}"
+    f"com.microsoft.azure:synapseml_2.13:{SYNAPSEML_VERSION}-spark4.1"
 )
+# Spark 4.0:
+# SYNAPSEML_COORDINATE=(
+#     f"com.microsoft.azure:synapseml_2.13:{SYNAPSEML_VERSION}-spark4.0"
+# )
+# Spark 3.5:
+# SYNAPSEML_COORDINATE=(
+#     f"com.microsoft.azure:synapseml_2.12:{SYNAPSEML_VERSION}"
+# )
 
 spark = (
     SparkSession.builder.appName("MyApp")

--- a/README.md
+++ b/README.md
@@ -227,20 +227,25 @@ You can use SynapseML in both your Scala and PySpark notebooks. To get started w
 
 ### Python Standalone
 
-Install the Python wrapper and PySpark version for one complete runtime variant,
-then start Spark with that variant's JVM artifact:
+Choose exactly one complete runtime variant below, then start Spark with that
+variant's JVM artifact.
+
+**Spark 4.1 / Python 3.13**
 
 ```bash
-SYNAPSEML_VERSION=1.1.3
+python -m pip install "synapseml==1.1.3" "pyspark>=4.1,<4.2"
+```
 
-# Spark 4.1 / Python 3.13
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.1,<4.2"
+**Spark 4.0 / Python 3.12**
 
-# Spark 4.0 / Python 3.12
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.0,<4.1"
+```bash
+python -m pip install "synapseml==1.1.3" "pyspark>=4.0,<4.1"
+```
 
-# Spark 3.5 / Python 3.11
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=3.5,<3.6"
+**Spark 3.5 / Python 3.11**
+
+```bash
+python -m pip install "synapseml==1.1.3" "pyspark>=3.5,<3.6"
 ```
 
 ```python

--- a/docs/Explore Algorithms/Anomaly Detection/Quickstart - Isolation Forests.ipynb
+++ b/docs/Explore Algorithms/Anomaly Detection/Quickstart - Isolation Forests.ipynb
@@ -29,7 +29,7 @@
    "source": [
     "## Prerequisites\n",
     " - If running on Synapse, you'll need to [create an AML workspace and set up linked Service](../../Use%20with%20MLFlow/Overview.md) and add the following installation cell.\n",
-    " - If running on Fabric, you need to add the following installation cell and attach the notebook to a lakehouse. On the left side of your notebook, select Add to add an existing lakehouse or create a new one."
+    " - If running on Fabric, choose the coordinate and Scala binary version from the [installation matrix](../../Get%20Started/Install%20SynapseML.md), add the following installation cell, and attach the notebook to a lakehouse. On the left side of your notebook, select Add to add an existing lakehouse or create a new one."
    ]
   },
   {
@@ -42,9 +42,9 @@
     "# {\n",
     "#   \"name\": \"synapseml\",\n",
     "#   \"conf\": {\n",
-    "#       \"spark.jars.packages\": \"com.microsoft.azure:synapseml_2.12:<THE_SYNAPSEML_VERSION_YOU_WANT>\",\n",
+    "#       \"spark.jars.packages\": \"<COORDINATE_FROM_THE_INSTALL_MATRIX>\",\n",
     "#       \"spark.jars.repositories\": \"https://mmlspark.blob.core.windows.net/maven\",\n",
-    "#       \"spark.jars.excludes\": \"org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind\",\n",
+    "#       \"spark.jars.excludes\": \"org.scala-lang:scala-reflect,org.apache.spark:spark-tags_<SCALA_BINARY_VERSION>,org.scalactic:scalactic_<SCALA_BINARY_VERSION>,org.scalatest:scalatest_<SCALA_BINARY_VERSION>,com.fasterxml.jackson.core:jackson-databind\",\n",
     "#       \"spark.yarn.user.classpath.first\": \"true\",\n",
     "#       \"spark.sql.parquet.enableVectorizedReader\": \"false\"\n",
     "#   }\n",

--- a/docs/Explore Algorithms/Anomaly Detection/Quickstart - Isolation Forests.ipynb
+++ b/docs/Explore Algorithms/Anomaly Detection/Quickstart - Isolation Forests.ipynb
@@ -29,7 +29,8 @@
    "source": [
     "## Prerequisites\n",
     " - If running on Synapse, you'll need to [create an AML workspace and set up linked Service](../../Use%20with%20MLFlow/Overview.md) and add the following installation cell.\n",
-    " - If running on Fabric, choose the coordinate and Scala binary version from the [installation matrix](../../Get%20Started/Install%20SynapseML.md), add the following installation cell, and attach the notebook to a lakehouse. On the left side of your notebook, select Add to add an existing lakehouse or create a new one."
+    " - This notebook's existing dependency set and installation cell are scoped to Spark 3.5 / Scala 2.12. Do not substitute a Spark 4 coordinate: the pinned dependencies below are not a Python 3.12/3.13 setup.\n",
+    " - If running on Fabric with a Spark 3.5 runtime, add the following installation cell and attach the notebook to a lakehouse. On the left side of your notebook, select Add to add an existing lakehouse or create a new one."
    ]
   },
   {
@@ -42,9 +43,9 @@
     "# {\n",
     "#   \"name\": \"synapseml\",\n",
     "#   \"conf\": {\n",
-    "#       \"spark.jars.packages\": \"<COORDINATE_FROM_THE_INSTALL_MATRIX>\",\n",
+    "#       \"spark.jars.packages\": \"com.microsoft.azure:synapseml_2.12:1.1.3\",\n",
     "#       \"spark.jars.repositories\": \"https://mmlspark.blob.core.windows.net/maven\",\n",
-    "#       \"spark.jars.excludes\": \"org.scala-lang:scala-reflect,org.apache.spark:spark-tags_<SCALA_BINARY_VERSION>,org.scalactic:scalactic_<SCALA_BINARY_VERSION>,org.scalatest:scalatest_<SCALA_BINARY_VERSION>,com.fasterxml.jackson.core:jackson-databind\",\n",
+    "#       \"spark.jars.excludes\": \"org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind\",\n",
     "#       \"spark.yarn.user.classpath.first\": \"true\",\n",
     "#       \"spark.sql.parquet.enableVectorizedReader\": \"false\"\n",
     "#   }\n",

--- a/docs/Explore Algorithms/Deep Learning/Getting Started.md
+++ b/docs/Explore Algorithms/Deep Learning/Getting Started.md
@@ -32,8 +32,11 @@ Coordinate: com.microsoft.azure:synapseml_2.12:1.1.3
 Repository: https://mmlspark.blob.core.windows.net/maven
 ```
 
-For Spark 4, use the Scala 2.13 coordinate and Spark-specific version suffix in
-the [installation matrix](../../Get%20Started/Install%20SynapseML.md).
+For Spark 4.0 use
+`com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0`; for Spark 4.1 use
+`com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1`. See the
+[installation guide](../../Get%20Started/Install%20SynapseML.md) for complete
+copy-ready commands.
 The historical Databricks 10.4.x runtime named above is an older Spark line; do
 not combine it with the current Spark 3.5 artifact. If you retain that runtime,
 select a compatible older SynapseML release instead.

--- a/docs/Explore Algorithms/Deep Learning/Getting Started.md
+++ b/docs/Explore Algorithms/Deep Learning/Getting Started.md
@@ -24,8 +24,8 @@ Run the following command:
 pip install synapseml==1.1.3
 ```
 
-The Python wheel supplies wrappers but does not install the JVM package. This
-sample uses a Spark 3 / Scala 2.12 runtime, so add the following Maven library:
+The Python wheel supplies wrappers but does not install the JVM package. The
+Maven example below targets Spark 3.5 / Scala 2.12:
 
 ```
 Coordinate: com.microsoft.azure:synapseml_2.12:1.1.3
@@ -34,6 +34,9 @@ Repository: https://mmlspark.blob.core.windows.net/maven
 
 For Spark 4, use the Scala 2.13 coordinate and Spark-specific version suffix in
 the [installation matrix](../../Get%20Started/Install%20SynapseML.md).
+The historical Databricks 10.4.x runtime named above is an older Spark line; do
+not combine it with the current Spark 3.5 artifact. If you retain that runtime,
+select a compatible older SynapseML release instead.
 
 :::note
 If you install the jar package, follow the first two cells of this [sample](../Quickstart%20-%20Fine-tune%20a%20Vision%20Classifier#environment-setup----reinstall-horovod-based-on-new-version-of-pytorch)

--- a/docs/Explore Algorithms/Deep Learning/Getting Started.md
+++ b/docs/Explore Algorithms/Deep Learning/Getting Started.md
@@ -24,11 +24,17 @@ Run the following command:
 pip install synapseml==1.1.3
 ```
 
-An alternative is installing the SynapseML jar package in library management section, by adding:
+The Python wheel supplies wrappers but does not install the JVM package. This
+sample uses a Spark 3 / Scala 2.12 runtime, so add the following Maven library:
+
 ```
 Coordinate: com.microsoft.azure:synapseml_2.12:1.1.3
 Repository: https://mmlspark.blob.core.windows.net/maven
 ```
+
+For Spark 4, use the Scala 2.13 coordinate and Spark-specific version suffix in
+the [installation matrix](../../Get%20Started/Install%20SynapseML.md).
+
 :::note
 If you install the jar package, follow the first two cells of this [sample](../Quickstart%20-%20Fine-tune%20a%20Vision%20Classifier#environment-setup----reinstall-horovod-based-on-new-version-of-pytorch)
 to ensure horovod recognizes SynapseML.

--- a/docs/Explore Algorithms/Deep Learning/ONNX.md
+++ b/docs/Explore Algorithms/Deep Learning/ONNX.md
@@ -82,8 +82,8 @@ module artifacts.
   ```xml
   <dependency>
     <groupId>com.microsoft.azure</groupId>
-    <artifactId>synapseml-deep-learning_<scala-binary-version></artifactId>
-    <version><synapseml-deep-learning-version></version>
+    <artifactId>synapseml-deep-learning_SCALA_BINARY_VERSION</artifactId>
+    <version>SYNAPSEML_DEEP_LEARNING_VERSION</version>
     <exclusions>
       <exclusion>
         <groupId>com.microsoft.onnxruntime</groupId>

--- a/docs/Explore Algorithms/Deep Learning/ONNX.md
+++ b/docs/Explore Algorithms/Deep Learning/ONNX.md
@@ -103,8 +103,12 @@ module artifacts.
   flag (format `groupId:artifactId`, no version):
 
   ```bash
+  # Spark 4.1 example; use the matching table value for another runtime.
+  SYNAPSEML_VERSION="1.1.3"
+  SYNAPSEML_DEEP_LEARNING_COORDINATE="com.microsoft.azure:synapseml-deep-learning_2.13:${SYNAPSEML_VERSION}-spark4.1"
+
   spark-submit \
-    --packages <synapseml-deep-learning-coordinate>,com.microsoft.onnxruntime:onnxruntime_gpu:1.17.3 \
+    --packages "${SYNAPSEML_DEEP_LEARNING_COORDINATE},com.microsoft.onnxruntime:onnxruntime_gpu:1.17.3" \
     --exclude-packages com.microsoft.onnxruntime:onnxruntime \
     your_script.py
   ```

--- a/docs/Explore Algorithms/Deep Learning/ONNX.md
+++ b/docs/Explore Algorithms/Deep Learning/ONNX.md
@@ -39,15 +39,34 @@ would be a no-op). After installing, verify that exactly one `ai.onnxruntime` ja
 ever see both `onnxruntime-<version>.jar` and `onnxruntime_gpu-<version>.jar` on the same classpath, the
 exclusion is missing or attached to the wrong dependency.
 
-Choose the SynapseML Scala suffix and version from the
-[installation matrix](../../Get%20Started/Install%20SynapseML.md). In the examples
-below, `<synapseml-coordinate>` means that complete runtime-specific coordinate.
+The examples below install the `synapseml-deep-learning` JVM module directly.
+Use the current base release:
+
+```bash
+SYNAPSEML_VERSION="1.1.3"
+```
+
+Then select the module version and complete coordinate from the Spark runtime:
+
+| Spark runtime | Scala binary version | `<synapseml-deep-learning-version>` | `<synapseml-deep-learning-coordinate>` |
+| --- | --- | --- | --- |
+| Spark 3.5.x | 2.12 | `${SYNAPSEML_VERSION}` | `com.microsoft.azure:synapseml-deep-learning_2.12:${SYNAPSEML_VERSION}` |
+| Spark 4.0.x | 2.13 | `${SYNAPSEML_VERSION}-spark4.0` | `com.microsoft.azure:synapseml-deep-learning_2.13:${SYNAPSEML_VERSION}-spark4.0` |
+| Spark 4.1.x | 2.13 | `${SYNAPSEML_VERSION}-spark4.1` | `com.microsoft.azure:synapseml-deep-learning_2.13:${SYNAPSEML_VERSION}-spark4.1` |
+
+Replace the variable with its assigned value in UIs that do not expand shell
+variables, and resolve these modules from
+`https://mmlspark.blob.core.windows.net/maven`. If you intentionally install the
+aggregate `synapseml` artifact instead, use its coordinate from the
+[installation matrix](../../Get%20Started/Install%20SynapseML.md) and attach the
+exclusion to that aggregate dependency. Do not install both the aggregate and
+module artifacts.
 
 - **sbt** (per-dependency exclusion, attached to the SynapseML dependency):
 
   ```scala
   libraryDependencies ++= Seq(
-    ("com.microsoft.azure" %% "synapseml-deep-learning" % "<version>")
+    ("com.microsoft.azure" %% "synapseml-deep-learning" % "<synapseml-deep-learning-version>")
       .exclude("com.microsoft.onnxruntime", "onnxruntime"),
     "com.microsoft.onnxruntime" % "onnxruntime_gpu" % "<onnxruntime-version>"
   )
@@ -64,7 +83,7 @@ below, `<synapseml-coordinate>` means that complete runtime-specific coordinate.
   <dependency>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>synapseml-deep-learning_<scala-binary-version></artifactId>
-    <version><synapseml-artifact-version></version>
+    <version><synapseml-deep-learning-version></version>
     <exclusions>
       <exclusion>
         <groupId>com.microsoft.onnxruntime</groupId>
@@ -85,7 +104,7 @@ below, `<synapseml-coordinate>` means that complete runtime-specific coordinate.
 
   ```bash
   spark-submit \
-    --packages <synapseml-coordinate>,com.microsoft.onnxruntime:onnxruntime_gpu:1.17.3 \
+    --packages <synapseml-deep-learning-coordinate>,com.microsoft.onnxruntime:onnxruntime_gpu:1.17.3 \
     --exclude-packages com.microsoft.onnxruntime:onnxruntime \
     your_script.py
   ```
@@ -94,7 +113,7 @@ below, `<synapseml-coordinate>` means that complete runtime-specific coordinate.
   flags) are `spark.jars.packages` and `spark.jars.excludes`:
 
   ```
-  spark.jars.packages=<synapseml-coordinate>,com.microsoft.onnxruntime:onnxruntime_gpu:1.17.3
+  spark.jars.packages=<synapseml-deep-learning-coordinate>,com.microsoft.onnxruntime:onnxruntime_gpu:1.17.3
   spark.jars.excludes=com.microsoft.onnxruntime:onnxruntime
   ```
 
@@ -106,7 +125,7 @@ below, `<synapseml-coordinate>` means that complete runtime-specific coordinate.
   [
     {
       "maven": {
-        "coordinates": "<synapseml-coordinate>",
+        "coordinates": "<synapseml-deep-learning-coordinate>",
         "exclusions": ["com.microsoft.onnxruntime:onnxruntime"]
       }
     },

--- a/docs/Explore Algorithms/Deep Learning/ONNX.md
+++ b/docs/Explore Algorithms/Deep Learning/ONNX.md
@@ -103,8 +103,7 @@ module artifacts.
   flag (format `groupId:artifactId`, no version):
 
   ```bash
-  # Spark 4.1 example; use the matching table value for another runtime.
-  SYNAPSEML_VERSION="1.1.3"
+  # Spark 4.1 example. First set SYNAPSEML_VERSION as shown above.
   SYNAPSEML_DEEP_LEARNING_COORDINATE="com.microsoft.azure:synapseml-deep-learning_2.13:${SYNAPSEML_VERSION}-spark4.1"
 
   spark-submit \

--- a/docs/Explore Algorithms/Deep Learning/ONNX.md
+++ b/docs/Explore Algorithms/Deep Learning/ONNX.md
@@ -39,6 +39,10 @@ would be a no-op). After installing, verify that exactly one `ai.onnxruntime` ja
 ever see both `onnxruntime-<version>.jar` and `onnxruntime_gpu-<version>.jar` on the same classpath, the
 exclusion is missing or attached to the wrong dependency.
 
+Choose the SynapseML Scala suffix and version from the
+[installation matrix](../../Get%20Started/Install%20SynapseML.md). In the examples
+below, `<synapseml-coordinate>` means that complete runtime-specific coordinate.
+
 - **sbt** (per-dependency exclusion, attached to the SynapseML dependency):
 
   ```scala
@@ -59,8 +63,8 @@ exclusion is missing or attached to the wrong dependency.
   ```xml
   <dependency>
     <groupId>com.microsoft.azure</groupId>
-    <artifactId>synapseml-deep-learning_2.12</artifactId>
-    <version>...</version>
+    <artifactId>synapseml-deep-learning_<scala-binary-version></artifactId>
+    <version><synapseml-artifact-version></version>
     <exclusions>
       <exclusion>
         <groupId>com.microsoft.onnxruntime</groupId>
@@ -81,7 +85,7 @@ exclusion is missing or attached to the wrong dependency.
 
   ```bash
   spark-submit \
-    --packages com.microsoft.azure:synapseml_2.12:<version>,com.microsoft.onnxruntime:onnxruntime_gpu:1.17.3 \
+    --packages <synapseml-coordinate>,com.microsoft.onnxruntime:onnxruntime_gpu:1.17.3 \
     --exclude-packages com.microsoft.onnxruntime:onnxruntime \
     your_script.py
   ```
@@ -90,7 +94,7 @@ exclusion is missing or attached to the wrong dependency.
   flags) are `spark.jars.packages` and `spark.jars.excludes`:
 
   ```
-  spark.jars.packages=com.microsoft.azure:synapseml_2.12:<version>,com.microsoft.onnxruntime:onnxruntime_gpu:1.17.3
+  spark.jars.packages=<synapseml-coordinate>,com.microsoft.onnxruntime:onnxruntime_gpu:1.17.3
   spark.jars.excludes=com.microsoft.onnxruntime:onnxruntime
   ```
 
@@ -102,7 +106,7 @@ exclusion is missing or attached to the wrong dependency.
   [
     {
       "maven": {
-        "coordinates": "com.microsoft.azure:synapseml-deep-learning_2.12:<version>",
+        "coordinates": "<synapseml-coordinate>",
         "exclusions": ["com.microsoft.onnxruntime:onnxruntime"]
       }
     },

--- a/docs/Explore Algorithms/Deep Learning/ONNX.md
+++ b/docs/Explore Algorithms/Deep Learning/ONNX.md
@@ -40,24 +40,19 @@ ever see both `onnxruntime-<version>.jar` and `onnxruntime_gpu-<version>.jar` on
 exclusion is missing or attached to the wrong dependency.
 
 The examples below install the `synapseml-deep-learning` JVM module directly.
-Use the current base release:
+Choose the complete module coordinate matching the Spark runtime:
 
-```bash
-SYNAPSEML_VERSION="1.1.3"
-```
+| Spark runtime | Scala | SynapseML deep-learning coordinate |
+| --- | --- | --- |
+| Spark 3.5.x | 2.12 | `com.microsoft.azure:synapseml-deep-learning_2.12:1.1.3` |
+| Spark 4.0.1+ (`<4.1`) | 2.13 | `com.microsoft.azure:synapseml-deep-learning_2.13:1.1.3-spark4.0` |
+| Spark 4.1.x | 2.13 | `com.microsoft.azure:synapseml-deep-learning_2.13:1.1.3-spark4.1` |
 
-Then select the module version and complete coordinate from the Spark runtime:
-
-| Spark runtime | Scala binary version | `<synapseml-deep-learning-version>` | `<synapseml-deep-learning-coordinate>` |
-| --- | --- | --- | --- |
-| Spark 3.5.x | 2.12 | `${SYNAPSEML_VERSION}` | `com.microsoft.azure:synapseml-deep-learning_2.12:${SYNAPSEML_VERSION}` |
-| Spark 4.0.x | 2.13 | `${SYNAPSEML_VERSION}-spark4.0` | `com.microsoft.azure:synapseml-deep-learning_2.13:${SYNAPSEML_VERSION}-spark4.0` |
-| Spark 4.1.x | 2.13 | `${SYNAPSEML_VERSION}-spark4.1` | `com.microsoft.azure:synapseml-deep-learning_2.13:${SYNAPSEML_VERSION}-spark4.1` |
-
-Replace the variable with its assigned value in UIs that do not expand shell
-variables, and resolve these modules from
-`https://mmlspark.blob.core.windows.net/maven`. If you intentionally install the
-aggregate `synapseml` artifact instead, use its coordinate from the
+Resolve these modules from
+`https://mmlspark.blob.core.windows.net/maven`. The complete examples below use
+Spark 4.1. For Spark 4.0 or 3.5, replace the SynapseML dependency with the exact
+coordinate from the table. If you intentionally install the aggregate
+`synapseml` artifact instead, use its coordinate from the
 [installation matrix](../../Get%20Started/Install%20SynapseML.md) and attach the
 exclusion to that aggregate dependency. Do not install both the aggregate and
 module artifacts.
@@ -65,10 +60,12 @@ module artifacts.
 - **sbt** (per-dependency exclusion, attached to the SynapseML dependency):
 
   ```scala
+  resolvers += "SynapseML" at "https://mmlspark.blob.core.windows.net/maven"
+
   libraryDependencies ++= Seq(
-    ("com.microsoft.azure" %% "synapseml-deep-learning" % "<synapseml-deep-learning-version>")
+    ("com.microsoft.azure" % "synapseml-deep-learning_2.13" % "1.1.3-spark4.1")
       .exclude("com.microsoft.onnxruntime", "onnxruntime"),
-    "com.microsoft.onnxruntime" % "onnxruntime_gpu" % "<onnxruntime-version>"
+    "com.microsoft.onnxruntime" % "onnxruntime_gpu" % "1.17.3"
   )
   ```
 
@@ -80,10 +77,17 @@ module artifacts.
   unexcluded dependency:
 
   ```xml
+  <repositories>
+    <repository>
+      <id>SynapseML</id>
+      <url>https://mmlspark.blob.core.windows.net/maven</url>
+    </repository>
+  </repositories>
+
   <dependency>
     <groupId>com.microsoft.azure</groupId>
-    <artifactId>synapseml-deep-learning_SCALA_BINARY_VERSION</artifactId>
-    <version>SYNAPSEML_DEEP_LEARNING_VERSION</version>
+    <artifactId>synapseml-deep-learning_2.13</artifactId>
+    <version>1.1.3-spark4.1</version>
     <exclusions>
       <exclusion>
         <groupId>com.microsoft.onnxruntime</groupId>
@@ -103,11 +107,9 @@ module artifacts.
   flag (format `groupId:artifactId`, no version):
 
   ```bash
-  # Spark 4.1 example. First set SYNAPSEML_VERSION as shown above.
-  SYNAPSEML_DEEP_LEARNING_COORDINATE="com.microsoft.azure:synapseml-deep-learning_2.13:${SYNAPSEML_VERSION}-spark4.1"
-
   spark-submit \
-    --packages "${SYNAPSEML_DEEP_LEARNING_COORDINATE},com.microsoft.onnxruntime:onnxruntime_gpu:1.17.3" \
+    --repositories "https://mmlspark.blob.core.windows.net/maven" \
+    --packages "com.microsoft.azure:synapseml-deep-learning_2.13:1.1.3-spark4.1,com.microsoft.onnxruntime:onnxruntime_gpu:1.17.3" \
     --exclude-packages com.microsoft.onnxruntime:onnxruntime \
     your_script.py
   ```
@@ -116,7 +118,8 @@ module artifacts.
   flags) are `spark.jars.packages` and `spark.jars.excludes`:
 
   ```
-  spark.jars.packages=<synapseml-deep-learning-coordinate>,com.microsoft.onnxruntime:onnxruntime_gpu:1.17.3
+  spark.jars.repositories=https://mmlspark.blob.core.windows.net/maven
+  spark.jars.packages=com.microsoft.azure:synapseml-deep-learning_2.13:1.1.3-spark4.1,com.microsoft.onnxruntime:onnxruntime_gpu:1.17.3
   spark.jars.excludes=com.microsoft.onnxruntime:onnxruntime
   ```
 
@@ -128,7 +131,8 @@ module artifacts.
   [
     {
       "maven": {
-        "coordinates": "<synapseml-deep-learning-coordinate>",
+        "coordinates": "com.microsoft.azure:synapseml-deep-learning_2.13:1.1.3-spark4.1",
+        "repo": "https://mmlspark.blob.core.windows.net/maven",
         "exclusions": ["com.microsoft.onnxruntime:onnxruntime"]
       }
     },

--- a/docs/Get Started/Install SynapseML.md
+++ b/docs/Get Started/Install SynapseML.md
@@ -2,9 +2,48 @@
 title: Install SynapseML
 description: Install SynapseML
 ---
+## Choose the artifact that matches your Spark runtime
+
+SynapseML installation has two parts:
+
+1. language wrappers such as the `synapseml` Python package; and
+2. JVM artifacts loaded by Spark.
+
+Installing the Python package does **not** add the JVM artifacts. A Python
+wrapper can import successfully while its JVM class is missing. In particular,
+using a `_2.12` artifact with Spark 4 can cause errors such as
+`LightGBMClassifier does not exist in the JVM`.
+
+The examples on this page use the current base release:
+
+```bash
+SYNAPSEML_VERSION="1.1.3"
+```
+
+Choose the coordinate from the Spark runtime, not from the Python version:
+
+| Spark runtime | Scala binary version | Port Python baseline | Release tag | Maven coordinate |
+| --- | --- | --- | --- | --- |
+| Spark 3.5.x | 2.12 | Python 3.11 | `v${SYNAPSEML_VERSION}` | `com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}` |
+| Spark 4.0.x | 2.13 | Python 3.12 | `v${SYNAPSEML_VERSION}-spark4.0` | `com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.0` |
+| Spark 4.1.x | 2.13 | Python 3.13 | `v${SYNAPSEML_VERSION}-spark4.1` | `com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1` |
+
+In a UI that does not expand shell variables, replace
+`${SYNAPSEML_VERSION}` with the value assigned above.
+The Spark 4 rows are separately published ports. The same
+`synapseml==${SYNAPSEML_VERSION}` Python wheel is used with either port; the
+Spark runtime determines which JVM coordinate to load. Always add the
+SynapseML repository because the Spark 4 artifacts are published there:
+
+```text
+https://mmlspark.blob.core.windows.net/maven
+```
+
 ## Microsoft Fabric
 
-SynapseML is already installed in Microsoft Fabric notebooks. To change the version please place the following in the first cell of your notebook: 
+SynapseML is already installed in Microsoft Fabric notebooks. To override it,
+first check the notebook runtime's Spark and Scala versions, then substitute the
+matching full coordinate and Scala binary version from the matrix above:
 
 
 ```bash
@@ -12,9 +51,9 @@ SynapseML is already installed in Microsoft Fabric notebooks. To change the vers
 {
   "name": "synapseml",
   "conf": {
-      "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:<THE_SYNAPSEML_VERSION_YOU_WANT>",
+      "spark.jars.packages": "<COORDINATE_FROM_THE_MATRIX_ABOVE>",
       "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
-      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
+      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_<SCALA_BINARY_VERSION>,org.scalactic:scalactic_<SCALA_BINARY_VERSION>,org.scalatest:scalatest_<SCALA_BINARY_VERSION>,com.fasterxml.jackson.core:jackson-databind",
       "spark.yarn.user.classpath.first": "true",
       "spark.sql.parquet.enableVectorizedReader": "false"
   }
@@ -74,39 +113,77 @@ For Spark3.3 pools:
 ## Python
 
 To try out SynapseML on a Python (or Conda) installation, you can get Spark
-installed via pip with `pip install pyspark`.
+installed via pip. Install the Python wrapper and start Spark with the matching
+JVM artifact. This copy-paste example is for Spark 4.1 and Python 3.13. For
+Spark 4.0, install `pyspark>=4.0,<4.1` instead and set `SPARK_LINE="4.0"`:
+
+```bash
+SYNAPSEML_VERSION=1.1.3
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.1,<4.2"
+```
 
 ```python
-import pyspark
-spark = pyspark.sql.SparkSession.builder.appName("MyApp") \
-            # Use 1.1.3 version for spark 3.5 and 1.0.15 version for Spark3.4
-            .config("spark.jars.packages", "com.microsoft.azure:synapseml_2.12:1.1.3") \
-            .config("spark.jars.repositories", "https://mmlspark.blob.core.windows.net/maven") \
-            .getOrCreate()
+from pyspark.sql import SparkSession
+
+SYNAPSEML_VERSION="1.1.3"
+SPARK_LINE="4.1"
+SYNAPSEML_COORDINATE=(
+    f"com.microsoft.azure:synapseml_2.13:"
+    f"{SYNAPSEML_VERSION}-spark{SPARK_LINE}"
+)
+
+spark = (
+    SparkSession.builder.appName("MyApp")
+    .config("spark.jars.packages", SYNAPSEML_COORDINATE)
+    .config(
+        "spark.jars.repositories",
+        "https://mmlspark.blob.core.windows.net/maven",
+    )
+    .getOrCreate()
+)
 import synapse.ml
 ```
+
+For Spark 3.5, use
+`SYNAPSEML_COORDINATE=f"com.microsoft.azure:synapseml_2.12:{SYNAPSEML_VERSION}"`.
 
 ## SBT
 
 If you're building a Spark application in Scala, add the following lines to
-your `build.sbt`:
+your `build.sbt`. For Spark 4.1 (use `SPARK_LINE="4.0"` for Spark 4.0):
 
 ```scala
+val SYNAPSEML_VERSION="1.1.3"
+val SPARK_LINE="4.1"
 resolvers += "SynapseML" at "https://mmlspark.blob.core.windows.net/maven"
-// Use 1.1.3 version for spark 3.5 and 1.0.15 version for Spark3.4
-libraryDependencies += "com.microsoft.azure" % "synapseml_2.12" % "1.1.3"
+libraryDependencies +=
+  "com.microsoft.azure" % "synapseml_2.13" %
+    s"$SYNAPSEML_VERSION-spark$SPARK_LINE"
 ```
+
+For Spark 3.5, use
+`"com.microsoft.azure" % "synapseml_2.12" % SYNAPSEML_VERSION`.
 
 ## Spark package
 
 SynapseML can be conveniently installed on existing Spark clusters via the
-`--packages` option, examples:
+`--packages` option. Include `--repositories` for the Spark 4 ports:
 
 ```bash
-# Use 1.1.3 version for spark 3.5 and 1.0.15 version for Spark3.4
-spark-shell --packages com.microsoft.azure:synapseml_2.12:1.1.3
-pyspark --packages com.microsoft.azure:synapseml_2.12:1.1.3
-spark-submit --packages com.microsoft.azure:synapseml_2.12:1.1.3 MyApp.jar
+SYNAPSEML_VERSION=1.1.3
+SYNAPSEML_REPOSITORY=https://mmlspark.blob.core.windows.net/maven
+
+# Spark 4.0
+pyspark --repositories "$SYNAPSEML_REPOSITORY" \
+  --packages "com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.0"
+
+# Spark 4.1
+pyspark --repositories "$SYNAPSEML_REPOSITORY" \
+  --packages "com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1"
+
+# Spark 3.5
+pyspark --repositories "$SYNAPSEML_REPOSITORY" \
+  --packages "com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}"
 ```
 
 A similar technique can be used in other Spark contexts too. For example, you can use SynapseML
@@ -121,12 +198,13 @@ cloud](http://community.cloud.databricks.com), create a new [library from Maven
 coordinates](https://docs.databricks.com/user-guide/libraries.html#libraries-from-maven-pypi-or-spark-packages)
 in your workspace.
 
-For the coordinates use: `com.microsoft.azure:synapseml_2.12:1.1.3` for Spark3.4 Cluster and
- `com.microsoft.azure:synapseml_2.12:0.11.4-spark3.3` for Spark3.3 Cluster;
-Add the resolver: `https://mmlspark.blob.core.windows.net/maven`. Ensure this library is
-attached to your target cluster(s).
-
-Finally, ensure that your Spark cluster has at least Spark 3.2 and Scala 2.12.
+Use the coordinate matching the cluster's Spark and Scala versions from the
+matrix above. For example, a Spark 4.1 / Scala 2.13 cluster uses
+`com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1`, while a
+Spark 3.5 / Scala 2.12 cluster uses
+`com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}`. Add the resolver
+`https://mmlspark.blob.core.windows.net/maven`, attach the library to the target
+cluster, and restart it before importing `synapse.ml`.
 
 You can use SynapseML in both your Scala and PySpark notebooks. To get started with our example notebooks, import the following databricks archive:
 
@@ -134,7 +212,9 @@ You can use SynapseML in both your Scala and PySpark notebooks. To get started w
 
 ## Apache Livy and HDInsight
 
-To install SynapseML from within a Jupyter notebook served by Apache Livy, the following configure magic can be used. You'll need to start a new session after this configure cell is executed.
+To install SynapseML from within a Jupyter notebook served by Apache Livy, the
+following Spark 3.5 / Scala 2.12 configure magic can be used. You'll need to
+start a new session after this configure cell is executed.
 
 Excluding certain packages from the library may be necessary due to current issues with Livy 0.5
 
@@ -143,22 +223,23 @@ Excluding certain packages from the library may be necessary due to current issu
 {
     "name": "synapseml",
     "conf": {
-        # Use 1.1.3 version for spark 3.5 and 1.0.15 version for Spark3.4
         "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:1.1.3",
+        "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
         "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind"
     }
 }
 ```
 
-In Azure Synapse, "spark.yarn.user.classpath.first" should be set to "true" to override the existing SynapseML packages
+In Azure Synapse, `spark.yarn.user.classpath.first` should be set to `true` to
+override the existing SynapseML packages:
 
 ```
 %%configure -f
 {
     "name": "synapseml",
     "conf": {
-        # Use 1.1.3 version for spark 3.5 and 1.0.15 version for Spark3.4
         "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:1.1.3",
+        "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
         "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
         "spark.yarn.user.classpath.first": "true"
     }
@@ -198,4 +279,3 @@ If you encounter issues, reach out to our support email!
 To try out SynapseML using the R autogenerated wrappers, [see our
 instructions](../../Reference/R%20Setup).  Note: This feature is still under development
 and some necessary custom wrappers may be missing.
-

--- a/docs/Get Started/Install SynapseML.md
+++ b/docs/Get Started/Install SynapseML.md
@@ -14,39 +14,46 @@ wrapper can import successfully while its JVM class is missing. In particular,
 using a `_2.12` artifact with Spark 4 can cause errors such as
 `LightGBMClassifier does not exist in the JVM`.
 
-The examples on this page use the current base release:
+Choose one complete published build from the Spark runtime. `master` is the
+canonical Spark 3.5 development line; Spark 4.0 and Spark 4.1 are maintained on
+their corresponding branches.
 
-```bash
-SYNAPSEML_VERSION="1.1.3"
-```
+| Code line | Spark runtime | Scala | Python baseline | Release tag | Python package | Maven coordinate |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`master`](https://github.com/microsoft/SynapseML/tree/master) | Spark 3.5.x | 2.12 | Python 3.11 | [`v1.1.3`](https://github.com/microsoft/SynapseML/tree/v1.1.3) | `synapseml==1.1.3` | `com.microsoft.azure:synapseml_2.12:1.1.3` |
+| [`spark4.0`](https://github.com/microsoft/SynapseML/tree/spark4.0) | Spark 4.0.1+ (`<4.1`) | 2.13 | Python 3.12 | [`v1.1.3-spark4.0`](https://github.com/microsoft/SynapseML/tree/v1.1.3-spark4.0) | `synapseml==1.1.3` | `com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0` |
+| [`spark4.1`](https://github.com/microsoft/SynapseML/tree/spark4.1) | Spark 4.1.x | 2.13 | Python 3.13 | [`v1.1.3-spark4.1`](https://github.com/microsoft/SynapseML/tree/v1.1.3-spark4.1) | `synapseml==1.1.3` | `com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1` |
 
-Choose the coordinate from the Spark runtime, not from the Python version:
-
-| Spark runtime | Scala binary version | Port Python baseline | Release tag | Maven coordinate |
-| --- | --- | --- | --- | --- |
-| Spark 3.5.x | 2.12 | Python 3.11 | `v${SYNAPSEML_VERSION}` | `com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}` |
-| Spark 4.0.x | 2.13 | Python 3.12 | `v${SYNAPSEML_VERSION}-spark4.0` | `com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.0` |
-| Spark 4.1.x | 2.13 | Python 3.13 | `v${SYNAPSEML_VERSION}-spark4.1` | `com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1` |
-
-In a UI that does not expand shell variables, replace
-`${SYNAPSEML_VERSION}` with the value assigned above.
-The Spark 4 rows correspond to the explicit published tags shown; documentation
-tests lock their artifact versions so a base-version bump cannot silently
-advertise an unpublished port. The same `synapseml==${SYNAPSEML_VERSION}`
-Python wheel is
-used with either port; the Spark runtime determines which JVM coordinate to
-load. Always add the SynapseML repository because the Spark 4 artifacts are
-published there:
+Always add the SynapseML repository:
 
 ```text
 https://mmlspark.blob.core.windows.net/maven
 ```
 
+## Latest master snapshot
+
+The latest successful `master` build targets Spark 3.5 and Scala 2.12. This
+copy-ready command reads the current snapshot version published by CI and starts
+Spark with that exact JVM build:
+
+```bash
+MASTER_VERSION="$(
+  curl -fsSL https://mmlspark.blob.core.windows.net/icons/badges/master_version3.svg |
+    sed -n 's/.*aria-label="master version: \([^"]*\)".*/\1/p'
+)"
+test -n "$MASTER_VERSION"
+spark-shell \
+  --repositories "https://mmlspark.blob.core.windows.net/maven" \
+  --packages "com.microsoft.azure:synapseml_2.12:${MASTER_VERSION}"
+```
+
+The PyPI package contains released Python wrappers. If you need Python APIs
+that are new on `master`, [build the matching wheel from source](../Reference/Developer%20Setup.md).
+
 ## Microsoft Fabric
 
-SynapseML is already installed in Microsoft Fabric notebooks. To override it,
-first check the notebook runtime's Spark and Scala versions, then substitute the
-matching full coordinate and Scala binary version from the matrix above:
+SynapseML is already installed in Microsoft Fabric notebooks. The following
+copy-ready override targets a Spark 4.1 / Scala 2.13 runtime:
 
 
 ```bash
@@ -54,9 +61,9 @@ matching full coordinate and Scala binary version from the matrix above:
 {
   "name": "synapseml",
   "conf": {
-      "spark.jars.packages": "<COORDINATE_FROM_THE_MATRIX_ABOVE>",
+      "spark.jars.packages": "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1",
       "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
-      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_<SCALA_BINARY_VERSION>,org.scalactic:scalactic_<SCALA_BINARY_VERSION>,org.scalatest:scalatest_<SCALA_BINARY_VERSION>,com.fasterxml.jackson.core:jackson-databind",
+      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.13,org.scalactic:scalactic_2.13,org.scalatest:scalatest_2.13,com.fasterxml.jackson.core:jackson-databind",
       "spark.yarn.user.classpath.first": "true",
       "spark.sql.parquet.enableVectorizedReader": "false"
   }
@@ -66,9 +73,8 @@ matching full coordinate and Scala binary version from the matrix above:
 
 ## Synapse
 
-SynapseML is already installed in Synapse Analytics notebooks. To change the version please place the following in the first cell of your notebook:
-
-For Spark3.5 pools
+Current Synapse Analytics pools use Spark 3.5. To override the preinstalled
+version, place the following in the first cell of your notebook:
 ```python
 %%configure -f
 {
@@ -83,82 +89,43 @@ For Spark3.5 pools
 }
 ```
 
-For Spark3.4 pools
-```python
-%%configure -f
-{
-  "name": "synapseml",
-  "conf": {
-      "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:1.0.15",
-      "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
-      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
-      "spark.yarn.user.classpath.first": "true",
-      "spark.sql.parquet.enableVectorizedReader": "false"
-  }
-}
-```
-
-For Spark3.3 pools:
-```python
-%%configure -f
-{
-  "name": "synapseml",
-  "conf": {
-      "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:0.11.4-spark3.3",
-      "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
-      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
-      "spark.yarn.user.classpath.first": "true",
-      "spark.sql.parquet.enableVectorizedReader": "false"
-  }
-}
-```
-
 ## Python
 
 To try out SynapseML on a Python (or Conda) installation, you can get Spark
-installed via pip. Using the `SYNAPSEML_VERSION` assigned above, choose exactly
-one complete runtime variant below, then start Spark with that variant's JVM
-artifact.
+installed via pip. Choose exactly one complete runtime variant below, then
+start Spark with that variant's JVM artifact.
 
 **Spark 4.1 / Python 3.13**
 
 ```bash
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.1,<4.2"
+python -m pip install "synapseml==1.1.3" "pyspark>=4.1,<4.2"
 ```
 
 **Spark 4.0 / Python 3.12**
 
 ```bash
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.0.1,<4.1"
+python -m pip install "synapseml==1.1.3" "pyspark>=4.0.1,<4.1"
 ```
 
 **Spark 3.5 / Python 3.11**
 
 ```bash
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=3.5,<3.6"
+python -m pip install "synapseml==1.1.3" "pyspark>=3.5,<3.6"
 ```
 
 ```python
 from pyspark.sql import SparkSession
 
-SYNAPSEML_VERSION="1.1.3"
-
-# Select the coordinate matching the PySpark command used above.
-SYNAPSEML_COORDINATE=(
-    f"com.microsoft.azure:synapseml_2.13:{SYNAPSEML_VERSION}-spark4.1"
-)
+# Spark 4.1. Select the coordinate matching the PySpark command used above.
+synapseml_coordinate = "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1"
 # Spark 4.0:
-# SYNAPSEML_COORDINATE=(
-#     f"com.microsoft.azure:synapseml_2.13:{SYNAPSEML_VERSION}-spark4.0"
-# )
+# synapseml_coordinate = "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0"
 # Spark 3.5:
-# SYNAPSEML_COORDINATE=(
-#     f"com.microsoft.azure:synapseml_2.12:{SYNAPSEML_VERSION}"
-# )
+# synapseml_coordinate = "com.microsoft.azure:synapseml_2.12:1.1.3"
 
 spark = (
     SparkSession.builder.appName("MyApp")
-    .config("spark.jars.packages", SYNAPSEML_COORDINATE)
+    .config("spark.jars.packages", synapseml_coordinate)
     .config(
         "spark.jars.repositories",
         "https://mmlspark.blob.core.windows.net/maven",
@@ -171,40 +138,53 @@ import synapse.ml
 ## SBT
 
 If you're building a Spark application in Scala, add the following lines to
-your `build.sbt`. For Spark 4.1 (use `SPARK_LINE="4.0"` for Spark 4.0):
+your `build.sbt`. Choose the dependency matching your Spark runtime.
+
+**Spark 4.1**
 
 ```scala
-val SYNAPSEML_VERSION="1.1.3"
-val SPARK_LINE="4.1"
 resolvers += "SynapseML" at "https://mmlspark.blob.core.windows.net/maven"
 libraryDependencies +=
-  "com.microsoft.azure" % "synapseml_2.13" %
-    s"$SYNAPSEML_VERSION-spark$SPARK_LINE"
+  "com.microsoft.azure" % "synapseml_2.13" % "1.1.3-spark4.1"
 ```
 
-For Spark 3.5, use
-`"com.microsoft.azure" % "synapseml_2.12" % SYNAPSEML_VERSION`.
+**Spark 4.0**
+
+```scala
+resolvers += "SynapseML" at "https://mmlspark.blob.core.windows.net/maven"
+libraryDependencies +=
+  "com.microsoft.azure" % "synapseml_2.13" % "1.1.3-spark4.0"
+```
+
+**Spark 3.5**
+
+```scala
+resolvers += "SynapseML" at "https://mmlspark.blob.core.windows.net/maven"
+libraryDependencies +=
+  "com.microsoft.azure" % "synapseml_2.12" % "1.1.3"
+```
 
 ## Spark package
 
 SynapseML can be conveniently installed on existing Spark clusters via the
-`--packages` option. Include `--repositories` for the Spark 4 ports:
+`--packages` option. Each example below is independently copyable.
 
 ```bash
-SYNAPSEML_VERSION=1.1.3
-SYNAPSEML_REPOSITORY=https://mmlspark.blob.core.windows.net/maven
-
-# Spark 4.0
-pyspark --repositories "$SYNAPSEML_REPOSITORY" \
-  --packages "com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.0"
-
 # Spark 4.1
-pyspark --repositories "$SYNAPSEML_REPOSITORY" \
-  --packages "com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1"
+pyspark --repositories "https://mmlspark.blob.core.windows.net/maven" \
+  --packages "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1"
+```
 
+```bash
+# Spark 4.0
+pyspark --repositories "https://mmlspark.blob.core.windows.net/maven" \
+  --packages "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0"
+```
+
+```bash
 # Spark 3.5
-pyspark --repositories "$SYNAPSEML_REPOSITORY" \
-  --packages "com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}"
+pyspark --repositories "https://mmlspark.blob.core.windows.net/maven" \
+  --packages "com.microsoft.azure:synapseml_2.12:1.1.3"
 ```
 
 A similar technique can be used in other Spark contexts too. For example, you can use SynapseML
@@ -219,13 +199,17 @@ cloud](http://community.cloud.databricks.com), create a new [library from Maven
 coordinates](https://docs.databricks.com/user-guide/libraries.html#libraries-from-maven-pypi-or-spark-packages)
 in your workspace.
 
-Use the coordinate matching the cluster's Spark and Scala versions from the
-matrix above. For example, a Spark 4.1 / Scala 2.13 cluster uses
-`com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1`, while a
-Spark 3.5 / Scala 2.12 cluster uses
-`com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}`. Add the resolver
-`https://mmlspark.blob.core.windows.net/maven`, attach the library to the target
-cluster, and restart it before importing `synapse.ml`.
+Use one of these exact Maven coordinates:
+
+- Spark 4.1 / Scala 2.13:
+  `com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1`
+- Spark 4.0 / Scala 2.13:
+  `com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0`
+- Spark 3.5 / Scala 2.12:
+  `com.microsoft.azure:synapseml_2.12:1.1.3`
+
+Add the resolver `https://mmlspark.blob.core.windows.net/maven`, attach the
+library to the target cluster, and restart it before importing `synapse.ml`.
 
 You can use SynapseML in both your Scala and PySpark notebooks. To get started with our example notebooks, import the following databricks archive:
 

--- a/docs/Get Started/Install SynapseML.md
+++ b/docs/Get Started/Install SynapseML.md
@@ -31,8 +31,9 @@ Choose the coordinate from the Spark runtime, not from the Python version:
 In a UI that does not expand shell variables, replace
 `${SYNAPSEML_VERSION}` with the value assigned above.
 The Spark 4 rows correspond to the explicit published tags shown; documentation
-tests lock those tags so a base-version bump cannot silently advertise an
-unpublished port. The same `synapseml==${SYNAPSEML_VERSION}` Python wheel is
+tests lock their artifact versions so a base-version bump cannot silently
+advertise an unpublished port. The same `synapseml==${SYNAPSEML_VERSION}`
+Python wheel is
 used with either port; the Spark runtime determines which JVM coordinate to
 load. Always add the SynapseML repository because the Spark 4 artifacts are
 published there:
@@ -115,25 +116,26 @@ For Spark3.3 pools:
 ## Python
 
 To try out SynapseML on a Python (or Conda) installation, you can get Spark
-installed via pip. Choose exactly one complete runtime variant below, then
-start Spark with that variant's JVM artifact.
+installed via pip. Using the `SYNAPSEML_VERSION` assigned above, choose exactly
+one complete runtime variant below, then start Spark with that variant's JVM
+artifact.
 
 **Spark 4.1 / Python 3.13**
 
 ```bash
-python -m pip install "synapseml==1.1.3" "pyspark>=4.1,<4.2"
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.1,<4.2"
 ```
 
 **Spark 4.0 / Python 3.12**
 
 ```bash
-python -m pip install "synapseml==1.1.3" "pyspark>=4.0,<4.1"
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.0,<4.1"
 ```
 
 **Spark 3.5 / Python 3.11**
 
 ```bash
-python -m pip install "synapseml==1.1.3" "pyspark>=3.5,<3.6"
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=3.5,<3.6"
 ```
 
 ```python

--- a/docs/Get Started/Install SynapseML.md
+++ b/docs/Get Started/Install SynapseML.md
@@ -30,10 +30,12 @@ Choose the coordinate from the Spark runtime, not from the Python version:
 
 In a UI that does not expand shell variables, replace
 `${SYNAPSEML_VERSION}` with the value assigned above.
-The Spark 4 rows are separately published ports. The same
-`synapseml==${SYNAPSEML_VERSION}` Python wheel is used with either port; the
-Spark runtime determines which JVM coordinate to load. Always add the
-SynapseML repository because the Spark 4 artifacts are published there:
+The Spark 4 rows correspond to the explicit published tags shown; documentation
+tests lock those tags so a base-version bump cannot silently advertise an
+unpublished port. The same `synapseml==${SYNAPSEML_VERSION}` Python wheel is
+used with either port; the Spark runtime determines which JVM coordinate to
+load. Always add the SynapseML repository because the Spark 4 artifacts are
+published there:
 
 ```text
 https://mmlspark.blob.core.windows.net/maven
@@ -113,24 +115,39 @@ For Spark3.3 pools:
 ## Python
 
 To try out SynapseML on a Python (or Conda) installation, you can get Spark
-installed via pip. Install the Python wrapper and start Spark with the matching
-JVM artifact. This copy-paste example is for Spark 4.1 and Python 3.13. For
-Spark 4.0, install `pyspark>=4.0,<4.1` instead and set `SPARK_LINE="4.0"`:
+installed via pip. Install the Python wrapper and PySpark version for one
+complete runtime variant, then start Spark with that variant's JVM artifact:
 
 ```bash
 SYNAPSEML_VERSION=1.1.3
+
+# Spark 4.1 / Python 3.13
 python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.1,<4.2"
+
+# Spark 4.0 / Python 3.12
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.0,<4.1"
+
+# Spark 3.5 / Python 3.11
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=3.5,<3.6"
 ```
 
 ```python
 from pyspark.sql import SparkSession
 
 SYNAPSEML_VERSION="1.1.3"
-SPARK_LINE="4.1"
+
+# Select the coordinate matching the PySpark command used above.
 SYNAPSEML_COORDINATE=(
-    f"com.microsoft.azure:synapseml_2.13:"
-    f"{SYNAPSEML_VERSION}-spark{SPARK_LINE}"
+    f"com.microsoft.azure:synapseml_2.13:{SYNAPSEML_VERSION}-spark4.1"
 )
+# Spark 4.0:
+# SYNAPSEML_COORDINATE=(
+#     f"com.microsoft.azure:synapseml_2.13:{SYNAPSEML_VERSION}-spark4.0"
+# )
+# Spark 3.5:
+# SYNAPSEML_COORDINATE=(
+#     f"com.microsoft.azure:synapseml_2.12:{SYNAPSEML_VERSION}"
+# )
 
 spark = (
     SparkSession.builder.appName("MyApp")
@@ -143,9 +160,6 @@ spark = (
 )
 import synapse.ml
 ```
-
-For Spark 3.5, use
-`SYNAPSEML_COORDINATE=f"com.microsoft.azure:synapseml_2.12:{SYNAPSEML_VERSION}"`.
 
 ## SBT
 

--- a/docs/Get Started/Install SynapseML.md
+++ b/docs/Get Started/Install SynapseML.md
@@ -129,7 +129,7 @@ python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.1,<4.2"
 **Spark 4.0 / Python 3.12**
 
 ```bash
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.0,<4.1"
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.0.1,<4.1"
 ```
 
 **Spark 3.5 / Python 3.11**

--- a/docs/Get Started/Install SynapseML.md
+++ b/docs/Get Started/Install SynapseML.md
@@ -115,20 +115,25 @@ For Spark3.3 pools:
 ## Python
 
 To try out SynapseML on a Python (or Conda) installation, you can get Spark
-installed via pip. Install the Python wrapper and PySpark version for one
-complete runtime variant, then start Spark with that variant's JVM artifact:
+installed via pip. Choose exactly one complete runtime variant below, then
+start Spark with that variant's JVM artifact.
+
+**Spark 4.1 / Python 3.13**
 
 ```bash
-SYNAPSEML_VERSION=1.1.3
+python -m pip install "synapseml==1.1.3" "pyspark>=4.1,<4.2"
+```
 
-# Spark 4.1 / Python 3.13
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.1,<4.2"
+**Spark 4.0 / Python 3.12**
 
-# Spark 4.0 / Python 3.12
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.0,<4.1"
+```bash
+python -m pip install "synapseml==1.1.3" "pyspark>=4.0,<4.1"
+```
 
-# Spark 3.5 / Python 3.11
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=3.5,<3.6"
+**Spark 3.5 / Python 3.11**
+
+```bash
+python -m pip install "synapseml==1.1.3" "pyspark>=3.5,<3.6"
 ```
 
 ```python

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -12,7 +12,10 @@ SynapseML (previously known as MMLSpark), is an open-source library that simplif
 
 With SynapseML, you can build scalable and intelligent systems to solve challenges in domains such as anomaly detection, computer vision, deep learning, text analytics, and others. SynapseML can train and evaluate models on single-node, multi-node, and elastically resizable clusters of computers. This lets you scale your work without wasting resources. SynapseML is usable across Python, R, Scala, Java, and .NET. Furthermore, its API abstracts over a wide variety of databases, file systems, and cloud data stores to simplify experiments no matter where data is located.
 
-SynapseML requires Scala 2.12, Spark 3.2+, and Python 3.8+.
+SynapseML publishes JVM artifacts for specific Spark and Scala combinations:
+Spark 3.5 uses Scala 2.12, while Spark 4.0 and 4.1 use Scala 2.13. Select the
+matching artifact in the
+[installation guide](Get%20Started/Install%20SynapseML.md).
 
 import Link from '@docusaurus/Link';
 

--- a/docs/Reference/R Setup.md
+++ b/docs/Reference/R Setup.md
@@ -19,7 +19,7 @@ release. If you are using sparklyr, you can use
 On Windows, download
 [WinUtils.exe](https://github.com/steveloughran/winutils/blob/master/hadoop-3.0.0/bin/winutils.exe)
 and copy it into the `bin` directory of your Spark installation, for example,
-`C:\Users\user\AppData\Local\Spark\spark-3.3.2-bin-hadoop3\bin`.
+`C:\Users\user\AppData\Local\Spark\spark-3.5.0-bin-hadoop3\bin`.
 
 The R bindings are published as one archive per SynapseML module. A combined
 `synapseml-1.1.3.zip` archive is not published. Install `synapseml-core` and
@@ -49,10 +49,11 @@ sparklyr connections, `sparklyr.shell.repositories` supplies the repository to
 `spark-submit`, while `extensions = character()` prevents the wrappers' embedded
 registration from overriding it:
 
-> The examples below use Spark 3.5 / Scala 2.12. Spark 4 uses Scala 2.13 and a
-> Spark-specific artifact version; substitute the coordinate from the
-> [installation matrix](../Get%20Started/Install%20SynapseML.md). The R component
-> archive version remains the base SynapseML version.
+> The examples below use Spark 3.5 / Scala 2.12 with
+> `com.microsoft.azure:synapseml_2.12:1.1.3`. For Spark 4.0 use
+> `com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0`; for Spark 4.1 use
+> `com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1`. The R component archive
+> version remains `1.1.3`.
 
 ```R
 library(sparklyr)

--- a/docs/Reference/R Setup.md
+++ b/docs/Reference/R Setup.md
@@ -49,6 +49,11 @@ sparklyr connections, `sparklyr.shell.repositories` supplies the repository to
 `spark-submit`, while `extensions = character()` prevents the wrappers' embedded
 registration from overriding it:
 
+> The examples below use Spark 3.5 / Scala 2.12. Spark 4 uses Scala 2.13 and a
+> Spark-specific artifact version; substitute the coordinate from the
+> [installation matrix](../Get%20Started/Install%20SynapseML.md). The R component
+> archive version remains the base SynapseML version.
+
 ```R
 library(sparklyr)
 library(dplyr)

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -24,11 +24,25 @@ from typing import List, Optional, Tuple
 # SELF-ANCHORED: pattern contains SynapseML-identifying text. Safe anywhere.
 SELF_ANCHORED = [
     "synapseml_2.12:{V}",
+    "synapseml_2.13:{V}-spark4.0",
+    "synapseml_2.13:{V}-spark4.1",
+    "synapseml-deep-learning_2.12:{V}",
+    "synapseml-deep-learning_2.13:{V}-spark4.0",
+    "synapseml-deep-learning_2.13:{V}-spark4.1",
     "synapseml=={V}",
     "synapseml-{V}.zip",
+    "synapseml-core-{V}.zip",
+    "synapseml-cognitive-{V}.zip",
+    "synapseml-deep-learning-{V}.zip",
+    "synapseml-lightgbm-{V}.zip",
+    "synapseml-opencv-{V}.zip",
+    "synapseml-vw-{V}.zip",
     "synapseml:{V}",
     "SynapseMLExamplesv{V}.dbc",
     "SynapseML/v{V}",
+    "SynapseML/tree/v{V}",
+    "v{V}-spark4.0",
+    "v{V}-spark4.1",
     "SynapseML v{V}",
     "SynapseML {V}",
     "SYNAPSEML_VERSION={V}",
@@ -43,6 +57,8 @@ SELF_ANCHORED = [
 LINE_ANCHORED = [
     ("--version {V}", ["SynapseML"]),
     ('% "{V}"', ["synapseml"]),
+    ('% "{V}-spark4.0"', ["synapseml"]),
+    ('% "{V}-spark4.1"', ["synapseml"]),
     ("{V} version for", ["spark", "Spark"]),
     ("`{V}` tag", ["mmlspark"]),
 ]
@@ -51,6 +67,34 @@ LINE_ANCHORED = [
 FILE_ANCHORED = [
     ('version = "{V}"', ["website/docusaurus.config.js"]),
     ('version: "{V}"', ["website/docusaurus.config.js"]),
+    ('const version = "{V}";', ["website/src/installArtifacts.js"]),
+    (
+        "<version>{V}-spark4.1</version>",
+        [
+            "docs/Explore Algorithms/Deep Learning/ONNX.md",
+            "website/docs/Explore Algorithms/Deep Learning/ONNX.md",
+        ],
+    ),
+    (
+        'version = "{V}",',
+        [
+            "core/src/test/scala/com/microsoft/azure/synapse/ml/codegen/VerifyRCodegen.scala"
+        ],
+    ),
+    (
+        'pythonizedVersion = "{V}",',
+        [
+            "core/src/test/scala/com/microsoft/azure/synapse/ml/codegen/VerifyRCodegen.scala"
+        ],
+    ),
+    (
+        'rVersion = "{V}",',
+        [
+            "core/src/test/scala/com/microsoft/azure/synapse/ml/codegen/VerifyRCodegen.scala"
+        ],
+    ),
+    ("{V}-python3.12-", ["pipeline.yaml"]),
+    ("{V}-python3.13-", ["pipeline.yaml"]),
 ]
 
 # ── Denylists and allowlists ──────────────────────────────────────────────────

--- a/scripts/test_bump_version.py
+++ b/scripts/test_bump_version.py
@@ -166,6 +166,20 @@ class TestMustAnchor:
         r = _analyze(f'"com.microsoft.azure" % "synapseml_2.12" % "{V}"')
         assert r.matches and not r.unanchored
 
+    @pytest.mark.parametrize(
+        "coordinate",
+        [
+            f"com.microsoft.azure:synapseml_2.13:{V}-spark4.0",
+            f"com.microsoft.azure:synapseml_2.13:{V}-spark4.1",
+            f"com.microsoft.azure:synapseml-deep-learning_2.12:{V}",
+            f"com.microsoft.azure:synapseml-deep-learning_2.13:{V}-spark4.0",
+            f"com.microsoft.azure:synapseml-deep-learning_2.13:{V}-spark4.1",
+        ],
+    )
+    def test_runtime_specific_maven_coords(self, coordinate):
+        r = _analyze(coordinate)
+        assert r.matches and not r.unanchored
+
     def test_pip_install(self):
         r = _analyze(f"pip install synapseml=={V}")
         assert r.matches and not r.unanchored
@@ -203,8 +217,20 @@ class TestMustAnchor:
         r = _analyze(f"version-{V}-blue")
         assert r.matches and not r.unanchored
 
-    def test_r_package(self):
-        r = _analyze(f"synapseml-{V}.zip")
+    @pytest.mark.parametrize(
+        "archive",
+        [
+            f"synapseml-{V}.zip",
+            f"synapseml-core-{V}.zip",
+            f"synapseml-cognitive-{V}.zip",
+            f"synapseml-deep-learning-{V}.zip",
+            f"synapseml-lightgbm-{V}.zip",
+            f"synapseml-opencv-{V}.zip",
+            f"synapseml-vw-{V}.zip",
+        ],
+    )
+    def test_r_package(self, archive):
+        r = _analyze(archive)
         assert r.matches and not r.unanchored
 
     def test_prose_v_prefix(self):
@@ -223,6 +249,11 @@ class TestMustAnchor:
         r = _analyze(f'"com.microsoft.azure" % "synapseml_2.12" % "{V}"')
         assert r.matches and not r.unanchored
 
+    @pytest.mark.parametrize("port", ["spark4.0", "spark4.1"])
+    def test_sbt_spark_port_line_anchored(self, port):
+        r = _analyze(f'"com.microsoft.azure" % "synapseml_2.13" % "{V}-{port}"')
+        assert r.matches and not r.unanchored
+
     def test_comment_line_anchored(self):
         r = _analyze(f"# Use {V} version for spark 3.5")
         assert r.matches and not r.unanchored
@@ -233,6 +264,53 @@ class TestMustAnchor:
 
     def test_docusaurus_file_anchored_colon(self):
         r = _analyze(f'version: "{V}"', rel="website/docusaurus.config.js")
+        assert r.matches and not r.unanchored
+
+    def test_install_artifacts_file_anchored_version(self):
+        r = _analyze(
+            f'const version = "{V}";',
+            rel="website/src/installArtifacts.js",
+        )
+        assert r.matches and not r.unanchored
+
+    @pytest.mark.parametrize(
+        "rel",
+        [
+            "docs/Explore Algorithms/Deep Learning/ONNX.md",
+            "website/docs/Explore Algorithms/Deep Learning/ONNX.md",
+        ],
+    )
+    def test_onnx_maven_file_anchored_version(self, rel):
+        r = _analyze(
+            f"<version>{V}-spark4.1</version>",
+            rel=rel,
+        )
+        assert r.matches and not r.unanchored
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            f'version = "{V}",',
+            f'pythonizedVersion = "{V}",',
+            f'rVersion = "{V}",',
+        ],
+    )
+    def test_r_codegen_file_anchored_versions(self, line):
+        r = _analyze(
+            line,
+            rel=(
+                "core/src/test/scala/com/microsoft/azure/synapse/ml/"
+                "codegen/VerifyRCodegen.scala"
+            ),
+        )
+        assert r.matches and not r.unanchored
+
+    @pytest.mark.parametrize("python_version", ["3.12", "3.13"])
+    def test_pipeline_snapshot_file_anchored_version(self, python_version):
+        r = _analyze(
+            f"{V}-python{python_version}-102-bfba9c82-SNAPSHOT",
+            rel="pipeline.yaml",
+        )
         assert r.matches and not r.unanchored
 
     def test_synapseml_colon(self):

--- a/website/src/installArtifacts.js
+++ b/website/src/installArtifacts.js
@@ -1,36 +1,38 @@
-const pythonPackage = "synapseml==1.1.3";
-const pythonPackagePrefix = "synapseml==";
-if (
-  !pythonPackage.startsWith(pythonPackagePrefix) ||
-  pythonPackage.length === pythonPackagePrefix.length
-) {
-  throw new Error(`Invalid SynapseML Python package pin: ${pythonPackage}`);
-}
-const version = pythonPackage.slice(pythonPackagePrefix.length);
+const version = "1.1.3";
+const pythonPackage = `synapseml==${version}`;
 const repository = "https://mmlspark.blob.core.windows.net/maven";
 
 const installArtifacts = Object.freeze({
   version,
   repository,
   spark35: Object.freeze({
+    branch: "master",
     coordinate: `com.microsoft.azure:synapseml_2.12:${version}`,
     pythonBaseline: "3.11",
     pythonPackage,
     pysparkSpec: ">=3.5,<3.6",
+    releaseTag: `v${version}`,
+    sparkRuntime: "3.5.x",
     scalaBinaryVersion: "2.12",
   }),
   spark40: Object.freeze({
+    branch: "spark4.0",
     coordinate: `com.microsoft.azure:synapseml_2.13:${version}-spark4.0`,
     pythonBaseline: "3.12",
     pythonPackage,
     pysparkSpec: ">=4.0.1,<4.1",
+    releaseTag: `v${version}-spark4.0`,
+    sparkRuntime: "4.0.1+ (<4.1)",
     scalaBinaryVersion: "2.13",
   }),
   spark41: Object.freeze({
+    branch: "spark4.1",
     coordinate: `com.microsoft.azure:synapseml_2.13:${version}-spark4.1`,
     pythonBaseline: "3.13",
     pythonPackage,
     pysparkSpec: ">=4.1,<4.2",
+    releaseTag: `v${version}-spark4.1`,
+    sparkRuntime: "4.1.x",
     scalaBinaryVersion: "2.13",
   }),
 });

--- a/website/src/installArtifacts.js
+++ b/website/src/installArtifacts.js
@@ -1,0 +1,30 @@
+const pythonPackage = "synapseml==1.1.3";
+const version = pythonPackage.split("==")[1];
+const repository = "https://mmlspark.blob.core.windows.net/maven";
+
+const installArtifacts = Object.freeze({
+  repository,
+  spark35: Object.freeze({
+    coordinate: `com.microsoft.azure:synapseml_2.12:${version}`,
+    pythonBaseline: "3.11",
+    pythonPackage,
+    pysparkSpec: ">=3.5,<3.6",
+    scalaBinaryVersion: "2.12",
+  }),
+  spark40: Object.freeze({
+    coordinate: `com.microsoft.azure:synapseml_2.13:${version}-spark4.0`,
+    pythonBaseline: "3.12",
+    pythonPackage,
+    pysparkSpec: ">=4.0,<4.1",
+    scalaBinaryVersion: "2.13",
+  }),
+  spark41: Object.freeze({
+    coordinate: `com.microsoft.azure:synapseml_2.13:${version}-spark4.1`,
+    pythonBaseline: "3.13",
+    pythonPackage,
+    pysparkSpec: ">=4.1,<4.2",
+    scalaBinaryVersion: "2.13",
+  }),
+});
+
+module.exports = installArtifacts;

--- a/website/src/installArtifacts.js
+++ b/website/src/installArtifacts.js
@@ -10,6 +10,7 @@ const version = pythonPackage.slice(pythonPackagePrefix.length);
 const repository = "https://mmlspark.blob.core.windows.net/maven";
 
 const installArtifacts = Object.freeze({
+  version,
   repository,
   spark35: Object.freeze({
     coordinate: `com.microsoft.azure:synapseml_2.12:${version}`,

--- a/website/src/installArtifacts.js
+++ b/website/src/installArtifacts.js
@@ -1,5 +1,12 @@
 const pythonPackage = "synapseml==1.1.3";
-const version = pythonPackage.split("==")[1];
+const pythonPackagePrefix = "synapseml==";
+if (
+  !pythonPackage.startsWith(pythonPackagePrefix) ||
+  pythonPackage.length === pythonPackagePrefix.length
+) {
+  throw new Error(`Invalid SynapseML Python package pin: ${pythonPackage}`);
+}
+const version = pythonPackage.slice(pythonPackagePrefix.length);
 const repository = "https://mmlspark.blob.core.windows.net/maven";
 
 const installArtifacts = Object.freeze({

--- a/website/src/installArtifacts.js
+++ b/website/src/installArtifacts.js
@@ -23,7 +23,7 @@ const installArtifacts = Object.freeze({
     coordinate: `com.microsoft.azure:synapseml_2.13:${version}-spark4.0`,
     pythonBaseline: "3.12",
     pythonPackage,
-    pysparkSpec: ">=4.0,<4.1",
+    pysparkSpec: ">=4.0.1,<4.1",
     scalaBinaryVersion: "2.13",
   }),
   spark41: Object.freeze({

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -153,7 +153,7 @@ function Feature({ imageUrl, title, description }) {
         </div>
       )}
       <h3>{title}</h3>
-      <p>{description}</p>
+      <div>{description}</div>
     </div>
   );
 }
@@ -383,32 +383,34 @@ pyspark --repositories "${repository}" --packages "${spark35.coordinate}"`}
                     <a href="https://docs.databricks.com/user-guide/libraries.html#libraries-from-maven-pypi-or-spark-packages">
                       library from Maven coordinates
                     </a>{" "}
-                    in your workspace. in your workspace.
+                    in your workspace.
                   </p>
-                  <p>
+                  <div>
                     <p>Choose the coordinate matching the cluster runtime:</p>
-                    Spark 4.1 / Scala 2.13:
+                    <p>Spark 4.1 / Scala 2.13:</p>
                     <CodeSnippet
                       snippet={spark41.coordinate}
                       lang="bash"
                     ></CodeSnippet>
-                    Spark 4.0 / Scala 2.13:
+                    <p>Spark 4.0 / Scala 2.13:</p>
                     <CodeSnippet
                       snippet={spark40.coordinate}
                       lang="bash"
                     ></CodeSnippet>
-                    Spark 3.5 / Scala 2.12:
+                    <p>Spark 3.5 / Scala 2.12:</p>
                     <CodeSnippet
                       snippet={spark35.coordinate}
                       lang="bash"
                     ></CodeSnippet>
-                    with the resolver:
+                    <p>Use the following resolver:</p>
                     <CodeSnippet
                       snippet={repository}
                       lang="bash"
                     ></CodeSnippet>
-                    Ensure this library is attached to your target cluster(s).
-                  </p>
+                    <p>
+                      Ensure this library is attached to your target cluster(s).
+                    </p>
+                  </div>
                   <p>
                     Restart the cluster after attaching the library so the JVM
                     artifact is available before importing <code>synapse.ml</code>.

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -446,17 +446,23 @@ pyspark --repositories "${repository}" --packages "${spark35.coordinate}"`}
                   ></CodeSnippet>
                 </TabItem>
                 <TabItem value="Python">
-                  Install both the Python wrapper and the PySpark version
-                  matching the selected JVM artifact.
+                  <p>
+                    Choose exactly one Python/PySpark runtime variant matching
+                    the selected JVM artifact.
+                  </p>
+                  <p>Spark 4.1 / Python {spark41.pythonBaseline}:</p>
                   <CodeSnippet
-                    snippet={`# Spark 4.1 / Python ${spark41.pythonBaseline}
-python -m pip install "${spark41.pythonPackage}" "pyspark${spark41.pysparkSpec}"
-
-# Spark 4.0 / Python ${spark40.pythonBaseline}
-python -m pip install "${spark40.pythonPackage}" "pyspark${spark40.pysparkSpec}"
-
-# Spark 3.5 / Python ${spark35.pythonBaseline}
-python -m pip install "${spark35.pythonPackage}" "pyspark${spark35.pysparkSpec}"`}
+                    snippet={`python -m pip install "${spark41.pythonPackage}" "pyspark${spark41.pysparkSpec}"`}
+                    lang="bash"
+                  ></CodeSnippet>
+                  <p>Spark 4.0 / Python {spark40.pythonBaseline}:</p>
+                  <CodeSnippet
+                    snippet={`python -m pip install "${spark40.pythonPackage}" "pyspark${spark40.pysparkSpec}"`}
+                    lang="bash"
+                  ></CodeSnippet>
+                  <p>Spark 3.5 / Python {spark35.pythonBaseline}:</p>
+                  <CodeSnippet
+                    snippet={`python -m pip install "${spark35.pythonPackage}" "pyspark${spark35.pysparkSpec}"`}
                     lang="bash"
                   ></CodeSnippet>
                   <CodeSnippet
@@ -488,7 +494,7 @@ libraryDependencies +=
 // Spark 3.5:
 // libraryDependencies +=
 //   "com.microsoft.azure" % "synapseml_2.12" % "${spark35.coordinate.split(":")[2]}"`}
-                    lang="jsx"
+                    lang="scala"
                   ></CodeSnippet>
                 </TabItem>
               </Tabs>

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -303,7 +303,7 @@ function Home() {
 {
   "name": "synapseml",
   "conf": {
-      "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:1.1.3",
+      "spark.jars.packages": "${spark35.coordinate}",
       "spark.jars.repositories": "${repository}",
       "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
       "spark.yarn.user.classpath.first": "true",

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -12,7 +12,7 @@ import TabItem from "@theme/TabItem";
 import clsx from "clsx";
 import installArtifacts from "@site/src/installArtifacts";
 
-const { repository, spark35, spark40, spark41 } = installArtifacts;
+const { version, repository, spark35, spark40, spark41 } = installArtifacts;
 
 const snippets = [
   {
@@ -256,33 +256,51 @@ function Home() {
               <table>
                 <thead>
                   <tr>
+                    <th>Code line</th>
                     <th>Spark</th>
                     <th>Scala</th>
                     <th>Python baseline</th>
+                    <th>Release tag</th>
                     <th>Maven coordinate</th>
                   </tr>
                 </thead>
                 <tbody>
                   <tr>
-                    <td>3.5</td>
+                    <td><code>{spark35.branch}</code></td>
+                    <td>{spark35.sparkRuntime}</td>
                     <td>{spark35.scalaBinaryVersion}</td>
                     <td>{spark35.pythonBaseline}</td>
+                    <td><code>{spark35.releaseTag}</code></td>
                     <td><code>{spark35.coordinate}</code></td>
                   </tr>
                   <tr>
-                    <td>4.0</td>
+                    <td><code>{spark40.branch}</code></td>
+                    <td>{spark40.sparkRuntime}</td>
                     <td>{spark40.scalaBinaryVersion}</td>
                     <td>{spark40.pythonBaseline}</td>
+                    <td><code>{spark40.releaseTag}</code></td>
                     <td><code>{spark40.coordinate}</code></td>
                   </tr>
                   <tr>
-                    <td>4.1</td>
+                    <td><code>{spark41.branch}</code></td>
+                    <td>{spark41.sparkRuntime}</td>
                     <td>{spark41.scalaBinaryVersion}</td>
                     <td>{spark41.pythonBaseline}</td>
+                    <td><code>{spark41.releaseTag}</code></td>
                     <td><code>{spark41.coordinate}</code></td>
                   </tr>
                 </tbody>
               </table>
+              <p>
+                All released Python variants use{" "}
+                <code>synapseml=={version}</code>. To try the latest successful{" "}
+                <code>master</code> build instead of the release, use the
+                copy-ready snapshot command in the{" "}
+                <Link to={useBaseUrl("docs/next/Get%20Started/Install%20SynapseML#latest-master-snapshot")}>
+                  installation guide
+                </Link>
+                .
+              </p>
               <Tabs
                 defaultValue="Fabric"
                 values={[
@@ -296,29 +314,16 @@ function Home() {
                 ]}
               >
                 <TabItem value="Synapse">
-                  <p>SynapseML can be installed on Synapse adding the following to the first cell of a notebook:</p>
-                  For Spark3.5 pools:
+                  <p>
+                    Current Synapse pools use Spark 3.5. Add the following to
+                    the first cell of a notebook:
+                  </p>
                   <CodeSnippet
                     snippet={`%%configure -f
 {
   "name": "synapseml",
   "conf": {
       "spark.jars.packages": "${spark35.coordinate}",
-      "spark.jars.repositories": "${repository}",
-      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
-      "spark.yarn.user.classpath.first": "true",
-      "spark.sql.parquet.enableVectorizedReader": "false"
-  }
-}`}
-                    lang="bash"
-                  ></CodeSnippet>
-                  For Spark3.4 pools:
-                  <CodeSnippet
-                    snippet={`%%configure -f
-{
-  "name": "synapseml",
-  "conf": {
-      "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:1.0.15",
       "spark.jars.repositories": "${repository}",
       "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
       "spark.yarn.user.classpath.first": "true",

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -10,6 +10,9 @@ import SampleSnippet from "@site/src/theme/SampleSnippet";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import clsx from "clsx";
+import installArtifacts from "@site/src/installArtifacts";
+
+const { repository, spark35, spark40, spark41 } = installArtifacts;
 
 const snippets = [
   {
@@ -127,9 +130,9 @@ const features = [
     description: (
       <>
         <p>
-          SynapseML is Open Source and can be installed and used on any Spark 3
-          infrastructure including your local machine, Databricks, Synapse
-          Analytics, and others.
+          SynapseML is Open Source and can be installed on supported Spark 3.5
+          and Spark 4 infrastructure, including your local machine, Databricks,
+          Synapse Analytics, and others.
         </p>
       </>
     ),
@@ -244,10 +247,42 @@ function Home() {
             <div className={classnames(`${styles.pitch} col`)}>
               <h2>Installation</h2>
               <p>
-                Written in Scala, and support multiple languages.{" "}
+                SynapseML&apos;s Python package supplies language wrappers; Spark
+                must also load the JVM artifact matching its Scala binary
+                version.{" "}
                 <a href="https://github.com/microsoft/SynapseML">Open source</a>{" "}
                 and cloud native.
               </p>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Spark</th>
+                    <th>Scala</th>
+                    <th>Python baseline</th>
+                    <th>Maven coordinate</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>3.5</td>
+                    <td>{spark35.scalaBinaryVersion}</td>
+                    <td>{spark35.pythonBaseline}</td>
+                    <td><code>{spark35.coordinate}</code></td>
+                  </tr>
+                  <tr>
+                    <td>4.0</td>
+                    <td>{spark40.scalaBinaryVersion}</td>
+                    <td>{spark40.pythonBaseline}</td>
+                    <td><code>{spark40.coordinate}</code></td>
+                  </tr>
+                  <tr>
+                    <td>4.1</td>
+                    <td>{spark41.scalaBinaryVersion}</td>
+                    <td>{spark41.pythonBaseline}</td>
+                    <td><code>{spark41.coordinate}</code></td>
+                  </tr>
+                </tbody>
+              </table>
               <Tabs
                 defaultValue="Fabric"
                 values={[
@@ -269,7 +304,7 @@ function Home() {
   "name": "synapseml",
   "conf": {
       "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:1.1.3",
-      "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
+      "spark.jars.repositories": "${repository}",
       "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
       "spark.yarn.user.classpath.first": "true",
       "spark.sql.parquet.enableVectorizedReader": "false"
@@ -284,7 +319,7 @@ function Home() {
   "name": "synapseml",
   "conf": {
       "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:1.0.15",
-      "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
+      "spark.jars.repositories": "${repository}",
       "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
       "spark.yarn.user.classpath.first": "true",
       "spark.sql.parquet.enableVectorizedReader": "false"
@@ -294,15 +329,20 @@ function Home() {
                   ></CodeSnippet>
                 </TabItem>
                 <TabItem value="Fabric">
-                  <p>SynapseML is preinstalled on Fabric. To install a different version, add the following to the first cell of a notebook:</p>
+                  <p>
+                    SynapseML is preinstalled on Fabric. Before overriding it,
+                    check the runtime&apos;s Spark and Scala versions. This
+                    example selects the published Spark 4.1 / Scala 2.13
+                    artifact:
+                  </p>
                   <CodeSnippet
                     snippet={`%%configure -f
 {
   "name": "synapseml",
   "conf": {
-      "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:[THE_SYNAPSEML_VERSION_YOU_WANT]",
-      "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
-      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
+      "spark.jars.packages": "${spark41.coordinate}",
+      "spark.jars.repositories": "${repository}",
+      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.13,org.scalactic:scalactic_2.13,org.scalatest:scalatest_2.13,com.fasterxml.jackson.core:jackson-databind",
       "spark.yarn.user.classpath.first": "true",
       "spark.sql.parquet.enableVectorizedReader": "false"
   }
@@ -312,11 +352,16 @@ function Home() {
                 </TabItem>
                 <TabItem value="Spark Packages">
                   SynapseML can be conveniently installed on existing Spark
-                  clusters via the --packages option, examples:
+                  clusters via the --packages option:
                   <CodeSnippet
-                    snippet={`spark-shell --packages com.microsoft.azure:synapseml_2.12:1.1.3 # Please use 1.1.3 version for Spark3.5 and 1.0.15 version for Spark3.4
-pyspark --packages com.microsoft.azure:synapseml_2.12:1.1.3
-spark-submit --packages com.microsoft.azure:synapseml_2.12:1.1.3 MyApp.jar `}
+                    snippet={`# Spark 4.1
+pyspark --repositories "${repository}" --packages "${spark41.coordinate}"
+
+# Spark 4.0
+pyspark --repositories "${repository}" --packages "${spark40.coordinate}"
+
+# Spark 3.5
+pyspark --repositories "${repository}" --packages "${spark35.coordinate}"`}
                     lang="bash"
                   ></CodeSnippet>
                   This can be used in other Spark contexts too. For example, you
@@ -341,27 +386,32 @@ spark-submit --packages com.microsoft.azure:synapseml_2.12:1.1.3 MyApp.jar `}
                     in your workspace. in your workspace.
                   </p>
                   <p>
-                    <p>For the coordinates:</p>
-                    Spark 3.5 Cluster:
+                    <p>Choose the coordinate matching the cluster runtime:</p>
+                    Spark 4.1 / Scala 2.13:
                     <CodeSnippet
-                      snippet={`com.microsoft.azure:synapseml_2.12:1.1.3`}
+                      snippet={spark41.coordinate}
                       lang="bash"
                     ></CodeSnippet>
-                    Spark 3.4 Cluster:
+                    Spark 4.0 / Scala 2.13:
                     <CodeSnippet
-                      snippet={`com.microsoft.azure:synapseml_2.12:1.0.15`}
+                      snippet={spark40.coordinate}
+                      lang="bash"
+                    ></CodeSnippet>
+                    Spark 3.5 / Scala 2.12:
+                    <CodeSnippet
+                      snippet={spark35.coordinate}
                       lang="bash"
                     ></CodeSnippet>
                     with the resolver:
                     <CodeSnippet
-                      snippet={`https://mmlspark.blob.core.windows.net/maven`}
+                      snippet={repository}
                       lang="bash"
                     ></CodeSnippet>
                     Ensure this library is attached to your target cluster(s).
                   </p>
                   <p>
-                    Finally, ensure that your Spark cluster has at least Spark
-                    3.4 and Scala 2.12.
+                    Restart the cluster after attaching the library so the JVM
+                    artifact is available before importing <code>synapse.ml</code>.
                   </p>
                   You can use SynapseML in both your Scala and PySpark
                   notebooks. To get started with our example notebooks import
@@ -394,20 +444,31 @@ spark-submit --packages com.microsoft.azure:synapseml_2.12:1.1.3 MyApp.jar `}
                   ></CodeSnippet>
                 </TabItem>
                 <TabItem value="Python">
-                  To try out SynapseML on a Python (or Conda) installation you
-                  can get Spark installed via pip with
+                  Install both the Python wrapper and the PySpark version
+                  matching the selected JVM artifact.
                   <CodeSnippet
-                    snippet={`pip install pyspark`}
+                    snippet={`# Spark 4.1 / Python ${spark41.pythonBaseline}
+python -m pip install "${spark41.pythonPackage}" "pyspark${spark41.pysparkSpec}"
+
+# Spark 4.0 / Python ${spark40.pythonBaseline}
+python -m pip install "${spark40.pythonPackage}" "pyspark${spark40.pysparkSpec}"
+
+# Spark 3.5 / Python ${spark35.pythonBaseline}
+python -m pip install "${spark35.pythonPackage}" "pyspark${spark35.pysparkSpec}"`}
                     lang="bash"
                   ></CodeSnippet>
-                  You can then use pyspark as in the above example, or from
-                  python:
                   <CodeSnippet
-                    snippet={`import pyspark
-spark = (pyspark.sql.SparkSession.builder.appName("MyApp")
-        .config("spark.jars.packages", "com.microsoft.azure:synapseml_2.12:1.1.3") # Please use 1.1.3 version for Spark3.5 and 1.0.15 version for Spark3.4
-        .config("spark.jars.repositories", "https://mmlspark.blob.core.windows.net/maven")
-        .getOrCreate())
+                    snippet={`from pyspark.sql import SparkSession
+
+# Spark 4.1; use "${spark40.coordinate}" for Spark 4.0 or
+# "${spark35.coordinate}" for Spark 3.5.
+coordinate = "${spark41.coordinate}"
+spark = (
+    SparkSession.builder.appName("MyApp")
+    .config("spark.jars.packages", coordinate)
+    .config("spark.jars.repositories", "${repository}")
+    .getOrCreate()
+)
 import synapse.ml`}
                     lang="python"
                   ></CodeSnippet>
@@ -416,8 +477,15 @@ import synapse.ml`}
                   If you are building a Spark application in Scala, add the
                   following lines to your build.sbt:
                   <CodeSnippet
-                    snippet={`resolvers += "SynapseML" at "https://mmlspark.blob.core.windows.net/maven"
-libraryDependencies += "com.microsoft.azure" %% "synapseml_2.12" % "1.1.3" // Please use 1.1.3 version for Spark3.5 and 1.0.15 version for Spark3.4`}
+                    snippet={`resolvers += "SynapseML" at "${repository}"
+
+// Spark 4.1; use "${spark40.coordinate}" for Spark 4.0.
+libraryDependencies +=
+  "com.microsoft.azure" % "synapseml_2.13" % "${spark41.coordinate.split(":")[2]}"
+
+// Spark 3.5:
+// libraryDependencies +=
+//   "com.microsoft.azure" % "synapseml_2.12" % "${spark35.coordinate.split(":")[2]}"`}
                     lang="jsx"
                   ></CodeSnippet>
                 </TabItem>

--- a/website/test/installDocs.test.js
+++ b/website/test/installDocs.test.js
@@ -1,0 +1,129 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const config = fs.readFileSync(
+  path.join(repoRoot, 'website', 'docusaurus.config.js'),
+  'utf8',
+);
+const currentVersion = config.match(/let version = "([0-9.]+)"/)?.[1];
+const publishedVersions = JSON.parse(
+  fs.readFileSync(path.join(repoRoot, 'website', 'versions.json'), 'utf8'),
+);
+
+assert.ok(currentVersion, 'expected a current SynapseML documentation version');
+assert.equal(publishedVersions[0], currentVersion);
+
+const installGuides = [
+  path.join(repoRoot, 'README.md'),
+  path.join(repoRoot, 'docs', 'Get Started', 'Install SynapseML.md'),
+  path.join(
+    repoRoot,
+    'website',
+    'versioned_docs',
+    `version-${currentVersion}`,
+    'Get Started',
+    'Install SynapseML.md',
+  ),
+];
+
+for (const guide of installGuides) {
+  test(`Spark runtime matrix is complete in ${path.relative(repoRoot, guide)}`, () => {
+    const markdown = fs.readFileSync(guide, 'utf8');
+
+    assert.ok(
+      markdown.includes(`SYNAPSEML_VERSION="${currentVersion}"`),
+      'the release bump mechanism must own the documented base version',
+    );
+    assert.ok(
+      markdown.includes(
+        'com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}',
+      ),
+    );
+    assert.ok(
+      markdown.includes(
+        'com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.0',
+      ),
+    );
+    assert.ok(
+      markdown.includes(
+        'com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1',
+      ),
+    );
+    assert.ok(
+      markdown.includes(
+        '| Spark 4.0.x | 2.13 | Python 3.12 | ' +
+          '`v${SYNAPSEML_VERSION}-spark4.0` |',
+      ),
+    );
+    assert.ok(
+      markdown.includes(
+        '| Spark 4.1.x | 2.13 | Python 3.13 | ' +
+          '`v${SYNAPSEML_VERSION}-spark4.1` |',
+      ),
+    );
+    assert.match(markdown, /does \*\*not\*\* add the\s+JVM artifacts/);
+    assert.match(markdown, /LightGBMClassifier does not exist in the JVM/);
+    assert.match(markdown, /pyspark>=4\.1,<4\.2/);
+    assert.match(markdown, /--repositories "\$SYNAPSEML_REPOSITORY"/);
+    assert.match(
+      markdown,
+      /https:\/\/mmlspark\.blob\.core\.windows\.net\/maven/,
+    );
+    assert.doesNotMatch(markdown, /mmlspark\.azureedge\.net/);
+  });
+}
+
+test('specialized install guides defer to the runtime matrix', () => {
+  const overview = fs.readFileSync(
+    path.join(repoRoot, 'docs', 'Overview.md'),
+    'utf8',
+  );
+  const deepLearning = fs.readFileSync(
+    path.join(
+      repoRoot,
+      'docs',
+      'Explore Algorithms',
+      'Deep Learning',
+      'Getting Started.md',
+    ),
+    'utf8',
+  );
+  const onnx = fs.readFileSync(
+    path.join(
+      repoRoot,
+      'docs',
+      'Explore Algorithms',
+      'Deep Learning',
+      'ONNX.md',
+    ),
+    'utf8',
+  );
+  const rSetup = fs.readFileSync(
+    path.join(repoRoot, 'docs', 'Reference', 'R Setup.md'),
+    'utf8',
+  );
+  const isolationForest = fs.readFileSync(
+    path.join(
+      repoRoot,
+      'docs',
+      'Explore Algorithms',
+      'Anomaly Detection',
+      'Quickstart - Isolation Forests.ipynb',
+    ),
+    'utf8',
+  );
+
+  assert.doesNotMatch(overview, /requires Scala 2\.12/);
+  assert.match(overview, /Spark 4\.0 and 4\.1 use Scala 2\.13/);
+  assert.match(deepLearning, /Python wheel supplies wrappers/);
+  assert.match(deepLearning, /installation matrix/);
+  assert.match(onnx, /<synapseml-coordinate>/);
+  assert.doesNotMatch(onnx, /synapseml_2\.12:<version>/);
+  assert.match(rSetup, /examples below use Spark 3\.5 \/ Scala 2\.12/);
+  assert.match(rSetup, /installation matrix/);
+  assert.match(isolationForest, /COORDINATE_FROM_THE_INSTALL_MATRIX/);
+  assert.doesNotMatch(isolationForest, /THE_SYNAPSEML_VERSION_YOU_WANT/);
+});

--- a/website/test/installDocs.test.js
+++ b/website/test/installDocs.test.js
@@ -209,6 +209,19 @@ test('specialized install guides state their runtime scope', () => {
   );
   assert.match(onnx, /<synapseml-deep-learning-coordinate>/);
   assert.match(onnx, /<synapseml-deep-learning-version>/);
+  assert.match(
+    onnx,
+    /<artifactId>synapseml-deep-learning_SCALA_BINARY_VERSION<\/artifactId>/,
+  );
+  assert.match(
+    onnx,
+    /<version>SYNAPSEML_DEEP_LEARNING_VERSION<\/version>/,
+  );
+  assert.doesNotMatch(
+    onnx,
+    /<artifactId>synapseml-deep-learning_<[^>]+><\/artifactId>/,
+  );
+  assert.doesNotMatch(onnx, /<version><[^>]+><\/version>/);
   assert.doesNotMatch(onnx, /<synapseml-coordinate>/);
   assert.doesNotMatch(onnx, /<synapseml-artifact-version>/);
   assert.doesNotMatch(onnx, /--packages\s+<synapseml/);

--- a/website/test/installDocs.test.js
+++ b/website/test/installDocs.test.js
@@ -62,6 +62,10 @@ test('published Spark port versions are explicitly locked', () => {
   }
 });
 
+test('Spark 4.0 installation excludes the binary-incompatible 4.0.0 runtime', () => {
+  assert.equal(installArtifacts.spark40.pysparkSpec, '>=4.0.1,<4.1');
+});
+
 const installGuides = [
   path.join(repoRoot, 'README.md'),
   path.join(repoRoot, 'docs', 'Get Started', 'Install SynapseML.md'),

--- a/website/test/installDocs.test.js
+++ b/website/test/installDocs.test.js
@@ -1,9 +1,17 @@
 const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
 
 const repoRoot = path.resolve(__dirname, '..', '..');
+const installArtifacts = require('../src/installArtifacts');
+const publishedPorts = JSON.parse(
+  fs.readFileSync(
+    path.join(__dirname, 'published-spark-ports.lock'),
+    'utf8',
+  ),
+);
 const config = fs.readFileSync(
   path.join(repoRoot, 'website', 'docusaurus.config.js'),
   'utf8',
@@ -15,6 +23,70 @@ const publishedVersions = JSON.parse(
 
 assert.ok(currentVersion, 'expected a current SynapseML documentation version');
 assert.equal(publishedVersions[0], currentVersion);
+
+const portCases = [
+  {
+    key: 'spark4.0',
+    websiteKey: 'spark40',
+    sparkVersionPattern: /val sparkVersion = "4\.0\.[0-9]+"/,
+  },
+  {
+    key: 'spark4.1',
+    websiteKey: 'spark41',
+    sparkVersionPattern: /val sparkVersion = "4\.1\.[0-9]+"/,
+  },
+];
+
+function git(...args) {
+  return childProcess.execFileSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  }).trim();
+}
+
+function expandDocumentedVersion(markdown) {
+  return markdown.replaceAll('${SYNAPSEML_VERSION}', currentVersion);
+}
+
+test('published Spark port metadata matches tagged source', () => {
+  for (const portCase of portCases) {
+    const locked = publishedPorts[portCase.key];
+    const websiteArtifact = installArtifacts[portCase.websiteKey];
+
+    assert.ok(locked, `missing locked metadata for ${portCase.key}`);
+    assert.equal(git('tag', '--list', locked.releaseTag), locked.releaseTag);
+    assert.equal(
+      locked.artifactVersion,
+      locked.releaseTag.replace(/^v/, ''),
+    );
+    assert.ok(locked.coordinate.endsWith(`:${locked.artifactVersion}`));
+    assert.equal(websiteArtifact.coordinate, locked.coordinate);
+    assert.equal(websiteArtifact.pythonBaseline, locked.pythonBaseline);
+    assert.equal(websiteArtifact.pythonPackage, locked.pythonPackage);
+    assert.equal(websiteArtifact.pysparkSpec, locked.pysparkSpec);
+    assert.equal(
+      websiteArtifact.scalaBinaryVersion,
+      locked.scalaBinaryVersion,
+    );
+
+    const build = git('show', `${locked.releaseTag}:build.sbt`);
+    const environment = git('show', `${locked.releaseTag}:environment.yml`);
+    assert.match(build, portCase.sparkVersionPattern);
+    assert.match(
+      build,
+      new RegExp(
+        `ThisBuild / scalaVersion := "${locked.scalaBinaryVersion.replace(
+          '.',
+          '\\.',
+        )}\\.[0-9]+"`,
+      ),
+    );
+    assert.match(
+      environment,
+      new RegExp(`^  - python=${locked.pythonBaseline}(?:\\.[0-9]+)?$`, 'm'),
+    );
+  }
+});
 
 const installGuides = [
   path.join(repoRoot, 'README.md'),
@@ -32,51 +104,53 @@ const installGuides = [
 for (const guide of installGuides) {
   test(`Spark runtime matrix is complete in ${path.relative(repoRoot, guide)}`, () => {
     const markdown = fs.readFileSync(guide, 'utf8');
+    const expanded = expandDocumentedVersion(markdown);
 
     assert.ok(
       markdown.includes(`SYNAPSEML_VERSION="${currentVersion}"`),
       'the release bump mechanism must own the documented base version',
     );
-    assert.ok(
-      markdown.includes(
-        'com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}',
-      ),
-    );
-    assert.ok(
-      markdown.includes(
-        'com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.0',
-      ),
-    );
-    assert.ok(
-      markdown.includes(
-        'com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1',
-      ),
-    );
-    assert.ok(
-      markdown.includes(
-        '| Spark 4.0.x | 2.13 | Python 3.12 | ' +
-          '`v${SYNAPSEML_VERSION}-spark4.0` |',
-      ),
-    );
-    assert.ok(
-      markdown.includes(
-        '| Spark 4.1.x | 2.13 | Python 3.13 | ' +
-          '`v${SYNAPSEML_VERSION}-spark4.1` |',
-      ),
-    );
+    assert.ok(expanded.includes(installArtifacts.spark35.coordinate));
+    for (const portCase of portCases) {
+      const locked = publishedPorts[portCase.key];
+      assert.ok(expanded.includes(locked.coordinate));
+      assert.ok(expanded.includes(locked.releaseTag));
+    }
     assert.match(markdown, /does \*\*not\*\* add the\s+JVM artifacts/);
     assert.match(markdown, /LightGBMClassifier does not exist in the JVM/);
+    assert.match(markdown, /Spark 4\.1 \/ Python 3\.13/);
     assert.match(markdown, /pyspark>=4\.1,<4\.2/);
-    assert.match(markdown, /--repositories "\$SYNAPSEML_REPOSITORY"/);
+    assert.match(markdown, /Spark 4\.0 \/ Python 3\.12/);
+    assert.match(markdown, /pyspark>=4\.0,<4\.1/);
+    assert.match(markdown, /Spark 3\.5 \/ Python 3\.11/);
+    assert.match(markdown, /pyspark>=3\.5,<3\.6/);
     assert.match(
       markdown,
-      /https:\/\/mmlspark\.blob\.core\.windows\.net\/maven/,
+      /synapseml_2\.12:\$\{SYNAPSEML_VERSION\}/,
     );
+    assert.match(markdown, /--repositories "\$SYNAPSEML_REPOSITORY"/);
+    assert.match(markdown, new RegExp(installArtifacts.repository));
     assert.doesNotMatch(markdown, /mmlspark\.azureedge\.net/);
   });
 }
 
-test('specialized install guides defer to the runtime matrix', () => {
+test('website landing page uses every supported runtime variant', () => {
+  const index = fs.readFileSync(
+    path.join(repoRoot, 'website', 'src', 'pages', 'index.js'),
+    'utf8',
+  );
+
+  assert.match(index, /import installArtifacts from "@site\/src\/installArtifacts"/);
+  for (const key of ['spark35', 'spark40', 'spark41']) {
+    assert.match(index, new RegExp(`${key}\\.coordinate`));
+    assert.match(index, new RegExp(`${key}\\.pythonBaseline`));
+    assert.match(index, new RegExp(`${key}\\.pysparkSpec`));
+  }
+  assert.doesNotMatch(index, /THE_SYNAPSEML_VERSION_YOU_WANT/);
+  assert.doesNotMatch(index, /only Spark 3|any Spark 3 infrastructure/);
+});
+
+test('specialized install guides state their runtime scope', () => {
   const overview = fs.readFileSync(
     path.join(repoRoot, 'docs', 'Overview.md'),
     'utf8',
@@ -124,6 +198,12 @@ test('specialized install guides defer to the runtime matrix', () => {
   assert.doesNotMatch(onnx, /synapseml_2\.12:<version>/);
   assert.match(rSetup, /examples below use Spark 3\.5 \/ Scala 2\.12/);
   assert.match(rSetup, /installation matrix/);
-  assert.match(isolationForest, /COORDINATE_FROM_THE_INSTALL_MATRIX/);
-  assert.doesNotMatch(isolationForest, /THE_SYNAPSEML_VERSION_YOU_WANT/);
+  assert.match(isolationForest, /scoped to Spark 3\.5 \/ Scala 2\.12/);
+  assert.match(isolationForest, /not a Python 3\.12\/3\.13 setup/);
+  assert.match(
+    isolationForest,
+    /com\.microsoft\.azure:synapseml_2\.12:1\.1\.3/,
+  );
+  assert.doesNotMatch(isolationForest, /synapseml_2\.13/);
+  assert.doesNotMatch(isolationForest, /COORDINATE_FROM_THE_INSTALL_MATRIX/);
 });

--- a/website/test/installDocs.test.js
+++ b/website/test/installDocs.test.js
@@ -1,253 +1,240 @@
-const assert = require('node:assert/strict');
-const fs = require('node:fs');
-const path = require('node:path');
-const test = require('node:test');
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
 
-const repoRoot = path.resolve(__dirname, '..', '..');
-const installArtifacts = require('../src/installArtifacts');
+const repoRoot = path.resolve(__dirname, "..", "..");
+const installArtifacts = require("../src/installArtifacts");
 const publishedPorts = JSON.parse(
   fs.readFileSync(
-    path.join(__dirname, 'published-spark-ports.lock'),
-    'utf8',
+    path.join(__dirname, "published-spark-ports.lock"),
+    "utf8",
   ),
 );
 const publishedVersions = JSON.parse(
-  fs.readFileSync(path.join(repoRoot, 'website', 'versions.json'), 'utf8'),
+  fs.readFileSync(path.join(repoRoot, "website", "versions.json"), "utf8"),
 );
 const currentVersion = installArtifacts.version;
+const artifacts = [
+  installArtifacts.spark35,
+  installArtifacts.spark40,
+  installArtifacts.spark41,
+];
+
+function read(...segments) {
+  return fs.readFileSync(path.join(repoRoot, ...segments), "utf8");
+}
 
 assert.match(
   currentVersion,
   /^\d+\.\d+\.\d+$/,
-  'expected an explicit current SynapseML version',
+  "expected an explicit current SynapseML version",
 );
 assert.equal(
   publishedVersions[0],
   currentVersion,
-  'website versions.json must start with the current SynapseML version',
+  "website versions.json must start with the current SynapseML version",
 );
 
-const portCases = [
-  {
-    key: 'spark4.0',
-    websiteKey: 'spark40',
-  },
-  {
-    key: 'spark4.1',
-    websiteKey: 'spark41',
-  },
-];
-
-function expandDocumentedVersion(markdown) {
-  return markdown.replaceAll('${SYNAPSEML_VERSION}', currentVersion);
-}
-
-test('published Spark port versions are explicitly locked', () => {
-  for (const portCase of portCases) {
-    const lockedVersion = publishedPorts[portCase.key];
-    const websiteArtifact = installArtifacts[portCase.websiteKey];
-    const expectedVersion = `${currentVersion}-${portCase.key}`;
-    const expectedCoordinate =
-      `com.microsoft.azure:synapseml_2.13:${lockedVersion}`;
-
+test("published Spark port versions are explicitly locked", () => {
+  for (const [port, artifact] of [
+    ["spark4.0", installArtifacts.spark40],
+    ["spark4.1", installArtifacts.spark41],
+  ]) {
+    const expectedVersion = `${currentVersion}-${port}`;
     assert.equal(
-      lockedVersion,
+      publishedPorts[port],
       expectedVersion,
-      `update website/test/published-spark-ports.lock only after ` +
-        `${expectedVersion} is published`,
+      `update published-spark-ports.lock only after ${expectedVersion} is published`,
     );
-    assert.equal(websiteArtifact.coordinate, expectedCoordinate);
-    assert.equal(websiteArtifact.pythonPackage, `synapseml==${currentVersion}`);
-    assert.equal(websiteArtifact.scalaBinaryVersion, '2.13');
+    assert.equal(
+      artifact.coordinate,
+      `com.microsoft.azure:synapseml_2.13:${expectedVersion}`,
+    );
+    assert.equal(artifact.releaseTag, `v${expectedVersion}`);
   }
 });
 
-test('Spark 4.0 installation excludes the binary-incompatible 4.0.0 runtime', () => {
-  assert.equal(installArtifacts.spark40.pysparkSpec, '>=4.0.1,<4.1');
+test("runtime metadata identifies the maintained code lines", () => {
+  assert.deepEqual(
+    artifacts.map((artifact) => artifact.branch),
+    ["master", "spark4.0", "spark4.1"],
+  );
+  assert.equal(installArtifacts.spark35.sparkRuntime, "3.5.x");
+  assert.equal(installArtifacts.spark40.sparkRuntime, "4.0.1+ (<4.1)");
+  assert.equal(installArtifacts.spark41.sparkRuntime, "4.1.x");
+  assert.equal(installArtifacts.spark40.pysparkSpec, ">=4.0.1,<4.1");
+  for (const artifact of artifacts) {
+    assert.equal(artifact.pythonPackage, `synapseml==${currentVersion}`);
+  }
 });
 
 const installGuides = [
-  path.join(repoRoot, 'README.md'),
-  path.join(repoRoot, 'docs', 'Get Started', 'Install SynapseML.md'),
-  path.join(
-    repoRoot,
-    'website',
-    'versioned_docs',
-    `version-${currentVersion}`,
-    'Get Started',
-    'Install SynapseML.md',
-  ),
+  {
+    path: ["README.md"],
+    hasMasterSnapshot: true,
+  },
+  {
+    path: ["docs", "Get Started", "Install SynapseML.md"],
+    hasMasterSnapshot: true,
+  },
+  {
+    path: [
+      "website",
+      "versioned_docs",
+      `version-${currentVersion}`,
+      "Get Started",
+      "Install SynapseML.md",
+    ],
+    hasMasterSnapshot: false,
+  },
 ];
 
 for (const guide of installGuides) {
-  test(`Spark runtime matrix is complete in ${path.relative(repoRoot, guide)}`, () => {
-    const markdown = fs.readFileSync(guide, 'utf8');
-    const expanded = expandDocumentedVersion(markdown);
+  const relativePath = guide.path.join("/");
+  test(`installation examples are concrete in ${relativePath}`, () => {
+    const markdown = read(...guide.path);
 
-    assert.ok(
-      markdown.includes(`SYNAPSEML_VERSION="${currentVersion}"`),
-      'the release bump mechanism must own the documented base version',
-    );
-    assert.ok(expanded.includes(installArtifacts.spark35.coordinate));
-    for (const portCase of portCases) {
-      const lockedVersion = publishedPorts[portCase.key];
-      assert.ok(
-        expanded.includes(
-          `com.microsoft.azure:synapseml_2.13:${lockedVersion}`,
-        ),
-      );
-      assert.ok(expanded.includes(`v${lockedVersion}`));
-    }
     assert.match(markdown, /does \*\*not\*\* add the\s+JVM artifacts/);
     assert.match(markdown, /LightGBMClassifier does not exist in the JVM/);
-    assert.match(
-      markdown,
-      /choose exactly\s+one complete\s+runtime variant/i,
-    );
-    for (const [sparkVersion, artifact] of [
-      ['4.1', installArtifacts.spark41],
-      ['4.0', installArtifacts.spark40],
-      ['3.5', installArtifacts.spark35],
-    ]) {
-      const runtime = `Spark ${sparkVersion} / Python ${artifact.pythonBaseline}`;
-      const pysparkSpec = `pyspark${artifact.pysparkSpec}`;
-      const escapedRuntime = runtime.replaceAll('.', '\\.');
-      const escapedSpec = pysparkSpec.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      assert.match(
-        markdown,
-        new RegExp(
-          `\\*\\*${escapedRuntime}\\*\\*\\s+\\x60\\x60\\x60bash\\s+` +
-            `python -m pip install [^\\n]+${escapedSpec}[^\\n]+\\s+\\x60\\x60\\x60`,
-        ),
-      );
-    }
-    assert.match(
-      markdown,
-      /synapseml_2\.12:\$\{SYNAPSEML_VERSION\}/,
-    );
-    assert.match(markdown, /--repositories "\$SYNAPSEML_REPOSITORY"/);
+    assert.match(markdown, /choose exactly one complete runtime variant/i);
     assert.ok(markdown.includes(installArtifacts.repository));
+
+    for (const artifact of artifacts) {
+      assert.ok(markdown.includes(artifact.coordinate));
+      assert.ok(markdown.includes(artifact.releaseTag));
+      assert.ok(markdown.includes(artifact.pythonPackage));
+      assert.ok(markdown.includes(`pyspark${artifact.pysparkSpec}`));
+    }
+
+    assert.doesNotMatch(markdown, /\$\{SYNAPSEML_VERSION\}/);
+    assert.doesNotMatch(markdown, /COORDINATE_FROM_THE_MATRIX_ABOVE/);
+    assert.doesNotMatch(markdown, /SCALA_BINARY_VERSION/);
+    assert.doesNotMatch(markdown, /THE_SYNAPSEML_VERSION_YOU_WANT/);
     assert.doesNotMatch(markdown, /mmlspark\.azureedge\.net/);
+    assert.doesNotMatch(markdown, /For Spark ?3\.[34] [Pp]ools/);
+    assert.doesNotMatch(markdown, /synapseml_2\.12:0\.11\.4-spark3\.3/);
+    assert.doesNotMatch(markdown, /synapseml_2\.12:1\.0\.15/);
+
+    if (guide.hasMasterSnapshot) {
+      assert.match(markdown, /^#{2,3} Latest master snapshot/m);
+      assert.ok(markdown.includes("master_version3.svg"));
+      assert.match(markdown, /MASTER_VERSION=/);
+      assert.match(markdown, /spark-shell/);
+    } else {
+      assert.doesNotMatch(markdown, /master_version3\.svg/);
+    }
   });
 }
 
-test('website landing page uses every supported runtime variant', () => {
-  const index = fs.readFileSync(
-    path.join(repoRoot, 'website', 'src', 'pages', 'index.js'),
-    'utf8',
-  );
+test("website landing page exposes only maintained runtime installs", () => {
+  const index = read("website", "src", "pages", "index.js");
 
-  assert.match(index, /import installArtifacts from "@site\/src\/installArtifacts"/);
-  for (const key of ['spark35', 'spark40', 'spark41']) {
-    assert.match(index, new RegExp(`${key}\\.coordinate`));
-    assert.match(index, new RegExp(`${key}\\.pythonBaseline`));
-    assert.match(index, new RegExp(`${key}\\.pysparkSpec`));
+  assert.match(
+    index,
+    /import installArtifacts from "@site\/src\/installArtifacts"/,
+  );
+  for (const key of ["spark35", "spark40", "spark41"]) {
+    for (const field of [
+      "branch",
+      "coordinate",
+      "pythonBaseline",
+      "pysparkSpec",
+      "releaseTag",
+      "sparkRuntime",
+    ]) {
+      assert.match(index, new RegExp(`${key}\\.${field}`));
+    }
   }
-  assert.doesNotMatch(index, /THE_SYNAPSEML_VERSION_YOU_WANT/);
-  assert.doesNotMatch(index, /only Spark 3|any Spark 3 infrastructure/);
+  assert.match(index, /latest successful/);
+  assert.match(
+    index,
+    /docs\/next\/Get%20Started\/Install%20SynapseML#latest-master-snapshot/,
+  );
   assert.match(index, /Choose exactly one Python\/PySpark runtime variant/);
   assert.match(index, /lang="scala"/);
   assert.doesNotMatch(index, /lang="jsx"/);
-  assert.doesNotMatch(
-    index,
-    /com\.microsoft\.azure:synapseml_2\.12:1\.1\.3/,
-  );
+  assert.doesNotMatch(index, /Spark3\.4|Spark 3\.4|Spark3\.3|Spark 3\.3/);
+  assert.doesNotMatch(index, /synapseml_2\.12:1\.0\.15/);
+  assert.doesNotMatch(index, /THE_SYNAPSEML_VERSION_YOU_WANT/);
   assert.doesNotMatch(index, /<p>\s*<p>/);
   assert.doesNotMatch(index, /<p>\{description\}<\/p>/);
 });
 
-test('specialized install guides state their runtime scope', () => {
-  const overview = fs.readFileSync(
-    path.join(repoRoot, 'docs', 'Overview.md'),
-    'utf8',
+test("specialized install guides use concrete maintained coordinates", () => {
+  const overview = read("docs", "Overview.md");
+  const deepLearning = read(
+    "docs",
+    "Explore Algorithms",
+    "Deep Learning",
+    "Getting Started.md",
   );
-  const deepLearning = fs.readFileSync(
-    path.join(
-      repoRoot,
-      'docs',
-      'Explore Algorithms',
-      'Deep Learning',
-      'Getting Started.md',
-    ),
-    'utf8',
+  const versionedDeepLearning = read(
+    "website",
+    "versioned_docs",
+    `version-${currentVersion}`,
+    "Explore Algorithms",
+    "Deep Learning",
+    "Getting Started.md",
   );
-  const onnx = fs.readFileSync(
-    path.join(
-      repoRoot,
-      'docs',
-      'Explore Algorithms',
-      'Deep Learning',
-      'ONNX.md',
-    ),
-    'utf8',
+  const onnx = read(
+    "docs",
+    "Explore Algorithms",
+    "Deep Learning",
+    "ONNX.md",
   );
-  const rSetup = fs.readFileSync(
-    path.join(repoRoot, 'docs', 'Reference', 'R Setup.md'),
-    'utf8',
+  const rSetup = read("docs", "Reference", "R Setup.md");
+  const versionedRSetup = read(
+    "website",
+    "versioned_docs",
+    `version-${currentVersion}`,
+    "Reference",
+    "R Setup.md",
   );
-  const isolationForest = fs.readFileSync(
-    path.join(
-      repoRoot,
-      'docs',
-      'Explore Algorithms',
-      'Anomaly Detection',
-      'Quickstart - Isolation Forests.ipynb',
-    ),
-    'utf8',
+  const isolationForest = read(
+    "docs",
+    "Explore Algorithms",
+    "Anomaly Detection",
+    "Quickstart - Isolation Forests.ipynb",
   );
 
   assert.doesNotMatch(overview, /requires Scala 2\.12/);
   assert.match(overview, /Spark 4\.0 and 4\.1 use Scala 2\.13/);
-  assert.match(deepLearning, /Python wheel supplies wrappers/);
-  assert.match(deepLearning, /installation matrix/);
-  assert.match(deepLearning, /targets Spark 3\.5 \/ Scala 2\.12/);
-  assert.doesNotMatch(deepLearning, /sample uses a Spark 3 \/ Scala 2\.12/);
-  const expandedOnnx = expandDocumentedVersion(onnx);
-  assert.ok(
-    onnx.includes(`SYNAPSEML_VERSION="${currentVersion}"`),
-    'the release bump mechanism must own the ONNX module version',
-  );
-  assert.match(onnx, /<synapseml-deep-learning-coordinate>/);
-  assert.match(onnx, /<synapseml-deep-learning-version>/);
-  assert.match(
-    onnx,
-    /<artifactId>synapseml-deep-learning_SCALA_BINARY_VERSION<\/artifactId>/,
-  );
-  assert.match(
-    onnx,
-    /<version>SYNAPSEML_DEEP_LEARNING_VERSION<\/version>/,
-  );
-  assert.doesNotMatch(
-    onnx,
-    /<artifactId>synapseml-deep-learning_<[^>]+><\/artifactId>/,
-  );
-  assert.doesNotMatch(onnx, /<version><[^>]+><\/version>/);
-  assert.doesNotMatch(onnx, /<synapseml-coordinate>/);
-  assert.doesNotMatch(onnx, /<synapseml-artifact-version>/);
-  assert.doesNotMatch(onnx, /--packages\s+<synapseml/);
-  assert.match(
-    onnx,
-    /--packages "\$\{SYNAPSEML_DEEP_LEARNING_COORDINATE\},/,
-  );
-  for (const key of ['spark35', 'spark40', 'spark41']) {
+
+  for (const guide of [deepLearning, versionedDeepLearning]) {
+    assert.match(guide, /Python wheel supplies wrappers/);
+    assert.ok(guide.includes(installArtifacts.spark40.coordinate));
+    assert.ok(guide.includes(installArtifacts.spark41.coordinate));
+  }
+
+  for (const artifact of artifacts) {
     assert.ok(
-      expandedOnnx.includes(
-        installArtifacts[key].coordinate.replace(
-          ':synapseml_',
-          ':synapseml-deep-learning_',
+      onnx.includes(
+        artifact.coordinate.replace(
+          ":synapseml_",
+          ":synapseml-deep-learning_",
         ),
       ),
     );
   }
   assert.ok(onnx.includes(installArtifacts.repository));
-  assert.match(rSetup, /examples below use Spark 3\.5 \/ Scala 2\.12/);
-  assert.match(rSetup, /installation matrix/);
+  assert.doesNotMatch(onnx, /SYNAPSEML_VERSION/);
+  assert.doesNotMatch(onnx, /SCALA_BINARY_VERSION/);
+  assert.doesNotMatch(onnx, /SYNAPSEML_DEEP_LEARNING_VERSION/);
+  assert.doesNotMatch(onnx, /<synapseml-deep-learning/);
+  assert.match(onnx, /resolvers \+= "SynapseML"/);
+  assert.match(onnx, /<id>SynapseML<\/id>/);
+  assert.match(onnx, /"repo": "https:\/\/mmlspark\.blob\.core\.windows\.net\/maven"/);
+
+  for (const guide of [rSetup, versionedRSetup]) {
+    assert.ok(guide.includes(installArtifacts.spark35.coordinate));
+    assert.ok(guide.includes(installArtifacts.spark40.coordinate));
+    assert.ok(guide.includes(installArtifacts.spark41.coordinate));
+    assert.doesNotMatch(guide, /spark-3\.3\./);
+  }
+
   assert.match(isolationForest, /scoped to Spark 3\.5 \/ Scala 2\.12/);
   assert.match(isolationForest, /not a Python 3\.12\/3\.13 setup/);
-  assert.match(
-    isolationForest,
-    /com\.microsoft\.azure:synapseml_2\.12:1\.1\.3/,
-  );
+  assert.ok(isolationForest.includes(installArtifacts.spark35.coordinate));
   assert.doesNotMatch(isolationForest, /synapseml_2\.13/);
-  assert.doesNotMatch(isolationForest, /COORDINATE_FROM_THE_INSTALL_MATRIX/);
 });

--- a/website/test/installDocs.test.js
+++ b/website/test/installDocs.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const childProcess = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
@@ -15,75 +14,51 @@ const publishedPorts = JSON.parse(
 const publishedVersions = JSON.parse(
   fs.readFileSync(path.join(repoRoot, 'website', 'versions.json'), 'utf8'),
 );
-const currentVersion = publishedVersions[0];
+const currentVersion = installArtifacts.version;
 
 assert.match(
   currentVersion,
   /^\d+\.\d+\.\d+$/,
-  'expected the first published documentation version to be current',
+  'expected an explicit current SynapseML version',
+);
+assert.equal(
+  publishedVersions[0],
+  currentVersion,
+  'website versions.json must start with the current SynapseML version',
 );
 
 const portCases = [
   {
     key: 'spark4.0',
     websiteKey: 'spark40',
-    sparkVersionPattern: /val sparkVersion = "4\.0\.[0-9]+"/,
   },
   {
     key: 'spark4.1',
     websiteKey: 'spark41',
-    sparkVersionPattern: /val sparkVersion = "4\.1\.[0-9]+"/,
   },
 ];
-
-function git(...args) {
-  return childProcess.execFileSync('git', args, {
-    cwd: repoRoot,
-    encoding: 'utf8',
-  }).trim();
-}
 
 function expandDocumentedVersion(markdown) {
   return markdown.replaceAll('${SYNAPSEML_VERSION}', currentVersion);
 }
 
-test('published Spark port metadata matches tagged source', () => {
+test('published Spark port versions are explicitly locked', () => {
   for (const portCase of portCases) {
-    const locked = publishedPorts[portCase.key];
+    const lockedVersion = publishedPorts[portCase.key];
     const websiteArtifact = installArtifacts[portCase.websiteKey];
+    const expectedVersion = `${currentVersion}-${portCase.key}`;
+    const expectedCoordinate =
+      `com.microsoft.azure:synapseml_2.13:${lockedVersion}`;
 
-    assert.ok(locked, `missing locked metadata for ${portCase.key}`);
-    assert.equal(git('tag', '--list', locked.releaseTag), locked.releaseTag);
     assert.equal(
-      locked.artifactVersion,
-      locked.releaseTag.replace(/^v/, ''),
+      lockedVersion,
+      expectedVersion,
+      `update website/test/published-spark-ports.lock only after ` +
+        `${expectedVersion} is published`,
     );
-    assert.ok(locked.coordinate.endsWith(`:${locked.artifactVersion}`));
-    assert.equal(websiteArtifact.coordinate, locked.coordinate);
-    assert.equal(websiteArtifact.pythonBaseline, locked.pythonBaseline);
-    assert.equal(websiteArtifact.pythonPackage, locked.pythonPackage);
-    assert.equal(websiteArtifact.pysparkSpec, locked.pysparkSpec);
-    assert.equal(
-      websiteArtifact.scalaBinaryVersion,
-      locked.scalaBinaryVersion,
-    );
-
-    const build = git('show', `${locked.releaseTag}:build.sbt`);
-    const environment = git('show', `${locked.releaseTag}:environment.yml`);
-    assert.match(build, portCase.sparkVersionPattern);
-    assert.match(
-      build,
-      new RegExp(
-        `ThisBuild / scalaVersion := "${locked.scalaBinaryVersion.replace(
-          '.',
-          '\\.',
-        )}\\.[0-9]+"`,
-      ),
-    );
-    assert.match(
-      environment,
-      new RegExp(`^  - python=${locked.pythonBaseline}(?:\\.[0-9]+)?$`, 'm'),
-    );
+    assert.equal(websiteArtifact.coordinate, expectedCoordinate);
+    assert.equal(websiteArtifact.pythonPackage, `synapseml==${currentVersion}`);
+    assert.equal(websiteArtifact.scalaBinaryVersion, '2.13');
   }
 });
 
@@ -111,24 +86,27 @@ for (const guide of installGuides) {
     );
     assert.ok(expanded.includes(installArtifacts.spark35.coordinate));
     for (const portCase of portCases) {
-      const locked = publishedPorts[portCase.key];
-      assert.ok(expanded.includes(locked.coordinate));
-      assert.ok(expanded.includes(locked.releaseTag));
+      const lockedVersion = publishedPorts[portCase.key];
+      assert.ok(
+        expanded.includes(
+          `com.microsoft.azure:synapseml_2.13:${lockedVersion}`,
+        ),
+      );
+      assert.ok(expanded.includes(`v${lockedVersion}`));
     }
     assert.match(markdown, /does \*\*not\*\* add the\s+JVM artifacts/);
     assert.match(markdown, /LightGBMClassifier does not exist in the JVM/);
-    assert.match(markdown, /Spark 4\.1 \/ Python 3\.13/);
-    assert.match(markdown, /pyspark>=4\.1,<4\.2/);
-    assert.match(markdown, /Spark 4\.0 \/ Python 3\.12/);
-    assert.match(markdown, /pyspark>=4\.0,<4\.1/);
-    assert.match(markdown, /Spark 3\.5 \/ Python 3\.11/);
-    assert.match(markdown, /pyspark>=3\.5,<3\.6/);
-    assert.match(markdown, /Choose exactly one complete runtime variant/);
-    for (const [runtime, pysparkSpec] of [
-      ['Spark 4.1 / Python 3.13', 'pyspark>=4.1,<4.2'],
-      ['Spark 4.0 / Python 3.12', 'pyspark>=4.0,<4.1'],
-      ['Spark 3.5 / Python 3.11', 'pyspark>=3.5,<3.6'],
+    assert.match(
+      markdown,
+      /choose exactly\s+one complete\s+runtime variant/i,
+    );
+    for (const [sparkVersion, artifact] of [
+      ['4.1', installArtifacts.spark41],
+      ['4.0', installArtifacts.spark40],
+      ['3.5', installArtifacts.spark35],
     ]) {
+      const runtime = `Spark ${sparkVersion} / Python ${artifact.pythonBaseline}`;
+      const pysparkSpec = `pyspark${artifact.pysparkSpec}`;
       const escapedRuntime = runtime.replaceAll('.', '\\.');
       const escapedSpec = pysparkSpec.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       assert.match(

--- a/website/test/installDocs.test.js
+++ b/website/test/installDocs.test.js
@@ -12,17 +12,16 @@ const publishedPorts = JSON.parse(
     'utf8',
   ),
 );
-const config = fs.readFileSync(
-  path.join(repoRoot, 'website', 'docusaurus.config.js'),
-  'utf8',
-);
-const currentVersion = config.match(/let version = "([0-9.]+)"/)?.[1];
 const publishedVersions = JSON.parse(
   fs.readFileSync(path.join(repoRoot, 'website', 'versions.json'), 'utf8'),
 );
+const currentVersion = publishedVersions[0];
 
-assert.ok(currentVersion, 'expected a current SynapseML documentation version');
-assert.equal(publishedVersions[0], currentVersion);
+assert.match(
+  currentVersion,
+  /^\d+\.\d+\.\d+$/,
+  'expected the first published documentation version to be current',
+);
 
 const portCases = [
   {
@@ -196,6 +195,8 @@ test('specialized install guides state their runtime scope', () => {
   assert.match(overview, /Spark 4\.0 and 4\.1 use Scala 2\.13/);
   assert.match(deepLearning, /Python wheel supplies wrappers/);
   assert.match(deepLearning, /installation matrix/);
+  assert.match(deepLearning, /targets Spark 3\.5 \/ Scala 2\.12/);
+  assert.doesNotMatch(deepLearning, /sample uses a Spark 3 \/ Scala 2\.12/);
   const expandedOnnx = expandDocumentedVersion(onnx);
   assert.ok(
     onnx.includes(`SYNAPSEML_VERSION="${currentVersion}"`),
@@ -205,6 +206,11 @@ test('specialized install guides state their runtime scope', () => {
   assert.match(onnx, /<synapseml-deep-learning-version>/);
   assert.doesNotMatch(onnx, /<synapseml-coordinate>/);
   assert.doesNotMatch(onnx, /<synapseml-artifact-version>/);
+  assert.doesNotMatch(onnx, /--packages\s+<synapseml/);
+  assert.match(
+    onnx,
+    /--packages "\$\{SYNAPSEML_DEEP_LEARNING_COORDINATE\},/,
+  );
   for (const key of ['spark35', 'spark40', 'spark41']) {
     assert.ok(
       expandedOnnx.includes(

--- a/website/test/installDocs.test.js
+++ b/website/test/installDocs.test.js
@@ -148,6 +148,8 @@ test('website landing page uses every supported runtime variant', () => {
   }
   assert.doesNotMatch(index, /THE_SYNAPSEML_VERSION_YOU_WANT/);
   assert.doesNotMatch(index, /only Spark 3|any Spark 3 infrastructure/);
+  assert.doesNotMatch(index, /<p>\s*<p>/);
+  assert.doesNotMatch(index, /<p>\{description\}<\/p>/);
 });
 
 test('specialized install guides state their runtime scope', () => {
@@ -194,8 +196,26 @@ test('specialized install guides state their runtime scope', () => {
   assert.match(overview, /Spark 4\.0 and 4\.1 use Scala 2\.13/);
   assert.match(deepLearning, /Python wheel supplies wrappers/);
   assert.match(deepLearning, /installation matrix/);
-  assert.match(onnx, /<synapseml-coordinate>/);
-  assert.doesNotMatch(onnx, /synapseml_2\.12:<version>/);
+  const expandedOnnx = expandDocumentedVersion(onnx);
+  assert.ok(
+    onnx.includes(`SYNAPSEML_VERSION="${currentVersion}"`),
+    'the release bump mechanism must own the ONNX module version',
+  );
+  assert.match(onnx, /<synapseml-deep-learning-coordinate>/);
+  assert.match(onnx, /<synapseml-deep-learning-version>/);
+  assert.doesNotMatch(onnx, /<synapseml-coordinate>/);
+  assert.doesNotMatch(onnx, /<synapseml-artifact-version>/);
+  for (const key of ['spark35', 'spark40', 'spark41']) {
+    assert.ok(
+      expandedOnnx.includes(
+        installArtifacts[key].coordinate.replace(
+          ':synapseml_',
+          ':synapseml-deep-learning_',
+        ),
+      ),
+    );
+  }
+  assert.match(onnx, new RegExp(installArtifacts.repository));
   assert.match(rSetup, /examples below use Spark 3\.5 \/ Scala 2\.12/);
   assert.match(rSetup, /installation matrix/);
   assert.match(isolationForest, /scoped to Spark 3\.5 \/ Scala 2\.12/);

--- a/website/test/installDocs.test.js
+++ b/website/test/installDocs.test.js
@@ -128,7 +128,7 @@ for (const guide of installGuides) {
       /synapseml_2\.12:\$\{SYNAPSEML_VERSION\}/,
     );
     assert.match(markdown, /--repositories "\$SYNAPSEML_REPOSITORY"/);
-    assert.match(markdown, new RegExp(installArtifacts.repository));
+    assert.ok(markdown.includes(installArtifacts.repository));
     assert.doesNotMatch(markdown, /mmlspark\.azureedge\.net/);
   });
 }
@@ -147,6 +147,10 @@ test('website landing page uses every supported runtime variant', () => {
   }
   assert.doesNotMatch(index, /THE_SYNAPSEML_VERSION_YOU_WANT/);
   assert.doesNotMatch(index, /only Spark 3|any Spark 3 infrastructure/);
+  assert.doesNotMatch(
+    index,
+    /com\.microsoft\.azure:synapseml_2\.12:1\.1\.3/,
+  );
   assert.doesNotMatch(index, /<p>\s*<p>/);
   assert.doesNotMatch(index, /<p>\{description\}<\/p>/);
 });
@@ -221,7 +225,7 @@ test('specialized install guides state their runtime scope', () => {
       ),
     );
   }
-  assert.match(onnx, new RegExp(installArtifacts.repository));
+  assert.ok(onnx.includes(installArtifacts.repository));
   assert.match(rSetup, /examples below use Spark 3\.5 \/ Scala 2\.12/);
   assert.match(rSetup, /installation matrix/);
   assert.match(isolationForest, /scoped to Spark 3\.5 \/ Scala 2\.12/);

--- a/website/test/installDocs.test.js
+++ b/website/test/installDocs.test.js
@@ -123,6 +123,22 @@ for (const guide of installGuides) {
     assert.match(markdown, /pyspark>=4\.0,<4\.1/);
     assert.match(markdown, /Spark 3\.5 \/ Python 3\.11/);
     assert.match(markdown, /pyspark>=3\.5,<3\.6/);
+    assert.match(markdown, /Choose exactly one complete runtime variant/);
+    for (const [runtime, pysparkSpec] of [
+      ['Spark 4.1 / Python 3.13', 'pyspark>=4.1,<4.2'],
+      ['Spark 4.0 / Python 3.12', 'pyspark>=4.0,<4.1'],
+      ['Spark 3.5 / Python 3.11', 'pyspark>=3.5,<3.6'],
+    ]) {
+      const escapedRuntime = runtime.replaceAll('.', '\\.');
+      const escapedSpec = pysparkSpec.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      assert.match(
+        markdown,
+        new RegExp(
+          `\\*\\*${escapedRuntime}\\*\\*\\s+\\x60\\x60\\x60bash\\s+` +
+            `python -m pip install [^\\n]+${escapedSpec}[^\\n]+\\s+\\x60\\x60\\x60`,
+        ),
+      );
+    }
     assert.match(
       markdown,
       /synapseml_2\.12:\$\{SYNAPSEML_VERSION\}/,
@@ -147,6 +163,9 @@ test('website landing page uses every supported runtime variant', () => {
   }
   assert.doesNotMatch(index, /THE_SYNAPSEML_VERSION_YOU_WANT/);
   assert.doesNotMatch(index, /only Spark 3|any Spark 3 infrastructure/);
+  assert.match(index, /Choose exactly one Python\/PySpark runtime variant/);
+  assert.match(index, /lang="scala"/);
+  assert.doesNotMatch(index, /lang="jsx"/);
   assert.doesNotMatch(
     index,
     /com\.microsoft\.azure:synapseml_2\.12:1\.1\.3/,

--- a/website/test/published-spark-ports.lock
+++ b/website/test/published-spark-ports.lock
@@ -1,20 +1,4 @@
 {
-  "spark4.0": {
-    "artifactVersion": "1.1.3-spark4.0",
-    "coordinate": "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0",
-    "pythonBaseline": "3.12",
-    "pythonPackage": "synapseml==1.1.3",
-    "pysparkSpec": ">=4.0,<4.1",
-    "releaseTag": "v1.1.3-spark4.0",
-    "scalaBinaryVersion": "2.13"
-  },
-  "spark4.1": {
-    "artifactVersion": "1.1.3-spark4.1",
-    "coordinate": "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1",
-    "pythonBaseline": "3.13",
-    "pythonPackage": "synapseml==1.1.3",
-    "pysparkSpec": ">=4.1,<4.2",
-    "releaseTag": "v1.1.3-spark4.1",
-    "scalaBinaryVersion": "2.13"
-  }
+  "spark4.0": "1.1.3-spark4.0",
+  "spark4.1": "1.1.3-spark4.1"
 }

--- a/website/test/published-spark-ports.lock
+++ b/website/test/published-spark-ports.lock
@@ -1,0 +1,20 @@
+{
+  "spark4.0": {
+    "artifactVersion": "1.1.3-spark4.0",
+    "coordinate": "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0",
+    "pythonBaseline": "3.12",
+    "pythonPackage": "synapseml==1.1.3",
+    "pysparkSpec": ">=4.0,<4.1",
+    "releaseTag": "v1.1.3-spark4.0",
+    "scalaBinaryVersion": "2.13"
+  },
+  "spark4.1": {
+    "artifactVersion": "1.1.3-spark4.1",
+    "coordinate": "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1",
+    "pythonBaseline": "3.13",
+    "pythonPackage": "synapseml==1.1.3",
+    "pysparkSpec": ">=4.1,<4.2",
+    "releaseTag": "v1.1.3-spark4.1",
+    "scalaBinaryVersion": "2.13"
+  }
+}

--- a/website/versioned_docs/version-1.1.3/Explore Algorithms/Anomaly Detection/Quickstart - Isolation Forests.md
+++ b/website/versioned_docs/version-1.1.3/Explore Algorithms/Anomaly Detection/Quickstart - Isolation Forests.md
@@ -10,7 +10,8 @@ To learn more about the Isolation Forest model please refer to the original pape
 
 ## Prerequisites
  - If running on Synapse, you'll need to [create an AML workspace and set up linked Service](../../Use%20with%20MLFlow/Overview.md) and add the following installation cell.
- - If running on Fabric, choose the coordinate and Scala binary version from the [installation matrix](../../Get%20Started/Install%20SynapseML.md), add the following installation cell, and attach the notebook to a lakehouse. On the left side of your notebook, select Add to add an existing lakehouse or create a new one.
+ - This notebook's existing dependency set and installation cell are scoped to Spark 3.5 / Scala 2.12. Do not substitute a Spark 4 coordinate: the pinned dependencies below are not a Python 3.12/3.13 setup.
+ - If running on Fabric with a Spark 3.5 runtime, add the following installation cell and attach the notebook to a lakehouse. On the left side of your notebook, select Add to add an existing lakehouse or create a new one.
 
 
 ```python
@@ -18,9 +19,9 @@ To learn more about the Isolation Forest model please refer to the original pape
 # {
 #   "name": "synapseml",
 #   "conf": {
-#       "spark.jars.packages": "<COORDINATE_FROM_THE_INSTALL_MATRIX>",
+#       "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:1.1.3",
 #       "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
-#       "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_<SCALA_BINARY_VERSION>,org.scalactic:scalactic_<SCALA_BINARY_VERSION>,org.scalatest:scalatest_<SCALA_BINARY_VERSION>,com.fasterxml.jackson.core:jackson-databind",
+#       "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
 #       "spark.yarn.user.classpath.first": "true",
 #       "spark.sql.parquet.enableVectorizedReader": "false"
 #   }

--- a/website/versioned_docs/version-1.1.3/Explore Algorithms/Anomaly Detection/Quickstart - Isolation Forests.md
+++ b/website/versioned_docs/version-1.1.3/Explore Algorithms/Anomaly Detection/Quickstart - Isolation Forests.md
@@ -10,7 +10,7 @@ To learn more about the Isolation Forest model please refer to the original pape
 
 ## Prerequisites
  - If running on Synapse, you'll need to [create an AML workspace and set up linked Service](../../Use%20with%20MLFlow/Overview.md) and add the following installation cell.
- - If running on Fabric, you need to add the following installation cell and attach the notebook to a lakehouse. On the left side of your notebook, select Add to add an existing lakehouse or create a new one.
+ - If running on Fabric, choose the coordinate and Scala binary version from the [installation matrix](../../Get%20Started/Install%20SynapseML.md), add the following installation cell, and attach the notebook to a lakehouse. On the left side of your notebook, select Add to add an existing lakehouse or create a new one.
 
 
 ```python
@@ -18,9 +18,9 @@ To learn more about the Isolation Forest model please refer to the original pape
 # {
 #   "name": "synapseml",
 #   "conf": {
-#       "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:<THE_SYNAPSEML_VERSION_YOU_WANT>",
+#       "spark.jars.packages": "<COORDINATE_FROM_THE_INSTALL_MATRIX>",
 #       "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
-#       "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
+#       "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_<SCALA_BINARY_VERSION>,org.scalactic:scalactic_<SCALA_BINARY_VERSION>,org.scalatest:scalatest_<SCALA_BINARY_VERSION>,com.fasterxml.jackson.core:jackson-databind",
 #       "spark.yarn.user.classpath.first": "true",
 #       "spark.sql.parquet.enableVectorizedReader": "false"
 #   }

--- a/website/versioned_docs/version-1.1.3/Explore Algorithms/Deep Learning/Getting Started.md
+++ b/website/versioned_docs/version-1.1.3/Explore Algorithms/Deep Learning/Getting Started.md
@@ -32,8 +32,11 @@ Coordinate: com.microsoft.azure:synapseml_2.12:1.1.3
 Repository: https://mmlspark.blob.core.windows.net/maven
 ```
 
-For Spark 4, use the Scala 2.13 coordinate and Spark-specific version suffix in
-the [installation matrix](../../Get%20Started/Install%20SynapseML.md).
+For Spark 4.0 use
+`com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0`; for Spark 4.1 use
+`com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1`. See the
+[installation guide](../../Get%20Started/Install%20SynapseML.md) for complete
+copy-ready commands.
 The historical Databricks 10.4.x runtime named above is an older Spark line; do
 not combine it with the current Spark 3.5 artifact. If you retain that runtime,
 select a compatible older SynapseML release instead.

--- a/website/versioned_docs/version-1.1.3/Explore Algorithms/Deep Learning/Getting Started.md
+++ b/website/versioned_docs/version-1.1.3/Explore Algorithms/Deep Learning/Getting Started.md
@@ -24,8 +24,8 @@ Run the following command:
 pip install synapseml==1.1.3
 ```
 
-The Python wheel supplies wrappers but does not install the JVM package. This
-sample uses a Spark 3 / Scala 2.12 runtime, so add the following Maven library:
+The Python wheel supplies wrappers but does not install the JVM package. The
+Maven example below targets Spark 3.5 / Scala 2.12:
 
 ```
 Coordinate: com.microsoft.azure:synapseml_2.12:1.1.3
@@ -34,6 +34,9 @@ Repository: https://mmlspark.blob.core.windows.net/maven
 
 For Spark 4, use the Scala 2.13 coordinate and Spark-specific version suffix in
 the [installation matrix](../../Get%20Started/Install%20SynapseML.md).
+The historical Databricks 10.4.x runtime named above is an older Spark line; do
+not combine it with the current Spark 3.5 artifact. If you retain that runtime,
+select a compatible older SynapseML release instead.
 
 :::note
 If you install the jar package, follow the first two cells of this [sample](../Quickstart%20-%20Fine-tune%20a%20Vision%20Classifier#environment-setup----reinstall-horovod-based-on-new-version-of-pytorch)

--- a/website/versioned_docs/version-1.1.3/Explore Algorithms/Deep Learning/Getting Started.md
+++ b/website/versioned_docs/version-1.1.3/Explore Algorithms/Deep Learning/Getting Started.md
@@ -24,11 +24,17 @@ Run the following command:
 pip install synapseml==1.1.3
 ```
 
-An alternative is installing the SynapseML jar package in library management section, by adding:
+The Python wheel supplies wrappers but does not install the JVM package. This
+sample uses a Spark 3 / Scala 2.12 runtime, so add the following Maven library:
+
 ```
 Coordinate: com.microsoft.azure:synapseml_2.12:1.1.3
 Repository: https://mmlspark.blob.core.windows.net/maven
 ```
+
+For Spark 4, use the Scala 2.13 coordinate and Spark-specific version suffix in
+the [installation matrix](../../Get%20Started/Install%20SynapseML.md).
+
 :::note
 If you install the jar package, follow the first two cells of this [sample](../Quickstart%20-%20Fine-tune%20a%20Vision%20Classifier#environment-setup----reinstall-horovod-based-on-new-version-of-pytorch)
 to ensure horovod recognizes SynapseML.

--- a/website/versioned_docs/version-1.1.3/Get Started/Install SynapseML.md
+++ b/website/versioned_docs/version-1.1.3/Get Started/Install SynapseML.md
@@ -2,9 +2,48 @@
 title: Install SynapseML
 description: Install SynapseML
 ---
+## Choose the artifact that matches your Spark runtime
+
+SynapseML installation has two parts:
+
+1. language wrappers such as the `synapseml` Python package; and
+2. JVM artifacts loaded by Spark.
+
+Installing the Python package does **not** add the JVM artifacts. A Python
+wrapper can import successfully while its JVM class is missing. In particular,
+using a `_2.12` artifact with Spark 4 can cause errors such as
+`LightGBMClassifier does not exist in the JVM`.
+
+The examples on this page use the current base release:
+
+```bash
+SYNAPSEML_VERSION="1.1.3"
+```
+
+Choose the coordinate from the Spark runtime, not from the Python version:
+
+| Spark runtime | Scala binary version | Port Python baseline | Release tag | Maven coordinate |
+| --- | --- | --- | --- | --- |
+| Spark 3.5.x | 2.12 | Python 3.11 | `v${SYNAPSEML_VERSION}` | `com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}` |
+| Spark 4.0.x | 2.13 | Python 3.12 | `v${SYNAPSEML_VERSION}-spark4.0` | `com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.0` |
+| Spark 4.1.x | 2.13 | Python 3.13 | `v${SYNAPSEML_VERSION}-spark4.1` | `com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1` |
+
+In a UI that does not expand shell variables, replace
+`${SYNAPSEML_VERSION}` with the value assigned above.
+The Spark 4 rows are separately published ports. The same
+`synapseml==${SYNAPSEML_VERSION}` Python wheel is used with either port; the
+Spark runtime determines which JVM coordinate to load. Always add the
+SynapseML repository because the Spark 4 artifacts are published there:
+
+```text
+https://mmlspark.blob.core.windows.net/maven
+```
+
 ## Microsoft Fabric
 
-SynapseML is already installed in Microsoft Fabric notebooks. To change the version please place the following in the first cell of your notebook: 
+SynapseML is already installed in Microsoft Fabric notebooks. To override it,
+first check the notebook runtime's Spark and Scala versions, then substitute the
+matching full coordinate and Scala binary version from the matrix above:
 
 
 ```bash
@@ -12,9 +51,9 @@ SynapseML is already installed in Microsoft Fabric notebooks. To change the vers
 {
   "name": "synapseml",
   "conf": {
-      "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:<THE_SYNAPSEML_VERSION_YOU_WANT>",
+      "spark.jars.packages": "<COORDINATE_FROM_THE_MATRIX_ABOVE>",
       "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
-      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
+      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_<SCALA_BINARY_VERSION>,org.scalactic:scalactic_<SCALA_BINARY_VERSION>,org.scalatest:scalatest_<SCALA_BINARY_VERSION>,com.fasterxml.jackson.core:jackson-databind",
       "spark.yarn.user.classpath.first": "true",
       "spark.sql.parquet.enableVectorizedReader": "false"
   }
@@ -74,39 +113,77 @@ For Spark3.3 pools:
 ## Python
 
 To try out SynapseML on a Python (or Conda) installation, you can get Spark
-installed via pip with `pip install pyspark`.
+installed via pip. Install the Python wrapper and start Spark with the matching
+JVM artifact. This copy-paste example is for Spark 4.1 and Python 3.13. For
+Spark 4.0, install `pyspark>=4.0,<4.1` instead and set `SPARK_LINE="4.0"`:
+
+```bash
+SYNAPSEML_VERSION=1.1.3
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.1,<4.2"
+```
 
 ```python
-import pyspark
-spark = pyspark.sql.SparkSession.builder.appName("MyApp") \
-            # Use 1.1.3 version for spark 3.5 and 1.0.15 version for Spark3.4
-            .config("spark.jars.packages", "com.microsoft.azure:synapseml_2.12:1.1.3") \
-            .config("spark.jars.repositories", "https://mmlspark.blob.core.windows.net/maven") \
-            .getOrCreate()
+from pyspark.sql import SparkSession
+
+SYNAPSEML_VERSION="1.1.3"
+SPARK_LINE="4.1"
+SYNAPSEML_COORDINATE=(
+    f"com.microsoft.azure:synapseml_2.13:"
+    f"{SYNAPSEML_VERSION}-spark{SPARK_LINE}"
+)
+
+spark = (
+    SparkSession.builder.appName("MyApp")
+    .config("spark.jars.packages", SYNAPSEML_COORDINATE)
+    .config(
+        "spark.jars.repositories",
+        "https://mmlspark.blob.core.windows.net/maven",
+    )
+    .getOrCreate()
+)
 import synapse.ml
 ```
+
+For Spark 3.5, use
+`SYNAPSEML_COORDINATE=f"com.microsoft.azure:synapseml_2.12:{SYNAPSEML_VERSION}"`.
 
 ## SBT
 
 If you're building a Spark application in Scala, add the following lines to
-your `build.sbt`:
+your `build.sbt`. For Spark 4.1 (use `SPARK_LINE="4.0"` for Spark 4.0):
 
 ```scala
+val SYNAPSEML_VERSION="1.1.3"
+val SPARK_LINE="4.1"
 resolvers += "SynapseML" at "https://mmlspark.blob.core.windows.net/maven"
-// Use 1.1.3 version for spark 3.5 and 1.0.15 version for Spark3.4
-libraryDependencies += "com.microsoft.azure" % "synapseml_2.12" % "1.1.3"
+libraryDependencies +=
+  "com.microsoft.azure" % "synapseml_2.13" %
+    s"$SYNAPSEML_VERSION-spark$SPARK_LINE"
 ```
+
+For Spark 3.5, use
+`"com.microsoft.azure" % "synapseml_2.12" % SYNAPSEML_VERSION`.
 
 ## Spark package
 
 SynapseML can be conveniently installed on existing Spark clusters via the
-`--packages` option, examples:
+`--packages` option. Include `--repositories` for the Spark 4 ports:
 
 ```bash
-# Use 1.1.3 version for spark 3.5 and 1.0.15 version for Spark3.4
-spark-shell --packages com.microsoft.azure:synapseml_2.12:1.1.3
-pyspark --packages com.microsoft.azure:synapseml_2.12:1.1.3
-spark-submit --packages com.microsoft.azure:synapseml_2.12:1.1.3 MyApp.jar
+SYNAPSEML_VERSION=1.1.3
+SYNAPSEML_REPOSITORY=https://mmlspark.blob.core.windows.net/maven
+
+# Spark 4.0
+pyspark --repositories "$SYNAPSEML_REPOSITORY" \
+  --packages "com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.0"
+
+# Spark 4.1
+pyspark --repositories "$SYNAPSEML_REPOSITORY" \
+  --packages "com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1"
+
+# Spark 3.5
+pyspark --repositories "$SYNAPSEML_REPOSITORY" \
+  --packages "com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}"
 ```
 
 A similar technique can be used in other Spark contexts too. For example, you can use SynapseML
@@ -121,12 +198,13 @@ cloud](http://community.cloud.databricks.com), create a new [library from Maven
 coordinates](https://docs.databricks.com/user-guide/libraries.html#libraries-from-maven-pypi-or-spark-packages)
 in your workspace.
 
-For the coordinates use: `com.microsoft.azure:synapseml_2.12:1.1.3` for Spark3.4 Cluster and
- `com.microsoft.azure:synapseml_2.12:0.11.4-spark3.3` for Spark3.3 Cluster;
-Add the resolver: `https://mmlspark.blob.core.windows.net/maven`. Ensure this library is
-attached to your target cluster(s).
-
-Finally, ensure that your Spark cluster has at least Spark 3.2 and Scala 2.12.
+Use the coordinate matching the cluster's Spark and Scala versions from the
+matrix above. For example, a Spark 4.1 / Scala 2.13 cluster uses
+`com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1`, while a
+Spark 3.5 / Scala 2.12 cluster uses
+`com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}`. Add the resolver
+`https://mmlspark.blob.core.windows.net/maven`, attach the library to the target
+cluster, and restart it before importing `synapse.ml`.
 
 You can use SynapseML in both your Scala and PySpark notebooks. To get started with our example notebooks, import the following databricks archive:
 
@@ -134,7 +212,9 @@ You can use SynapseML in both your Scala and PySpark notebooks. To get started w
 
 ## Apache Livy and HDInsight
 
-To install SynapseML from within a Jupyter notebook served by Apache Livy, the following configure magic can be used. You'll need to start a new session after this configure cell is executed.
+To install SynapseML from within a Jupyter notebook served by Apache Livy, the
+following Spark 3.5 / Scala 2.12 configure magic can be used. You'll need to
+start a new session after this configure cell is executed.
 
 Excluding certain packages from the library may be necessary due to current issues with Livy 0.5
 
@@ -143,22 +223,23 @@ Excluding certain packages from the library may be necessary due to current issu
 {
     "name": "synapseml",
     "conf": {
-        # Use 1.1.3 version for spark 3.5 and 1.0.15 version for Spark3.4
         "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:1.1.3",
+        "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
         "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind"
     }
 }
 ```
 
-In Azure Synapse, "spark.yarn.user.classpath.first" should be set to "true" to override the existing SynapseML packages
+In Azure Synapse, `spark.yarn.user.classpath.first` should be set to `true` to
+override the existing SynapseML packages:
 
 ```
 %%configure -f
 {
     "name": "synapseml",
     "conf": {
-        # Use 1.1.3 version for spark 3.5 and 1.0.15 version for Spark3.4
         "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:1.1.3",
+        "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
         "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
         "spark.yarn.user.classpath.first": "true"
     }
@@ -198,4 +279,3 @@ If you encounter issues, reach out to our support email!
 To try out SynapseML using the R autogenerated wrappers, [see our
 instructions](../../Reference/R%20Setup).  Note: This feature is still under development
 and some necessary custom wrappers may be missing.
-

--- a/website/versioned_docs/version-1.1.3/Get Started/Install SynapseML.md
+++ b/website/versioned_docs/version-1.1.3/Get Started/Install SynapseML.md
@@ -14,29 +14,17 @@ wrapper can import successfully while its JVM class is missing. In particular,
 using a `_2.12` artifact with Spark 4 can cause errors such as
 `LightGBMClassifier does not exist in the JVM`.
 
-The examples on this page use the current base release:
+Choose one complete published build from the Spark runtime. `master` is the
+canonical Spark 3.5 development line; Spark 4.0 and Spark 4.1 are maintained on
+their corresponding branches.
 
-```bash
-SYNAPSEML_VERSION="1.1.3"
-```
+| Code line | Spark runtime | Scala | Python baseline | Release tag | Python package | Maven coordinate |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`master`](https://github.com/microsoft/SynapseML/tree/master) | Spark 3.5.x | 2.12 | Python 3.11 | [`v1.1.3`](https://github.com/microsoft/SynapseML/tree/v1.1.3) | `synapseml==1.1.3` | `com.microsoft.azure:synapseml_2.12:1.1.3` |
+| [`spark4.0`](https://github.com/microsoft/SynapseML/tree/spark4.0) | Spark 4.0.1+ (`<4.1`) | 2.13 | Python 3.12 | [`v1.1.3-spark4.0`](https://github.com/microsoft/SynapseML/tree/v1.1.3-spark4.0) | `synapseml==1.1.3` | `com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0` |
+| [`spark4.1`](https://github.com/microsoft/SynapseML/tree/spark4.1) | Spark 4.1.x | 2.13 | Python 3.13 | [`v1.1.3-spark4.1`](https://github.com/microsoft/SynapseML/tree/v1.1.3-spark4.1) | `synapseml==1.1.3` | `com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1` |
 
-Choose the coordinate from the Spark runtime, not from the Python version:
-
-| Spark runtime | Scala binary version | Port Python baseline | Release tag | Maven coordinate |
-| --- | --- | --- | --- | --- |
-| Spark 3.5.x | 2.12 | Python 3.11 | `v${SYNAPSEML_VERSION}` | `com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}` |
-| Spark 4.0.x | 2.13 | Python 3.12 | `v${SYNAPSEML_VERSION}-spark4.0` | `com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.0` |
-| Spark 4.1.x | 2.13 | Python 3.13 | `v${SYNAPSEML_VERSION}-spark4.1` | `com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1` |
-
-In a UI that does not expand shell variables, replace
-`${SYNAPSEML_VERSION}` with the value assigned above.
-The Spark 4 rows correspond to the explicit published tags shown; documentation
-tests lock their artifact versions so a base-version bump cannot silently
-advertise an unpublished port. The same `synapseml==${SYNAPSEML_VERSION}`
-Python wheel is
-used with either port; the Spark runtime determines which JVM coordinate to
-load. Always add the SynapseML repository because the Spark 4 artifacts are
-published there:
+Always add the SynapseML repository:
 
 ```text
 https://mmlspark.blob.core.windows.net/maven
@@ -44,9 +32,8 @@ https://mmlspark.blob.core.windows.net/maven
 
 ## Microsoft Fabric
 
-SynapseML is already installed in Microsoft Fabric notebooks. To override it,
-first check the notebook runtime's Spark and Scala versions, then substitute the
-matching full coordinate and Scala binary version from the matrix above:
+SynapseML is already installed in Microsoft Fabric notebooks. The following
+copy-ready override targets a Spark 4.1 / Scala 2.13 runtime:
 
 
 ```bash
@@ -54,9 +41,9 @@ matching full coordinate and Scala binary version from the matrix above:
 {
   "name": "synapseml",
   "conf": {
-      "spark.jars.packages": "<COORDINATE_FROM_THE_MATRIX_ABOVE>",
+      "spark.jars.packages": "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1",
       "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
-      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_<SCALA_BINARY_VERSION>,org.scalactic:scalactic_<SCALA_BINARY_VERSION>,org.scalatest:scalatest_<SCALA_BINARY_VERSION>,com.fasterxml.jackson.core:jackson-databind",
+      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.13,org.scalactic:scalactic_2.13,org.scalatest:scalatest_2.13,com.fasterxml.jackson.core:jackson-databind",
       "spark.yarn.user.classpath.first": "true",
       "spark.sql.parquet.enableVectorizedReader": "false"
   }
@@ -66,9 +53,8 @@ matching full coordinate and Scala binary version from the matrix above:
 
 ## Synapse
 
-SynapseML is already installed in Synapse Analytics notebooks. To change the version please place the following in the first cell of your notebook:
-
-For Spark3.5 pools
+Current Synapse Analytics pools use Spark 3.5. To override the preinstalled
+version, place the following in the first cell of your notebook:
 ```python
 %%configure -f
 {
@@ -83,82 +69,43 @@ For Spark3.5 pools
 }
 ```
 
-For Spark3.4 pools
-```python
-%%configure -f
-{
-  "name": "synapseml",
-  "conf": {
-      "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:1.0.15",
-      "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
-      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
-      "spark.yarn.user.classpath.first": "true",
-      "spark.sql.parquet.enableVectorizedReader": "false"
-  }
-}
-```
-
-For Spark3.3 pools:
-```python
-%%configure -f
-{
-  "name": "synapseml",
-  "conf": {
-      "spark.jars.packages": "com.microsoft.azure:synapseml_2.12:0.11.4-spark3.3",
-      "spark.jars.repositories": "https://mmlspark.blob.core.windows.net/maven",
-      "spark.jars.excludes": "org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.12,org.scalactic:scalactic_2.12,org.scalatest:scalatest_2.12,com.fasterxml.jackson.core:jackson-databind",
-      "spark.yarn.user.classpath.first": "true",
-      "spark.sql.parquet.enableVectorizedReader": "false"
-  }
-}
-```
-
 ## Python
 
 To try out SynapseML on a Python (or Conda) installation, you can get Spark
-installed via pip. Using the `SYNAPSEML_VERSION` assigned above, choose exactly
-one complete runtime variant below, then start Spark with that variant's JVM
-artifact.
+installed via pip. Choose exactly one complete runtime variant below, then
+start Spark with that variant's JVM artifact.
 
 **Spark 4.1 / Python 3.13**
 
 ```bash
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.1,<4.2"
+python -m pip install "synapseml==1.1.3" "pyspark>=4.1,<4.2"
 ```
 
 **Spark 4.0 / Python 3.12**
 
 ```bash
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.0.1,<4.1"
+python -m pip install "synapseml==1.1.3" "pyspark>=4.0.1,<4.1"
 ```
 
 **Spark 3.5 / Python 3.11**
 
 ```bash
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=3.5,<3.6"
+python -m pip install "synapseml==1.1.3" "pyspark>=3.5,<3.6"
 ```
 
 ```python
 from pyspark.sql import SparkSession
 
-SYNAPSEML_VERSION="1.1.3"
-
-# Select the coordinate matching the PySpark command used above.
-SYNAPSEML_COORDINATE=(
-    f"com.microsoft.azure:synapseml_2.13:{SYNAPSEML_VERSION}-spark4.1"
-)
+# Spark 4.1. Select the coordinate matching the PySpark command used above.
+synapseml_coordinate = "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1"
 # Spark 4.0:
-# SYNAPSEML_COORDINATE=(
-#     f"com.microsoft.azure:synapseml_2.13:{SYNAPSEML_VERSION}-spark4.0"
-# )
+# synapseml_coordinate = "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0"
 # Spark 3.5:
-# SYNAPSEML_COORDINATE=(
-#     f"com.microsoft.azure:synapseml_2.12:{SYNAPSEML_VERSION}"
-# )
+# synapseml_coordinate = "com.microsoft.azure:synapseml_2.12:1.1.3"
 
 spark = (
     SparkSession.builder.appName("MyApp")
-    .config("spark.jars.packages", SYNAPSEML_COORDINATE)
+    .config("spark.jars.packages", synapseml_coordinate)
     .config(
         "spark.jars.repositories",
         "https://mmlspark.blob.core.windows.net/maven",
@@ -171,40 +118,53 @@ import synapse.ml
 ## SBT
 
 If you're building a Spark application in Scala, add the following lines to
-your `build.sbt`. For Spark 4.1 (use `SPARK_LINE="4.0"` for Spark 4.0):
+your `build.sbt`. Choose the dependency matching your Spark runtime.
+
+**Spark 4.1**
 
 ```scala
-val SYNAPSEML_VERSION="1.1.3"
-val SPARK_LINE="4.1"
 resolvers += "SynapseML" at "https://mmlspark.blob.core.windows.net/maven"
 libraryDependencies +=
-  "com.microsoft.azure" % "synapseml_2.13" %
-    s"$SYNAPSEML_VERSION-spark$SPARK_LINE"
+  "com.microsoft.azure" % "synapseml_2.13" % "1.1.3-spark4.1"
 ```
 
-For Spark 3.5, use
-`"com.microsoft.azure" % "synapseml_2.12" % SYNAPSEML_VERSION`.
+**Spark 4.0**
+
+```scala
+resolvers += "SynapseML" at "https://mmlspark.blob.core.windows.net/maven"
+libraryDependencies +=
+  "com.microsoft.azure" % "synapseml_2.13" % "1.1.3-spark4.0"
+```
+
+**Spark 3.5**
+
+```scala
+resolvers += "SynapseML" at "https://mmlspark.blob.core.windows.net/maven"
+libraryDependencies +=
+  "com.microsoft.azure" % "synapseml_2.12" % "1.1.3"
+```
 
 ## Spark package
 
 SynapseML can be conveniently installed on existing Spark clusters via the
-`--packages` option. Include `--repositories` for the Spark 4 ports:
+`--packages` option. Each example below is independently copyable.
 
 ```bash
-SYNAPSEML_VERSION=1.1.3
-SYNAPSEML_REPOSITORY=https://mmlspark.blob.core.windows.net/maven
-
-# Spark 4.0
-pyspark --repositories "$SYNAPSEML_REPOSITORY" \
-  --packages "com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.0"
-
 # Spark 4.1
-pyspark --repositories "$SYNAPSEML_REPOSITORY" \
-  --packages "com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1"
+pyspark --repositories "https://mmlspark.blob.core.windows.net/maven" \
+  --packages "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1"
+```
 
+```bash
+# Spark 4.0
+pyspark --repositories "https://mmlspark.blob.core.windows.net/maven" \
+  --packages "com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0"
+```
+
+```bash
 # Spark 3.5
-pyspark --repositories "$SYNAPSEML_REPOSITORY" \
-  --packages "com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}"
+pyspark --repositories "https://mmlspark.blob.core.windows.net/maven" \
+  --packages "com.microsoft.azure:synapseml_2.12:1.1.3"
 ```
 
 A similar technique can be used in other Spark contexts too. For example, you can use SynapseML
@@ -219,13 +179,17 @@ cloud](http://community.cloud.databricks.com), create a new [library from Maven
 coordinates](https://docs.databricks.com/user-guide/libraries.html#libraries-from-maven-pypi-or-spark-packages)
 in your workspace.
 
-Use the coordinate matching the cluster's Spark and Scala versions from the
-matrix above. For example, a Spark 4.1 / Scala 2.13 cluster uses
-`com.microsoft.azure:synapseml_2.13:${SYNAPSEML_VERSION}-spark4.1`, while a
-Spark 3.5 / Scala 2.12 cluster uses
-`com.microsoft.azure:synapseml_2.12:${SYNAPSEML_VERSION}`. Add the resolver
-`https://mmlspark.blob.core.windows.net/maven`, attach the library to the target
-cluster, and restart it before importing `synapse.ml`.
+Use one of these exact Maven coordinates:
+
+- Spark 4.1 / Scala 2.13:
+  `com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1`
+- Spark 4.0 / Scala 2.13:
+  `com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0`
+- Spark 3.5 / Scala 2.12:
+  `com.microsoft.azure:synapseml_2.12:1.1.3`
+
+Add the resolver `https://mmlspark.blob.core.windows.net/maven`, attach the
+library to the target cluster, and restart it before importing `synapse.ml`.
 
 You can use SynapseML in both your Scala and PySpark notebooks. To get started with our example notebooks, import the following databricks archive:
 

--- a/website/versioned_docs/version-1.1.3/Get Started/Install SynapseML.md
+++ b/website/versioned_docs/version-1.1.3/Get Started/Install SynapseML.md
@@ -31,8 +31,9 @@ Choose the coordinate from the Spark runtime, not from the Python version:
 In a UI that does not expand shell variables, replace
 `${SYNAPSEML_VERSION}` with the value assigned above.
 The Spark 4 rows correspond to the explicit published tags shown; documentation
-tests lock those tags so a base-version bump cannot silently advertise an
-unpublished port. The same `synapseml==${SYNAPSEML_VERSION}` Python wheel is
+tests lock their artifact versions so a base-version bump cannot silently
+advertise an unpublished port. The same `synapseml==${SYNAPSEML_VERSION}`
+Python wheel is
 used with either port; the Spark runtime determines which JVM coordinate to
 load. Always add the SynapseML repository because the Spark 4 artifacts are
 published there:
@@ -115,25 +116,26 @@ For Spark3.3 pools:
 ## Python
 
 To try out SynapseML on a Python (or Conda) installation, you can get Spark
-installed via pip. Choose exactly one complete runtime variant below, then
-start Spark with that variant's JVM artifact.
+installed via pip. Using the `SYNAPSEML_VERSION` assigned above, choose exactly
+one complete runtime variant below, then start Spark with that variant's JVM
+artifact.
 
 **Spark 4.1 / Python 3.13**
 
 ```bash
-python -m pip install "synapseml==1.1.3" "pyspark>=4.1,<4.2"
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.1,<4.2"
 ```
 
 **Spark 4.0 / Python 3.12**
 
 ```bash
-python -m pip install "synapseml==1.1.3" "pyspark>=4.0,<4.1"
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.0,<4.1"
 ```
 
 **Spark 3.5 / Python 3.11**
 
 ```bash
-python -m pip install "synapseml==1.1.3" "pyspark>=3.5,<3.6"
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=3.5,<3.6"
 ```
 
 ```python

--- a/website/versioned_docs/version-1.1.3/Get Started/Install SynapseML.md
+++ b/website/versioned_docs/version-1.1.3/Get Started/Install SynapseML.md
@@ -30,10 +30,12 @@ Choose the coordinate from the Spark runtime, not from the Python version:
 
 In a UI that does not expand shell variables, replace
 `${SYNAPSEML_VERSION}` with the value assigned above.
-The Spark 4 rows are separately published ports. The same
-`synapseml==${SYNAPSEML_VERSION}` Python wheel is used with either port; the
-Spark runtime determines which JVM coordinate to load. Always add the
-SynapseML repository because the Spark 4 artifacts are published there:
+The Spark 4 rows correspond to the explicit published tags shown; documentation
+tests lock those tags so a base-version bump cannot silently advertise an
+unpublished port. The same `synapseml==${SYNAPSEML_VERSION}` Python wheel is
+used with either port; the Spark runtime determines which JVM coordinate to
+load. Always add the SynapseML repository because the Spark 4 artifacts are
+published there:
 
 ```text
 https://mmlspark.blob.core.windows.net/maven
@@ -113,24 +115,39 @@ For Spark3.3 pools:
 ## Python
 
 To try out SynapseML on a Python (or Conda) installation, you can get Spark
-installed via pip. Install the Python wrapper and start Spark with the matching
-JVM artifact. This copy-paste example is for Spark 4.1 and Python 3.13. For
-Spark 4.0, install `pyspark>=4.0,<4.1` instead and set `SPARK_LINE="4.0"`:
+installed via pip. Install the Python wrapper and PySpark version for one
+complete runtime variant, then start Spark with that variant's JVM artifact:
 
 ```bash
 SYNAPSEML_VERSION=1.1.3
+
+# Spark 4.1 / Python 3.13
 python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.1,<4.2"
+
+# Spark 4.0 / Python 3.12
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.0,<4.1"
+
+# Spark 3.5 / Python 3.11
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=3.5,<3.6"
 ```
 
 ```python
 from pyspark.sql import SparkSession
 
 SYNAPSEML_VERSION="1.1.3"
-SPARK_LINE="4.1"
+
+# Select the coordinate matching the PySpark command used above.
 SYNAPSEML_COORDINATE=(
-    f"com.microsoft.azure:synapseml_2.13:"
-    f"{SYNAPSEML_VERSION}-spark{SPARK_LINE}"
+    f"com.microsoft.azure:synapseml_2.13:{SYNAPSEML_VERSION}-spark4.1"
 )
+# Spark 4.0:
+# SYNAPSEML_COORDINATE=(
+#     f"com.microsoft.azure:synapseml_2.13:{SYNAPSEML_VERSION}-spark4.0"
+# )
+# Spark 3.5:
+# SYNAPSEML_COORDINATE=(
+#     f"com.microsoft.azure:synapseml_2.12:{SYNAPSEML_VERSION}"
+# )
 
 spark = (
     SparkSession.builder.appName("MyApp")
@@ -143,9 +160,6 @@ spark = (
 )
 import synapse.ml
 ```
-
-For Spark 3.5, use
-`SYNAPSEML_COORDINATE=f"com.microsoft.azure:synapseml_2.12:{SYNAPSEML_VERSION}"`.
 
 ## SBT
 

--- a/website/versioned_docs/version-1.1.3/Get Started/Install SynapseML.md
+++ b/website/versioned_docs/version-1.1.3/Get Started/Install SynapseML.md
@@ -129,7 +129,7 @@ python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.1,<4.2"
 **Spark 4.0 / Python 3.12**
 
 ```bash
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.0,<4.1"
+python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.0.1,<4.1"
 ```
 
 **Spark 3.5 / Python 3.11**

--- a/website/versioned_docs/version-1.1.3/Get Started/Install SynapseML.md
+++ b/website/versioned_docs/version-1.1.3/Get Started/Install SynapseML.md
@@ -115,20 +115,25 @@ For Spark3.3 pools:
 ## Python
 
 To try out SynapseML on a Python (or Conda) installation, you can get Spark
-installed via pip. Install the Python wrapper and PySpark version for one
-complete runtime variant, then start Spark with that variant's JVM artifact:
+installed via pip. Choose exactly one complete runtime variant below, then
+start Spark with that variant's JVM artifact.
+
+**Spark 4.1 / Python 3.13**
 
 ```bash
-SYNAPSEML_VERSION=1.1.3
+python -m pip install "synapseml==1.1.3" "pyspark>=4.1,<4.2"
+```
 
-# Spark 4.1 / Python 3.13
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.1,<4.2"
+**Spark 4.0 / Python 3.12**
 
-# Spark 4.0 / Python 3.12
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=4.0,<4.1"
+```bash
+python -m pip install "synapseml==1.1.3" "pyspark>=4.0,<4.1"
+```
 
-# Spark 3.5 / Python 3.11
-python -m pip install "synapseml==${SYNAPSEML_VERSION}" "pyspark>=3.5,<3.6"
+**Spark 3.5 / Python 3.11**
+
+```bash
+python -m pip install "synapseml==1.1.3" "pyspark>=3.5,<3.6"
 ```
 
 ```python

--- a/website/versioned_docs/version-1.1.3/Overview.md
+++ b/website/versioned_docs/version-1.1.3/Overview.md
@@ -12,7 +12,10 @@ SynapseML (previously known as MMLSpark), is an open-source library that simplif
 
 With SynapseML, you can build scalable and intelligent systems to solve challenges in domains such as anomaly detection, computer vision, deep learning, text analytics, and others. SynapseML can train and evaluate models on single-node, multi-node, and elastically resizable clusters of computers. This lets you scale your work without wasting resources. SynapseML is usable across Python, R, Scala, Java, and .NET. Furthermore, its API abstracts over a wide variety of databases, file systems, and cloud data stores to simplify experiments no matter where data is located.
 
-SynapseML requires Scala 2.12, Spark 3.2+, and Python 3.8+.
+SynapseML publishes JVM artifacts for specific Spark and Scala combinations:
+Spark 3.5 uses Scala 2.12, while Spark 4.0 and 4.1 use Scala 2.13. Select the
+matching artifact in the
+[installation guide](Get%20Started/Install%20SynapseML.md).
 
 import Link from '@docusaurus/Link';
 

--- a/website/versioned_docs/version-1.1.3/Reference/R Setup.md
+++ b/website/versioned_docs/version-1.1.3/Reference/R Setup.md
@@ -19,7 +19,7 @@ release. If you are using sparklyr, you can use
 On Windows, download
 [WinUtils.exe](https://github.com/steveloughran/winutils/blob/master/hadoop-3.0.0/bin/winutils.exe)
 and copy it into the `bin` directory of your Spark installation, for example,
-`C:\Users\user\AppData\Local\Spark\spark-3.3.2-bin-hadoop3\bin`.
+`C:\Users\user\AppData\Local\Spark\spark-3.5.0-bin-hadoop3\bin`.
 
 The R bindings are published as one archive per SynapseML module. A combined
 `synapseml-1.1.3.zip` archive is not published. Install `synapseml-core` and
@@ -49,10 +49,11 @@ sparklyr connections, `sparklyr.shell.repositories` supplies the repository to
 `spark-submit`, while `extensions = character()` prevents the wrappers' embedded
 registration from overriding it:
 
-> The examples below use Spark 3.5 / Scala 2.12. Spark 4 uses Scala 2.13 and a
-> Spark-specific artifact version; substitute the coordinate from the
-> [installation matrix](../Get%20Started/Install%20SynapseML.md). The R component
-> archive version remains the base SynapseML version.
+> The examples below use Spark 3.5 / Scala 2.12 with
+> `com.microsoft.azure:synapseml_2.12:1.1.3`. For Spark 4.0 use
+> `com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0`; for Spark 4.1 use
+> `com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1`. The R component archive
+> version remains `1.1.3`.
 
 ```R
 library(sparklyr)

--- a/website/versioned_docs/version-1.1.3/Reference/R Setup.md
+++ b/website/versioned_docs/version-1.1.3/Reference/R Setup.md
@@ -49,6 +49,11 @@ sparklyr connections, `sparklyr.shell.repositories` supplies the repository to
 `spark-submit`, while `extensions = character()` prevents the wrappers' embedded
 registration from overriding it:
 
+> The examples below use Spark 3.5 / Scala 2.12. Spark 4 uses Scala 2.13 and a
+> Spark-specific artifact version; substitute the coordinate from the
+> [installation matrix](../Get%20Started/Install%20SynapseML.md). The R component
+> archive version remains the base SynapseML version.
+
 ```R
 library(sparklyr)
 library(dplyr)


### PR DESCRIPTION
## Summary

- add a Spark runtime / Scala binary / Python baseline / release tag / Maven artifact matrix
- document copy-paste Spark 3.5, 4.0, and 4.1 installs across the README, canonical/versioned install guides, and website landing page
- explain that the PyPI wheel supplies wrappers but does not load JVM classes
- gate Spark port coordinates with two explicit published artifact versions in a deterministic, non-network regression test
- keep the Isolation Forest quickstart honestly scoped to its Spark 3.5 / Scala 2.12 dependency baseline

## Review blockers resolved

1. **Primary website surface:** `website/src/pages/index.js` uses centralized Spark 3.5/4.0/4.1 coordinates and complete Python variants; `installDocs.test.js` covers this surface.
2. **Complete Spark 3.5 Python variant:** README, canonical install docs, and current versioned docs specify Python 3.11, `pyspark>=3.5,<3.6`, and the `_2.12` JVM coordinate together.
3. **Isolation Forest compatibility:** the notebook remains explicitly Spark 3.5 / Scala 2.12 because its pinned `numpy==1.22.4` dependency is not a Python 3.12/3.13 setup.
4. **No manufactured port releases:** `published-spark-ports.lock` contains only the two independently verified Spark 4 artifact versions. Tests compare rendered documentation and website coordinates to that lock; they do not invoke Git or assume full repository history.

## Before

Current installation surfaces directed users to Scala 2.12 artifacts such as:

```text
com.microsoft.azure:synapseml_2.12:1.1.3
```

On Spark 4, which uses Scala 2.13, that can leave the Python wrapper importable but the matching JVM class unavailable, producing `LightGBMClassifier does not exist in the JVM`.

## After

```text
Spark 3.5 / Scala 2.12 / Python 3.11 -> com.microsoft.azure:synapseml_2.12:1.1.3
Spark 4.0 / Scala 2.13 / Python 3.12 -> com.microsoft.azure:synapseml_2.13:1.1.3-spark4.0
Spark 4.1 / Scala 2.13 / Python 3.13 -> com.microsoft.azure:synapseml_2.13:1.1.3-spark4.1
```

All variants use `synapseml==1.1.3`; Spark 4 artifacts require `https://mmlspark.blob.core.windows.net/maven`.

## Published artifact evidence

- live tags `v1.1.3-spark4.0` and `v1.1.3-spark4.1` exist
- [Spark 4.0 aggregate POM](https://mmlspark.blob.core.windows.net/maven/com/microsoft/azure/synapseml_2.13/1.1.3-spark4.0/synapseml_2.13-1.1.3-spark4.0.pom) and [LightGBM JAR](https://mmlspark.blob.core.windows.net/maven/com/microsoft/azure/synapseml-lightgbm_2.13/1.1.3-spark4.0/synapseml-lightgbm_2.13-1.1.3-spark4.0.jar) return HTTP 200
- [Spark 4.1 aggregate POM](https://mmlspark.blob.core.windows.net/maven/com/microsoft/azure/synapseml_2.13/1.1.3-spark4.1/synapseml_2.13-1.1.3-spark4.1.pom) and [LightGBM JAR](https://mmlspark.blob.core.windows.net/maven/com/microsoft/azure/synapseml-lightgbm_2.13/1.1.3-spark4.1/synapseml-lightgbm_2.13-1.1.3-spark4.1.jar) return HTTP 200
- both JARs contain `com/microsoft/azure/synapse/ml/lightgbm/LightGBMClassifier.class`

## Future version updates

1. Run the normal context-anchored base-version update. `website/src/installArtifacts.js` exposes the base version from its release-managed `synapseml==...` pin, and the current docs reuse `SYNAPSEML_VERSION` instead of repeating the number in each command.
2. Publish and verify each Spark port artifact independently.
3. Grep `website/test/published-spark-ports.lock` and update its two values only after the corresponding artifacts exist. The lock is intentionally excluded from automatic base-version replacement.
4. Run `npm test` from `website`. A base-version bump fails until both explicitly locked port versions agree with the documented coordinates.

No commit mapping, tag checkout, `git show`, or full-history clone is required.

## Validation

- `npm test` in `website`: 31/31 passed
- documentation projection completed successfully
- JavaScript syntax, lock JSON, and `git diff --check` passed
- real local Spark sessions resolved the published artifacts, instantiated `UDFTransformer`, and completed `spark.range(3).count()` on Spark 3.5.0 / Python 3.11, Spark 4.0.1 / Python 3.12, and Spark 4.1.0 / Python 3.12
- Spark 4.0.0 was explicitly rejected after reproducing a JVM `NoSuchMethodError`; the install floor is now `pyspark>=4.0.1,<4.1`, matching the published POM compile baseline
- documentation tests have no child-process or Git-history dependency
- no commit SHA mappings were introduced
- exact-head Linux website production build and dead-link scan passed
- local Windows production build reaches client/server compilation but is blocked by existing generated-MDX parsing failures in three unchanged docs
- repository-wide Black reports nine pre-existing non-doc formatting failures; this PR changes no checked Python source
- exact-head Azure validation was requested after this update

## Review follow-up

- All three review threads have evidence replies and are resolved.
- Every historical suppressed Copilot finding was fixed and documented in PR comments.
- Current-head Copilot review covered 15/16 changed files with zero new or suppressed findings.
- Current-head website build, dead-link scan, CodeQL, dependency review, title, WIP, and CLA checks passed.

Closes #2402




