### PR TITLE
test: add Fabric OpenAIPrompt end-to-end gate

### DIFF
--- a/.github/skills/fabric-e2e/SKILL.md
+++ b/.github/skills/fabric-e2e/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: fabric-e2e
+description: Run SynapseML pull-request code on a real Microsoft Fabric Spark runtime with fabric-spark-cli. Use for Fabric E2E validation, runtime-only bugs, jar provenance, LightGBM native or concurrency issues, and PR evidence that local Spark tests cannot provide.
+compatibility: Windows, Linux, or WSL with Python 3.10+, Azure CLI authentication, fabric-spark-cli, and access to a Fabric test workspace.
+---
+
+# SynapseML Fabric E2E
+
+Use the checked-in runner for real Fabric validation. Do not recreate the
+legacy Fabric REST/Spark Job Definition client or manually upload jars.
+
+## Important
+
+- Resolve the PR base branch and load `synapseml-branches` first.
+- Read the live `fabric-spark-cli` batch and notebook help before composing a
+  run because their flags evolve.
+- Always pass `--workspace`; unattended runs must never use an interactive
+  picker.
+- Build jars from the exact checkout under test. A green run against a
+  runtime-bundled or previously published jar is not PR evidence.
+- Do not pass credentials through scenario arguments or Spark configuration.
+- For OpenAI scenarios, use Fabric's implicit workload endpoint and MWC token.
+  Never add an Azure OpenAI key to CLI arguments, Spark configuration, or
+  retained logs.
+- The runner creates a unique scratch lakehouse and deletes that exact item in
+  `finally`. Notebook profiles also create and delete one unique notebook. Use
+  `--keep-lakehouse` only for active debugging, then delete it.
+- Do not expose Fabric credentials to untrusted fork builds.
+
+## Workflow
+
+### 1. Confirm the live CLI and scenarios
+
+Run `fabric-spark-cli --help`, `fabric-spark-cli batch submit --help`,
+`fabric-spark-cli notebook run --help`, and:
+
+```bash
+python tools/fabric_e2e/run.py --list-scenarios
+```
+
+### 2. Prove managed runtime access
+
+Run `runtime-smoke` with an explicit test workspace:
+
+```bash
+python tools/fabric_e2e/run.py \
+  --scenario runtime-smoke \
+  --workspace <workspace>
+```
+
+Capture the `SYNAPSEML_FABRIC_E2E_EVIDENCE` path. The evidence must contain a
+Fabric application ID and runtime Spark version.
+
+### 3. Build the exact SynapseML jars
+
+Use the JDK selected by `synapseml-local-setup`. Build only the affected module
+and its dependencies. Do not use a jar from another checkout or an earlier CI
+run.
+
+### 4. Run the relevant PR scenario
+
+Pass jars in classpath-precedence order with one `--extra-jar` per jar.
+For LightGBM, include the exact `lightgbmlib` dependency between core and the
+SynapseML LightGBM jar so Fabric cannot mix PR Scala code with a bundled JNI
+library. The scenario also overrides `java.library.path` on the driver and
+executors so `NativeLoader` extracts both `.so` files from that exact jar
+instead of accepting Fabric's preinstalled native libraries:
+
+```bash
+python tools/fabric_e2e/run.py \
+  --scenario lightgbm-streaming \
+  --workspace <workspace> \
+  --extra-jar <core-jar> \
+  --extra-jar <lightgbmlib-jar> \
+  --extra-jar <lightgbm-jar>
+```
+
+For the PySpark AI Functions origin check, pass exact core and cognitive jars.
+The scenario imports the public `OpenAIPrompt` wrapper and requires Fabric's
+implicit OpenAI endpoint; it must not be adapted to inject a model key. The
+runner executes this scenario as a Fabric platform notebook because direct
+batch/Lakehouse execution does not supply the LLM workload-operation context:
+
+```bash
+python tools/fabric_e2e/run.py \
+  --scenario openai-prompt-ai-functions \
+  --workspace <workspace> \
+  --extra-jar <core-jar> \
+  --extra-jar <cognitive-jar>
+```
+
+When the jars came from another Git worktree, pass that checkout through
+`--source-repo` so evidence records the producing commit rather than the
+runner's checkout.
+
+Put any `--scenario-args` last. See
+[references/scenarios.md](references/scenarios.md) for profiles and arguments.
+
+### 5. Review evidence
+
+Require all of the following before citing the run:
+
+- commit SHA is the checkout under review;
+- every jar has a SHA-256 digest;
+- class-source paths name the supplied jars;
+- `junit.xml` and `runner.log` exist, plus downloaded Fabric logs for batch
+  profiles or `executed-notebook.ipynb` for notebook profiles;
+- scratch-lakehouse cleanup succeeded.
+
+For a passing claim, also require `status` to be `passed` and runtime evidence
+to show the intended Spark version and topology. A failed run is valid blocking
+evidence when `runtimeDiagnostics` proves the expected class and native-library
+sources; cite the failure and do not relabel it as a successful Fabric check.
+
+Do not describe a generic runtime smoke as coverage for a module-specific
+behavior. Cite the exact scenario and evidence path in the PR.

--- a/.github/skills/fabric-e2e/references/scenarios.md
+++ b/.github/skills/fabric-e2e/references/scenarios.md
@@ -1,0 +1,123 @@
+# Fabric E2E scenarios
+
+## `runtime-smoke`
+
+Runs a four-partition DataFrame action and records the Fabric application ID,
+Spark version, and default parallelism. It proves managed Fabric Spark access,
+not SynapseML module behavior.
+
+## `jar-provenance`
+
+Requires one `--extra-jar`. By default it loads
+`com.microsoft.azure.synapse.ml.build.BuildInfo$`, asserts that the class source
+contains the supplied jar's basename, and runs a distributed DataFrame action.
+
+Override the class or expected token by putting scenario arguments last:
+
+```bash
+python tools/fabric_e2e/run.py \
+  --scenario jar-provenance \
+  --workspace <workspace> \
+  --extra-jar <jar> \
+  --scenario-args \
+  --class-name <fully-qualified-class> \
+  --expected-jar-token <jar-basename>
+```
+
+## `lightgbm-streaming`
+
+Requires core, the exact `lightgbmlib` dependency, and the SynapseML LightGBM
+jar, in that order. It asserts all three class sources, creates deterministic
+synthetic training and validation data, and performs repeated public
+`LightGBMClassifier.fit()` and prediction operations with streaming transfer
+and single-dataset mode. Omitting `lightgbmlib` can mix the PR classes with an
+incompatible runtime-bundled JNI library.
+
+The manifest forces a non-runtime `java.library.path` for the driver and
+executors. This makes `NativeLoader` extract `lib_lightgbm.so` and
+`lib_lightgbm_swig.so` from the supplied JNI jar. The scenario records the
+driver's effective path and `/proc/<pid>/maps` entries before fitting. Do not
+override those two Spark settings unless the replacement preserves this
+isolation.
+
+Useful overrides:
+
+- `--rows <n>`: generated row count; default 4000.
+- `--partitions <n>`: Spark and LightGBM task count; default 4.
+- `--native-threads <n>`: LightGBM native threads per task; default 2.
+- `--repetitions <n>`: repeated fits; default 2.
+
+For issue #2333 diagnostics, begin with the default starter pool. Use an
+explicit ephemeral topology only when the test requires it:
+
+```bash
+python tools/fabric_e2e/run.py \
+  --scenario lightgbm-streaming \
+  --workspace <workspace> \
+  --node-size Medium \
+  --node-count 1 \
+  --extra-jar <core-jar> \
+  --extra-jar <lightgbmlib-jar> \
+  --extra-jar <lightgbm-jar> \
+  --scenario-args --repetitions 20
+```
+
+The scenario reports executor addresses and configured executor cores. Do not
+claim multi-core coverage if that evidence does not show the intended topology.
+
+## `openai-prompt-ai-functions`
+
+Requires exact core and cognitive jars, in that order. It imports the public
+PySpark `OpenAIPrompt` wrapper and proves that the JVM `FabricClient`,
+`OpenAIPrompt`, and `OpenAIResponses` classes came from those supplied jars.
+
+The scenario uses Fabric's implicit OpenAI workload endpoint and MWC token. It
+must not receive a subscription key, AAD token, endpoint, or other credential
+through scenario arguments or Spark configuration. The retained evidence
+records only that the implicit endpoint was selected; it does not record the
+endpoint URL or response text.
+
+This profile uses `fabric-spark-cli notebook run`, not `batch submit`.
+Platform-notebook execution supplies the notebook artifact context required by
+the implicit LLM endpoint. A direct batch attached only to a Lakehouse reaches
+the endpoint but is rejected because its workload-operation context is invalid.
+The runner generates a unique notebook, retains its executed form, and deletes
+that exact notebook and scratch lakehouse after the run.
+Platform notebooks use the workspace's configured runtime and pool, so the
+runner rejects `--runtime`, `--node-size`, and `--node-count` for this profile.
+
+One small structured prompt covers the origin behaviors used by PySpark AI
+Functions: prompt interpolation and generation, sentiment classification,
+summarization, translation, structured extraction, null propagation, usage,
+and service-error handling. Assertions target schema, row count, obvious
+sentiment labels, non-empty generated fields, null behavior, and empty error
+columns rather than brittle exact prose.
+
+The default model is `gpt-5-mini`. Override it only when the target Fabric
+tenant enables a different supported model:
+
+```bash
+python tools/fabric_e2e/run.py \
+  --scenario openai-prompt-ai-functions \
+  --workspace <workspace> \
+  --extra-jar <core-jar> \
+  --extra-jar <cognitive-jar> \
+  --scenario-args --model <model>
+```
+
+## Outputs
+
+Each run writes under `target/fabric-e2e/<run-id>/` unless `--output-dir` is
+provided:
+
+- `evidence.json`: source commit, CLI version, jar hashes, Spark configuration,
+  runtime evidence or pre-failure diagnostics, submission result, and cleanup
+  result.
+- `junit.xml`: one test result suitable for CI publication.
+- `runner.log`: complete runner and CLI output.
+- `fabric-logs/`: downloaded driver and executor logs for batch profiles.
+- `scenario.ipynb` and `executed-notebook.ipynb`: generated input and retained
+  output for notebook profiles.
+
+The default cleanup deletes the unique lakehouse and, for notebook profiles,
+the unique notebook created for that run.

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -103,6 +103,8 @@ variables:
   SYNAPSEML_GPU_SMOKE_TESTS: $[eq(variables['Build.Reason'], 'PullRequest')]
   # Run coverage only on PRs, master, or tag builds to speed up feature branch builds
   runCoverage: $[or(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))]
