### PR TITLE
ci: harden Key Vault-backed Fabric E2E

### DIFF
--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricNotebookTests.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricNotebookTests.scala
@@ -10,8 +10,10 @@ import com.microsoft.azure.synapse.ml.fabric.{FabricTestConstants, HasFabricOper
 import java.io.{File, PrintWriter}
 import java.time.LocalDateTime
 import java.util.concurrent.{ExecutorService, Executors, TimeUnit}
+import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future, blocking}
+import scala.util.control.NonFatal
 
 trait HasFabricNotebookTestConnection extends HasFabricOperationsConnection {
   fabricClientId = Some(FabricTestConstants.INTEGRATION_APP_ID)
@@ -148,8 +150,9 @@ class FabricNotebookTests extends TestBase with HasFabricNotebookTestConnection 
 
   override def afterAll(): Unit = {
     try {
-      FabricNotebookTests.shutdownExecutor(executorService)
-      cleanupTrackedArtifacts()
+      FabricNotebookTests.shutdownAndCleanup(
+        FabricNotebookTests.shutdownExecutor(executorService),
+        cleanupTrackedArtifacts())
     } finally {
       super.afterAll()
     }
@@ -202,6 +205,34 @@ object FabricNotebookTests {
         executorService.shutdownNow()
         Thread.currentThread().interrupt()
         throw e
+    }
+  }
+
+  private[nbtest] def shutdownAndCleanup(shutdown: => Unit, cleanup: => Unit): Unit = {
+    val failures = ListBuffer.empty[Throwable]
+    var interrupted = false
+    try {
+      shutdown
+    } catch {
+      case error: InterruptedException =>
+        interrupted = true
+        failures += error
+      case NonFatal(error) => failures += error
+    }
+    try {
+      cleanup
+    } catch {
+      case error: InterruptedException =>
+        interrupted = true
+        failures += error
+      case NonFatal(error) => failures += error
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt()
+    }
+    failures.headOption.foreach { failure =>
+      failures.tail.foreach(failure.addSuppressed)
+      throw failure
     }
   }
 

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricTestArtifactTrackerSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nbtest/FabricTestArtifactTrackerSuite.scala
@@ -121,4 +121,42 @@ class FabricTestArtifactTrackerSuite extends AnyFunSuite {
       executor.shutdownNow()
     }
   }
+
+  test("Attempt artifact cleanup after executor shutdown fails") {
+    val shutdownFailure = new RuntimeException("shutdown failed")
+    val cleanupFailure = new RuntimeException("cleanup failed")
+    var cleanupAttempted = false
+
+    val thrown = intercept[RuntimeException] {
+      FabricNotebookTests.shutdownAndCleanup(
+        throw shutdownFailure,
+        {
+          cleanupAttempted = true
+          throw cleanupFailure
+        })
+    }
+
+    assert(cleanupAttempted)
+    assert(thrown eq shutdownFailure)
+    assert(thrown.getSuppressed.toSeq == Seq(cleanupFailure))
+  }
+
+  test("Attempt artifact cleanup after executor shutdown is interrupted") {
+    var cleanupAttempted = false
+    try {
+      val thrown = intercept[InterruptedException] {
+        FabricNotebookTests.shutdownAndCleanup(
+          throw new InterruptedException("shutdown interrupted"),
+          {
+            cleanupAttempted = true
+          })
+      }
+
+      assert(cleanupAttempted)
+      assert(thrown.getMessage == "shutdown interrupted")
+      assert(Thread.currentThread().isInterrupted)
+    } finally {
+      Thread.interrupted()
+    }
+  }
 }

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1643,6 +1643,18 @@ jobs:
         sed -n '/^resolvers ++= Seq(/,/^)/p' build.sbt | grep -qF 'Resolver.mavenLocal' || {
           echo "##vso[task.logissue type=error]Failed to add Resolver.mavenLocal to the resolvers block"; exit 1; }
 
+        if [ "$COMPAT_LANE" = "python" ]; then
+          # The OSS checkout already emits PEP 561 package data. Internal's compatibility
+          # helper still recognizes only the former one-line setup.py declaration,
+          # so teach the disposable checkout the current exact representation
+          # instead of rewriting OSS package metadata or disabling its typing gate.
+          oss_codegen="$(Agent.BuildDirectory)/s/core/src/main/scala/com/microsoft/azure/synapse/ml/codegen/PyCodegen.scala"
+          grep -qF '"": ["*.pyi", "py.typed"]' "$oss_codegen" || {
+            echo "##vso[task.logissue type=error]OSS PyCodegen no longer declares the expected PEP 561 package data"; exit 1; }
+          python "$(Agent.BuildDirectory)/s/tools/ci/patch_internal_typing_support.py" \
+            utils/typing_build_support.py
+        fi
+
         echo "=== Modified build.sbt ==="
         grep -n 'synapseMLVersion' build.sbt
         grep -n -A4 'resolvers ++=' build.sbt
