### PR TITLE
fix: diagnose LightGBM reproducibility mismatches

### DIFF
--- a/docs/Explore Algorithms/LightGBM/Overview.md
+++ b/docs/Explore Algorithms/LightGBM/Overview.md
@@ -125,7 +125,8 @@ scores. Compare the exact rows and metadata before interpreting a higher trainin
 serialization defect; stable validation AUC can instead indicate training-set overfit.
 
 When `deterministic=True`, SynapseML logs a warning if Spark marks the training query as
-nondeterministic or if neither `force_col_wise=true` nor `force_row_wise=true` is enabled.
+nondeterministic. For effective CPU training, it also warns if neither `force_col_wise=true`
+nor `force_row_wise=true` is enabled.
 
 #### GPU training with a custom OpenCL native library
 

--- a/docs/Explore Algorithms/LightGBM/Overview.md
+++ b/docs/Explore Algorithms/LightGBM/Overview.md
@@ -102,6 +102,31 @@ You can mix *passThroughArgs* and explicit args, as shown in the example. Synaps
 merges them to create one argument string to send to LightGBM. If you set a parameter in
 both places, *passThroughArgs* takes precedence.
 
+#### Reproducible training
+
+`deterministic=True` applies to LightGBM after Spark has produced the training rows. For
+CPU training, LightGBM also recommends selecting one histogram strategy explicitly:
+
+```python
+model = LightGBMClassifier(
+    deterministic=True,
+    seed=777,
+    passThroughArgs="force_col_wise=true",
+).fit(train)
+```
+
+This does not make a nondeterministic Spark query deterministic. Operations such as
+`orderBy(rand())` without a seed can be evaluated again for each action, so a write and a
+later `fit()` may consume different row order or even a different sample. Materialize one
+training snapshot before comparing fits: write and reload it, or persist it and complete a
+materializing action before training. A Parquet reload can therefore expose an input-lineage
+difference without changing vector values, feature metadata, labels, weights, or initial
+scores. Compare the exact rows and metadata before interpreting a higher training AUC as a
+serialization defect; stable validation AUC can instead indicate training-set overfit.
+
+When `deterministic=True`, SynapseML logs a warning if Spark marks the training query as
+nondeterministic or if neither `force_col_wise=true` nor `force_row_wise=true` is enabled.
+
 #### GPU training with a custom OpenCL native library
 
 SynapseML's published `lightgbmlib` artifact contains CPU-only native libraries. Only

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMBase.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMBase.scala
@@ -77,17 +77,19 @@ trait LightGBMBase[TrainedModel <: Model[TrainedModel] with LightGBMModelParams]
       .orElse(get(deterministic))
       .contains(true)
     if (deterministicTraining) {
-      val histogramModes = configuredParameters.filter { case (name, _) => forcedHistogramModes.contains(name) }
-      if (!histogramModes.values.exists(LightGBMUtils.isEnabledParameterValue)) {
-        warnings +=
-          "deterministic=true does not by itself select a stable LightGBM histogram strategy. " +
-            "For reproducibility on CPU, set passThroughArgs to force_col_wise=true or force_row_wise=true, " +
-            "as required by LightGBM's deterministic parameter documentation."
-      }
-      if (histogramModes.values.count(LightGBMUtils.isEnabledParameterValue) > 1) {
-        warnings +=
-          "Both force_col_wise and force_row_wise are enabled in passThroughArgs. LightGBM requires choosing " +
-            "exactly one histogram strategy for deterministic CPU training."
+      if (getEffectiveDeviceType == LightGBMConstants.CPUDeviceType) {
+        val histogramModes = configuredParameters.filter { case (name, _) => forcedHistogramModes.contains(name) }
+        if (!histogramModes.values.exists(LightGBMUtils.isEnabledParameterValue)) {
+          warnings +=
+            "deterministic=true does not by itself select a stable LightGBM histogram strategy. " +
+              "For reproducibility on CPU, set passThroughArgs to force_col_wise=true or force_row_wise=true, " +
+              "as required by LightGBM's deterministic parameter documentation."
+        }
+        if (histogramModes.values.count(LightGBMUtils.isEnabledParameterValue) > 1) {
+          warnings +=
+            "Both force_col_wise and force_row_wise are enabled in passThroughArgs. LightGBM requires choosing " +
+              "exactly one histogram strategy for deterministic CPU training."
+        }
       }
 
       if (!dataset.queryExecution.optimizedPlan.deterministic) {

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMBase.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMBase.scala
@@ -28,6 +28,8 @@ trait LightGBMBase[TrainedModel <: Model[TrainedModel] with LightGBMModelParams]
   with LightGBMParams with ComplexParamsWritable
   with HasFeaturesColSpark with HasLabelColSpark with LightGBMPerformance with SynapseMLLogging {
 
+  private val forcedHistogramModes = Set("force_col_wise", "force_row_wise")
+
   /** Trains the LightGBM model.  If batches are specified, breaks training dataset into batches for training.
     *
     * @param dataset The input dataset to train.
@@ -35,6 +37,7 @@ trait LightGBMBase[TrainedModel <: Model[TrainedModel] with LightGBMModelParams]
     */
   protected def train(dataset: Dataset[_]): TrainedModel = {
     LightGBMUtils.initializeNativeLibrary()
+    logReproducibilityWarnings(dataset)
 
     val isMultiBatch = getNumBatches > 0
     val numBatches = if (isMultiBatch) getNumBatches else 1
@@ -62,6 +65,43 @@ trait LightGBMBase[TrainedModel <: Model[TrainedModel] with LightGBMModelParams]
         trainOneDataBatch(dataset, batchIndex = 0, 1)
       }
     }, dataset.columns.length)
+  }
+
+  private[lightgbm] def reproducibilityWarningMessages(dataset: Dataset[_]): Seq[String] = {
+    val warnings = scala.collection.mutable.ArrayBuffer[String]()
+    val configuredArgs = get(passThroughArgs).getOrElse("")
+    val configuredParameters =
+      LightGBMUtils.parameterValues(configuredArgs, forcedHistogramModes + "deterministic")
+    val deterministicTraining = configuredParameters.get("deterministic")
+      .map(LightGBMUtils.isEnabledParameterValue)
+      .orElse(get(deterministic))
+      .contains(true)
+    if (deterministicTraining) {
+      val histogramModes = configuredParameters.filter { case (name, _) => forcedHistogramModes.contains(name) }
+      if (!histogramModes.values.exists(LightGBMUtils.isEnabledParameterValue)) {
+        warnings +=
+          "deterministic=true does not by itself select a stable LightGBM histogram strategy. " +
+            "For reproducibility on CPU, set passThroughArgs to force_col_wise=true or force_row_wise=true, " +
+            "as required by LightGBM's deterministic parameter documentation."
+      }
+      if (histogramModes.values.count(LightGBMUtils.isEnabledParameterValue) > 1) {
+        warnings +=
+          "Both force_col_wise and force_row_wise are enabled in passThroughArgs. LightGBM requires choosing " +
+            "exactly one histogram strategy for deterministic CPU training."
+      }
+
+      if (!dataset.queryExecution.optimizedPlan.deterministic) {
+        warnings +=
+          "The training DataFrame contains nondeterministic Spark expressions. Repeated fit() calls can consume " +
+            "different rows or row order even when LightGBM seeds and deterministic=true are set. Materialize and " +
+            "reload the exact training snapshot, or persist it and complete one materializing action, before fit()."
+      }
+    }
+    warnings.toSeq
+  }
+
+  private def logReproducibilityWarnings(dataset: Dataset[_]): Unit = {
+    reproducibilityWarningMessages(dataset).foreach(log.warn)
   }
 
   def beforeTrainBatch(batchIndex: Int, dataset: Dataset[_], model: Option[TrainedModel]): Unit = {

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMUtils.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMUtils.scala
@@ -15,6 +15,7 @@ import java.util.Locale
 /** Helper utilities for LightGBM learners */
 object LightGBMUtils {
   private val DeviceParamNames = Set("device", "device_type")
+  private val TrueValues = Set("1", "+1", "true", "yes")
 
   private def removeLightGBMQuotationSymbols(value: String): String = {
     def isQuote(char: Char): Boolean = char == '\'' || char == '"'
@@ -37,6 +38,12 @@ object LightGBMUtils {
 
   private[lightgbm] def hasDeviceParameter(parameters: String): Boolean =
     parseLightGBMParams(parameters).keys.exists(DeviceParamNames)
+
+  private[lightgbm] def parameterValues(parameters: String, names: Set[String]): Map[String, String] =
+    parseLightGBMParams(parameters).filter { case (name, _) => names.contains(name) }
+
+  private[lightgbm] def isEnabledParameterValue(value: String): Boolean =
+    TrueValues.contains(value.toLowerCase(Locale.ROOT))
 
   private[lightgbm] def effectiveDeviceType(parameters: String): Option[String] = {
     val params = parseLightGBMParams(parameters)

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMUtils.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/LightGBMUtils.scala
@@ -15,7 +15,7 @@ import java.util.Locale
 /** Helper utilities for LightGBM learners */
 object LightGBMUtils {
   private val DeviceParamNames = Set("device", "device_type")
-  private val TrueValues = Set("1", "+1", "true", "yes")
+  private val TrueValues = Set("1", "+1", "true", "yes", "on")
 
   private def removeLightGBMQuotationSymbols(value: String): String = {
     def isQuote(char: Char): Boolean = char == '\'' || char == '"'

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMParquetReproducibilitySuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMParquetReproducibilitySuite.scala
@@ -1,0 +1,145 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm.split1
+
+import com.microsoft.azure.synapse.ml.lightgbm._
+import org.apache.spark.ml.attribute.AttributeGroup
+import org.apache.spark.ml.evaluation.BinaryClassificationEvaluator
+import org.apache.spark.ml.feature.{StringIndexer, VectorAssembler}
+import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions._
+
+// scalastyle:off magic.number
+class LightGBMParquetReproducibilitySuite extends LightGBMTestUtils {
+
+  private class ReproducibilityProbe extends LightGBMClassifier {
+    def warningMessages(dataset: DataFrame): Seq[String] = reproducibilityWarningMessages(dataset)
+  }
+
+  private def makeTrainingData(): DataFrame = {
+    val source = spark.range(0, 500, 1, 4)
+      .withColumn(labelCol, when(col("id") % 11 === 0, 1.0).otherwise(0.0))
+      .withColumn(weightCol, when(col(labelCol) === 1.0, 2.0).otherwise(1.0))
+      .withColumn(initScoreCol, lit(0.0))
+      .withColumn("category", concat(lit("c"), (col("id") % 3).cast("string")))
+      .withColumn("f0", when(col("id") % 2 === 0, (col("id") % 17).cast("double")).otherwise(0.0))
+      .withColumn("f1", when(col(labelCol) === 1.0, 1.0).otherwise(0.0))
+      .withColumn("f2", when(col("id") % 5 === 0, 1.0).otherwise(0.0))
+      .withColumn("f3", when(col("id") % 7 === 0, 1.0).otherwise(0.0))
+
+    val indexed = new StringIndexer()
+      .setInputCol("category")
+      .setOutputCol("categoryIndex")
+      .fit(source)
+      .transform(source)
+    new VectorAssembler()
+      .setInputCols(Array("categoryIndex", "f0", "f1", "f2", "f3"))
+      .setOutputCol(featuresCol)
+      .transform(indexed)
+      .select("id", labelCol, weightCol, initScoreCol, featuresCol)
+      .orderBy(rand())
+  }
+
+  private def estimator: LightGBMClassifier = {
+    new LightGBMClassifier()
+      .setFeaturesCol(featuresCol)
+      .setLabelCol(labelCol)
+      .setWeightCol(weightCol)
+      .setInitScoreCol(initScoreCol)
+      .setRawPredictionCol(rawPredCol)
+      .setNumIterations(20)
+      .setNumLeaves(16)
+      .setLearningRate(0.1)
+      .setBaggingFraction(0.9)
+      .setBaggingFreq(1)
+      .setFeatureFraction(0.8)
+      .setSeed(777)
+      .setBaggingSeed(521)
+      .setDataRandomSeed(777)
+      .setDeterministic(true)
+      .setNumTasks(2)
+      .setNumThreads(1)
+      .setDefaultListenPort(13940)
+      .setUseBarrierExecutionMode(true)
+      .setSamplingMode(LightGBMConstants.SubsetSamplingModeGlobal)
+      .setDataTransferMode(LightGBMConstants.StreamingDataTransferMode)
+  }
+
+  private def auc(model: LightGBMClassificationModel, data: DataFrame): Double = {
+    new BinaryClassificationEvaluator()
+      .setLabelCol(labelCol)
+      .setRawPredictionCol(rawPredCol)
+      .setMetricName("areaUnderROC")
+      .setNumBins(0)
+      .evaluate(model.transform(data))
+  }
+
+  test("Deterministic training warns about Spark lineage and LightGBM histogram selection") {
+    val assembled = makeTrainingData()
+    assert(!assembled.queryExecution.optimizedPlan.deterministic)
+
+    val probe = new ReproducibilityProbe()
+      .setDeterministic(true)
+    val warnings = probe.warningMessages(assembled)
+    assert(warnings.exists(_.contains("nondeterministic Spark expressions")))
+    assert(warnings.exists(_.contains("force_col_wise=true or force_row_wise=true")))
+
+    val forcedProbe = new ReproducibilityProbe()
+      .setDeterministic(true)
+      .setPassThroughArgs("force_col_wise=true")
+    val forcedWarnings = forcedProbe.warningMessages(assembled)
+    assert(forcedWarnings.exists(_.contains("nondeterministic Spark expressions")))
+    assert(!forcedWarnings.exists(_.contains("does not by itself select a stable LightGBM histogram strategy")))
+
+    val conflictingProbe = new ReproducibilityProbe()
+      .setDeterministic(true)
+      .setPassThroughArgs("force_col_wise=true force_row_wise=true")
+    assert(conflictingProbe.warningMessages(assembled)
+      .exists(_.contains("Both force_col_wise and force_row_wise are enabled")))
+
+    val passThroughProbe = new ReproducibilityProbe()
+      .setPassThroughArgs("deterministic=true force_col_wise=true")
+    assert(passThroughProbe.warningMessages(assembled)
+      .exists(_.contains("nondeterministic Spark expressions")))
+
+    val overriddenProbe = new ReproducibilityProbe()
+      .setDeterministic(true)
+      .setPassThroughArgs("deterministic=false")
+    assert(overriddenProbe.warningMessages(assembled).isEmpty)
+  }
+
+  test("Parquet round trips preserve deterministic LightGBM training inputs and outputs") {
+    val assembled = makeTrainingData()
+
+    val parquetPath = tmpDir.resolve("lightgbm-parquet-reproducibility").toString
+    assembled.write.mode("overwrite").parquet(parquetPath)
+    val reloaded = spark.read.parquet(parquetPath)
+
+    val memoryRows = assembled.orderBy("id").collect()
+    val parquetRows = reloaded.orderBy("id").collect()
+    assert(memoryRows.sameElements(parquetRows))
+    assert(assembled.schema.map(field => field.name -> field.metadata.json) ===
+      reloaded.schema.map(field => field.name -> field.metadata.json))
+    assert(AttributeGroup.fromStructField(assembled.schema(featuresCol)) ===
+      AttributeGroup.fromStructField(reloaded.schema(featuresCol)))
+    assert(assembled.select(featuresCol).collect().map(_.getAs[Vector](0).getClass.getName).toSet ===
+      reloaded.select(featuresCol).collect().map(_.getAs[Vector](0).getClass.getName).toSet)
+
+    val forcedEstimator = estimator.setPassThroughArgs("force_col_wise=true")
+    val memoryModels = Array.fill(2)(forcedEstimator.fit(assembled))
+    val parquetModels = Array.fill(2)(forcedEstimator.fit(reloaded))
+    val nativeModels = (memoryModels ++ parquetModels).map(_.getNativeModel())
+    assert(nativeModels.distinct.length === 1)
+
+    val predictionColumns = Seq("id", rawPredCol, "probability", "prediction")
+    val predictions = (memoryModels ++ parquetModels).map { model =>
+      model.transform(reloaded).select(predictionColumns.map(col): _*).orderBy("id").collect()
+    }
+    assert(predictions.tail.forall(_.sameElements(predictions.head)))
+
+    val aucValues = memoryModels.map(auc(_, assembled)) ++ parquetModels.map(auc(_, reloaded))
+    assert(aucValues.max - aucValues.min < 1e-12)
+  }
+}

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMParquetReproducibilitySuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMParquetReproducibilitySuite.scala
@@ -10,6 +10,7 @@ import org.apache.spark.ml.feature.{StringIndexer, VectorAssembler}
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions._
+import org.apache.spark.storage.StorageLevel
 
 // scalastyle:off magic.number
 class LightGBMParquetReproducibilitySuite extends LightGBMTestUtils {
@@ -61,7 +62,7 @@ class LightGBMParquetReproducibilitySuite extends LightGBMTestUtils {
       .setDeterministic(true)
       .setNumTasks(2)
       .setNumThreads(1)
-      .setDefaultListenPort(13940)
+      .setDefaultListenPort(getAndIncrementPort())
       .setUseBarrierExecutionMode(true)
       .setSamplingMode(LightGBMConstants.SubsetSamplingModeGlobal)
       .setDataTransferMode(LightGBMConstants.StreamingDataTransferMode)
@@ -74,6 +75,11 @@ class LightGBMParquetReproducibilitySuite extends LightGBMTestUtils {
       .setMetricName("areaUnderROC")
       .setNumBins(0)
       .evaluate(model.transform(data))
+  }
+
+  private def assertOnlySparkLineageWarning(warnings: Seq[String]): Unit = {
+    assert(warnings.exists(_.contains("nondeterministic Spark expressions")))
+    assert(!warnings.exists(_.contains("histogram strategy")))
   }
 
   test("Deterministic training warns about Spark lineage and LightGBM histogram selection") {
@@ -108,38 +114,66 @@ class LightGBMParquetReproducibilitySuite extends LightGBMTestUtils {
       .setDeterministic(true)
       .setPassThroughArgs("deterministic=false")
     assert(overriddenProbe.warningMessages(assembled).isEmpty)
+
+    val gpuProbe = new ReproducibilityProbe()
+      .setDeterministic(true)
+      .setDeviceType(LightGBMConstants.GPUDeviceType)
+    assertOnlySparkLineageWarning(gpuProbe.warningMessages(assembled))
+
+    val cudaProbe = new ReproducibilityProbe()
+      .setDeterministic(true)
+      .setPassThroughArgs("device=cuda")
+    assertOnlySparkLineageWarning(cudaProbe.warningMessages(assembled))
+
+    val passThroughCpuProbe = new ReproducibilityProbe()
+      .setDeterministic(true)
+      .setDeviceType(LightGBMConstants.GPUDeviceType)
+      .setPassThroughArgs("device_type=cpu")
+    val passThroughCpuWarnings = passThroughCpuProbe.warningMessages(assembled)
+    assert(passThroughCpuWarnings.exists(_.contains("nondeterministic Spark expressions")))
+    assert(passThroughCpuWarnings.exists(_.contains("histogram strategy")))
+
+    val passThroughGpuProbe = new ReproducibilityProbe()
+      .setDeterministic(true)
+      .setPassThroughArgs("device_type=gpu")
+    assertOnlySparkLineageWarning(passThroughGpuProbe.warningMessages(assembled))
   }
 
   test("Parquet round trips preserve deterministic LightGBM training inputs and outputs") {
-    val assembled = makeTrainingData()
+    val assembled = makeTrainingData().persist(StorageLevel.MEMORY_AND_DISK)
+    try {
+      assert(assembled.count() === 500)
 
-    val parquetPath = tmpDir.resolve("lightgbm-parquet-reproducibility").toString
-    assembled.write.mode("overwrite").parquet(parquetPath)
-    val reloaded = spark.read.parquet(parquetPath)
+      val parquetPath = tmpDir.resolve("lightgbm-parquet-reproducibility").toString
+      assembled.write.mode("overwrite").parquet(parquetPath)
+      val reloaded = spark.read.parquet(parquetPath)
 
-    val memoryRows = assembled.orderBy("id").collect()
-    val parquetRows = reloaded.orderBy("id").collect()
-    assert(memoryRows.sameElements(parquetRows))
-    assert(assembled.schema.map(field => field.name -> field.metadata.json) ===
-      reloaded.schema.map(field => field.name -> field.metadata.json))
-    assert(AttributeGroup.fromStructField(assembled.schema(featuresCol)) ===
-      AttributeGroup.fromStructField(reloaded.schema(featuresCol)))
-    assert(assembled.select(featuresCol).collect().map(_.getAs[Vector](0).getClass.getName).toSet ===
-      reloaded.select(featuresCol).collect().map(_.getAs[Vector](0).getClass.getName).toSet)
+      val memoryRows = assembled.orderBy("id").collect()
+      val parquetRows = reloaded.orderBy("id").collect()
+      assert(memoryRows.sameElements(parquetRows))
+      assert(assembled.schema.map(field => field.name -> field.metadata.json) ===
+        reloaded.schema.map(field => field.name -> field.metadata.json))
+      assert(AttributeGroup.fromStructField(assembled.schema(featuresCol)) ===
+        AttributeGroup.fromStructField(reloaded.schema(featuresCol)))
+      assert(assembled.select(featuresCol).collect().map(_.getAs[Vector](0).getClass.getName).toSet ===
+        reloaded.select(featuresCol).collect().map(_.getAs[Vector](0).getClass.getName).toSet)
 
-    val forcedEstimator = estimator.setPassThroughArgs("force_col_wise=true")
-    val memoryModels = Array.fill(2)(forcedEstimator.fit(assembled))
-    val parquetModels = Array.fill(2)(forcedEstimator.fit(reloaded))
-    val nativeModels = (memoryModels ++ parquetModels).map(_.getNativeModel())
-    assert(nativeModels.distinct.length === 1)
+      val forcedEstimator = estimator.setPassThroughArgs("force_col_wise=true")
+      val memoryModels = Array.fill(2)(forcedEstimator.fit(assembled))
+      val parquetModels = Array.fill(2)(forcedEstimator.fit(reloaded))
+      val nativeModels = (memoryModels ++ parquetModels).map(_.getNativeModel())
+      assert(nativeModels.distinct.length === 1)
 
-    val predictionColumns = Seq("id", rawPredCol, "probability", "prediction")
-    val predictions = (memoryModels ++ parquetModels).map { model =>
-      model.transform(reloaded).select(predictionColumns.map(col): _*).orderBy("id").collect()
+      val predictionColumns = Seq("id", rawPredCol, "probability", "prediction")
+      val predictions = (memoryModels ++ parquetModels).map { model =>
+        model.transform(reloaded).select(predictionColumns.map(col): _*).orderBy("id").collect()
+      }
+      assert(predictions.tail.forall(_.sameElements(predictions.head)))
+
+      val aucValues = memoryModels.map(auc(_, assembled)) ++ parquetModels.map(auc(_, reloaded))
+      assert(aucValues.max - aucValues.min < 1e-12)
+    } finally {
+      assembled.unpersist()
     }
-    assert(predictions.tail.forall(_.sameElements(predictions.head)))
-
-    val aucValues = memoryModels.map(auc(_, assembled)) ++ parquetModels.map(auc(_, reloaded))
-    assert(aucValues.max - aucValues.min < 1e-12)
   }
 }

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMParquetReproducibilitySuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMParquetReproducibilitySuite.scala
@@ -40,7 +40,14 @@ class LightGBMParquetReproducibilitySuite extends LightGBMTestUtils {
       .setOutputCol(featuresCol)
       .transform(indexed)
       .select("id", labelCol, weightCol, initScoreCol, featuresCol)
-      .orderBy(rand())
+  }
+
+  private def makeNondeterministicData(): DataFrame = spark.range(0, 10).select(col("id")).orderBy(rand())
+
+  private def canonicalTrainingLayout(data: DataFrame): DataFrame = {
+    data.repartition(numPartitions, col("id"))
+      .sortWithinPartitions("id")
+      .persist(StorageLevel.MEMORY_AND_DISK)
   }
 
   private def estimator: LightGBMClassifier = {
@@ -83,7 +90,7 @@ class LightGBMParquetReproducibilitySuite extends LightGBMTestUtils {
   }
 
   test("Deterministic training warns about Spark lineage and LightGBM histogram selection") {
-    val assembled = makeTrainingData()
+    val assembled = makeNondeterministicData()
     assert(!assembled.queryExecution.optimizedPlan.deterministic)
 
     val probe = new ReproducibilityProbe()
@@ -140,53 +147,43 @@ class LightGBMParquetReproducibilitySuite extends LightGBMTestUtils {
   }
 
   test("Parquet round trips preserve deterministic LightGBM training inputs and outputs") {
-    val assembled = makeTrainingData().persist(StorageLevel.MEMORY_AND_DISK)
+    val assembled = makeTrainingData()
+    val parquetPath = tmpDir.resolve("lightgbm-parquet-reproducibility").toString
+    assembled.write.mode("overwrite").parquet(parquetPath)
+    val reloaded = spark.read.parquet(parquetPath)
+
+    // Match physical row and partition order so this comparison isolates Parquet encoding.
+    val memoryTraining = canonicalTrainingLayout(assembled)
+    val parquetTraining = canonicalTrainingLayout(reloaded)
     try {
-      assert(assembled.count() === 500)
-
-      val parquetPath = tmpDir.resolve("lightgbm-parquet-reproducibility").toString
-      assembled.write.mode("overwrite").parquet(parquetPath)
-      val reloaded = spark.read.parquet(parquetPath)
-
-      val memoryRows = assembled.orderBy("id").collect()
-      val parquetRows = reloaded.orderBy("id").collect()
+      val memoryRows = memoryTraining.orderBy("id").collect()
+      val parquetRows = parquetTraining.orderBy("id").collect()
+      assert(memoryRows.length === 500)
       assert(memoryRows.sameElements(parquetRows))
       assert(assembled.schema.map(field => field.name -> field.metadata.json) ===
         reloaded.schema.map(field => field.name -> field.metadata.json))
       assert(AttributeGroup.fromStructField(assembled.schema(featuresCol)) ===
         AttributeGroup.fromStructField(reloaded.schema(featuresCol)))
-      assert(assembled.select(featuresCol).collect().map(_.getAs[Vector](0).getClass.getName).toSet ===
-        reloaded.select(featuresCol).collect().map(_.getAs[Vector](0).getClass.getName).toSet)
+      assert(memoryTraining.select(featuresCol).collect().map(_.getAs[Vector](0).getClass.getName).toSet ===
+        parquetTraining.select(featuresCol).collect().map(_.getAs[Vector](0).getClass.getName).toSet)
 
-      // Match physical row and partition order so this comparison isolates Parquet encoding.
-      val memoryTraining = assembled.repartition(numPartitions, col("id")).sortWithinPartitions("id")
-        .persist(StorageLevel.MEMORY_AND_DISK)
-      val parquetTraining = reloaded.repartition(numPartitions, col("id")).sortWithinPartitions("id")
-        .persist(StorageLevel.MEMORY_AND_DISK)
-      try {
-        assert(memoryTraining.count() === 500)
-        assert(parquetTraining.count() === 500)
+      val forcedEstimator = estimator.setPassThroughArgs("force_col_wise=true")
+      val memoryModels = Array.fill(2)(forcedEstimator.fit(memoryTraining))
+      val parquetModels = Array.fill(2)(forcedEstimator.fit(parquetTraining))
+      val nativeModels = (memoryModels ++ parquetModels).map(_.getNativeModel())
+      assert(nativeModels.distinct.length === 1)
 
-        val forcedEstimator = estimator.setPassThroughArgs("force_col_wise=true")
-        val memoryModels = Array.fill(2)(forcedEstimator.fit(memoryTraining))
-        val parquetModels = Array.fill(2)(forcedEstimator.fit(parquetTraining))
-        val nativeModels = (memoryModels ++ parquetModels).map(_.getNativeModel())
-        assert(nativeModels.distinct.length === 1)
-
-        val predictionColumns = Seq("id", rawPredCol, "probability", "prediction")
-        val predictions = (memoryModels ++ parquetModels).map { model =>
-          model.transform(reloaded).select(predictionColumns.map(col): _*).orderBy("id").collect()
-        }
-        assert(predictions.tail.forall(_.sameElements(predictions.head)))
-
-        val aucValues = memoryModels.map(auc(_, memoryTraining)) ++ parquetModels.map(auc(_, parquetTraining))
-        assert(aucValues.max - aucValues.min < 1e-12)
-      } finally {
-        memoryTraining.unpersist()
-        parquetTraining.unpersist()
+      val predictionColumns = Seq("id", rawPredCol, "probability", "prediction")
+      val predictions = (memoryModels ++ parquetModels).map { model =>
+        model.transform(reloaded).select(predictionColumns.map(col): _*).orderBy("id").collect()
       }
+      assert(predictions.tail.forall(_.sameElements(predictions.head)))
+
+      val aucValues = memoryModels.map(auc(_, memoryTraining)) ++ parquetModels.map(auc(_, parquetTraining))
+      assert(aucValues.max - aucValues.min < 1e-12)
     } finally {
-      assembled.unpersist()
+      memoryTraining.unpersist()
+      parquetTraining.unpersist()
     }
   }
 }

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMParquetReproducibilitySuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/LightGBMParquetReproducibilitySuite.scala
@@ -158,20 +158,33 @@ class LightGBMParquetReproducibilitySuite extends LightGBMTestUtils {
       assert(assembled.select(featuresCol).collect().map(_.getAs[Vector](0).getClass.getName).toSet ===
         reloaded.select(featuresCol).collect().map(_.getAs[Vector](0).getClass.getName).toSet)
 
-      val forcedEstimator = estimator.setPassThroughArgs("force_col_wise=true")
-      val memoryModels = Array.fill(2)(forcedEstimator.fit(assembled))
-      val parquetModels = Array.fill(2)(forcedEstimator.fit(reloaded))
-      val nativeModels = (memoryModels ++ parquetModels).map(_.getNativeModel())
-      assert(nativeModels.distinct.length === 1)
+      // Match physical row and partition order so this comparison isolates Parquet encoding.
+      val memoryTraining = assembled.repartition(numPartitions, col("id")).sortWithinPartitions("id")
+        .persist(StorageLevel.MEMORY_AND_DISK)
+      val parquetTraining = reloaded.repartition(numPartitions, col("id")).sortWithinPartitions("id")
+        .persist(StorageLevel.MEMORY_AND_DISK)
+      try {
+        assert(memoryTraining.count() === 500)
+        assert(parquetTraining.count() === 500)
 
-      val predictionColumns = Seq("id", rawPredCol, "probability", "prediction")
-      val predictions = (memoryModels ++ parquetModels).map { model =>
-        model.transform(reloaded).select(predictionColumns.map(col): _*).orderBy("id").collect()
+        val forcedEstimator = estimator.setPassThroughArgs("force_col_wise=true")
+        val memoryModels = Array.fill(2)(forcedEstimator.fit(memoryTraining))
+        val parquetModels = Array.fill(2)(forcedEstimator.fit(parquetTraining))
+        val nativeModels = (memoryModels ++ parquetModels).map(_.getNativeModel())
+        assert(nativeModels.distinct.length === 1)
+
+        val predictionColumns = Seq("id", rawPredCol, "probability", "prediction")
+        val predictions = (memoryModels ++ parquetModels).map { model =>
+          model.transform(reloaded).select(predictionColumns.map(col): _*).orderBy("id").collect()
+        }
+        assert(predictions.tail.forall(_.sameElements(predictions.head)))
+
+        val aucValues = memoryModels.map(auc(_, memoryTraining)) ++ parquetModels.map(auc(_, parquetTraining))
+        assert(aucValues.max - aucValues.min < 1e-12)
+      } finally {
+        memoryTraining.unpersist()
+        parquetTraining.unpersist()
       }
-      assert(predictions.tail.forall(_.sameElements(predictions.head)))
-
-      val aucValues = memoryModels.map(auc(_, assembled)) ++ parquetModels.map(auc(_, reloaded))
-      assert(aucValues.max - aucValues.min < 1e-12)
     } finally {
       assembled.unpersist()
     }

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMCommon.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMCommon.scala
@@ -589,6 +589,28 @@ class VerifyLightGBMCommon extends TestBase with LightGBMTestUtils {
     }
   }
 
+  test("Verify enabled pass-through parameter parsing matches LightGBM boolean syntax") {
+    val names = Set("force_col_wise", "force_row_wise")
+    Seq("force_col_wise=true",
+        "force_col_wise=TRUE",
+        "force_row_wise=1",
+        "force_row_wise=+1",
+        "force_col_wise=yes",
+        """force_col_wise="true"""").foreach { parameters =>
+      val values = LightGBMUtils.parameterValues(parameters, names).values
+      assert(values.exists(LightGBMUtils.isEnabledParameterValue))
+    }
+    Seq("",
+        "force_col_wise=false",
+        "force_row_wise=0",
+        "force_col_wise=no",
+        "note=force_col_wise=true",
+        "force_col_wise true").foreach { parameters =>
+      val values = LightGBMUtils.parameterValues(parameters, names).values
+      assert(!values.exists(LightGBMUtils.isEnabledParameterValue))
+    }
+  }
+
   test("Verify booster guidance uses the shared effective device parser") {
     Seq(
       """device_type="CUDA"""" -> "device_type=cuda",

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMCommon.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/VerifyLightGBMCommon.scala
@@ -596,6 +596,7 @@ class VerifyLightGBMCommon extends TestBase with LightGBMTestUtils {
         "force_row_wise=1",
         "force_row_wise=+1",
         "force_col_wise=yes",
+        "force_row_wise=on",
         """force_col_wise="true"""").foreach { parameters =>
       val values = LightGBMUtils.parameterValues(parameters, names).values
       assert(values.exists(LightGBMUtils.isEnabledParameterValue))


### PR DESCRIPTION
## Summary

- warn when effective `deterministic=true` training uses nondeterministic Spark lineage
- restrict LightGBM forced-histogram guidance to effective CPU training, honoring typed and pass-through device precedence
- recognize all covered LightGBM true values, including `on`
- document snapshot materialization and the difference between training overfit and data mismatch
- add a public `LightGBMClassifier` Parquet regression covering exact rows, metadata, vector representation, weights, init scores, repeated native model dumps, predictions, and AUC

## Findings

The issue's dramatic AUC difference was not reproducible as a Parquet or SynapseML serialization defect. Under LightGBM's documented deterministic contract, exact model comparison succeeds when the same stable snapshot and physical row/partition layout are used.

The report's unseeded Spark random ordering is a nondeterministic query plan, and write, fit, and evaluation are separate actions. A Parquet read can also change physical row/partition order without changing serialized values or metadata. The regression therefore keeps nondeterministic lineage solely in a cheap plan-only warning fixture, verifies exact rows/metadata/vector representation, then canonicalizes and materializes both training layouts only inside the test before exact model/prediction comparison. No product sort, repartition, caching, estimator-default, or serialization behavior changed.

A near-perfect training AUC with stable validation AUC can additionally reflect overfit rather than data corruption.

## Maintainability audit

- Diagnostics reuse the existing pass-through parser and effective-device resolver; no duplicate device-precedence implementation was added.
- Query inspection is gated on effective deterministic training, reads only Spark's optimized logical plan, and launches no Spark action.
- Default training behavior and serialized parameters are unchanged; the product change only logs actionable warnings.
- The warning test uses a ten-row nondeterministic plan without fitting the full feature pipeline.
- The parity test retains only two justified canonical caches. Required row collection materializes them, and `try/finally` guarantees cleanup; redundant source caching and three count actions were removed.

## Review fixes

- CPU-only histogram warnings use the existing effective-device resolver; tests cover CPU, typed GPU, pass-through CUDA, typed GPU overridden to CPU, and typed CPU overridden to GPU.
- The parity regression uses deterministic source data, canonical test-only row/partition layout, and guaranteed cleanup.
- The suite uses `getAndIncrementPort()` instead of fixed port `13940`.
- LightGBM boolean `on` is recognized and covered by parser regression tests.
- Documentation distinguishes device-independent lineage warnings from CPU-only histogram guidance.
- All prior Copilot review threads were answered with evidence and resolved; the suppressed `on` finding was addressed and recorded in a PR comment.

## Validation

### Spark 3.5 / Scala 2.12 / JDK 11

- full `LightGBMParquetReproducibilitySuite`: 2/2 passed on head `79f16fdb2c`
- `lightgbm/compile` and `lightgbm/Test/compile`
- LightGBM production/test scalastyle: 0 findings
- `sbt codegen`
- pinned `black==22.3.0 --check --extend-exclude 'docs/' .`

### Spark 4.1 / Scala 2.13 / JDK 17 replay

- full `LightGBMParquetReproducibilitySuite`: 2/2 passed on replay of head `79f16fdb2c`
- `lightgbm/compile` and `lightgbm/Test/compile`
- LightGBM production/test scalastyle: 0 findings
- `sbt codegen`
- pinned `black==22.3.0 --check --extend-exclude 'docs/' .`

Azure validation is intentionally not retriggered here; build 231708782 was canceled before useful validation, and the parent will rerun serialized.

Refs #2394