+  # The platform-notebook OpenAIPrompt gate currently targets the Spark 3.5 Fabric workspace.
+  runFabricOpenAIPrompt: $[or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.SourceBranch'], 'refs/heads/spark3.5'), eq(variables['System.PullRequest.TargetBranch'], 'refs/heads/master'), eq(variables['System.PullRequest.TargetBranch'], 'refs/heads/spark3.5'), eq(variables['System.PullRequest.TargetBranch'], 'master'), eq(variables['System.PullRequest.TargetBranch'], 'spark3.5'))]
 
 jobs:
 - job: BuildAndCacheSbt
@@ -311,9 +313,9 @@ jobs:
 - job: FabricE2E
   dependsOn: BuildAndCacheSbt
   displayName: 'Fabric E2E'
-  condition: and(succeeded(), eq('${{ parameters.testFabricE2E }}', true))
-  timeoutInMinutes: 120
-  cancelTimeoutInMinutes: 0
+  condition: and(succeeded(), eq('${{ parameters.testFabricE2E }}', true), ne(variables['System.PullRequest.IsFork'], 'True'))
+  timeoutInMinutes: 180
+  cancelTimeoutInMinutes: 5
   pool:
     vmImage: $(UBUNTU_VERSION)
   steps:
@@ -341,6 +343,98 @@ jobs:
         INTEGRATION_CERTIFICATE: $(sempy-integration-certificate)
         INTEGRATION_WORKSPACE_PREFIX: $(sempy-integration-workspace-prefix)
       condition: and(succeeded(), eq(variables.runTests, 'True'))
+    - task: AzureCLI@2
+      displayName: 'Run OpenAIPrompt on Fabric'
+      timeoutInMinutes: 45
+      inputs:
+        azureSubscription: 'SynapseML Build'
+        scriptLocation: inlineScript
+        scriptType: bash
+        inlineScript: |
+          set -eo pipefail
+          artifact_root='$(Build.ArtifactStagingDirectory)/fabric-openai-e2e'
+          mkdir -p "$artifact_root"
+          echo "##vso[task.setvariable variable=fabricOpenAIPromptAttempted]true"
+          source activate synapseml
+          set -u
+
+          sbt core/packageBin cognitive/packageBin
+
+          resolve_module_jar() {
+            local module="$1"
+            local artifact="$2"
+            local -a matches
+            mapfile -t matches < <(
+              find "$module/target" -type f -name "${artifact}_*.jar" \
+                ! -name '*-sources.jar' \
+                ! -name '*-javadoc.jar' \
+                ! -name '*-tests.jar' \
+                ! -name '*-assembly*.jar' |
+                sort
+            )
+            if [ "${#matches[@]}" -ne 1 ]; then
+              echo "Expected exactly one $artifact package jar, found ${#matches[@]}:" >&2
+              printf '  %s\n' "${matches[@]}" >&2
+              return 1
+            fi
+            printf '%s\n' "${matches[0]}"
+          }
+
+          core_jar="$(resolve_module_jar core synapseml-core)"
+          cognitive_jar="$(resolve_module_jar cognitive synapseml-cognitive)"
+
+          feed='msdata.pkgs.visualstudio.com/A365/_packaging/SynapseMaven/pypi/simple'
+          feed_token="$(
+            az account get-access-token \
+              --resource 499b84ac-1321-427f-aa17-267ca6975798 \
+              --query accessToken \
+              --output tsv
+          )"
+          export PIP_INDEX_URL="https://azure:${feed_token}@${feed}"
+          export PIP_DISABLE_PIP_VERSION_CHECK=1
+          python -m pip install --quiet --pre \
+            'fabric-spark-cli==0.1.20260807.5'
+          unset PIP_INDEX_URL feed_token
+          fabric-spark-cli --version
+
+          integration_username="${INTEGRATION_ACCOUNT%%@*}"
+          workspace="${INTEGRATION_WORKSPACE_PREFIX} ${integration_username}"
+          fabric_env="$(
+            printf '%s' "$INTEGRATION_ENV" | tr '[:upper:]' '[:lower:]'
+          )"
+          output_dir="$artifact_root/run"
+          if [ -e "$output_dir" ]; then
+            echo "Fabric evidence output already exists: $output_dir" >&2
+            exit 1
+          fi
+
+          python tools/fabric_e2e/run.py \
+            --scenario openai-prompt-ai-functions \
+            --workspace "$workspace" \
+            --env "$fabric_env" \
+            --source-repo '$(Build.SourcesDirectory)' \
+            --output-dir "$output_dir" \
+            --extra-jar "$core_jar" \
+            --extra-jar "$cognitive_jar"
+      env:
+        INTEGRATION_ENV: $(sempy-integration-region)
+        INTEGRATION_ACCOUNT: $(sempy-integration-account)
+        INTEGRATION_WORKSPACE_PREFIX: $(sempy-integration-workspace-prefix)
+      condition: and(succeeded(), eq(variables.runTests, 'True'), eq(variables.runFabricOpenAIPrompt, true))
+    - task: PublishTestResults@2
+      displayName: 'Publish Fabric OpenAIPrompt Results'
+      inputs:
+        testResultsFormat: JUnit
+        testResultsFiles: '$(Build.ArtifactStagingDirectory)/fabric-openai-e2e/**/junit.xml'
+        testRunTitle: 'Fabric OpenAIPrompt E2E'
+        failTaskOnFailedTests: true
+      condition: and(succeededOrFailed(), eq(variables.fabricOpenAIPromptAttempted, 'true'))
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish Fabric OpenAIPrompt Evidence'
+      inputs:
+        targetPath: '$(Build.ArtifactStagingDirectory)/fabric-openai-e2e'
+        artifact: 'fabric-openai-e2e'
+      condition: and(succeededOrFailed(), eq(variables.fabricOpenAIPromptAttempted, 'true'))
     - task: PublishTestResults@2
       displayName: 'Publish Test Results'
       inputs:

