### PR TITLE
fix: clean up failed LightGBM streaming datasets

### DIFF
--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/StreamingPartitionTask.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/StreamingPartitionTask.scala
@@ -348,18 +348,21 @@ class StreamingPartitionTask extends BasePartitionTask {
 
   private def createSharedValidationDataset(ctx: PartitionTaskContext, rowCount: Int): LightGBMDataset = {
     val pointer = lightgbmlib.voidpp_handle()
-    val reference = ctx.sharedState.datasetState.streamingDataset.get.datasetPtr
-    LightGBMUtils.validate(
-      lightgbmlib.LGBM_DatasetCreateByReference(reference, rowCount, pointer),
-      "Dataset create from reference")
+    val dataset = try {
+      val reference = ctx.sharedState.datasetState.streamingDataset.get.datasetPtr
+      LightGBMUtils.validate(
+        lightgbmlib.LGBM_DatasetCreateByReference(reference, rowCount, pointer),
+        "Dataset create from reference")
+      new LightGBMDataset(lightgbmlib.voidpp_value(pointer))
+    } finally {
+      lightgbmlib.delete_voidpp(pointer)
+    }
 
-    val datasetPtr = lightgbmlib.voidpp_value(pointer)
-    LightGBMUtils.validate(
-      lightgbmlib.LGBM_DatasetSetWaitForManualFinish(datasetPtr, 1),
-      "Dataset LGBM_DatasetSetWaitForManualFinish")
-
-    lightgbmlib.delete_voidpp(pointer)
-    val dataset = new LightGBMDataset(datasetPtr)
-    dataset.setFeatureNames(ctx.trainingCtx.featureNames, ctx.trainingCtx.numCols)
+    ReferenceDatasetUtils.initializeOwnedDataset(dataset) {
+      LightGBMUtils.validate(
+        lightgbmlib.LGBM_DatasetSetWaitForManualFinish(dataset.datasetPtr, 1),
+        "Dataset LGBM_DatasetSetWaitForManualFinish")
+      dataset.setFeatureNames(ctx.trainingCtx.featureNames, ctx.trainingCtx.numCols)
+    }
   }
 }

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/StreamingPartitionTask.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/StreamingPartitionTask.scala
@@ -129,7 +129,7 @@ class StreamingPartitionTask extends BasePartitionTask {
 
     // Now handle validation data, which comes from a broadcast-ed hardcoded array
     if (ctx.shouldCalcValidationDataset) {
-      ctx.sharedState.validationDatasetState.streamingDataset = Option(generateOptValidationDataset(ctx))
+      generateAndStoreValidationDataset(ctx)
     }
 
     // streaming does not use data state (it stores intermediate results in the context shared state),
@@ -151,23 +151,22 @@ class StreamingPartitionTask extends BasePartitionTask {
     ctx.sharedState.validationDatasetState.streamingDataset.get
   }
 
-  private def generateOptValidationDataset(ctx: PartitionTaskContext): LightGBMDataset = {
+  private def generateAndStoreValidationDataset(ctx: PartitionTaskContext): Unit = {
     val validationData = ctx.trainingCtx.validationData.get.value
 
     val validationDataset = createSharedValidationDataset(ctx, validationData.length)
 
-    insertRowsIntoDataset(
-      ctx,
-      validationDataset,
-      validationData.toIterator,
-      0,
-      validationData.length,
-      0)
-
-    // Complete the dataset here since we only add data to it once
-    LightGBMUtils.validate(lightgbmlib.LGBM_DatasetMarkFinished(validationDataset.datasetPtr),
-      "Dataset mark finished")
-    validationDataset
+    StreamingPartitionTask.initializeValidationDataset(validationDataset)(
+      insertRowsIntoDataset(
+        ctx,
+        validationDataset,
+        validationData.toIterator,
+        0,
+        validationData.length,
+        0))(
+      LightGBMUtils.validate(lightgbmlib.LGBM_DatasetMarkFinished(validationDataset.datasetPtr),
+        "Dataset mark finished"))(
+      ctx.sharedState.validationDatasetState.streamingDataset = Option(validationDataset))
   }
 
   private def insertRowsIntoTrainingDataset(ctx: PartitionTaskContext, inputRows: Iterator[Row]): Unit = {
@@ -363,6 +362,19 @@ class StreamingPartitionTask extends BasePartitionTask {
         lightgbmlib.LGBM_DatasetSetWaitForManualFinish(dataset.datasetPtr, 1),
         "Dataset LGBM_DatasetSetWaitForManualFinish")
       dataset.setFeatureNames(ctx.trainingCtx.featureNames, ctx.trainingCtx.numCols)
+    }
+  }
+}
+
+object StreamingPartitionTask {
+  private[lightgbm] def initializeValidationDataset(dataset: LightGBMDataset)
+                                                   (insertRows: => Unit)
+                                                   (markFinished: => Unit)
+                                                   (transferOwnership: => Unit): Unit = {
+    ReferenceDatasetUtils.initializeOwnedDataset(dataset) {
+      insertRows
+      markFinished
+      transferOwnership
     }
   }
 }

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/dataset/ReferenceDatasetUtils.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/dataset/ReferenceDatasetUtils.scala
@@ -111,18 +111,28 @@ object ReferenceDatasetUtils {
       count,
       datasetParams)
 