@@ -1904,7 +1916,7 @@ jobs:
     # gating ExcludeAIFunc step could finish. They remain covered by
     # SynapseML-Internal's own pipeline.
     - task: AzureCLI@2
-      displayName: 'Run Internal Python tests (ExcludeAIFunc)'
+      displayName: 'Run Internal Python compatibility tests'
       timeoutInMinutes: 30
       inputs:
         azureSubscription: 'SynapseML Build'
@@ -1937,8 +1949,15 @@ jobs:
             sleep 30
             python ./src/test/python/make_mlflow_models.py
           fi
-          echo "Running ExcludeAIFunc Python tests against OSS $OSS_VERSION..."
-          sbt testPythonExcludeAIFunc
+          # Internal's non-live suites create Spark in this process, while its typing
+          # suite verifies that importing the pandas-on-Spark facade does not create
+          # a Py4J gateway. Running both in one pytest process makes that assertion
+          # order-dependent. The common target preserves Internal's default live-test
+          # exclusions, runs the non-typing tests first, then validates the installed
+          # typing artifacts in a fresh Python process that clears PYTEST_ADDOPTS.
+          export PYTEST_ADDOPTS="${PYTEST_ADDOPTS:+$PYTEST_ADDOPTS }--ignore=typing"
+          echo "Running non-live and isolated typing tests against OSS $OSS_VERSION..."
+          sbt testPythonAIFuncCommon
       condition: and(succeeded(), eq(variables['COMPAT_LANE'], 'python'))
     - task: PublishTestResults@2
       displayName: 'Publish Internal Scala Test Results'

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -311,9 +311,15 @@ jobs:
 - job: FabricE2E
   dependsOn: BuildAndCacheSbt
   displayName: 'Fabric E2E'
-  condition: and(succeeded(), eq('${{ parameters.testFabricE2E }}', true))
+  condition: >-
+    and(
+      succeeded(),
+      eq(variables.runTests, 'True'),
+      eq('${{ parameters.testFabricE2E }}', true),
+      ne(variables['System.PullRequest.IsFork'], 'True')
+    )
   timeoutInMinutes: 120
-  cancelTimeoutInMinutes: 0
+  cancelTimeoutInMinutes: 5
   pool:
     vmImage: $(UBUNTU_VERSION)
   steps:
@@ -321,6 +327,16 @@ jobs:
     - template: templates/update_cli.yml
     - template: templates/conda.yml
     - template: templates/kv.yml
+      parameters:
+        secretsFilter: >
+          fabric-test-kv-name,
+          fabric-cert-kv-name,
+          ado-feed-token,
+          nexus-un,
+          nexus-pw,
+          pgp-private,
+          pgp-public,
+          pgp-pw
     - template: templates/fabric_kv.yml
     - template: templates/publish.yml
     - task: AzureCLI@2
@@ -330,23 +346,63 @@ jobs:
         scriptLocation: inlineScript
         scriptType: bash
         inlineScript: |
-          set -e
+          set -eo pipefail
+          artifact_root='$(Build.ArtifactStagingDirectory)/fabric-e2e'
+          mkdir -p "$artifact_root"
+          printf '%s\n' \
+            'authentication=key-vault' \
+            'source_version=$(Build.SourceVersion)' \
+            'suites=FabricTestCleanup,FabricSmokeTests,FabricNotebookTests' \
+            'e2e_step=preparing' \
+            > "$artifact_root/run-metadata.txt"
+
           source activate synapseml
+          printf '%s\n' 'e2e_step=running' >> "$artifact_root/run-metadata.txt"
+          set +e
           sbt \
             "testOnly com.microsoft.azure.synapse.ml.nbtest.FabricTestCleanup" \
             "testOnly com.microsoft.azure.synapse.ml.nbtest.FabricSmokeTests com.microsoft.azure.synapse.ml.nbtest.FabricNotebookTests"
+          sbt_exit_code=$?
+          set -e
+          printf 'e2e_step=finished\nsbt_exit_code=%s\n' "$sbt_exit_code" \
+            >> "$artifact_root/run-metadata.txt"
+          exit "$sbt_exit_code"
       env:
         INTEGRATION_ENV: $(sempy-integration-region)
         INTEGRATION_ACCOUNT: $(sempy-integration-account)
         INTEGRATION_CERTIFICATE: $(sempy-integration-certificate)
         INTEGRATION_WORKSPACE_PREFIX: $(sempy-integration-workspace-prefix)