--- a/tools/ci/tests/test_fabric_e2e.py
+++ b/tools/ci/tests/test_fabric_e2e.py
@@ -1,0 +1,325 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from tools.fabric_e2e.run import (
+    DIAGNOSTIC_MARKER,
+    RESULT_MARKER,
+    Scenario,
+    build_cleanup_command,
+    build_notebook_cleanup_command,
+    build_notebook_submission_command,
+    build_submission_command,
+    checked_jars,
+    console_safe_text,
+    diagnostic_failure_message,
+    downloaded_marker_output,
+    load_scenarios,
+    new_run_id,
+    parse_runtime_diagnostics,
+    parse_runtime_evidence,
+    resolve_scenario_args,
+    resolve_spark_conf,
+    write_scenario_notebook,
+)
+
+
+def test_manifest_scripts_exist_and_require_expected_jars():
+    scenarios = load_scenarios()
+
+    assert set(scenarios) == {
+        "jar-provenance",
+        "lightgbm-streaming",
+        "openai-prompt-ai-functions",
+        "runtime-smoke",
+    }
+    assert scenarios["runtime-smoke"].minimum_jars == 0
+    assert scenarios["jar-provenance"].minimum_jars == 1
+    assert scenarios["lightgbm-streaming"].minimum_jars == 3
+    assert scenarios["openai-prompt-ai-functions"].minimum_jars == 2
+    assert scenarios["openai-prompt-ai-functions"].execution == "notebook"
+    assert scenarios["openai-prompt-ai-functions"].default_args == (
+        "--expected-core-jar",
+        "{jar0Name}",
+        "--expected-cognitive-jar",
+        "{jar1Name}",
+    )
+    assert scenarios["lightgbm-streaming"].default_spark_conf == (
+        "spark.driver.extraJavaOptions="
+        "-Djava.library.path=/tmp/synapseml-fabric-e2e-native",
+        "spark.executor.extraJavaOptions="
+        "-Djava.library.path=/tmp/synapseml-fabric-e2e-native",
+    )
+    assert all(scenario.script.is_file() for scenario in scenarios.values())
+    assert all(
+        scenario.execution == "batch"
+        for name, scenario in scenarios.items()
+        if name != "openai-prompt-ai-functions"
+    )
+
+
+def test_openai_scenario_uses_implicit_fabric_auth_only():
+    scenario = load_scenarios()["openai-prompt-ai-functions"]
+    source = scenario.script.read_text(encoding="utf-8")
+
+    assert ".setSubscriptionKey(" not in source
+    assert ".setAADToken(" not in source
+    assert ".setCustomAuthHeader(" not in source
+    assert ".setCustomHeaders(" not in source
+    assert ".setUrl(" not in source
+    assert "AZURE_OPENAI_API_KEY" not in source
+    assert "OPENAI_API_KEY" not in source
+    assert "implicitFabricEndpoint" in source
+
+
+def test_submission_command_is_non_interactive_and_includes_overrides(tmp_path):
+    scenario = Scenario(
+        name="test",
+        description="test",
+        script=tmp_path / "scenario.py",
+        minimum_jars=1,
+        default_args=(),
+    )
+    jar = tmp_path / "override.jar"
+    command = build_submission_command(
+        executable="fabric-spark-cli",
+        scenario=scenario,
+        workspace="test-workspace",
+        lakehouse="scratch-lakehouse",
+        job_name="test-job",
+        output_dir=tmp_path / "logs",
+        environment="msit",
+        subscription="test-subscription",
+        runtime="1.3",
+        node_size="Medium",
+        node_count=1,
+        spark_conf=("spark.sql.shuffle.partitions=4",),
+        jars=(jar,),
+        scenario_args=("--expected", jar.name),
+    )
+
+    assert command[:4] == [
+        "fabric-spark-cli",
+        "batch",
+        "submit",
+        "--backend",
+    ]
+    assert command[command.index("--workspace") + 1] == "test-workspace"
+    assert command[command.index("--lakehouse") + 1] == "scratch-lakehouse"
+    assert command[command.index("--extra-jars") + 1] == str(jar)
+    assert command[command.index("--args") + 1] == "--expected override.jar"
+    assert "--no-overwrite" in command
+    assert "--download-log" in command
+
+
+def test_notebook_command_is_non_interactive_and_includes_overrides(tmp_path):
+    notebook = tmp_path / "scenario.ipynb"
+    jar = tmp_path / "override.jar"
+    command = build_notebook_submission_command(
+        executable="fabric-spark-cli",
+        notebook_path=notebook,
+        workspace="test-workspace",
+        lakehouse="scratch-lakehouse",
+        notebook_name="test-notebook",
+        output_path=tmp_path / "executed.ipynb",
+        environment="msit",
+        subscription="test-subscription",
+        spark_conf=("spark.sql.shuffle.partitions=4",),
+        jars=(jar,),
+    )
+
+    assert command[:3] == ["fabric-spark-cli", "notebook", "run"]
+    assert command[3] == str(notebook)
+    assert command[command.index("--workspace") + 1] == "test-workspace"
+    assert command[command.index("--lakehouse") + 1] == "scratch-lakehouse"
+    assert command[command.index("--name") + 1] == "test-notebook"
+    assert command[command.index("--extra-jars") + 1] == str(jar)
+    assert "--stdout" in command
+    assert "--output-file" in command
+    assert "--overwrite" not in command
+
+
+def test_generated_notebook_sets_scenario_argv_and_python_metadata(tmp_path):
+    script = tmp_path / "scenario.py"
+    script.write_text("print('scenario')\n", encoding="utf-8")
+    scenario = Scenario(
+        name="test",
+        description="test",
+        script=script,
+        minimum_jars=0,
+        default_args=(),
+        execution="notebook",
+    )
+    notebook_path = tmp_path / "scenario.ipynb"
+
+    write_scenario_notebook(notebook_path, scenario, ("--value", 'spaces and "quotes"'))
+
+    notebook = json.loads(notebook_path.read_text(encoding="utf-8"))
+    source = "".join(notebook["cells"][0]["source"])
+    assert notebook["metadata"]["language_info"]["name"] == "python"
+    assert notebook["metadata"]["kernelspec"]["name"] == "synapse_pyspark"
+    assert 'spaces and \\"quotes\\"' in source
+    assert "print('scenario')" in source
+
+
+def test_cleanup_targets_only_the_exact_scratch_lakehouse():
+    command = build_cleanup_command(
+        executable="fabric-spark-cli",
+        workspace="test-workspace",
+        lakehouse="synapseml_e2e_test_123",
+        environment="msit",
+    )
+
+    assert command[-1] == "synapseml_e2e_test_123"
+    assert "--yes" not in command
+    assert "clean" not in command
+
+
+def test_notebook_cleanup_targets_only_the_exact_item():
+    command = build_notebook_cleanup_command(
+        executable="fabric-spark-cli",
+        workspace="test-workspace",
+        notebook_name="synapseml-e2e-test-123",
+        environment="msit",
+    )
+
+    assert command[-2:] == ["--name", "synapseml-e2e-test-123"]
+    assert "--workspace" in command
+
+
+def test_result_marker_requires_one_json_object():
+    evidence = parse_runtime_evidence(
+        f'print("{RESULT_MARKER}" + json.dumps(evidence))\n'
+        f"prefix\n{RESULT_MARKER}{json.dumps({'sparkVersion': '3.5'})}\nsuffix\n"
+    )
+    assert evidence == {"sparkVersion": "3.5"}
+
+    with pytest.raises(ValueError, match="exactly one"):
+        parse_runtime_evidence("no result")
+    assert parse_runtime_evidence(f"{RESULT_MARKER}{{}}\n{RESULT_MARKER}{{}}\n") == {}
+    with pytest.raises(ValueError, match="exactly one"):
+        parse_runtime_evidence(
+            f'{RESULT_MARKER}{{}}\n{RESULT_MARKER}{{"attempt": 2}}\n'
+        )
+
+
+def test_diagnostic_markers_allow_partial_failure_evidence():
+    diagnostics = parse_runtime_diagnostics(
+        "prefix\n"
+        f"{DIAGNOSTIC_MARKER}{json.dumps({'phase': 'native-load'})}\n"
+        f"{DIAGNOSTIC_MARKER}{json.dumps({'phase': 'fit'})}\n"
+        "failure\n"
+    )
+
+    assert diagnostics == [{"phase": "native-load"}, {"phase": "fit"}]
+    assert parse_runtime_diagnostics("no diagnostics") == []
+    with pytest.raises(ValueError, match="JSON objects"):
+        parse_runtime_diagnostics(f"{DIAGNOSTIC_MARKER}[]")
+
+
+def test_downloaded_driver_stdout_supplies_markers(tmp_path):
+    first = tmp_path / "job" / "driver" / "attempt-1" / "stdout.log"
+    first.parent.mkdir(parents=True)
+    first.write_text(
+        f"{DIAGNOSTIC_MARKER}{json.dumps({'attempt': 1})}\n", encoding="utf-8"
+    )
+    duplicate = tmp_path / "job" / "driver" / "attempt-2" / "stdout.log"
+    duplicate.parent.mkdir(parents=True)
+    duplicate.write_text(
+        f"{DIAGNOSTIC_MARKER}{json.dumps({'attempt': 1})}\n"
+        f"{RESULT_MARKER}{json.dumps({'status': 'passed'})}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "job" / "driver" / "attempt-2" / "stderr.log").write_text(
+        f"{DIAGNOSTIC_MARKER}{json.dumps({'ignored': True})}\n", encoding="utf-8"
+    )
+
+    output = downloaded_marker_output(tmp_path)
+
+    assert parse_runtime_diagnostics(output) == [{"attempt": 1}]
+    assert parse_runtime_evidence(output) == {"status": "passed"}
+
+
+def test_last_structured_failure_is_used():
+    assert (
+        diagnostic_failure_message(
+            [
+                {"phase": "native-load"},
+                {"phase": "fit", "errorMessage": "native call failed"},
+            ]
+        )
+        == "native call failed"
+    )
+    assert diagnostic_failure_message([{"phase": "native-load"}]) is None
+
+
+def test_console_output_replaces_unsupported_glyphs():
+    assert console_safe_text("passed: ✓", "ascii") == "passed: ?"
+    assert console_safe_text("passed: ✓", "utf-8") == "passed: ✓"
+
+
+def test_scenario_placeholders_use_basenames(tmp_path):
+    scenario = Scenario(
+        name="test",
+        description="test",
+        script=tmp_path / "scenario.py",
+        minimum_jars=3,
+        default_args=("{firstJarName}", "{jar1Name}", "{lastJarName}"),
+    )
+    jars = (
+        tmp_path / "core.jar",
+        tmp_path / "lightgbmlib.jar",
+        tmp_path / "lightgbm.jar",
+    )
+
+    assert resolve_scenario_args(scenario, jars, ("--rows", "100")) == [
+        "core.jar",
+        "lightgbmlib.jar",
+        "lightgbm.jar",
+        "--rows",
+        "100",
+    ]
+
+
+def test_scenario_spark_conf_precedes_caller_overrides(tmp_path):
+    scenario = Scenario(
+        name="test",
+        description="test",
+        script=tmp_path / "scenario.py",
+        minimum_jars=0,
+        default_args=(),
+        default_spark_conf=("spark.executor.cores=4",),
+    )
+
+    assert resolve_spark_conf(scenario, ("spark.executor.cores=8",)) == [
+        "spark.executor.cores=4",
+        "spark.executor.cores=8",
+    ]
+
+
+def test_checked_jars_rejects_missing_and_non_jar_files(tmp_path):
+    jar = tmp_path / "module.jar"
+    jar.write_bytes(b"jar")
+    assert checked_jars([str(jar)]) == [jar.resolve()]
+
+    with pytest.raises(ValueError, match="does not exist"):
+        checked_jars([str(tmp_path / "missing.jar")])
+    text = tmp_path / "module.txt"
+    text.write_text("not a jar", encoding="utf-8")
+    with pytest.raises(ValueError, match="not a .jar"):
+        checked_jars([str(text)])
+
+
+def test_run_id_is_safe_and_timestamped():
+    run_id = new_run_id(
+        "LightGBM Streaming",
+        datetime(2026, 8, 18, 21, 0, tzinfo=timezone.utc),
+    )
+
+    assert run_id.startswith("lightgbm_streaming_20260818210000_")
+    assert len(run_id.rsplit("_", 1)[-1]) == 8

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -279,6 +279,63 @@ def test_fabric_e2e_cleans_stale_artifacts_before_running_tests():
     assert script.index(cleanup_command) < script.index(test_command)
 
 