-    // Initialize the dataset for streaming (allocates arrays mostly)
-    val maxOmpThreads = ctx.trainingParams.executionParams.maxStreamingOMPThreads
-    LightGBMUtils.validate(lightgbmlib.LGBM_DatasetInitStreaming(lightGBMDataset.datasetPtr,
-      ctx.trainingCtx.hasWeightsAsInt,
-      ctx.trainingCtx.hasInitialScoresAsInt,
-      ctx.trainingCtx.hasGroupsAsInt,
-      ctx.trainingParams.getNumClass,
-      ctx.executorPartitionCount,
-      maxOmpThreads),
-      "LGBM_DatasetInitStreaming")
+    initializeOwnedDataset(lightGBMDataset) {
+      // Initialize the dataset for streaming (allocates arrays mostly)
+      val maxOmpThreads = ctx.trainingParams.executionParams.maxStreamingOMPThreads
+      LightGBMUtils.validate(lightgbmlib.LGBM_DatasetInitStreaming(lightGBMDataset.datasetPtr,
+        ctx.trainingCtx.hasWeightsAsInt,
+        ctx.trainingCtx.hasInitialScoresAsInt,
+        ctx.trainingCtx.hasGroupsAsInt,
+        ctx.trainingParams.getNumClass,
+        ctx.executorPartitionCount,
+        maxOmpThreads),
+        "LGBM_DatasetInitStreaming")
 
-    lightGBMDataset.setFeatureNames(ctx.trainingCtx.featureNames, ctx.trainingCtx.numCols)
+      lightGBMDataset.setFeatureNames(ctx.trainingCtx.featureNames, ctx.trainingCtx.numCols)
+    }
+  }
+
+  private[lightgbm] def initializeOwnedDataset(dataset: LightGBMDataset)
+                                                (initialization: => Unit): LightGBMDataset = {
+    NetworkManager.withCleanupOnFailurePreservingPrimary(dataset.close()) {
+      initialization
+      dataset
+    }
   }
 
   private def toByteArray(buffer: SWIGTYPE_p_p_void, bufferLen: Int): Array[Byte] = {
@@ -152,17 +162,24 @@ object ReferenceDatasetUtils {
                                           datasetParams: String): LightGBMDataset = {
     // Convert byte array to native memory
     val datasetVoidPtr = lightgbmlib.voidpp_handle()
-    val nativeByteArray = SwigUtils.byteArrayToNative(serializedDataset)
-    LightGBMUtils.validate(lightgbmlib.LGBM_DatasetCreateFromSerializedReference( //scalastyle:ignore token
-      lightgbmlib.byte_to_voidp_ptr(nativeByteArray),
-      serializedDataset.length,
-      rowCount,
-      0, // Always zero since we will be using InitStreaming to do allocation
-      datasetParams,
-      datasetVoidPtr), "Dataset create from reference")
+    try {
+      val nativeByteArray = SwigUtils.byteArrayToNative(serializedDataset)
+      try {
+        LightGBMUtils.validate(lightgbmlib.LGBM_DatasetCreateFromSerializedReference( //scalastyle:ignore token
+          lightgbmlib.byte_to_voidp_ptr(nativeByteArray),
+          serializedDataset.length,
+          rowCount,
+          0, // Always zero since we will be using InitStreaming to do allocation
+          datasetParams,
+          datasetVoidPtr), "Dataset create from reference")
 
-    val datasetPtr: SWIGTYPE_p_void = lightgbmlib.voidpp_value(datasetVoidPtr)
-    lightgbmlib.delete_voidpp(datasetVoidPtr)
-    new LightGBMDataset(datasetPtr)
+        val datasetPtr: SWIGTYPE_p_void = lightgbmlib.voidpp_value(datasetVoidPtr)
+        new LightGBMDataset(datasetPtr)
+      } finally {
+        lightgbmlib.delete_byteArray(nativeByteArray)
+      }
+    } finally {
+      lightgbmlib.delete_voidpp(datasetVoidPtr)
+    }
   }
 }

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/dataset/ReferenceDatasetUtilsSuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/dataset/ReferenceDatasetUtilsSuite.scala
@@ -4,6 +4,7 @@
 package com.microsoft.azure.synapse.ml.lightgbm.dataset
 
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import com.microsoft.azure.synapse.ml.lightgbm.StreamingPartitionTask
 
 class ReferenceDatasetUtilsSuite extends TestBase {
   private class TrackingDataset(closeFailure: Option[RuntimeException] = None)
@@ -53,5 +54,45 @@ class ReferenceDatasetUtilsSuite extends TestBase {
     assert(thrown eq initializationFailure)
     assert(dataset.closeCount == 1)
     assert(thrown.getSuppressed.toSeq == Seq(cleanupFailure))
+  }
+
+  test("validation Dataset cleanup runs when row insertion fails before ownership transfer") {
+    val cleanupFailure = new RuntimeException("cleanup failed")
+    val dataset = new TrackingDataset(Option(cleanupFailure))
+    val insertionFailure = new IllegalStateException("row insertion failed")
+    var markFinishedCalled = false
+    var ownershipTransferred = false
+
+    val thrown = intercept[IllegalStateException] {
+      StreamingPartitionTask.initializeValidationDataset(dataset)(
+        throw insertionFailure)(
+        markFinishedCalled = true)(
+        ownershipTransferred = true)
+    }
+
+    assert(thrown eq insertionFailure)
+    assert(dataset.closeCount == 1)
+    assert(thrown.getSuppressed.toSeq == Seq(cleanupFailure))
+    assert(!markFinishedCalled)
+    assert(!ownershipTransferred)
+  }
+
+  test("validation Dataset cleanup runs when MarkFinished fails before ownership transfer") {
+    val dataset = new TrackingDataset()
+    val markFinishedFailure = new IllegalStateException("MarkFinished failed")
+    var insertionCalled = false
+    var ownershipTransferred = false
+
+    val thrown = intercept[IllegalStateException] {
+      StreamingPartitionTask.initializeValidationDataset(dataset)(
+        insertionCalled = true)(
+        throw markFinishedFailure)(
+        ownershipTransferred = true)
+    }
+
+    assert(thrown eq markFinishedFailure)
+    assert(dataset.closeCount == 1)
+    assert(insertionCalled)
+    assert(!ownershipTransferred)
   }
 }

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/dataset/ReferenceDatasetUtilsSuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/dataset/ReferenceDatasetUtilsSuite.scala
@@ -1,0 +1,57 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm.dataset
+
+import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+
+class ReferenceDatasetUtilsSuite extends TestBase {
+  private class TrackingDataset(closeFailure: Option[RuntimeException] = None)
+    extends LightGBMDataset(null) { // scalastyle:ignore null
+    var closeCount: Int = 0
+
+    override def close(): Unit = {
+      closeCount += 1
+      closeFailure.foreach(throw _)
+    }
+  }
+
+  test("initializeOwnedDataset leaves a successfully initialized Dataset open") {
+    val dataset = new TrackingDataset()
+
+    val result = ReferenceDatasetUtils.initializeOwnedDataset(dataset) {}
+
+    assert(result eq dataset)
+    assert(dataset.closeCount == 0)
+  }
+
+  test("initializeOwnedDataset closes the Dataset when initialization fails") {
+    val dataset = new TrackingDataset()
+    val initializationFailure = new IllegalStateException("initialization failed")
+
+    val thrown = intercept[IllegalStateException] {
+      ReferenceDatasetUtils.initializeOwnedDataset(dataset) {
+        throw initializationFailure
+      }
+    }
+
+    assert(thrown eq initializationFailure)
+    assert(dataset.closeCount == 1)
+  }
+
+  test("initializeOwnedDataset preserves initialization failure when close also fails") {
+    val cleanupFailure = new RuntimeException("cleanup failed")
+    val dataset = new TrackingDataset(Option(cleanupFailure))
+    val initializationFailure = new IllegalStateException("initialization failed")
+
+    val thrown = intercept[IllegalStateException] {
+      ReferenceDatasetUtils.initializeOwnedDataset(dataset) {
+        throw initializationFailure
+      }
+    }
+
+    assert(thrown eq initializationFailure)
+    assert(dataset.closeCount == 1)
+    assert(thrown.getSuppressed.toSeq == Seq(cleanupFailure))
+  }
+}

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/ReferenceDatasetUtilsSuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/ReferenceDatasetUtilsSuite.scala
@@ -1,10 +1,11 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in project root for information.
 