-      condition: and(succeeded(), eq(variables.runTests, 'True'))
+    - bash: |
+        set -euo pipefail
+        artifact_root='$(Build.ArtifactStagingDirectory)/fabric-e2e'
+        report_root='$(Build.SourcesDirectory)/core/target/test-reports'
+        mkdir -p "$artifact_root/test-reports"
+        if [ ! -f "$artifact_root/run-metadata.txt" ]; then
+          printf '%s\n' \
+            'authentication=key-vault' \
+            'source_version=$(Build.SourceVersion)' \
+            'e2e_step=not-started' \
+            > "$artifact_root/run-metadata.txt"
+        fi
+        if [ -d "$report_root" ]; then
+          find "$report_root" -maxdepth 1 -type f \
+            -name 'TEST-com.microsoft.azure.synapse.ml.nbtest.Fabric*.xml' \
+            -exec cp '{}' "$artifact_root/test-reports/" \;
+        fi
+      displayName: 'Collect Fabric E2E evidence'
+      condition: always()
     - task: PublishTestResults@2
       displayName: 'Publish Test Results'
       inputs:
         testResultsFiles: '**/test-reports/TEST-*.xml'
         failTaskOnFailedTests: true
-      condition: and(eq(variables.runTests, 'True'), succeededOrFailed())
+      condition: always()
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish Fabric E2E evidence'
+      inputs:
+        targetPath: '$(Build.ArtifactStagingDirectory)/fabric-e2e'
+        artifact: 'fabric-e2e-$(System.JobAttempt)'
+      condition: always()
 #
 - job: BuildDocker
   dependsOn: BuildAndCacheSbt

--- a/templates/fabric_kv.yml
+++ b/templates/fabric_kv.yml
@@ -23,26 +23,41 @@ steps:
         sempy-integration-workspace-prefix
       RunAsPreJob: false
 
-  # Compute certificate secret name from account
-  # E.g. user@tenant.onmicrosoft.com => user-tenant
-  - bash: |
-      account="$(sempy-integration-account)"
-      username=$(echo "$account" | cut -d'@' -f1)
-      tenant=$(echo "$account" | cut -d'@' -f2 | cut -d'.' -f1)
-      cert_name="${username}-${tenant}"
-      echo "Computed certificate secret name: ${cert_name}"
-      echo "##vso[task.setvariable variable=cert-adminuser-bami]${cert_name}"
-    displayName: 'Compute certificate secret name from account'
-    condition: ${{ parameters.condition }}
-
-  # Download the account certificate
   - task: AzureCLI@2
-    displayName: 'Get certificate from Key Vault'
+    displayName: 'Get Fabric Test Certificate from Key Vault'
     condition: ${{ parameters.condition }}
     inputs:
       azureSubscription: 'SynapseMLFabricTestCreds'
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
-        cert_value=$(az keyvault secret show --vault-name "$(fabric-cert-kv-name)" --name "$(cert-adminuser-bami)" --query "value" -o tsv)
-        echo "##vso[task.setvariable variable=sempy-integration-certificate;issecret=true]$cert_value"
+        set -euo pipefail
+
+        username="${INTEGRATION_ACCOUNT%%@*}"
+        tenant_domain="${INTEGRATION_ACCOUNT#*@}"
+        tenant="${tenant_domain%%.*}"
+        if [[ "$tenant_domain" == "$INTEGRATION_ACCOUNT" ||
+              -z "$username" ||
+              -z "$tenant" ||
+              "$tenant_domain" == *"@"* ]]; then
+          echo "Fabric integration account must use the username@tenant format." >&2
+          exit 1
+        fi
+        certificate_secret_name="${username}-${tenant}"
+        certificate_value="$(
+          az keyvault secret show \
+            --vault-name "$FABRIC_CERT_KEY_VAULT_NAME" \
+            --name "$certificate_secret_name" \
+            --query value \
+            --output tsv \
+            --only-show-errors
+        )"
+        if [ -z "$certificate_value" ]; then
+          echo "Fabric integration certificate was empty." >&2
+          exit 1
+        fi
+        printf '##vso[task.setvariable variable=sempy-integration-certificate;issecret=true]%s\n' \
+          "$certificate_value"
+    env:
+      FABRIC_CERT_KEY_VAULT_NAME: $(fabric-cert-kv-name)
+      INTEGRATION_ACCOUNT: $(sempy-integration-account)

--- a/templates/kv.yml
+++ b/templates/kv.yml
@@ -1,6 +1,12 @@
+parameters:
+  - name: secretsFilter
+    type: string
+    default: '*'
+
 steps:
   - task: AzureKeyVault@2
     retryCountOnTaskFailure: 3
     inputs:
       azureSubscription: 'SynapseML Build'
       keyVaultName: mmlspark-keys
+      SecretsFilter: ${{ parameters.secretsFilter }}

--- a/templates/publish.yml
+++ b/templates/publish.yml
@@ -14,6 +14,7 @@ steps:
         sbt packagePython
         sbt publishBlob
     env:
+      ADO-FEED-TOKEN: $(ado-feed-token)
       NEXUS-UN: $(nexus-un)
       NEXUS-PW: $(nexus-pw)
       PGP-PRIVATE: $(pgp-private)

