### PR TITLE
fix: report versioned Fabric runtime metadata

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -504,16 +504,16 @@ abstract class OpenAIServicesBase(override val uid: String) extends CognitiveSer
 }
 
 private[openai] object OpenAIFabricHeaders {
-  private val extendedPropertiesHeader = "X-Taxonomy-ExtendedProperties"
-  private val trafficTypeHeader = "X-Taxonomy-TrafficType"
-  private val serviceTierHeader = "x-llm-service-tier"
+  private val ExtendedPropertiesHeader = "X-Taxonomy-ExtendedProperties"
+  private val TrafficTypeHeader = "X-Taxonomy-TrafficType"
+  private val ServiceTierHeader = "x-llm-service-tier"
 
-  lazy val values: Map[String, String] = build(PlatformDetails.FabricRuntime)
+  lazy val Values: Map[String, String] = build(PlatformDetails.FabricRuntime)
 
   private[openai] def build(runtime: String): Map[String, String] = Map(
-    trafficTypeHeader -> "Background",
-    serviceTierHeader -> "flex",
-    extendedPropertiesHeader ->
+    TrafficTypeHeader -> "Background",
+    ServiceTierHeader -> "flex",
+    ExtendedPropertiesHeader ->
       Map(
         "feature" -> "synapseml",
         "runtime" -> runtime
@@ -533,7 +533,7 @@ trait HasOpenAIFabricHeaders extends HasCognitiveServiceInput {
     val headers = super.getCustomHeaders(row)
     if (usingImplicitFabricEndpoint) {
       // SynapseML owns the complete workload classification on its implicit Fabric endpoint.
-      val fabricHeaders = OpenAIFabricHeaders.values
+      val fabricHeaders = OpenAIFabricHeaders.Values
       val remainingHeaders = headers.map(ServiceAuthHeaders.sanitizeHeaderMap).getOrElse(Map.empty)
         .filterNot { case (name, _) => fabricHeaders.keys.exists(_.equalsIgnoreCase(name)) }
       Some(if (remainingHeaders.isEmpty) fabricHeaders else remainingHeaders ++ fabricHeaders)

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -508,7 +508,7 @@ private[openai] object OpenAIFabricHeaders {
 
   private[openai] def build(runtime: String): Map[String, String] = Map(
     "X-Taxonomy-TrafficType" -> "Background",
-    "x-llm-service-tier" -> "flex",
+    "X-Llm-Service-Tier" -> "flex",
     "X-Taxonomy-ExtendedProperties" ->
       Map(
         "feature" -> "synapseml",

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -495,7 +495,7 @@ abstract class OpenAIServicesBase(override val uid: String) extends CognitiveSer
 
   protected[openai] def runningOnFabric: Boolean = PlatformDetails.runningOnFabric()
 
-  protected[openai] def fabricRuntime: String = PlatformDetails.CurrentPlatform
+  protected[openai] def fabricRuntime: String = PlatformDetails.FabricRuntime
 
   override protected def getInternalTransformer(schema: StructType): PipelineModel = {
     if (runningOnFabric && usingDefaultOpenAIEndpoint) {

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -495,8 +495,6 @@ abstract class OpenAIServicesBase(override val uid: String) extends CognitiveSer
 
   protected[openai] def runningOnFabric: Boolean = PlatformDetails.runningOnFabric()
 
-  protected[openai] def fabricRuntime: String = PlatformDetails.FabricRuntime
-
   override protected def getInternalTransformer(schema: StructType): PipelineModel = {
     if (runningOnFabric && usingDefaultOpenAIEndpoint) {
       assertModelStatus(getDeploymentName)
@@ -505,12 +503,26 @@ abstract class OpenAIServicesBase(override val uid: String) extends CognitiveSer
   }
 }
 
-trait HasOpenAIFabricHeaders extends HasCognitiveServiceInput {
-  self: OpenAIServicesBase =>
-
+private[openai] object OpenAIFabricHeaders {
   private val extendedPropertiesHeader = "X-Taxonomy-ExtendedProperties"
   private val trafficTypeHeader = "X-Taxonomy-TrafficType"
   private val serviceTierHeader = "x-llm-service-tier"
+
+  lazy val values: Map[String, String] = build(PlatformDetails.FabricRuntime)
+
+  private[openai] def build(runtime: String): Map[String, String] = Map(
+    trafficTypeHeader -> "Background",
+    serviceTierHeader -> "flex",
+    extendedPropertiesHeader ->
+      Map(
+        "feature" -> "synapseml",
+        "runtime" -> runtime
+      ).toJson.compactPrint
+  )
+}
+
+trait HasOpenAIFabricHeaders extends HasCognitiveServiceInput {
+  self: OpenAIServicesBase =>
 
   private def usingImplicitFabricEndpoint: Boolean = {
     val hasCustomUrlRoot = get(customUrlRoot).nonEmpty
@@ -521,18 +533,10 @@ trait HasOpenAIFabricHeaders extends HasCognitiveServiceInput {
     val headers = super.getCustomHeaders(row)
     if (usingImplicitFabricEndpoint) {
       // SynapseML owns the complete workload classification on its implicit Fabric endpoint.
-      val fabricHeaders = Map(
-        trafficTypeHeader -> "Background",
-        serviceTierHeader -> "flex",
-        extendedPropertiesHeader ->
-          Map(
-            "feature" -> "synapseml",
-            "runtime" -> fabricRuntime
-          ).toJson.compactPrint
-      )
+      val fabricHeaders = OpenAIFabricHeaders.values
       val remainingHeaders = headers.map(ServiceAuthHeaders.sanitizeHeaderMap).getOrElse(Map.empty)
         .filterNot { case (name, _) => fabricHeaders.keys.exists(_.equalsIgnoreCase(name)) }
-      Some(remainingHeaders ++ fabricHeaders)
+      Some(if (remainingHeaders.isEmpty) fabricHeaders else remainingHeaders ++ fabricHeaders)
     } else {
       headers
     }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -504,16 +504,12 @@ abstract class OpenAIServicesBase(override val uid: String) extends CognitiveSer
 }
 
 private[openai] object OpenAIFabricHeaders {
-  private val ExtendedPropertiesHeader = "X-Taxonomy-ExtendedProperties"
-  private val TrafficTypeHeader = "X-Taxonomy-TrafficType"
-  private val ServiceTierHeader = "x-llm-service-tier"
-
   lazy val Values: Map[String, String] = build(PlatformDetails.FabricRuntime)
 
   private[openai] def build(runtime: String): Map[String, String] = Map(
-    TrafficTypeHeader -> "Background",
-    ServiceTierHeader -> "flex",
-    ExtendedPropertiesHeader ->
+    "X-Taxonomy-TrafficType" -> "Background",
+    "x-llm-service-tier" -> "flex",
+    "X-Taxonomy-ExtendedProperties" ->
       Map(
         "feature" -> "synapseml",
         "runtime" -> runtime

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
@@ -4,6 +4,7 @@
 package com.microsoft.azure.synapse.ml.services.openai
 
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import com.microsoft.azure.synapse.ml.logging.common.PlatformDetails
 import com.microsoft.azure.synapse.ml.services.HasCognitiveServiceInput
 import org.apache.spark.sql.Row
 import spray.json._
@@ -26,8 +27,6 @@ class OpenAIFabricHeadersSuite extends TestBase {
     override protected[openai] def runningOnFabric: Boolean = isFabric
 
     override protected[openai] def usingDefaultOpenAIEndpoint: Boolean = usesDefaultEndpoint
-
-    override protected[openai] def fabricRuntime: String = "fabric_spark_3.5.4"
 
     def requestHeaders: Map[String, String] = {
       buildServiceAuthHeaders(
@@ -69,14 +68,16 @@ class OpenAIFabricHeadersSuite extends TestBase {
     )
   }
 
-  private def assertFabricHeaders(headers: Map[String, String]): Unit = {
+  private def assertFabricHeaders(
+      headers: Map[String, String],
+      expectedRuntime: String = PlatformDetails.FabricRuntime): Unit = {
     assert(headers("X-Taxonomy-TrafficType") == "Background")
     assert(headers("x-llm-service-tier") == "flex")
     assert(
       headers("X-Taxonomy-ExtendedProperties").parseJson ==
         JsObject(
           "feature" -> JsString("synapseml"),
-          "runtime" -> JsString("fabric_spark_3.5.4")
+          "runtime" -> JsString(expectedRuntime)
         )
     )
     fabricHeaderNames.foreach { headerName =>
@@ -88,6 +89,16 @@ class OpenAIFabricHeadersSuite extends TestBase {
     fabricHeaderNames.foreach { headerName =>
       assert(!headers.keys.exists(_.equalsIgnoreCase(headerName)))
     }
+  }
+
+  test("Fabric classification headers are initialized once per runtime") {
+    val first = OpenAIFabricHeaders.values
+    val second = OpenAIFabricHeaders.values
+
+    assert(first eq second)
+    assertFabricHeaders(
+      OpenAIFabricHeaders.build("fabric_spark_3.5.4"),
+      expectedRuntime = "fabric_spark_3.5.4")
   }
 
   test("default Fabric OpenAI requests include SynapseML classification headers") {

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
@@ -13,7 +13,7 @@ class OpenAIFabricHeadersSuite extends TestBase {
 
   private val fabricHeaderNames = Seq(
     "X-Taxonomy-TrafficType",
-    "x-llm-service-tier",
+    "X-Llm-Service-Tier",
     "X-Taxonomy-ExtendedProperties"
   )
 
@@ -72,7 +72,7 @@ class OpenAIFabricHeadersSuite extends TestBase {
       headers: Map[String, String],
       expectedRuntime: String = PlatformDetails.FabricRuntime): Unit = {
     assert(headers("X-Taxonomy-TrafficType") == "Background")
-    assert(headers("x-llm-service-tier") == "flex")
+    assert(headers("X-Llm-Service-Tier") == "flex")
     assert(
       headers("X-Taxonomy-ExtendedProperties").parseJson ==
         JsObject(

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
@@ -27,7 +27,7 @@ class OpenAIFabricHeadersSuite extends TestBase {
 
     override protected[openai] def usingDefaultOpenAIEndpoint: Boolean = usesDefaultEndpoint
 
-    override protected[openai] def fabricRuntime: String = "synapse_internal"
+    override protected[openai] def fabricRuntime: String = "fabric_spark_3.5.4"
 
     def requestHeaders: Map[String, String] = {
       buildServiceAuthHeaders(
@@ -76,7 +76,7 @@ class OpenAIFabricHeadersSuite extends TestBase {
       headers("X-Taxonomy-ExtendedProperties").parseJson ==
         JsObject(
           "feature" -> JsString("synapseml"),
-          "runtime" -> JsString("synapse_internal")
+          "runtime" -> JsString("fabric_spark_3.5.4")
         )
     )
     fabricHeaderNames.foreach { headerName =>

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
@@ -92,8 +92,8 @@ class OpenAIFabricHeadersSuite extends TestBase {
   }
 
   test("Fabric classification headers are initialized once per runtime") {
-    val first = OpenAIFabricHeaders.values
-    val second = OpenAIFabricHeaders.values
+    val first = OpenAIFabricHeaders.Values
+    val second = OpenAIFabricHeaders.Values
 
     assert(first eq second)
     assertFabricHeaders(

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/logging/common/PlatformDetails.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/logging/common/PlatformDetails.scala
@@ -15,9 +15,17 @@ object PlatformDetails {
   lazy val CurrentPlatform: String = currentPlatform()
   lazy val FabricRuntime: String = resolveFabricRuntime(
     runningOnFabric(),
-    Option(org.apache.spark.SPARK_VERSION),
+    sparkVersion,
     sys.env.get("PYTHON_VERSION")
   )
+
+  private[common] def sparkVersion: Option[String] = {
+    try {
+      Option(org.apache.spark.SPARK_VERSION).filter(_.nonEmpty)
+    } catch {
+      case _: LinkageError => None
+    }
+  }
 
   def currentPlatform(): String = {
     val azureService = sys.env.get("AZURE_SERVICE")

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/logging/common/PlatformDetails.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/logging/common/PlatformDetails.scala
@@ -13,16 +13,12 @@ object PlatformDetails {
   val PlatformUnknown = "unknown"
   val SynapseProjectName = "Microsoft.ProjectArcadia"
   lazy val CurrentPlatform: String = currentPlatform()
-  lazy val FabricRuntime: String = {
-    if (runningOnFabric()) {
-      resolveFabricRuntime(
-        Option(org.apache.spark.SPARK_VERSION),
-        sys.env.get("PYTHON_VERSION").orElse(sys.props.get("python.version"))
-      )
-    } else {
-      CurrentPlatform
-    }
-  }
+  lazy val FabricRuntime: String = resolveFabricRuntime(
+    runningOnFabric(),
+    Option(org.apache.spark.SPARK_VERSION),
+    sys.env.get("PYTHON_VERSION"),
+    CurrentPlatform
+  )
 
   def currentPlatform(): String = {
     val azureService = sys.env.get("AZURE_SERVICE")
@@ -56,16 +52,22 @@ object PlatformDetails {
   def runningOnFabric(): Boolean = runningOnSynapseInternal()
 
   private[common] def resolveFabricRuntime(
+      isFabric: Boolean,
       sparkVersion: Option[String],
-      pythonVersion: Option[String]): String = {
-    sparkVersion
-      .filter(_.nonEmpty)
-      .map(version => s"fabric_spark_$version")
-      .orElse(
-        pythonVersion
-          .filter(_.nonEmpty)
-          .map(version => s"fabric_python_$version")
-      )
-      .getOrElse("fabric")
+      pythonVersion: Option[String],
+      currentPlatform: String): String = {
+    if (!isFabric) {
+      currentPlatform
+    } else {
+      sparkVersion
+        .filter(_.nonEmpty)
+        .map(version => s"fabric_spark_$version")
+        .orElse(
+          pythonVersion
+            .filter(_.nonEmpty)
+            .map(version => s"fabric_python_$version")
+        )
+        .getOrElse("fabric")
+    }
   }
 }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/logging/common/PlatformDetails.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/logging/common/PlatformDetails.scala
@@ -16,8 +16,7 @@ object PlatformDetails {
   lazy val FabricRuntime: String = resolveFabricRuntime(
     runningOnFabric(),
     Option(org.apache.spark.SPARK_VERSION),
-    sys.env.get("PYTHON_VERSION"),
-    CurrentPlatform
+    sys.env.get("PYTHON_VERSION")
   )
 
   def currentPlatform(): String = {
@@ -54,10 +53,9 @@ object PlatformDetails {
   private[common] def resolveFabricRuntime(
       isFabric: Boolean,
       sparkVersion: Option[String],
-      pythonVersion: Option[String],
-      currentPlatform: String): String = {
+      pythonVersion: Option[String]): String = {
     if (!isFabric) {
-      currentPlatform
+      PlatformUnknown
     } else {
       sparkVersion
         .filter(_.nonEmpty)

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/logging/common/PlatformDetails.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/logging/common/PlatformDetails.scala
@@ -13,6 +13,16 @@ object PlatformDetails {
   val PlatformUnknown = "unknown"
   val SynapseProjectName = "Microsoft.ProjectArcadia"
   lazy val CurrentPlatform: String = currentPlatform()
+  lazy val FabricRuntime: String = {
+    if (runningOnFabric()) {
+      resolveFabricRuntime(
+        Option(org.apache.spark.SPARK_VERSION),
+        sys.env.get("PYTHON_VERSION").orElse(sys.props.get("python.version"))
+      )
+    } else {
+      CurrentPlatform
+    }
+  }
 
   def currentPlatform(): String = {
     val azureService = sys.env.get("AZURE_SERVICE")
@@ -44,4 +54,18 @@ object PlatformDetails {
   def runningOnSynapse(): Boolean = CurrentPlatform == PlatformSynapse
 
   def runningOnFabric(): Boolean = runningOnSynapseInternal()
+
+  private[common] def resolveFabricRuntime(
+      sparkVersion: Option[String],
+      pythonVersion: Option[String]): String = {
+    sparkVersion
+      .filter(_.nonEmpty)
+      .map(version => s"fabric_spark_$version")
+      .orElse(
+        pythonVersion
+          .filter(_.nonEmpty)
+          .map(version => s"fabric_python_$version")
+      )
+      .getOrElse("fabric")
+  }
 }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/logging/common/VerifyPlatformDetails.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/logging/common/VerifyPlatformDetails.scala
@@ -21,6 +21,22 @@ class VerifyPlatformDetails extends TestBase {
     assert(platform.nonEmpty)
   }
 
+  test("FabricRuntime returns a stable runtime value") {
+    val runtime = PlatformDetails.FabricRuntime
+    assert(runtime.nonEmpty)
+    assert(runtime === PlatformDetails.FabricRuntime)
+  }
+
+  test("resolveFabricRuntime prefers Spark and falls back to Python or Fabric") {
+    assert(
+      PlatformDetails.resolveFabricRuntime(Some("3.5.4"), Some("3.11.9")) ===
+        "fabric_spark_3.5.4")
+    assert(
+      PlatformDetails.resolveFabricRuntime(None, Some("3.11.9")) ===
+        "fabric_python_3.11.9")
+    assert(PlatformDetails.resolveFabricRuntime(None, None) === "fabric")
+  }
+
   test("currentPlatform returns a valid platform string") {
     val platform = PlatformDetails.currentPlatform()
     val validPlatforms = Set(

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/logging/common/VerifyPlatformDetails.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/logging/common/VerifyPlatformDetails.scala
@@ -29,12 +29,33 @@ class VerifyPlatformDetails extends TestBase {
 
   test("resolveFabricRuntime prefers Spark and falls back to Python or Fabric") {
     assert(
-      PlatformDetails.resolveFabricRuntime(Some("3.5.4"), Some("3.11.9")) ===
+      PlatformDetails.resolveFabricRuntime(
+        isFabric = true,
+        sparkVersion = Some("3.5.4"),
+        pythonVersion = Some("3.11.9"),
+        currentPlatform = "synapse_internal") ===
         "fabric_spark_3.5.4")
     assert(
-      PlatformDetails.resolveFabricRuntime(None, Some("3.11.9")) ===
+      PlatformDetails.resolveFabricRuntime(
+        isFabric = true,
+        sparkVersion = None,
+        pythonVersion = Some("3.11.9"),
+        currentPlatform = "synapse_internal") ===
         "fabric_python_3.11.9")
-    assert(PlatformDetails.resolveFabricRuntime(None, None) === "fabric")
+    assert(
+      PlatformDetails.resolveFabricRuntime(
+        isFabric = true,
+        sparkVersion = None,
+        pythonVersion = None,
+        currentPlatform = "synapse_internal") ===
+        "fabric")
+    assert(
+      PlatformDetails.resolveFabricRuntime(
+        isFabric = false,
+        sparkVersion = Some("3.5.4"),
+        pythonVersion = Some("3.11.9"),
+        currentPlatform = "databricks") ===
+        "databricks")
   }
 
   test("currentPlatform returns a valid platform string") {

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/logging/common/VerifyPlatformDetails.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/logging/common/VerifyPlatformDetails.scala
@@ -27,6 +27,10 @@ class VerifyPlatformDetails extends TestBase {
     assert(runtime === PlatformDetails.FabricRuntime)
   }
 
+  test("sparkVersion safely reports the packaged Spark runtime") {
+    assert(PlatformDetails.sparkVersion.contains(org.apache.spark.SPARK_VERSION))
+  }
+
   test("resolveFabricRuntime prefers Spark and falls back to Python or Fabric") {
     assert(
       PlatformDetails.resolveFabricRuntime(

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/logging/common/VerifyPlatformDetails.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/logging/common/VerifyPlatformDetails.scala
@@ -32,30 +32,26 @@ class VerifyPlatformDetails extends TestBase {
       PlatformDetails.resolveFabricRuntime(
         isFabric = true,
         sparkVersion = Some("3.5.4"),
-        pythonVersion = Some("3.11.9"),
-        currentPlatform = "synapse_internal") ===
+        pythonVersion = Some("3.11.9")) ===
         "fabric_spark_3.5.4")
     assert(
       PlatformDetails.resolveFabricRuntime(
         isFabric = true,
         sparkVersion = None,
-        pythonVersion = Some("3.11.9"),
-        currentPlatform = "synapse_internal") ===
+        pythonVersion = Some("3.11.9")) ===
         "fabric_python_3.11.9")
     assert(
       PlatformDetails.resolveFabricRuntime(
         isFabric = true,
         sparkVersion = None,
-        pythonVersion = None,
-        currentPlatform = "synapse_internal") ===
+        pythonVersion = None) ===
         "fabric")
     assert(
       PlatformDetails.resolveFabricRuntime(
         isFabric = false,
         sparkVersion = Some("3.5.4"),
-        pythonVersion = Some("3.11.9"),
-        currentPlatform = "databricks") ===
-        "databricks")
+        pythonVersion = Some("3.11.9")) ===
+        PlatformDetails.PlatformUnknown)
   }
 
   test("currentPlatform returns a valid platform string") {


### PR DESCRIPTION
## Summary

Update SynapseML Fabric LLM extended properties to report a versioned runtime:

```json
{"feature":"synapseml","runtime":"fabric_spark_<spark_version>|fabric_python_<python_version>|fabric|unknown"}
```

Runtime selection matches SynapseML-Internal:

1. When Fabric detection is false, report `unknown` for local, Databricks, and other non-Fabric environments.
2. On Fabric, prefer `fabric_spark_<spark_version>`.
3. If Spark is unavailable, use `fabric_python_<python_version>`.
4. Otherwise use `fabric`.

## Implementation

- Uses `PlatformDetails.FabricRuntime` as the shared runtime taxonomy owner.
- Safely treats unavailable Spark linkage as an absent Spark version, preserving the Python and generic Fabric fallbacks.
- Uses a Scala `lazy val`, so runtime detection runs once per JVM.
- Builds the complete immutable Fabric classification header map once per JVM, including ExtendedProperties JSON.
- Reuses that map across request rows; only request-specific custom-header sanitization and merging remains per request.
- Keeps existing Fabric-only and implicit-endpoint guards unchanged.
- SynapseML intentionally has no `function` field because this shared OpenAI transport represents generic SynapseML stages rather than an individual AI Functions operation.

Headers must still be attached to every outbound HTTP request, but their runtime detection and fixed value construction are not repeated.

## Validation

- `VerifyPlatformDetails`: 11 passed.
- `OpenAIFabricHeadersSuite`: 7 passed.
- Main and test compilation passed with JDK 11.
- Scala and test scalastyle passed.
- Latest automated review covers the current head with no findings.
- Full Azure CI was run twice; relevant completed tests were green, but both runs were blocked by external dependency/feed infrastructure failures also reproduced on `master`.

## References

- [AB#5533937 - Add Fabric LLM taxonomy headers to SynapseML](https://dev.azure.com/msdata/A365/_workitems/edit/5533937)
- [Prior header PR #2656](https://github.com/microsoft/SynapseML/pull/2656)
- [Python AI Functions PR #2253680](https://dev.azure.com/msdata/A365/_git/SynapseML-Internal/pullrequest/2253680)
- [Fabric taxonomy and class-of-service guidance](https://eng.ms/docs/synapse-data-science-fabric-product-synapse-data-science/llmendpoint/partnerdocs/taxonomyandclassofservice.html)