-package com.microsoft.azure.synapse.ml.lightgbm.dataset
+package com.microsoft.azure.synapse.ml.lightgbm.split1
 
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 import com.microsoft.azure.synapse.ml.lightgbm.StreamingPartitionTask
+import com.microsoft.azure.synapse.ml.lightgbm.dataset.{LightGBMDataset, ReferenceDatasetUtils}
 
 class ReferenceDatasetUtilsSuite extends TestBase {
   private class TrackingDataset(closeFailure: Option[RuntimeException] = None)
@@ -66,8 +67,8 @@ class ReferenceDatasetUtilsSuite extends TestBase {
     val thrown = intercept[IllegalStateException] {
       StreamingPartitionTask.initializeValidationDataset(dataset)(
         throw insertionFailure)(
-        markFinishedCalled = true)(
-        ownershipTransferred = true)
+        { markFinishedCalled = true })(
+        { ownershipTransferred = true })
     }
 
     assert(thrown eq insertionFailure)
@@ -85,9 +86,9 @@ class ReferenceDatasetUtilsSuite extends TestBase {
 
     val thrown = intercept[IllegalStateException] {
       StreamingPartitionTask.initializeValidationDataset(dataset)(
-        insertionCalled = true)(
+        { insertionCalled = true })(
         throw markFinishedFailure)(
-        ownershipTransferred = true)
+        { ownershipTransferred = true })
     }
 
     assert(thrown eq markFinishedFailure)

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/StreamingDatasetLifecycleSuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/StreamingDatasetLifecycleSuite.scala
@@ -1,0 +1,42 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm.split1
+
+import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMClassifier, LightGBMConstants}
+import org.apache.spark.ml.linalg.Vectors
+
+// scalastyle:off magic.number
+class StreamingDatasetLifecycleSuite extends LightGBMTestUtils {
+  test("streaming estimator supports repeated fits with validation data") {
+    import spark.implicits._
+
+    val data = (0 until 128).map { index =>
+      val label = (index % 2).toDouble
+      val validation = index % 5 == 0
+      val features = Vectors.dense(index % 7, (index * 3) % 11, label)
+      (label, validation, features)
+    }.toDF("label", "validation", "features").repartition(1).cache()
+
+    try {
+      val estimator = new LightGBMClassifier()
+        .setFeaturesCol("features")
+        .setLabelCol("label")
+        .setValidationIndicatorCol("validation")
+        .setDataTransferMode(LightGBMConstants.StreamingDataTransferMode)
+        .setNumTasks(1)
+        .setNumThreads(1)
+        .setMaxStreamingOMPThreads(1)
+        .setMicroBatchSize(16)
+        .setNumLeaves(4)
+        .setNumIterations(1)
+
+      (0 until 2).foreach { _ =>
+        estimator.setDefaultListenPort(getAndIncrementPort())
+        assert(estimator.fit(data).transform(data).count() == 128)
+      }
+    } finally {
+      data.unpersist()
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This is a partial safety fix for LightGBM streaming Dataset lifecycle defects discovered while investigating issue #2333.

- close newly created native training/reference Datasets when streaming initialization or feature naming fails
- close newly created native validation Datasets when manual-finish setup, feature naming, row insertion, `LGBM_DatasetMarkFinished`, or shared-state ownership transfer fails
- always release serialized-reference native byte arrays and `void**` output containers
- preserve the primary initialization error when cleanup also fails
- add deterministic ownership/error tests and a synthetic public-estimator repeated-fit test with validation data

Refs #2333

## Established concurrency finding

SynapseML intentionally shares one executor-local native streaming Dataset across partition tasks. Each task pushes rows using a distinct external thread index. Upstream LightGBM derives its internal push-buffer index from both that external index and the caller thread's OpenMP thread number.

The native allocation is sized using `maxStreamingOMPThreads`, but SynapseML cannot prove from `numThreads`, Spark executor cores, `spark.task.cpus`, or `TaskContext` what OpenMP team size every native caller thread will actually use. Therefore this PR does **not** add a speculative fail-fast check, globally lock ingestion, or force one executor core. Those approaches would reject or serialize configurations without establishing the native safety invariant.

## Scope and performance

This PR fixes independently provable native ownership leaks only. It does not claim to resolve the SIGSEGV/SIGBUS/double-free concurrency failure reported in #2333.

No row-push or micro-batch hot path changes. Cleanup is limited to Dataset creation/initialization failures and temporary serialized-reference buffers.

## Validation

Local toolchains:
- Spark 3.5.0 / Scala 2.12.17 / OpenJDK 11.0.31
- Spark 4.1.1 / Scala 2.13.17 / OpenJDK 17.0.19
- sbt 1.10.11

Passed locally:
- `ReferenceDatasetUtilsSuite` (moved to `lightgbm.split1`): 5/5 on Spark 3.5/Scala 2.12 and Spark 4.1/Scala 2.13, including deterministic insertion- and MarkFinished-failure cleanup
- `StreamingDatasetLifecycleSuite`: 1/1; two public `LightGBMClassifier.fit()` calls with streaming mode, validation data, cached reference reuse, prediction, and cleanup
- Spark 3.5/Scala 2.12: `lightgbm/compile` and `lightgbm/Test/compile`
- Spark 4.1/Scala 2.13/JDK 17 compatibility replay: `lightgbm/Test/compile`
- `PipelineTestCoverageSuite`: 1/1 on both Spark 3.5 and Spark 4.1
- `lightgbm/scalastyle` and `lightgbm/Test/scalastyle` on both Spark 3.5 and Spark 4.1
- `lightgbm/codegen`
- generated LightGBM Python wrapper `compileall`
- `black --check --extend-exclude 'docs/' .` (194 files unchanged)
- `git diff --check`

## Residual risk / required validation

Real multi-core executor validation on Fabric or equivalent native Linux infrastructure is still required to reproduce and resolve the original crash safely. Local validation exercised `local[*]` Spark scheduling but intentionally used one LightGBM task and one native thread for deterministic lifecycle coverage; it is not evidence that the native concurrency crash is fixed.

Azure build 231682017 passed all LightGBM unit shards, Python/R LightGBM, Fabric E2E, Databricks E2E, publish, Docker, and style. Its Spark 4.1 test-compile and matrix-coverage failures are addressed by the current head; Search1 was canceled after the build had already failed. No Azure rerun was triggered by this update.