--- a/tools/ci/patch_internal_typing_support.py
+++ b/tools/ci/patch_internal_typing_support.py
@@ -1,0 +1,89 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+"""Adapt Internal's typing package-data helper to current OSS code generation."""
+
+import argparse
+import ast
+from pathlib import Path
+import sys
+from typing import Optional, Sequence
+
+LEGACY_PACKAGE_DATA = (
+    'package_data={"synapseml": ["../LICENSE.txt", "../README.txt"], '
+    '"": ["*.pyi", "py.typed"]},'
+)
+CURRENT_PACKAGE_DATA = (
+    "package_data={\n"
+    '        "": ["*.pyi", "py.typed"],\n'
+    '        "synapseml": ["../LICENSE.txt", "../README.txt"],\n'
+    "    },"
+)
+CURRENT_DECLARATION = r"""TYPING_PACKAGE_DATA = (
+    "package_data={\n"
+    "        \"\": [\"*.pyi\", \"py.typed\"],\n"
+    "        \"synapseml\": [\"../LICENSE.txt\", \"../README.txt\"],\n"
+    "    },"
+)"""
+
+
+def patch_internal_typing_support(path: Path) -> bool:
+    """Update the known legacy constant and fail closed on unexpected drift."""
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    assignments = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "TYPING_PACKAGE_DATA"
+            for target in node.targets
+        )
+    ]
+    if len(assignments) != 1:
+        raise ValueError(
+            "Expected exactly one TYPING_PACKAGE_DATA assignment in "
+            f"{path}; found {len(assignments)}"
+        )
+
+    assignment = assignments[0]
+    try:
+        package_data = ast.literal_eval(assignment.value)
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            f"TYPING_PACKAGE_DATA must be a string literal in {path}"
+        ) from error
+    if not isinstance(package_data, str):
+        raise ValueError(f"TYPING_PACKAGE_DATA must be a string in {path}")
+    if package_data == CURRENT_PACKAGE_DATA:
+        return False
+    if package_data != LEGACY_PACKAGE_DATA:
+        raise ValueError(
+            f"Unsupported TYPING_PACKAGE_DATA value in {path}: {package_data!r}"
+        )
+
+    lines = source.splitlines(keepends=True)
+    replacement = [f"{line}\n" for line in CURRENT_DECLARATION.splitlines()]
+    lines[assignment.lineno - 1 : assignment.end_lineno] = replacement
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        stream.write("".join(lines))
+    return True
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path", type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        changed = patch_internal_typing_support(args.path)
+    except (OSError, SyntaxError, ValueError) as error:
+        parser.exit(2, f"error: {error}\n")
+
+    state = "updated" if changed else "already compatible"
+    print(f"Internal typing package-data helper is {state}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ci/tests/test_patch_internal_typing_support.py
+++ b/tools/ci/tests/test_patch_internal_typing_support.py
@@ -1,0 +1,58 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+import pytest
+
+from tools.ci.patch_internal_typing_support import (
+    CURRENT_DECLARATION,
+    CURRENT_PACKAGE_DATA,
+    LEGACY_PACKAGE_DATA,
+    patch_internal_typing_support,
+)
+
+
+def _helper_source(package_data):
+    return (
+        "ORIGINAL_PACKAGE_DATA = 'unused'\n"
+        f"TYPING_PACKAGE_DATA = {package_data!r}\n"
+        "AFTER_ASSIGNMENT = True\n"
+    )
+
+
+def test_updates_legacy_package_data_and_is_idempotent(tmp_path):
+    helper = tmp_path / "typing_build_support.py"
+    helper.write_text(_helper_source(LEGACY_PACKAGE_DATA), encoding="utf-8")
+
+    assert patch_internal_typing_support(helper)
+    patched = helper.read_text(encoding="utf-8")
+    assert CURRENT_DECLARATION in patched
+    assert not patch_internal_typing_support(helper)
+
+    namespace = {}
+    exec(patched, namespace)
+    assert namespace["TYPING_PACKAGE_DATA"] == CURRENT_PACKAGE_DATA
+    assert namespace["AFTER_ASSIGNMENT"]
+
+
+def test_rejects_unknown_package_data(tmp_path):
+    helper = tmp_path / "typing_build_support.py"
+    helper.write_text(_helper_source("package_data={}"), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Unsupported TYPING_PACKAGE_DATA"):
+        patch_internal_typing_support(helper)
+
+
+def test_rejects_missing_package_data_assignment(tmp_path):
+    helper = tmp_path / "typing_build_support.py"
+    helper.write_text("OTHER_VALUE = True\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="found 0"):
+        patch_internal_typing_support(helper)
+
+
+def test_rejects_nonliteral_package_data(tmp_path):
+    helper = tmp_path / "typing_build_support.py"
+    helper.write_text("TYPING_PACKAGE_DATA = build_value()\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must be a string literal"):
+        patch_internal_typing_support(helper)

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -545,6 +545,46 @@ def test_fabric_e2e_retains_results_and_metadata_on_failure():
     )
 
 
+def test_internal_python_adapts_typing_package_data_to_current_codegen():
+    data = yaml.safe_load(_pipeline_text())
+    jobs = {j.get("job"): j for j in _jobs(data["jobs"])}
+    internal = jobs["InternalCompat"]
+    retarget_step = next(
+        step
+        for step in internal["steps"]
+        if isinstance(step, dict)
+        and step.get("displayName") == "Retarget Internal to this build"
+    )
+
+    script = retarget_step["bash"]
+    assert 'if [ "$COMPAT_LANE" = "python" ]; then' in script
+    assert '"": ["*.pyi", "py.typed"]' in script
+    assert (
+        'python "$(Agent.BuildDirectory)/s/tools/ci/'
+        'patch_internal_typing_support.py"' in script
+    )
+    assert "utils/typing_build_support.py" in script
+
+
+def test_internal_python_isolates_typing_from_spark_tests():
+    data = yaml.safe_load(_pipeline_text())
+    jobs = {j.get("job"): j for j in _jobs(data["jobs"])}
+    internal = jobs["InternalCompat"]
+    test_step = next(
+        step
+        for step in internal["steps"]
+        if isinstance(step, dict)
+        and step.get("displayName") == "Run Internal Python compatibility tests"
+    )
+
+    script = test_step["inputs"]["inlineScript"]
+    assert '--ignore=typing"' in script
+    assert "sbt testPythonAIFuncCommon" in script
+    assert "sbt testPythonExcludeAIFunc" not in script
+    assert "COMPAT_LANE" in test_step["condition"]
+    assert "python" in test_step["condition"]
+
+
 def test_release_compat_accepts_github_target_and_uses_one_sbt_process():
     data = yaml.safe_load(_pipeline_text())
     jobs = {j.get("job"): j for j in _jobs(data["jobs"])}

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -24,6 +24,9 @@ SBT_RETRY = REPO_ROOT / "tools" / "ci" / "sbt_retry.sh"
 SBT_VERSION = REPO_ROOT / "tools" / "ci" / "get_sbt_version.sh"
 DATABRICKS_IMPACT = REPO_ROOT / "tools" / "ci" / "databricks_impact.py"
 DATABRICKS_STEPS_TPL = REPO_ROOT / "templates" / "databricks_e2e_steps.yml"
+KEY_VAULT_TPL = REPO_ROOT / "templates" / "kv.yml"
+FABRIC_KEY_VAULT_TPL = REPO_ROOT / "templates" / "fabric_kv.yml"
+PUBLISH_TPL = REPO_ROOT / "templates" / "publish.yml"
 CLEAN_ACR_PIPELINE = REPO_ROOT / ".pipelines" / "clean-acr.yml"
 DEMO_DOCKERFILE = REPO_ROOT / "tools" / "docker" / "demo" / "Dockerfile"
 MINIMAL_DOCKERFILE = REPO_ROOT / "tools" / "docker" / "minimal" / "Dockerfile"
@@ -46,6 +49,56 @@ def _jobs(node):
     elif isinstance(node, list):
         for value in node:
             yield from _jobs(value)
+
+
+def _secret_filter(value):
+    return set(value.replace(",", " ").split())
+
+
+def _fabric_certificate_script():
+    data = yaml.safe_load(FABRIC_KEY_VAULT_TPL.read_text())
+    certificate_task = next(
+        step
+        for step in data["steps"]
+        if step.get("displayName") == "Get Fabric Test Certificate from Key Vault"
+    )
+    return certificate_task["inputs"]["inlineScript"]
+
+
+def _run_fabric_certificate_script(
+    tmp_path, account, certificate="test-pfx", az_exit=0
+):
+    mock_az = tmp_path / "az"
+    mock_az.write_text(
+        """#!/usr/bin/env bash
+printf '%s\\n' "$@" > "$MOCK_AZ_ARGS"
+if [ "$MOCK_AZ_EXIT" -ne 0 ]; then
+  exit "$MOCK_AZ_EXIT"
+fi
+printf '%s' "$MOCK_CERTIFICATE"
+"""
+    )
+    mock_az.chmod(0o755)
+    az_args = tmp_path / "az-args.txt"
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{tmp_path}{os.pathsep}{env['PATH']}",
+            "FABRIC_CERT_KEY_VAULT_NAME": "test-cert-vault",
+            "INTEGRATION_ACCOUNT": account,
+            "MOCK_AZ_ARGS": str(az_args),
+            "MOCK_AZ_EXIT": str(az_exit),
+            "MOCK_CERTIFICATE": certificate,
+        }
+    )
+    result = subprocess.run(
+        ["bash", "-c", _fabric_certificate_script()],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return result, az_args
 
 
 def _release_compat_script():
@@ -300,6 +353,196 @@ def test_fabric_e2e_cleans_stale_artifacts_before_running_tests():
     assert cleanup_command in script
     assert test_command in script
     assert script.index(cleanup_command) < script.index(test_command)
+
+
+def test_fabric_e2e_keeps_key_vault_authentication_and_blocks_forks():
+    data = yaml.safe_load(_pipeline_text())
+    jobs = {j.get("job"): j for j in _jobs(data["jobs"])}
+    fabric_e2e = jobs["FabricE2E"]
+
+    condition = fabric_e2e["condition"]
+    assert "succeeded()" in condition
+    assert "variables.runTests" in condition
+    assert "parameters.testFabricE2E" in condition
+    assert "System.PullRequest.IsFork" in condition
+
+    template_steps = {
+        step["template"]: step
+        for step in fabric_e2e["steps"]
+        if isinstance(step, dict) and "template" in step
+    }
+    assert "templates/kv.yml" in template_steps
+    assert "templates/fabric_kv.yml" in template_steps
+    assert "templates/publish.yml" in template_steps
+    bootstrap_filter = _secret_filter(
+        template_steps["templates/kv.yml"]["parameters"]["secretsFilter"]
+    )
+    assert bootstrap_filter == {
+        "fabric-test-kv-name",
+        "fabric-cert-kv-name",
+        "ado-feed-token",
+        "nexus-un",
+        "nexus-pw",
+        "pgp-private",
+        "pgp-public",
+        "pgp-pw",
+    }
+
+    e2e = next(step for step in fabric_e2e["steps"] if step.get("displayName") == "E2E")
+    assert e2e["env"] == {
+        "INTEGRATION_ENV": "$(sempy-integration-region)",
+        "INTEGRATION_ACCOUNT": "$(sempy-integration-account)",
+        "INTEGRATION_CERTIFICATE": "$(sempy-integration-certificate)",
+        "INTEGRATION_WORKSPACE_PREFIX": "$(sempy-integration-workspace-prefix)",
+    }
+    assert e2e["inputs"]["azureSubscription"] == "SynapseML Build"
+    script = e2e["inputs"]["inlineScript"]
+    assert "authentication=key-vault" in script
+    assert "fabric-spark-cli" not in script
+    assert "INTEGRATION_AUTH_MODE" not in script
+    assert "fabricE2EAuthMode" not in _pipeline_text()
+
+    key_vault_template = yaml.safe_load(KEY_VAULT_TPL.read_text())
+    parameters = {
+        parameter["name"]: parameter for parameter in key_vault_template["parameters"]
+    }
+    assert parameters["secretsFilter"]["default"] == "*"
+    bootstrap_task = key_vault_template["steps"][0]
+    assert bootstrap_task["inputs"]["keyVaultName"] == "mmlspark-keys"
+    assert bootstrap_task["inputs"]["SecretsFilter"] == (
+        "${{ parameters.secretsFilter }}"
+    )
+
+    fabric_template = yaml.safe_load(FABRIC_KEY_VAULT_TPL.read_text())
+    assert len(fabric_template["steps"]) == 2
+    credential_task, certificate_task = fabric_template["steps"]
+    assert credential_task["inputs"]["KeyVaultName"] == "$(fabric-test-kv-name)"
+    assert _secret_filter(credential_task["inputs"]["SecretsFilter"]) == {
+        "sempy-integration-region",
+        "sempy-integration-account",
+        "sempy-integration-workspace-prefix",
+    }
+    certificate_script = certificate_task["inputs"]["inlineScript"]
+    assert "set -euo pipefail" in certificate_script
+    assert 'certificate_secret_name="${username}-${tenant}"' in certificate_script
+    assert '--vault-name "$FABRIC_CERT_KEY_VAULT_NAME"' in certificate_script
+    assert '--name "$certificate_secret_name"' in certificate_script
+    assert "--only-show-errors" in certificate_script
+    assert "Fabric integration certificate was empty." in certificate_script
+    assert "Computed certificate secret name" not in certificate_script
+    assert certificate_task["env"] == {
+        "FABRIC_CERT_KEY_VAULT_NAME": "$(fabric-cert-kv-name)",
+        "INTEGRATION_ACCOUNT": "$(sempy-integration-account)",
+    }
+    publish_template = yaml.safe_load(PUBLISH_TPL.read_text())
+    assert publish_template["steps"][0]["env"]["ADO-FEED-TOKEN"] == (
+        "$(ado-feed-token)"
+    )
+
+
+@pytest.mark.skipif(os.name != "posix", reason="certificate retrieval requires Bash")
+def test_fabric_certificate_lookup_derives_the_existing_secret_name(tmp_path):
+    result, az_args = _run_fabric_certificate_script(
+        tmp_path, "test-admin@test-tenant.onmicrosoft.com"
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == (
+        "##vso[task.setvariable variable=sempy-integration-certificate;"
+        "issecret=true]test-pfx\n"
+    )
+    assert "test-admin-test-tenant" not in result.stdout
+    assert az_args.read_text().splitlines() == [
+        "keyvault",
+        "secret",
+        "show",
+        "--vault-name",
+        "test-cert-vault",
+        "--name",
+        "test-admin-test-tenant",
+        "--query",
+        "value",
+        "--output",
+        "tsv",
+        "--only-show-errors",
+    ]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="certificate retrieval requires Bash")
+@pytest.mark.parametrize(
+    ("account", "certificate", "az_exit", "expected_error"),
+    [
+        ("not-an-account", "test-pfx", 0, "must use the username@tenant format"),
+        ("test@test@tenant", "test-pfx", 0, "must use the username@tenant format"),
+        (
+            "test-admin@test-tenant.onmicrosoft.com",
+            "",
+            0,
+            "certificate was empty",
+        ),
+        (
+            "test-admin@test-tenant.onmicrosoft.com",
+            "test-pfx",
+            17,
+            None,
+        ),
+    ],
+)
+def test_fabric_certificate_lookup_fails_closed(
+    tmp_path, account, certificate, az_exit, expected_error
+):
+    result, az_args = _run_fabric_certificate_script(
+        tmp_path, account, certificate=certificate, az_exit=az_exit
+    )
+
+    assert result.returncode != 0
+    if expected_error:
+        assert expected_error in result.stderr
+    if "@" not in account:
+        assert not az_args.exists()
+
+
+def test_fabric_e2e_retains_results_and_metadata_on_failure():
+    data = yaml.safe_load(_pipeline_text())
+    jobs = {j.get("job"): j for j in _jobs(data["jobs"])}
+    steps = jobs["FabricE2E"]["steps"]
+
+    e2e = next(step for step in steps if step.get("displayName") == "E2E")
+    script = e2e["inputs"]["inlineScript"]
+    assert "run-metadata.txt" in script
+    assert "source_version=$(Build.SourceVersion)" in script
+    assert "e2e_step=preparing" in script
+    assert "e2e_step=running" in script
+    assert "e2e_step=finished" in script
+    assert "sbt_exit_code=$?" in script
+    assert 'exit "$sbt_exit_code"' in script
+
+    collect = next(
+        step
+        for step in steps
+        if step.get("displayName") == "Collect Fabric E2E evidence"
+    )
+    assert collect["condition"] == "always()"
+    assert "INTEGRATION_ACCOUNT" not in collect["bash"]
+    assert "INTEGRATION_CERTIFICATE" not in collect["bash"]
+    assert "e2e_step=not-started" in collect["bash"]
+    assert "TEST-com.microsoft.azure.synapse.ml.nbtest.Fabric*.xml" in collect["bash"]
+
+    publish_results = next(
+        step for step in steps if step.get("displayName") == "Publish Test Results"
+    )
+    assert publish_results["condition"] == "always()"
+    assert publish_results["inputs"]["failTaskOnFailedTests"] is True
+
+    publish_evidence = next(
+        step
+        for step in steps
+        if step.get("displayName") == "Publish Fabric E2E evidence"
+    )
+    assert publish_evidence["condition"] == "always()"
+    assert publish_evidence["inputs"]["targetPath"] == (
+        "$(Build.ArtifactStagingDirectory)/fabric-e2e"
+    )
 
 
 def test_release_compat_accepts_github_target_and_uses_one_sbt_process():


### PR DESCRIPTION
## Summary

Keep SynapseML's existing Key Vault-backed Fabric E2E path unchanged, while
hardening when credentials are loaded, how the certificate is resolved, how
remote artifacts are cleaned up, what failure evidence is retained, and how
the external Internal Python compatibility lane handles current OSS code
generation.

This replaces the earlier broad runner/authentication rewrite with a focused
nine-file change: 622 additions and 26 deletions, mostly regression contracts.

The original E2E outage recovered through an operational account-alias update;
it did not require replacing the established certificate-authenticated test
path. This PR therefore does **not** change the Fabric tenant, integration
account, certificate, workspace, authentication mode, or execution model.

## Existing behavior intentionally preserved

- `mmlspark-keys` still supplies the `fabric-test-kv-name` and
  `fabric-cert-kv-name` locator aliases.
- The Fabric test vault still supplies `sempy-integration-region`,
  `sempy-integration-account`, and `sempy-integration-workspace-prefix`.
- The certificate vault is still queried for the same
  `<username>-<tenant-label>` PFX secret derived from the integration account.
- The test process still receives exactly:
  - `INTEGRATION_ENV`
  - `INTEGRATION_ACCOUNT`
  - `INTEGRATION_CERTIFICATE`
  - `INTEGRATION_WORKSPACE_PREFIX`
- The same per-user `SemPy <username>` workspace discovery, checkout
  publication, Spark Job Definition execution, smoke test, and five generated
  notebook tests remain in place.
- The existing `SynapseML Build` and `SynapseMLFabricTestCreds` service
  connections remain in place.

There is no `fabric-spark-cli` runner, Azure CLI authentication replacement,
authentication switch, DXT migration, or tenant selection logic in this patch.

## Hardening

### Credentials

- Gate the whole `Fabric E2E` job before checkout or secret-bearing setup when
  tests are disabled or the pull request is from a fork.
- Limit the bootstrap vault read to the two Fabric vault locators and the
  publication secrets this legacy path actually consumes.
- Keep `templates/kv.yml` backward compatible with an all-secrets default for
  existing callers.
- Validate the integration account before deriving the certificate secret
  name, quote every Azure CLI argument, propagate retrieval failures, and fail
  on an empty certificate.
- Stop logging the derived certificate-secret name and materialize only the PFX
  as a masked pipeline variable.
- Explicitly map the Azure Artifacts feed token needed while SBT initializes
  publication settings.

### Cleanup

- Attempt tracked Fabric artifact deletion even when executor shutdown fails or
  is interrupted.
- Preserve the first failure, attach a later cleanup failure as suppressed, and
  restore the thread interrupt flag before rethrowing.

### Failure evidence

- Record only non-secret run metadata: source version, authentication mode
  label, intended suites, execution phase, and SBT exit status.
- Always collect the Fabric JUnit XML and publish it with the metadata as a
  `fabric-e2e-$(System.JobAttempt)` pipeline artifact.
- Always run Azure test-result publication, including after credential,
  publication, test, or cancellation failures.
- Allow five minutes of cancellation cleanup/evidence time.

The retained artifact does not dump environment variables, resolved account or
vault values, certificate-secret names, or certificate contents.

### Internal Python compatibility

- Verify that OSS code generation still emits the expected PEP 561 package-data
  declaration before adapting anything.
- Parse the disposable Internal checkout's `TYPING_PACKAGE_DATA` assignment
  with Python AST, rewrite only its exact known legacy representation, accept
  the exact current representation idempotently, and fail closed on missing,
  duplicate, nonliteral, or unknown values.
- Keep Internal's typing gate enabled, but run it in the fresh Python process
  provided by `testPythonAIFuncCommon`; the Spark-backed suites ignore `typing`
  so a Py4J gateway created earlier in the process cannot invalidate the
  no-gateway typing assertion.

## Regression contracts

- Pipeline contracts pin the existing Key Vault-only authentication and four
  test-process variables.
- Linux Bash tests execute the inline certificate script with a mocked Azure
  CLI and cover compatible derivation, malformed accounts, an empty PFX, and
  retrieval failure.
- Scala tests cover cleanup after shutdown failure/interruption, first-failure
  preservation, suppressed cleanup failures, and interrupt restoration.
- Adapter tests cover the legacy rewrite, current-form idempotency, and
  fail-closed handling of missing, nonliteral, and unknown assignments.
- Pipeline contracts require both the fail-closed adapter and fresh-process
  typing isolation in the Python compatibility lane.

## Local validation

- Linux pipeline and adapter contracts: 76 passed.
- Windows pipeline and adapter contracts: 50 passed, 26 platform-specific tests
  skipped.
- The adapter updated the current Internal helper, preserved both package-data
  groups, and was idempotent on a second run.
- `FabricTestArtifactTrackerSuite`: 8/8 passed on JDK 11.
- Core main/test compile and Scala style passed on JDK 11.
- Repository Scala main/test style passed on JDK 11.
- Pinned `black==22.3.0`: all 201 checked Python files passed.

## Managed validation

Azure build
[`232823440`](https://dev.azure.com/msdata/A365/_build/results?buildId=232823440)
completed successfully against exact PR head
`230ec47bd82cc550d56dc955c52a0aac692a05c2` and merge SHA
`fc60b2372d1b6d9c37545547044a2209b0709696`.

- Build provenance is `reason=pullRequest`, `refs/pull/2669/merge`, and
  `system.pullRequest.sourceCommitId=230ec47bd82cc550d56dc955c52a0aac692a05c2`.
- All 69 Azure checks passed, including the parent pipeline, Fabric E2E,
  Databricks CPU/GPU E2E, Spark 4.1 release compatibility, and both Internal
  Scala and Python compatibility lanes.
- The repaired `SynapseML-Internal Compatibility Check python` lane passed on
  the exact head; its predecessor failure in build `232809033` is resolved.
- All 82 surfaced GitHub and Azure checks passed.
- Exact-head Copilot review covered 9/9 changed files, generated no comments,
  and has zero unresolved threads.
- Auto-merge remains armed; eligible human approval is the only remaining gate.
Tracks #2662 and ADO #5538675.