+def test_fabric_e2e_runs_openai_prompt_with_exact_artifacts():
+    data = yaml.safe_load(_pipeline_text())
+    jobs = {j.get("job"): j for j in _jobs(data["jobs"])}
+    fabric_e2e = jobs["FabricE2E"]
+
+    assert "System.PullRequest.IsFork" in fabric_e2e["condition"]
+    assert fabric_e2e["timeoutInMinutes"] >= 180
+    assert fabric_e2e["cancelTimeoutInMinutes"] >= 5
+
+    openai_steps = [
+        step
+        for step in fabric_e2e["steps"]
+        if isinstance(step, dict)
+        and step.get("displayName") == "Run OpenAIPrompt on Fabric"
+    ]
+    assert len(openai_steps) == 1
+    openai_step = openai_steps[0]
+    assert openai_step["task"] == "AzureCLI@2"
+    assert openai_step["inputs"]["azureSubscription"] == "SynapseML Build"
+    assert "runFabricOpenAIPrompt" in openai_step["condition"]
+
+    script = openai_step["inputs"]["inlineScript"]
+    assert "sbt core/packageBin cognitive/packageBin" in script
+    assert "fabric-spark-cli==0.1.20260807.5" in script
+    assert (
+        'workspace="${INTEGRATION_WORKSPACE_PREFIX} ${integration_username}"' in script
+    )
+    assert "--scenario openai-prompt-ai-functions" in script
+    assert '--extra-jar "$core_jar"' in script
+    assert '--extra-jar "$cognitive_jar"' in script
+    assert "fabricOpenAIPromptAttempted]true" in script
+    assert "OPENAI_API_KEY" not in script
+    assert "AZURE_OPENAI_API_KEY" not in script
+
+    result_steps = [
+        step
+        for step in fabric_e2e["steps"]
+        if isinstance(step, dict)
+        and step.get("displayName") == "Publish Fabric OpenAIPrompt Results"
+    ]
+    assert len(result_steps) == 1
+    assert result_steps[0]["task"] == "PublishTestResults@2"
+    assert result_steps[0]["inputs"]["testResultsFormat"] == "JUnit"
+    assert "fabricOpenAIPromptAttempted" in result_steps[0]["condition"]
+
+    artifact_steps = [
+        step
+        for step in fabric_e2e["steps"]
+        if isinstance(step, dict)
+        and step.get("displayName") == "Publish Fabric OpenAIPrompt Evidence"
+    ]
+    assert len(artifact_steps) == 1
+    assert artifact_steps[0]["task"] == "PublishPipelineArtifact@1"
+    assert artifact_steps[0]["inputs"]["artifact"] == "fabric-openai-e2e"
+    assert "fabricOpenAIPromptAttempted" in artifact_steps[0]["condition"]
+
+
 def test_release_compat_accepts_github_target_and_uses_one_sbt_process():
     data = yaml.safe_load(_pipeline_text())
     jobs = {j.get("job"): j for j in _jobs(data["jobs"])}

--- a/tools/fabric_e2e/run.py
+++ b/tools/fabric_e2e/run.py
@@ -1,0 +1,699 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+"""Run checked-in SynapseML scenarios on a managed Microsoft Fabric Spark runtime."""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence
+from xml.etree import ElementTree
+
+RESULT_MARKER = "SYNAPSEML_FABRIC_E2E_RESULT="
+DIAGNOSTIC_MARKER = "SYNAPSEML_FABRIC_E2E_DIAGNOSTIC="
+MANIFEST_PATH = Path(__file__).with_name("scenarios.json")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """A checked-in Fabric E2E scenario."""
+
+    name: str
+    description: str
+    script: Path
+    minimum_jars: int
+    default_args: Sequence[str]
+    execution: str = "batch"
+    default_spark_conf: Sequence[str] = ()
+
+
+def load_scenarios(manifest_path: Path = MANIFEST_PATH) -> Dict[str, Scenario]:
+    """Load and validate the checked-in scenario manifest."""
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    scenario_root = manifest_path.parent.resolve()
+    scenarios: Dict[str, Scenario] = {}
+    for name, raw in manifest.items():
+        script = (manifest_path.parent / raw["script"]).resolve()
+        if scenario_root not in script.parents or not script.is_file():
+            raise ValueError(f"Scenario {name!r} has an invalid script path: {script}")
+        minimum_jars = int(raw.get("minimumJars", 0))
+        if minimum_jars < 0:
+            raise ValueError(f"Scenario {name!r} has a negative minimumJars")
+        execution = str(raw.get("execution", "batch"))
+        if execution not in {"batch", "notebook"}:
+            raise ValueError(
+                f"Scenario {name!r} has an invalid execution mode: {execution}"
+            )
+        scenarios[name] = Scenario(
+            name=name,
+            description=str(raw["description"]),
+            script=script,
+            minimum_jars=minimum_jars,
+            default_args=tuple(str(value) for value in raw.get("defaultArgs", [])),
+            execution=execution,
+            default_spark_conf=tuple(
+                str(value) for value in raw.get("defaultSparkConf", [])
+            ),
+        )
+    if not scenarios:
+        raise ValueError("Fabric E2E scenario manifest is empty")
+    return scenarios
+
+
+def sha256_file(path: Path) -> str:
+    """Return a file's SHA-256 digest."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def sanitize_name(value: str) -> str:
+    """Return a Fabric-safe lowercase identifier."""
+    return re.sub(r"[^a-z0-9_]", "_", value.lower()).strip("_")
+
+
+def new_run_id(scenario_name: str, now: Optional[datetime] = None) -> str:
+    """Create a collision-resistant run identifier."""
+    timestamp = (now or datetime.now(timezone.utc)).strftime("%Y%m%d%H%M%S")
+    scenario = sanitize_name(scenario_name)[:20]
+    return f"{scenario}_{timestamp}_{uuid.uuid4().hex[:8]}"
+
+
+def resolve_scenario_args(
+    scenario: Scenario, jars: Sequence[Path], additional_args: Sequence[str]
+) -> List[str]:
+    """Expand manifest placeholders and append caller-provided scenario arguments."""
+    values = {
+        "firstJarName": jars[0].name if jars else "",
+        "lastJarName": jars[-1].name if jars else "",
+    }
+    values.update({f"jar{index}Name": jar.name for index, jar in enumerate(jars)})
+    defaults = [value.format(**values) for value in scenario.default_args]
+    return defaults + list(additional_args)
+
+
+def resolve_spark_conf(scenario: Scenario, additional_conf: Sequence[str]) -> List[str]:
+    """Combine scenario safety defaults with caller-provided Spark settings."""
+    return list(scenario.default_spark_conf) + list(additional_conf)
+
+
+def write_scenario_notebook(
+    path: Path, scenario: Scenario, scenario_args: Sequence[str]
+) -> None:
+    """Wrap a Python scenario in a Fabric platform notebook."""
+    source = scenario.script.read_text(encoding="utf-8")
+    argv = [scenario.script.name, *scenario_args]
+    cell_source = f"import sys\nsys.argv = {json.dumps(argv)}\n{source}"
+    notebook = {
+        "cells": [
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                "metadata": {},
+                "outputs": [],
+                "source": cell_source.splitlines(keepends=True),
+            }
+        ],
+        "metadata": {
+            "kernelspec": {
+                "display_name": "Synapse PySpark",
+                "language": "python",
+                "name": "synapse_pyspark",
+            },
+            "language_info": {"name": "python"},
+        },
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(notebook, indent=2) + "\n", encoding="utf-8")
+
+
+def build_submission_command(
+    executable: str,
+    scenario: Scenario,
+    workspace: str,
+    lakehouse: str,
+    job_name: str,
+    output_dir: Path,
+    environment: str,
+    jars: Sequence[Path],
+    scenario_args: Sequence[str],
+    subscription: Optional[str] = None,
+    runtime: Optional[str] = None,
+    node_size: Optional[str] = None,
+    node_count: Optional[int] = None,
+    spark_conf: Sequence[str] = (),
+) -> List[str]:
+    """Build a non-interactive fabric-spark-cli batch command."""
+    command = [
+        executable,
+        "batch",
+        "submit",
+        "--backend",
+        "fabric",
+        "--py",
+        str(scenario.script),
+        "--name",
+        job_name,
+        "--env",
+        environment,
+        "--workspace",
+        workspace,
+        "--lakehouse",
+        lakehouse,
+        "--no-overwrite",
+        "--download-log",
+        "-o",
+        str(output_dir),
+    ]
+    if subscription:
+        command.extend(("--subscription", subscription))
+    if runtime:
+        command.extend(("--runtime", runtime))
+    if node_size:
+        command.extend(("--node-size", node_size))
+    if node_count is not None:
+        command.extend(("--node-count", str(node_count)))
+    for entry in spark_conf:
+        command.extend(("--conf", entry))
+    if scenario_args:
+        command.extend(("--args", shlex.join(scenario_args)))
+    if jars:
+        command.extend(("--extra-jars", *(str(path) for path in jars)))
+    return command
+
+
+def build_notebook_submission_command(
+    executable: str,
+    notebook_path: Path,
+    workspace: str,
+    lakehouse: str,
+    notebook_name: str,
+    output_path: Path,
+    environment: str,
+    jars: Sequence[Path],
+    subscription: Optional[str] = None,
+    spark_conf: Sequence[str] = (),
+) -> List[str]:
+    """Build a non-interactive Fabric platform-notebook command."""
+    command = [
+        executable,
+        "notebook",
+        "run",
+        str(notebook_path),
+        "--name",
+        notebook_name,
+        "--stdout",
+        "--output-file",
+        str(output_path),
+        "--env",
+        environment,
+        "--workspace",
+        workspace,
+        "--lakehouse",
+        lakehouse,
+    ]
+    if subscription:
+        command.extend(("--subscription", subscription))
+    for entry in spark_conf:
+        command.extend(("--conf", entry))
+    if jars:
+        command.extend(("--extra-jars", *(str(path) for path in jars)))
+    return command
+
+
+def build_cleanup_command(
+    executable: str,
+    workspace: str,
+    lakehouse: str,
+    environment: str,
+    subscription: Optional[str] = None,
+) -> List[str]:
+    """Build an exact-name scratch lakehouse cleanup command."""
+    command = [
+        executable,
+        "lakehouse",
+        "delete",
+        "--env",
+        environment,
+        "--workspace",
+        workspace,
+    ]
+    if subscription:
+        command.extend(("--subscription", subscription))
+    command.append(lakehouse)
+    return command
+
+
+def build_notebook_cleanup_command(
+    executable: str,
+    workspace: str,
+    notebook_name: str,
+    environment: str,
+    subscription: Optional[str] = None,
+) -> List[str]:
+    """Build an exact-name Fabric notebook cleanup command."""
+    command = [
+        executable,
+        "notebook",
+        "delete",
+        "--env",
+        environment,
+        "--workspace",
+        workspace,
+    ]
+    if subscription:
+        command.extend(("--subscription", subscription))
+    command.extend(("--name", notebook_name))
+    return command
+
+
+def console_safe_text(value: str, encoding: Optional[str]) -> str:
+    """Replace characters unsupported by the active console encoding."""
+    resolved_encoding = encoding or "utf-8"
+    return value.encode(resolved_encoding, errors="replace").decode(resolved_encoding)
+
+
+def run_and_tee(command: Sequence[str], log_path: Path) -> tuple[int, str]:
+    """Run a command while streaming and retaining its combined output."""
+    environment = os.environ.copy()
+    environment["PYTHONUTF8"] = "1"
+    environment["PYTHONIOENCODING"] = "utf-8"
+    output: List[str] = []
+    with log_path.open("a", encoding="utf-8") as log:
+        process = subprocess.Popen(
+            list(command),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=environment,
+        )
+        try:
+            assert process.stdout is not None
+            for line in process.stdout:
+                sys.stdout.write(console_safe_text(line, sys.stdout.encoding))
+                sys.stdout.flush()
+                log.write(line)
+                output.append(line)
+            return process.wait(), "".join(output)
+        except BaseException:
+            process.terminate()
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+            raise
+
+
+def downloaded_marker_output(log_root: Path) -> str:
+    """Read structured scenario markers from downloaded driver stdout logs."""
+    marker_lines: List[str] = []
+    if not log_root.is_dir():
+        return ""
+    for path in sorted(log_root.rglob("stdout.log")):
+        with path.open(encoding="utf-8", errors="replace") as stream:
+            marker_lines.extend(
+                line
+                for line in stream
+                if RESULT_MARKER in line or DIAGNOSTIC_MARKER in line
+            )
+    return "".join(marker_lines)
+
+
+def marker_payloads(output: str, marker: str) -> List[str]:
+    """Return unique marker payloads in emission order."""
+    matches: List[str] = []
+    for line in output.splitlines():
+        if marker in line:
+            payload = line.split(marker, 1)[1].strip()
+            if payload[:1] in {"{", "["} and payload not in matches:
+                matches.append(payload)
+    return matches
+
+
+def parse_runtime_evidence(output: str) -> Mapping[str, object]:
+    """Parse the scenario's single structured result marker."""
+    matches = marker_payloads(output, RESULT_MARKER)
+    if len(matches) != 1:
+        raise ValueError(
+            f"Expected exactly one {RESULT_MARKER} marker, found {len(matches)}"
+        )
+    evidence = json.loads(matches[0])
+    if not isinstance(evidence, dict):
+        raise ValueError("Fabric scenario evidence must be a JSON object")
+    return evidence
+
+
+def parse_runtime_diagnostics(output: str) -> List[Mapping[str, object]]:
+    """Parse zero or more structured diagnostics emitted before a scenario completes."""
+    matches = marker_payloads(output, DIAGNOSTIC_MARKER)
+    diagnostics: List[Mapping[str, object]] = []
+    for match in matches:
+        diagnostic = json.loads(match)
+        if not isinstance(diagnostic, dict):
+            raise ValueError("Fabric scenario diagnostics must be JSON objects")
+        diagnostics.append(diagnostic)
+    return diagnostics
+
+
+def diagnostic_failure_message(
+    diagnostics: Sequence[Mapping[str, object]],
+) -> Optional[str]:
+    """Return the last structured scenario error, when one was emitted."""
+    for diagnostic in reversed(diagnostics):
+        message = diagnostic.get("errorMessage")
+        if isinstance(message, str) and message:
+            return message
+    return None
+
+
+def command_version(executable: str) -> str:
+    """Return the installed fabric-spark-cli version without failing the run."""
+    process = subprocess.run(
+        [executable, "--version"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    return (process.stdout or process.stderr).strip()
+
+
+def git_commit(repo_root: Path) -> str:
+    """Return the source commit used by this run."""
+    process = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    return process.stdout.strip() if process.returncode == 0 else "unknown"
+
+
+def write_junit(
+    path: Path,
+    scenario: str,
+    elapsed_seconds: float,
+    failure: Optional[str],
+    evidence_path: Path,
+) -> None:
+    """Write one JUnit test case for Azure Pipelines and local tooling."""
+    suite = ElementTree.Element(
+        "testsuite",
+        {
+            "name": "SynapseML Fabric E2E",
+            "tests": "1",
+            "failures": "1" if failure else "0",
+            "time": f"{elapsed_seconds:.3f}",
+        },
+    )
+    case = ElementTree.SubElement(
+        suite,
+        "testcase",
+        {
+            "classname": "fabric_e2e",
+            "name": scenario,
+            "time": f"{elapsed_seconds:.3f}",
+        },
+    )
+    if failure:
+        ElementTree.SubElement(
+            case, "failure", {"message": failure[:500]}
+        ).text = failure
+    ElementTree.SubElement(case, "system-out").text = f"Evidence: {evidence_path}"
+    ElementTree.ElementTree(suite).write(path, encoding="utf-8", xml_declaration=True)
+
+
+def checked_jars(raw_paths: Iterable[str]) -> List[Path]:
+    """Resolve jar arguments and reject missing or non-jar paths."""
+    jars = [Path(raw).expanduser().resolve() for raw in raw_paths]
+    for jar in jars:
+        if not jar.is_file() or jar.suffix.lower() != ".jar":
+            raise ValueError(f"Extra jar does not exist or is not a .jar file: {jar}")
+    return jars
+
+
+def create_parser(scenarios: Mapping[str, Scenario]) -> argparse.ArgumentParser:
+    """Create the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description="Run a checked-in SynapseML scenario on managed Fabric Spark."
+    )
+    parser.add_argument("--list-scenarios", action="store_true")
+    parser.add_argument("--scenario", choices=sorted(scenarios))
+    parser.add_argument(
+        "--workspace",
+        help="Fabric workspace name. Required for unattended execution.",
+    )
+    parser.add_argument("--env", default="msit", dest="environment")
+    parser.add_argument("--subscription")
+    parser.add_argument("--runtime")
+    parser.add_argument("--node-size")
+    parser.add_argument("--node-count", type=int)
+    parser.add_argument("--conf", action="append", default=[])
+    parser.add_argument("--extra-jar", action="append", default=[])
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument(
+        "--source-repo",
+        type=Path,
+        default=REPO_ROOT,
+        help="Checkout whose commit produced the supplied jars.",
+    )
+    parser.add_argument("--keep-lakehouse", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--scenario-args",
+        nargs=argparse.REMAINDER,
+        default=[],
+        help="Arguments passed to the scenario; this option must be last.",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Run a scenario and persist its evidence."""
+    scenarios = load_scenarios()
+    parser = create_parser(scenarios)
+    args = parser.parse_args(argv)
+
+    if args.list_scenarios:
+        for name in sorted(scenarios):
+            print(f"{name}: {scenarios[name].description}")
+        return 0
+    if not args.scenario:
+        parser.error("--scenario is required unless --list-scenarios is used")
+    if not args.workspace:
+        parser.error("--workspace is required for unattended execution")
+    if (args.node_size is None) != (args.node_count is None):
+        parser.error("--node-size and --node-count must be supplied together")
+    if args.node_count is not None and args.node_count < 1:
+        parser.error("--node-count must be positive")
+
+    executable = shutil.which("fabric-spark-cli")
+    if not executable:
+        parser.error("fabric-spark-cli is not installed or is not on PATH")
+
+    scenario = scenarios[args.scenario]
+    if scenario.execution == "notebook" and (
+        args.runtime or args.node_size or args.node_count is not None
+    ):
+        parser.error(
+            f"Scenario {scenario.name!r} uses Fabric platform-notebook execution, "
+            "which uses the workspace's configured runtime and pool"
+        )
+    try:
+        jars = checked_jars(args.extra_jar)
+    except ValueError as error:
+        parser.error(str(error))
+    if len(jars) < scenario.minimum_jars:
+        parser.error(
+            f"Scenario {scenario.name!r} requires at least "
+            f"{scenario.minimum_jars} --extra-jar value(s)"
+        )
+
+    run_id = new_run_id(scenario.name)
+    lakehouse = f"synapseml_e2e_{run_id}"
+    job_name = (
+        f"synapseml-e2e-{sanitize_name(scenario.name).replace('_', '-')}"
+        f"-{run_id.rsplit('_', 1)[-1]}"
+    )
+    output_dir = args.output_dir or REPO_ROOT / "target" / "fabric-e2e" / run_id
+    output_dir = output_dir.resolve()
+    source_repo = args.source_repo.expanduser().resolve()
+    if not (source_repo / ".git").exists():
+        parser.error(f"--source-repo is not a Git checkout: {source_repo}")
+    log_path = output_dir / "runner.log"
+    evidence_path = output_dir / "evidence.json"
+    junit_path = output_dir / "junit.xml"
+    notebook_path = output_dir / "scenario.ipynb"
+    scenario_args = resolve_scenario_args(scenario, jars, args.scenario_args)
+    spark_conf = resolve_spark_conf(scenario, args.conf)
+    if scenario.execution == "notebook":
+        command = build_notebook_submission_command(
+            executable=executable,
+            notebook_path=notebook_path,
+            workspace=args.workspace,
+            lakehouse=lakehouse,
+            notebook_name=job_name,
+            output_path=output_dir / "executed-notebook.ipynb",
+            environment=args.environment,
+            subscription=args.subscription,
+            spark_conf=spark_conf,
+            jars=jars,
+        )
+    else:
+        command = build_submission_command(
+            executable=executable,
+            scenario=scenario,
+            workspace=args.workspace,
+            lakehouse=lakehouse,
+            job_name=job_name,
+            output_dir=output_dir / "fabric-logs",
+            environment=args.environment,
+            subscription=args.subscription,
+            runtime=args.runtime,
+            node_size=args.node_size,
+            node_count=args.node_count,
+            spark_conf=spark_conf,
+            jars=jars,
+            scenario_args=scenario_args,
+        )
+    cleanup_command = build_cleanup_command(
+        executable=executable,
+        workspace=args.workspace,
+        lakehouse=lakehouse,
+        environment=args.environment,
+        subscription=args.subscription,
+    )
+    notebook_cleanup_command = (
+        build_notebook_cleanup_command(
+            executable=executable,
+            workspace=args.workspace,
+            notebook_name=job_name,
+            environment=args.environment,
+            subscription=args.subscription,
+        )
+        if scenario.execution == "notebook"
+        else None
+    )
+
+    if args.dry_run:
+        print(
+            json.dumps(
+                {
+                    "cleanupCommand": cleanup_command,
+                    "lakehouse": lakehouse,
+                    "notebookCleanupCommand": notebook_cleanup_command,
+                    "submissionCommand": command,
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    output_dir.mkdir(parents=True, exist_ok=False)
+    if scenario.execution == "notebook":
+        write_scenario_notebook(notebook_path, scenario, scenario_args)
+    started = datetime.now(timezone.utc)
+    submission_code = 1
+    cleanup_code: Optional[int] = None
+    notebook_cleanup_code: Optional[int] = None
+    output = ""
+    runtime_evidence: Mapping[str, object] = {}
+    runtime_diagnostics: List[Mapping[str, object]] = []
+    failure: Optional[str] = None
+    try:
+        submission_code, output = run_and_tee(command, log_path)
+        marker_output = output + downloaded_marker_output(output_dir / "fabric-logs")
+        try:
+            runtime_diagnostics = parse_runtime_diagnostics(marker_output)
+        except (ValueError, json.JSONDecodeError) as error:
+            failure = f"Invalid Fabric E2E diagnostics: {error}"
+        if submission_code != 0:
+            if failure is None:
+                detail = diagnostic_failure_message(runtime_diagnostics)
+                failure = f"fabric-spark-cli exited with code {submission_code}"
+                if detail:
+                    failure += f": {detail}"
+        elif failure is None:
+            try:
+                runtime_evidence = parse_runtime_evidence(marker_output)
+            except (ValueError, json.JSONDecodeError) as error:
+                failure = str(error)
+    finally:
+        if notebook_cleanup_command:
+            notebook_cleanup_code, notebook_cleanup_output = run_and_tee(
+                notebook_cleanup_command, log_path
+            )
+            output += notebook_cleanup_output
+            if notebook_cleanup_code != 0 and failure is None:
+                failure = (
+                    "Scratch notebook cleanup exited with code "
+                    f"{notebook_cleanup_code}"
+                )
+        if args.keep_lakehouse:
+            print(f"Keeping scratch lakehouse for debugging: {lakehouse}")
+        else:
+            cleanup_code, cleanup_output = run_and_tee(cleanup_command, log_path)
+            output += cleanup_output
+            if cleanup_code != 0 and failure is None:
+                failure = f"Scratch lakehouse cleanup exited with code {cleanup_code}"
+
+    finished = datetime.now(timezone.utc)
+    evidence = {
+        "cleanupExitCode": cleanup_code,
+        "commit": git_commit(source_repo),
+        "execution": scenario.execution,
+        "fabricSparkCliVersion": command_version(executable),
+        "finishedAt": finished.isoformat(),
+        "failure": failure,
+        "jars": [
+            {"name": jar.name, "path": str(jar), "sha256": sha256_file(jar)}
+            for jar in jars
+        ],
+        "lakehouse": lakehouse,
+        "notebookCleanupExitCode": notebook_cleanup_code,
+        "runtimeDiagnostics": runtime_diagnostics,
+        "runtimeEvidence": runtime_evidence,
+        "scenario": scenario.name,
+        "sparkConf": spark_conf,
+        "startedAt": started.isoformat(),
+        "status": "failed" if failure else "passed",
+        "submissionExitCode": submission_code,
+        "workspace": args.workspace,
+    }
+    evidence_path.write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+    write_junit(
+        junit_path,
+        scenario.name,
+        (finished - started).total_seconds(),
+        failure,
+        evidence_path,
+    )
+    print(f"SYNAPSEML_FABRIC_E2E_EVIDENCE={evidence_path}")
+    if failure:
+        print(f"Fabric E2E failed: {failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/fabric_e2e/scenarios.json
+++ b/tools/fabric_e2e/scenarios.json
@@ -1,0 +1,46 @@
+{
+  "jar-provenance": {
+    "defaultArgs": [
+      "--class-name",
+      "com.microsoft.azure.synapse.ml.build.BuildInfo$",
+      "--expected-jar-token",
+      "{lastJarName}"
+    ],
+    "description": "Prove that Fabric loads a supplied SynapseML jar and run a distributed Spark action.",
+    "minimumJars": 1,
+    "script": "scenarios/jar_provenance.py"
+  },
+  "lightgbm-streaming": {
+    "defaultArgs": [
+      "--expected-core-jar",
+      "{jar0Name}",
+      "--expected-native-jar",
+      "{jar1Name}",
+      "--expected-lightgbm-jar",
+      "{jar2Name}"
+    ],
+    "defaultSparkConf": [
+      "spark.driver.extraJavaOptions=-Djava.library.path=/tmp/synapseml-fabric-e2e-native",
+      "spark.executor.extraJavaOptions=-Djava.library.path=/tmp/synapseml-fabric-e2e-native"
+    ],
+    "description": "Run repeated LightGBM streaming fits with validation data on Fabric and assert jar provenance.",
+    "minimumJars": 3,
+    "script": "scenarios/lightgbm_streaming.py"
+  },
+  "openai-prompt-ai-functions": {
+    "defaultArgs": [
+      "--expected-core-jar",
+      "{jar0Name}",
+      "--expected-cognitive-jar",
+      "{jar1Name}"
+    ],
+    "description": "Run AI Functions origin behaviors through OpenAIPrompt on Fabric and assert jar provenance.",
+    "execution": "notebook",
+    "minimumJars": 2,
+    "script": "scenarios/openai_prompt_ai_functions.py"
+  },
+  "runtime-smoke": {
+    "description": "Run a distributed DataFrame action on the managed Fabric Spark runtime.",
+    "script": "scenarios/runtime_smoke.py"
+  }
+}

--- a/tools/fabric_e2e/scenarios/jar_provenance.py
+++ b/tools/fabric_e2e/scenarios/jar_provenance.py
@@ -1,0 +1,42 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+"""Assert that Fabric loaded an explicitly supplied SynapseML jar."""
+
+import argparse
+import json
+
+from pyspark.sql import SparkSession
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--class-name", required=True)
+parser.add_argument("--expected-jar-token", required=True)
+args = parser.parse_args()
+
+spark = SparkSession.builder.getOrCreate()
+loader = (
+    spark.sparkContext._jvm.java.lang.Thread.currentThread().getContextClassLoader()
+)
+loaded_class = spark.sparkContext._jvm.java.lang.Class.forName(
+    args.class_name, True, loader
+)
+code_source = str(
+    loaded_class.getProtectionDomain().getCodeSource().getLocation().toString()
+)
+assert args.expected_jar_token.lower() in code_source.lower(), (
+    f"Expected {args.class_name} to load from a jar containing "
+    f"{args.expected_jar_token!r}, got {code_source!r}"
+)
+
+count = spark.range(128).repartition(4).where("id % 4 = 0").count()
+assert count == 32, f"Expected 32 rows, got {count}"
+
+evidence = {
+    "applicationId": spark.sparkContext.applicationId,
+    "className": args.class_name,
+    "classSource": code_source,
+    "count": count,
+    "defaultParallelism": spark.sparkContext.defaultParallelism,
+    "sparkVersion": spark.version,
+}
+print("SYNAPSEML_FABRIC_E2E_RESULT=" + json.dumps(evidence, sort_keys=True))

--- a/tools/fabric_e2e/scenarios/lightgbm_streaming.py
+++ b/tools/fabric_e2e/scenarios/lightgbm_streaming.py
@@ -1,0 +1,181 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+"""Exercise repeated LightGBM streaming fits on managed Fabric Spark."""
+
+import argparse
+import json
+from pathlib import Path
+
+from pyspark.ml.feature import VectorAssembler
+from pyspark.sql import SparkSession, functions as sf
+from synapse.ml.lightgbm import LightGBMClassifier
+
+
+def class_source(spark_session, class_name):
+    loader = (
+        spark_session.sparkContext._jvm.java.lang.Thread.currentThread().getContextClassLoader()
+    )
+    loaded_class = spark_session.sparkContext._jvm.java.lang.Class.forName(
+        class_name, True, loader
+    )
+    return str(
+        loaded_class.getProtectionDomain().getCodeSource().getLocation().toString()
+    )
+
+
+def executor_addresses(spark_session):
+    iterator = (
+        spark_session.sparkContext._jsc.sc().getExecutorMemoryStatus().keysIterator()
+    )
+    addresses = []
+    while iterator.hasNext():
+        addresses.append(str(iterator.next()))
+    return sorted(addresses)
+
+
+def native_diagnostics(spark_session, class_sources):
+    jvm = spark_session.sparkContext._jvm
+    lightgbm_utils = getattr(
+        jvm.com.microsoft.azure.synapse.ml.lightgbm, "LightGBMUtils$"
+    )
+    getattr(lightgbm_utils, "MODULE$").initializeNativeLibrary()
+    driver_pid = int(jvm.java.lang.ProcessHandle.current().pid())
+    native_mappings = sorted(
+        {
+            line.split()[-1]
+            for line in Path(f"/proc/{driver_pid}/maps").read_text().splitlines()
+            if "lightgbm" in line.lower()
+        }
+    )
+    return {
+        **class_sources,
+        "applicationId": spark_session.sparkContext.applicationId,
+        "defaultParallelism": spark_session.sparkContext.defaultParallelism,
+        "driverJavaLibraryPath": str(
+            jvm.java.lang.System.getProperty("java.library.path")
+        ),
+        "driverJvmPid": driver_pid,
+        "driverNativeMappings": native_mappings,
+        "phase": "native-load",
+        "sparkVersion": spark_session.version,
+    }
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--expected-core-jar", required=True)
+parser.add_argument("--expected-lightgbm-jar", required=True)
+parser.add_argument("--expected-native-jar", required=True)
+parser.add_argument("--native-threads", type=int, default=2)
+parser.add_argument("--partitions", type=int, default=4)
+parser.add_argument("--repetitions", type=int, default=2)
+parser.add_argument("--rows", type=int, default=4000)
+args = parser.parse_args()
+
+if args.native_threads < 1 or args.partitions < 2:
+    raise ValueError(
+        "native-threads must be positive and partitions must be at least 2"
+    )
+if args.repetitions < 1 or args.rows < 100:
+    raise ValueError("repetitions must be positive and rows must be at least 100")
+
+spark = SparkSession.builder.getOrCreate()
+core_source = class_source(spark, "com.microsoft.azure.synapse.ml.build.BuildInfo$")
+lightgbm_source = class_source(
+    spark, "com.microsoft.azure.synapse.ml.lightgbm.LightGBMClassifier"
+)
+native_source = class_source(spark, "com.microsoft.ml.lightgbm.lightgbmlib")
+assert (
+    args.expected_core_jar.lower() in core_source.lower()
+), f"Expected the PR core jar {args.expected_core_jar!r}, got {core_source!r}"
+assert args.expected_native_jar.lower() in native_source.lower(), (
+    f"Expected the LightGBM JNI jar {args.expected_native_jar!r}, "
+    f"got {native_source!r}"
+)
+assert args.expected_lightgbm_jar.lower() in lightgbm_source.lower(), (
+    f"Expected the PR LightGBM jar {args.expected_lightgbm_jar!r}, "
+    f"got {lightgbm_source!r}"
+)
+diagnostics = native_diagnostics(
+    spark,
+    {
+        "coreClassSource": core_source,
+        "lightgbmClassSource": lightgbm_source,
+        "nativeClassSource": native_source,
+    },
+)
+print("SYNAPSEML_FABRIC_E2E_DIAGNOSTIC=" + json.dumps(diagnostics, sort_keys=True))
+
+raw = spark.range(args.rows).select(
+    (sf.col("id") % 2).cast("double").alias("label"),
+    ((sf.col("id") % 17) / 17.0).cast("double").alias("feature_1"),
+    (((sf.col("id") * 7) % 29) / 29.0).cast("double").alias("feature_2"),
+    (sf.col("id") % 5 == 0).alias("is_validation"),
+)
+dataset = (
+    VectorAssembler(inputCols=["feature_1", "feature_2"], outputCol="features")
+    .transform(raw)
+    .select("label", "features", "is_validation")
+    .repartition(args.partitions)
+    .cache()
+)
+assert dataset.count() == args.rows
+
+learner = LightGBMClassifier(
+    dataTransferMode="streaming",
+    featuresCol="features",
+    labelCol="label",
+    numIterations=5,
+    numLeaves=8,
+    numTasks=args.partitions,
+    numThreads=args.native_threads,
+    slotNames=["feature_one", "feature_two"],
+    useSingleDatasetMode=True,
+    validationIndicatorCol="is_validation",
+    verbosity=-1,
+)
+
+prediction_counts = []
+for repetition in range(args.repetitions):
+    try:
+        model = learner.fit(dataset)
+    except Exception as error:
+        error_lines = [line.strip() for line in str(error).splitlines() if line.strip()]
+        native_error = next(
+            (
+                line
+                for line in reversed(error_lines)
+                if "call failed in LightGBM" in line
+            ),
+            error_lines[-1] if error_lines else repr(error),
+        )
+        print(
+            "SYNAPSEML_FABRIC_E2E_DIAGNOSTIC="
+            + json.dumps(
+                {
+                    "errorMessage": native_error,
+                    "errorType": type(error).__name__,
+                    "fitAttempt": repetition + 1,
+                    "phase": "fit",
+                },
+                sort_keys=True,
+            )
+        )
+        raise
+    prediction_count = model.transform(dataset).select("prediction").count()
+    assert prediction_count == args.rows
+    prediction_counts.append(prediction_count)
+
+evidence = {
+    "applicationId": spark.sparkContext.applicationId,
+    "defaultParallelism": spark.sparkContext.defaultParallelism,
+    **diagnostics,
+    "executorAddresses": executor_addresses(spark),
+    "executorCores": spark.conf.get("spark.executor.cores", "unknown"),
+    "partitions": args.partitions,
+    "predictionCounts": prediction_counts,
+    "repetitions": args.repetitions,
+    "rows": args.rows,
+    "sparkVersion": spark.version,
+}
+print("SYNAPSEML_FABRIC_E2E_RESULT=" + json.dumps(evidence, sort_keys=True))

--- a/tools/fabric_e2e/scenarios/openai_prompt_ai_functions.py
+++ b/tools/fabric_e2e/scenarios/openai_prompt_ai_functions.py
@@ -1,0 +1,225 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+"""Exercise AI Functions origin behaviors through OpenAIPrompt on Fabric."""
+
+import argparse
+import inspect
+import json
+
+from pyspark.sql import SparkSession
+from synapse.ml.services.openai import OpenAIPrompt
+
+
+def class_source(spark_session, class_name):
+    loader = (
+        spark_session.sparkContext._jvm.java.lang.Thread.currentThread().getContextClassLoader()
+    )
+    loaded_class = spark_session.sparkContext._jvm.java.lang.Class.forName(
+        class_name, True, loader
+    )
+    return str(
+        loaded_class.getProtectionDomain().getCodeSource().getLocation().toString()
+    )
+
+
+def emit_diagnostic(payload):
+    print("SYNAPSEML_FABRIC_E2E_DIAGNOSTIC=" + json.dumps(payload, sort_keys=True))
+
+
+def concise_error(error):
+    lines = [line.strip() for line in str(error).splitlines() if line.strip()]
+    return (lines[-1] if lines else repr(error))[:1000]
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--expected-cognitive-jar", required=True)
+parser.add_argument("--expected-core-jar", required=True)
+parser.add_argument("--model", default="gpt-5-mini")
+args = parser.parse_args()
+
+spark = SparkSession.builder.getOrCreate()
+core_source = class_source(spark, "com.microsoft.azure.synapse.ml.fabric.FabricClient$")
+cognitive_source = class_source(
+    spark, "com.microsoft.azure.synapse.ml.services.openai.OpenAIPrompt"
+)
+responses_source = class_source(
+    spark, "com.microsoft.azure.synapse.ml.services.openai.OpenAIResponses"
+)
+assert (
+    args.expected_core_jar.lower() in core_source.lower()
+), f"Expected the PR core jar {args.expected_core_jar!r}, got {core_source!r}"
+assert args.expected_cognitive_jar.lower() in cognitive_source.lower(), (
+    f"Expected the PR cognitive jar {args.expected_cognitive_jar!r}, "
+    f"got {cognitive_source!r}"
+)
+assert args.expected_cognitive_jar.lower() in responses_source.lower(), (
+    f"Expected OpenAIResponses in {args.expected_cognitive_jar!r}, "
+    f"got {responses_source!r}"
+)
+
+prompt = (
+    OpenAIPrompt()
+    .setApiType("responses")
+    .setApiVersion("2025-04-01-preview")
+    .setConcurrency(1)
+    .setDeploymentName(args.model)
+    .setErrorCol("service_error")
+    .setOutputCol("analysis")
+    .setPostProcessing("json")
+    .setPostProcessingOptions(
+        {"jsonSchema": "sentiment STRING, summary STRING, spanish STRING"}
+    )
+    .setPromptTemplate(
+        """Analyze the review below and return only one JSON object.
+The object must contain exactly these string fields:
+- sentiment: exactly one of positive, negative, or neutral
+- summary: an English summary of at most eight words
+- spanish: a faithful Spanish translation of the review
+Review: {review}"""
+    )
+    .setResponseFormat("json_object")
+    .setSystemPrompt(
+        "Follow the requested JSON schema exactly. Do not add markdown or commentary."
+    )
+    .setUsageCol("usage")
+)
+
+java_prompt = prompt._java_obj
+fabric_client = getattr(
+    spark.sparkContext._jvm.com.microsoft.azure.synapse.ml.fabric, "FabricClient$"
+)
+fabric_endpoint = str(getattr(fabric_client, "MODULE$").MLWorkloadEndpointOpenAI())
+explicit_credentials = {
+    name: bool(java_prompt.isSet(java_prompt.getParam(name)))
+    for name in ("AADToken", "CustomAuthHeader", "customHeaders", "subscriptionKey")
+    if java_prompt.hasParam(name)
+}
+explicit_endpoint = bool(java_prompt.isSet(java_prompt.getParam("url")))
+assert not any(
+    explicit_credentials.values()
+), "The Fabric scenario must not set an explicit OpenAI credential"
+assert (
+    not explicit_endpoint
+), "The Fabric scenario must not set an explicit OpenAI endpoint"
+assert (
+    "/cognitive/openai/" in fabric_endpoint.lower()
+), "Fabric did not expose its implicit OpenAI workload endpoint"
+
+base_diagnostics = {
+    "apiType": "responses",
+    "applicationId": spark.sparkContext.applicationId,
+    "cognitiveClassSource": cognitive_source,
+    "coreClassSource": core_source,
+    "explicitCredentials": explicit_credentials,
+    "explicitEndpoint": explicit_endpoint,
+    "implicitFabricEndpoint": True,
+    "model": args.model,
+    "phase": "provenance",
+    "pythonWrapperSource": inspect.getfile(OpenAIPrompt),
+    "responsesClassSource": responses_source,
+    "sparkVersion": spark.version,
+}
+emit_diagnostic(base_diagnostics)
+
+cases = [
+    (
+        "positive",
+        "I love this product. It is excellent and works perfectly.",
+        "positive",
+    ),
+    (
+        "negative",
+        "This is terrible. It broke immediately and I hate it.",
+        "negative",
+    ),
+    (
+        "neutral",
+        "The package arrived on Tuesday and contains a black cable.",
+        "neutral",
+    ),
+    ("null", None, None),
+]
+dataset = spark.createDataFrame(
+    cases, "case_id STRING, review STRING, expected_sentiment STRING"
+)
+
+try:
+    result = prompt.transform(dataset)
+    expected_schema = "struct<sentiment:string,summary:string,spanish:string>"
+    actual_schema = result.schema["analysis"].dataType.simpleString()
+    assert (
+        actual_schema == expected_schema
+    ), f"Expected analysis schema {expected_schema}, got {actual_schema}"
+
+    rows = result.select(
+        "case_id",
+        "expected_sentiment",
+        "analysis",
+        "usage",
+        "service_error",
+    ).collect()
+    assert len(rows) == len(cases), f"Expected {len(cases)} rows, got {len(rows)}"
+
+    sentiments = {}
+    token_totals = {}
+    for row in rows:
+        case_id = row["case_id"]
+        if case_id == "null":
+            assert row["analysis"] is None, "Null input must produce null output"
+            assert row["usage"] is None, "Null input must not report model usage"
+            assert (
+                row["service_error"] is None
+            ), "Null input must not issue a failing service request"
+            continue
+
+        assert (
+            row["service_error"] is None
+        ), f"Case {case_id!r} returned a service error"
+        output = row["analysis"]
+        assert output is not None, f"Case {case_id!r} returned no structured output"
+        values = output.asDict()
+        sentiment = (values.get("sentiment") or "").strip().lower()
+        summary = (values.get("summary") or "").strip()
+        spanish = (values.get("spanish") or "").strip()
+        assert sentiment == row["expected_sentiment"], (
+            f"Case {case_id!r} expected sentiment "
+            f"{row['expected_sentiment']!r}, got {sentiment!r}"
+        )
+        assert summary, f"Case {case_id!r} returned an empty summary"
+        assert spanish, f"Case {case_id!r} returned an empty translation"
+        sentiments[case_id] = sentiment
+
+        usage = row["usage"]
+        assert usage is not None, f"Case {case_id!r} returned no usage data"
+        total_tokens = usage["total_tokens"]
+        assert total_tokens is None or total_tokens >= 0
+        token_totals[case_id] = total_tokens
+except Exception as error:
+    emit_diagnostic(
+        {
+            "errorMessage": concise_error(error),
+            "errorType": type(error).__name__,
+            "phase": "transform-and-assert",
+        }
+    )
+    raise
+
+evidence = {
+    **base_diagnostics,
+    "analysisSchema": actual_schema,
+    "caseCount": len(rows),
+    "nullPropagation": True,
+    "phase": "complete",
+    "sentiments": sentiments,
+    "testCases": [
+        "generate_response",
+        "analyze_sentiment",
+        "summarize",
+        "translate",
+        "structured_extraction",
+        "null_propagation",
+    ],
+    "tokenTotals": token_totals,
+}
+print("SYNAPSEML_FABRIC_E2E_RESULT=" + json.dumps(evidence, sort_keys=True))

--- a/tools/fabric_e2e/scenarios/runtime_smoke.py
+++ b/tools/fabric_e2e/scenarios/runtime_smoke.py
@@ -1,0 +1,20 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+"""Minimal managed Fabric Spark execution proof."""
+
+import json
+
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder.getOrCreate()
+count = spark.range(32).repartition(4).where("id % 2 = 0").count()
+assert count == 16, f"Expected 16 even values, got {count}"
+
+evidence = {
+    "applicationId": spark.sparkContext.applicationId,
+    "count": count,
+    "defaultParallelism": spark.sparkContext.defaultParallelism,
+    "sparkVersion": spark.version,
+}
+print("SYNAPSEML_FABRIC_E2E_RESULT=" + json.dumps(evidence, sort_keys=True))


### PR DESCRIPTION
## Related Issues/PRs

Motivated by the real-runtime validation gap exposed in #2662.

## What changes are proposed in this pull request?

Add a reusable, manifest-driven `fabric-spark-cli` path that runs exact
SynapseML build artifacts on a managed Fabric Spark runtime and retains
machine-readable evidence.

- Add batch and platform-notebook execution profiles with unique scratch
  lakehouses/notebooks and exact cleanup in `finally`.
- Record the source commit, jar SHA-256 hashes, runtime/application metadata,
  class-source provenance, diagnostics, JUnit, CLI output, and executed
  notebook.
- Add runtime smoke, jar provenance, LightGBM streaming, and
  `OpenAIPrompt` scenarios.
- Exercise `OpenAIPrompt` with AI Functions-inspired generation, sentiment,
  summarization, translation, structured extraction, null propagation, usage,
  and error-column cases.
- Use Fabric's implicit LLM authentication from a platform notebook; do not
  pass an endpoint, OpenAI key, subscription key, or AAD token.
- Extend `FabricE2E` to build the exact core/cognitive package jars, run the
  notebook scenario for `master` and `spark3.5`, skip untrusted fork PRs, and
  publish JUnit plus retained evidence.
- Add a repository skill describing repeatable local and PR workflows.

Platform-notebook execution is intentional: direct Fabric batch submission
does not carry the workload-operation context required by the implicit Fabric
LLM endpoint.

Managed proof completed with the exact commit jars:

- Fabric Spark runtime: `3.5.5.5.4.20260807.1`
- CLI: `fabric-spark-cli 0.1.20260807.5`
- Scenario: `openai-prompt-ai-functions`
- Result: passed, including exact core/cognitive class provenance
- Cleanup: notebook and lakehouse both exited `0`

The managed proof used developer authentication. This PR's `FabricE2E` run is
the remaining proof of the `SynapseML Build` service connection's workspace
permissions.

## How is this patch tested?

- [x] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

- `python -m pytest -q tools/ci/tests/test_fabric_e2e.py tools/ci/tests/test_pipeline_yaml.py`
- `sbt scalastyle test:scalastyle` with the repository-supported JDK
- `black --check --extend-exclude 'docs/'` over tracked and new Python sources
- Managed Fabric execution of the checked-in OpenAIPrompt scenario with exact
  core/cognitive jars

## Does this PR change any dependencies?

- [ ] No. You can skip this section.
- [x] Yes. Make sure the dependencies are resolved correctly, and list changes here.

The pipeline installs pinned `fabric-spark-cli==0.1.20260807.5` from the
existing authenticated SynapseMaven feed. No published SynapseML dependency or
dependency manifest changes.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.
