### PR TITLE
perf(ci): reuse Docker bootstrap layers

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -359,7 +359,9 @@ jobs:
     - bash: |
         set -euo pipefail
         VERSION=$(bash tools/ci/get_sbt_version.sh)
+        PYTHON_VERSION=$(bash tools/ci/get_python_version.sh)
         echo '##vso[task.setvariable variable=version]'$VERSION
+        echo '##vso[task.setvariable variable=pythonVersion]'$PYTHON_VERSION
         echo '##vso[task.setvariable variable=gittag]'$(git tag -l --points-at HEAD)
       displayName: 'Get Docker Tag + Version'
     # Build all images (runs on every build to validate Dockerfiles)
@@ -370,7 +372,9 @@ jobs:
         repository: mmlspark-demo
         Dockerfile: tools/docker/demo/Dockerfile
         buildContext: $(Build.SourcesDirectory)
-        arguments: --build-arg SYNAPSEML_VERSION=$(version)
+        arguments: >-
+          --build-arg SYNAPSEML_VERSION=$(version)
+          --build-arg PYTHON_VERSION=$(pythonVersion)
         tags: |
           $(version)
         addPipelineData: true
@@ -385,7 +389,9 @@ jobs:
         repository: mmlspark-minimal
         Dockerfile: tools/docker/minimal/Dockerfile
         buildContext: $(Build.SourcesDirectory)
-        arguments: --build-arg SYNAPSEML_VERSION=$(version)
+        arguments: >-
+          --build-arg SYNAPSEML_VERSION=$(version)
+          --build-arg PYTHON_VERSION=$(pythonVersion)
         tags: |
           $(version)
         addPipelineData: true

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -370,11 +370,14 @@ jobs:
         repository: mmlspark-demo
         Dockerfile: tools/docker/demo/Dockerfile
         buildContext: $(Build.SourcesDirectory)
-        arguments: --quiet --build-arg SYNAPSEML_VERSION=$(version)
+        arguments: --build-arg SYNAPSEML_VERSION=$(version)
         tags: |
           $(version)
         addPipelineData: true
         addBaseImageData: true
+      env:
+        DOCKER_BUILDKIT: "1"
+        BUILDKIT_PROGRESS: plain
     - task: Docker@2
       displayName: Minimal Image Build
       inputs:
@@ -382,11 +385,14 @@ jobs:
         repository: mmlspark-minimal
         Dockerfile: tools/docker/minimal/Dockerfile
         buildContext: $(Build.SourcesDirectory)
-        arguments: --quiet --build-arg SYNAPSEML_VERSION=$(version)
+        arguments: --build-arg SYNAPSEML_VERSION=$(version)
         tags: |
           $(version)
         addPipelineData: true
         addBaseImageData: true
+      env:
+        DOCKER_BUILDKIT: "1"
+        BUILDKIT_PROGRESS: plain
     # Push demo and minimal when Docker publishing is enabled on master
     - task: AzureCLI@2
       condition: and(eq(variables.isMaster, true), eq('${{ parameters.publishDockerImages }}', true))

--- a/tools/ci/get_python_version.sh
+++ b/tools/ci/get_python_version.sh
@@ -9,15 +9,16 @@ if [ ! -f "$environment_file" ]; then
   exit 1
 fi
 
-mapfile -t versions < <(
+versions="$(
   sed -nE 's/^[[:space:]]*-[[:space:]]*python=([^[:space:]#]+)[[:space:]]*(#.*)?$/\1/p' \
     "$environment_file"
-)
+)"
+version_count="$(printf '%s\n' "$versions" | grep -c . || true)"
 
-if [ "${#versions[@]}" -ne 1 ] ||
-  [[ ! "${versions[0]:-}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+if [ "$version_count" -ne 1 ] ||
+  ! printf '%s\n' "$versions" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
   echo "Expected exactly one pinned python=<version> dependency in $environment_file" >&2
   exit 1
 fi
 
-printf '%s\n' "${versions[0]}"
+printf '%s\n' "$versions"

--- a/tools/ci/get_python_version.sh
+++ b/tools/ci/get_python_version.sh
@@ -15,7 +15,7 @@ mapfile -t versions < <(
 )
 
 if [ "${#versions[@]}" -ne 1 ] ||
-  [[ ! "${versions[0]:-}" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
+  [[ ! "${versions[0]:-}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo "Expected exactly one pinned python=<version> dependency in $environment_file" >&2
   exit 1
 fi

--- a/tools/ci/get_python_version.sh
+++ b/tools/ci/get_python_version.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+environment_file="${1:-environment.yml}"
+
+if [ ! -f "$environment_file" ]; then
+  echo "Python environment file not found: $environment_file" >&2
+  exit 1
+fi
+
+mapfile -t versions < <(
+  sed -nE 's/^[[:space:]]*-[[:space:]]*python=([^[:space:]#]+)[[:space:]]*(#.*)?$/\1/p' \
+    "$environment_file"
+)
+
+if [ "${#versions[@]}" -ne 1 ] ||
+  [[ ! "${versions[0]:-}" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
+  echo "Expected exactly one pinned python=<version> dependency in $environment_file" >&2
+  exit 1
+fi
+
+printf '%s\n' "${versions[0]}"

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -1236,6 +1236,8 @@ def test_build_docker_reuses_bootstrap_layers_and_emits_progress():
     assert (
         'conda install -y "python=${PYTHON_VERSION}"' in MINIMAL_DOCKERFILE.read_text()
     )
+    assert "PYTHON_VERSION build argument is required" in DEMO_DOCKERFILE.read_text()
+    assert "PYTHON_VERSION build argument is required" in MINIMAL_DOCKERFILE.read_text()
 
 
 def test_publish_jobs_resolve_and_preserve_package_versions():

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -25,6 +25,8 @@ SBT_VERSION = REPO_ROOT / "tools" / "ci" / "get_sbt_version.sh"
 DATABRICKS_IMPACT = REPO_ROOT / "tools" / "ci" / "databricks_impact.py"
 DATABRICKS_STEPS_TPL = REPO_ROOT / "templates" / "databricks_e2e_steps.yml"
 CLEAN_ACR_PIPELINE = REPO_ROOT / ".pipelines" / "clean-acr.yml"
+DEMO_DOCKERFILE = REPO_ROOT / "tools" / "docker" / "demo" / "Dockerfile"
+MINIMAL_DOCKERFILE = REPO_ROOT / "tools" / "docker" / "minimal" / "Dockerfile"
 RELEASE_COMPAT_PREREQUISITES = (
     REPO_ROOT / ".pipelines" / "release-compat-prerequisites.txt"
 )
@@ -1190,6 +1192,33 @@ def test_build_docker_allows_time_for_both_image_builds():
     data = yaml.safe_load(_pipeline_text())
     jobs = {j.get("job"): j for j in _jobs(data["jobs"])}
     assert jobs["BuildDocker"]["timeoutInMinutes"] >= 120
+
+
+def test_build_docker_reuses_bootstrap_layers_and_emits_progress():
+    data = yaml.safe_load(_pipeline_text())
+    jobs = {j.get("job"): j for j in _jobs(data["jobs"])}
+    image_builds = [
+        step
+        for step in jobs["BuildDocker"]["steps"]
+        if step.get("displayName") in {"Demo Image Build", "Minimal Image Build"}
+    ]
+
+    assert len(image_builds) == 2
+    for step in image_builds:
+        assert "--quiet" not in step["inputs"]["arguments"]
+        assert step["env"]["DOCKER_BUILDKIT"] == "1"
+        assert step["env"]["BUILDKIT_PROGRESS"] == "plain"
+
+    dependency_marker = "# Install image-specific Python dependencies."
+    demo_bootstrap, separator, _ = DEMO_DOCKERFILE.read_text().partition(
+        dependency_marker
+    )
+    assert separator
+    minimal_bootstrap, separator, _ = MINIMAL_DOCKERFILE.read_text().partition(
+        dependency_marker
+    )
+    assert separator
+    assert demo_bootstrap == minimal_bootstrap
 
 
 def test_publish_jobs_resolve_and_preserve_package_versions():

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -1220,7 +1220,7 @@ def test_build_docker_reuses_bootstrap_layers_and_emits_progress():
     assert "tools/ci/get_python_version.sh" in version_step["bash"]
     assert "variable=pythonVersion" in version_step["bash"]
 
-    dependency_marker = "# Install image-specific Python dependencies."
+    dependency_marker = "# SYNAPSEML_BOOTSTRAP_END"
     demo_bootstrap, separator, _ = DEMO_DOCKERFILE.read_text().partition(
         dependency_marker
     )

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -1206,8 +1206,19 @@ def test_build_docker_reuses_bootstrap_layers_and_emits_progress():
     assert len(image_builds) == 2
     for step in image_builds:
         assert "--quiet" not in step["inputs"]["arguments"]
+        assert (
+            "--build-arg PYTHON_VERSION=$(pythonVersion)" in step["inputs"]["arguments"]
+        )
         assert step["env"]["DOCKER_BUILDKIT"] == "1"
         assert step["env"]["BUILDKIT_PROGRESS"] == "plain"
+
+    version_step = next(
+        step
+        for step in jobs["BuildDocker"]["steps"]
+        if step.get("displayName") == "Get Docker Tag + Version"
+    )
+    assert "tools/ci/get_python_version.sh" in version_step["bash"]
+    assert "variable=pythonVersion" in version_step["bash"]
 
     dependency_marker = "# Install image-specific Python dependencies."
     demo_bootstrap, separator, _ = DEMO_DOCKERFILE.read_text().partition(
@@ -1221,6 +1232,10 @@ def test_build_docker_reuses_bootstrap_layers_and_emits_progress():
     assert demo_bootstrap == minimal_bootstrap
     assert "pip install --no-cache-dir" in DEMO_DOCKERFILE.read_text()
     assert "pip install --no-cache-dir" in MINIMAL_DOCKERFILE.read_text()
+    assert 'conda install -y "python=${PYTHON_VERSION}"' in DEMO_DOCKERFILE.read_text()
+    assert (
+        'conda install -y "python=${PYTHON_VERSION}"' in MINIMAL_DOCKERFILE.read_text()
+    )
 
 
 def test_publish_jobs_resolve_and_preserve_package_versions():

--- a/tools/ci/tests/test_pipeline_yaml.py
+++ b/tools/ci/tests/test_pipeline_yaml.py
@@ -1219,6 +1219,8 @@ def test_build_docker_reuses_bootstrap_layers_and_emits_progress():
     )
     assert separator
     assert demo_bootstrap == minimal_bootstrap
+    assert "pip install --no-cache-dir" in DEMO_DOCKERFILE.read_text()
+    assert "pip install --no-cache-dir" in MINIMAL_DOCKERFILE.read_text()
 
 
 def test_publish_jobs_resolve_and_preserve_package_versions():

--- a/tools/ci/tests/test_python_version.py
+++ b/tools/ci/tests/test_python_version.py
@@ -24,6 +24,10 @@ def _run(environment_file: Path):
     )
 
 
+def test_script_avoids_bash_four_only_mapfile():
+    assert "mapfile" not in SCRIPT.read_text()
+
+
 def test_extracts_pinned_python_version(tmp_path):
     environment_file = tmp_path / "environment.yml"
     environment_file.write_text(

--- a/tools/ci/tests/test_python_version.py
+++ b/tools/ci/tests/test_python_version.py
@@ -1,0 +1,56 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "tools" / "ci" / "get_python_version.sh"
+
+
+def _bash_path(path: Path) -> str:
+    if path.drive == "":
+        return str(path)
+    drive = path.drive.rstrip(":").lower()
+    return f"/mnt/{drive}/{path.as_posix().split(':', 1)[1].lstrip('/')}"
+
+
+def _run(environment_file: Path):
+    return subprocess.run(
+        ["bash", _bash_path(SCRIPT), _bash_path(environment_file)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_extracts_pinned_python_version(tmp_path):
+    environment_file = tmp_path / "environment.yml"
+    environment_file.write_text(
+        "dependencies:\n  - python=3.11.8\n  - requests=2.32.5\n"
+    )
+
+    result = _run(environment_file)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "3.11.8\n"
+
+
+def test_rejects_unpinned_python_version(tmp_path):
+    environment_file = tmp_path / "environment.yml"
+    environment_file.write_text("dependencies:\n  - python=3\n")
+
+    result = _run(environment_file)
+
+    assert result.returncode != 0
+    assert "exactly one pinned" in result.stderr
+
+
+def test_rejects_multiple_python_versions(tmp_path):
+    environment_file = tmp_path / "environment.yml"
+    environment_file.write_text("dependencies:\n  - python=3.11.8\n  - python=3.12.4\n")
+
+    result = _run(environment_file)
+
+    assert result.returncode != 0
+    assert "exactly one pinned" in result.stderr

--- a/tools/ci/tests/test_python_version.py
+++ b/tools/ci/tests/test_python_version.py
@@ -46,6 +46,16 @@ def test_rejects_unpinned_python_version(tmp_path):
     assert "exactly one pinned" in result.stderr
 
 
+def test_rejects_minor_only_python_version(tmp_path):
+    environment_file = tmp_path / "environment.yml"
+    environment_file.write_text("dependencies:\n  - python=3.11\n")
+
+    result = _run(environment_file)
+
+    assert result.returncode != 0
+    assert "exactly one pinned" in result.stderr
+
+
 def test_rejects_multiple_python_versions(tmp_path):
     environment_file = tmp_path / "environment.yml"
     environment_file.write_text("dependencies:\n  - python=3.11.8\n  - python=3.12.4\n")

--- a/tools/docker/demo/Dockerfile
+++ b/tools/docker/demo/Dockerfile
@@ -41,6 +41,7 @@ RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SP
     && mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} /opt/spark \
     && rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
 
+# SYNAPSEML_BOOTSTRAP_END
 # Install image-specific Python dependencies.
 RUN test -n "${PYTHON_VERSION}" \
       || (echo "PYTHON_VERSION build argument is required" >&2; exit 1) \

--- a/tools/docker/demo/Dockerfile
+++ b/tools/docker/demo/Dockerfile
@@ -42,7 +42,7 @@ RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SP
 
 # Install image-specific Python dependencies.
 RUN conda install -y python=3 jupyter \
-    && pip install --upgrade "PyJWT>=2.12.0" \
+    && pip install --no-cache-dir --upgrade "PyJWT>=2.12.0" \
     && conda clean --all --yes
 
 # Patch netty 4.1.96.Final (CVE-2023-44487, CVE-2024-29025, CVE-2025-24970, ...) to 4.1.118.Final.

--- a/tools/docker/demo/Dockerfile
+++ b/tools/docker/demo/Dockerfile
@@ -1,6 +1,7 @@
 FROM mcr.microsoft.com/mirror/docker/library/ubuntu:22.04@sha256:104ae83764a5119017b8e8d6218fa0832b09df65aae7d5a6de29a85d813da2fb
 
 ARG SYNAPSEML_VERSION=1.1.3
+ARG PYTHON_VERSION
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV SPARK_VERSION=3.5.4
@@ -41,7 +42,8 @@ RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SP
     && rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
 
 # Install image-specific Python dependencies.
-RUN conda install -y python=3 jupyter \
+RUN test -n "${PYTHON_VERSION}" \
+    && conda install -y "python=${PYTHON_VERSION}" jupyter \
     && pip install --no-cache-dir --upgrade "PyJWT>=2.12.0" \
     && conda clean --all --yes
 

--- a/tools/docker/demo/Dockerfile
+++ b/tools/docker/demo/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get -qq update \
     && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
 
-# Install conda and required dependencies
+# Install the shared conda bootstrap before image-specific packages.
 RUN curl -sSL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh \
     && bash /tmp/miniconda.sh -bfp /usr/local \
     && rm -rf /tmp/miniconda.sh \
@@ -30,8 +30,6 @@ RUN curl -sSL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64
     && conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main \
     && conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r \
     && conda update -y conda \
-    && conda install -y python=3 jupyter \
-    && pip install --upgrade "PyJWT>=2.12.0" \
     && conda clean --all --yes
 
 ENV PATH=/usr/local/bin:${PATH}
@@ -41,6 +39,11 @@ RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SP
     && tar -xzf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \
     && mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} /opt/spark \
     && rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
+
+# Install image-specific Python dependencies.
+RUN conda install -y python=3 jupyter \
+    && pip install --upgrade "PyJWT>=2.12.0" \
+    && conda clean --all --yes
 
 # Patch netty 4.1.96.Final (CVE-2023-44487, CVE-2024-29025, CVE-2025-24970, ...) to 4.1.118.Final.
 # Spark 3.5.x pins netty 4.1.96 upstream; we override in-place since 4.1.x is binary-compatible.

--- a/tools/docker/demo/Dockerfile
+++ b/tools/docker/demo/Dockerfile
@@ -43,6 +43,7 @@ RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SP
 
 # Install image-specific Python dependencies.
 RUN test -n "${PYTHON_VERSION}" \
+      || (echo "PYTHON_VERSION build argument is required" >&2; exit 1) \
     && conda install -y "python=${PYTHON_VERSION}" jupyter \
     && pip install --no-cache-dir --upgrade "PyJWT>=2.12.0" \
     && conda clean --all --yes

--- a/tools/docker/demo/README.md
+++ b/tools/docker/demo/README.md
@@ -5,30 +5,19 @@ This dockerfile can be used to run notebooks on a local docker image. The image 
 To build the docker image from the current tip of `master` branch, run:
 
 ```
-docker build . \
-  --build-arg PYTHON_VERSION=$(bash tools/ci/get_python_version.sh) \
-  -f tools/docker/demo/Dockerfile \
-  -t synapseml
+docker build . --build-arg PYTHON_VERSION=$(bash tools/ci/get_python_version.sh) -f tools/docker/demo/Dockerfile -t synapseml
 ```
 
 If you wish to build the image from a specific version SynapseML version, run:
 ```
-docker build . \
-  --build-arg SYNAPSEML_VERSION=<YOUR-VERSION-HERE> \
-  --build-arg PYTHON_VERSION=$(bash tools/ci/get_python_version.sh) \
-  -f tools/docker/demo/Dockerfile \
-  -t synapseml:<VERSION-TAG>
+docker build . --build-arg SYNAPSEML_VERSION=<YOUR-VERSION-HERE> --build-arg PYTHON_VERSION=$(bash tools/ci/get_python_version.sh) -f tools/docker/demo/Dockerfile -t synapseml:<VERSION-TAG>
 ```
 
 eg.
 
 For building image with SynapseML version 1.1.3, run:
 ```
-docker build . \
-  --build-arg SYNAPSEML_VERSION=1.1.3 \
-  --build-arg PYTHON_VERSION=$(bash tools/ci/get_python_version.sh) \
-  -f tools/docker/demo/Dockerfile \
-  -t synapseml:1.1.3
+docker build . --build-arg SYNAPSEML_VERSION=1.1.3 --build-arg PYTHON_VERSION=$(bash tools/ci/get_python_version.sh) -f tools/docker/demo/Dockerfile -t synapseml:1.1.3
 ```
 
 # Run the image

--- a/tools/docker/demo/README.md
+++ b/tools/docker/demo/README.md
@@ -5,19 +5,30 @@ This dockerfile can be used to run notebooks on a local docker image. The image 
 To build the docker image from the current tip of `master` branch, run:
 
 ```
-docker build . -f tools/docker/demo/Dockerfile -t synapseml
+docker build . \
+  --build-arg PYTHON_VERSION=$(bash tools/ci/get_python_version.sh) \
+  -f tools/docker/demo/Dockerfile \
+  -t synapseml
 ```
 
 If you wish to build the image from a specific version SynapseML version, run:
 ```
-docker build . --build-arg SYNAPSEML_VERSION=<YOUR-VERSION-HERE> -f tools/docker/demo/Dockerfile -t synapseml:<VERSION-TAG>
+docker build . \
+  --build-arg SYNAPSEML_VERSION=<YOUR-VERSION-HERE> \
+  --build-arg PYTHON_VERSION=$(bash tools/ci/get_python_version.sh) \
+  -f tools/docker/demo/Dockerfile \
+  -t synapseml:<VERSION-TAG>
 ```
 
 eg.
 
 For building image with SynapseML version 1.1.3, run:
 ```
-docker build . --build-arg SYNAPSEML_VERSION=1.1.3 -f tools/docker/demo/Dockerfile -t synapseml:1.1.3
+docker build . \
+  --build-arg SYNAPSEML_VERSION=1.1.3 \
+  --build-arg PYTHON_VERSION=$(bash tools/ci/get_python_version.sh) \
+  -f tools/docker/demo/Dockerfile \
+  -t synapseml:1.1.3
 ```
 
 # Run the image

--- a/tools/docker/minimal/Dockerfile
+++ b/tools/docker/minimal/Dockerfile
@@ -41,6 +41,7 @@ RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SP
     && mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} /opt/spark \
     && rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
 
+# SYNAPSEML_BOOTSTRAP_END
 # Install image-specific Python dependencies.
 RUN test -n "${PYTHON_VERSION}" \
       || (echo "PYTHON_VERSION build argument is required" >&2; exit 1) \

--- a/tools/docker/minimal/Dockerfile
+++ b/tools/docker/minimal/Dockerfile
@@ -1,6 +1,7 @@
 FROM mcr.microsoft.com/mirror/docker/library/ubuntu:22.04@sha256:104ae83764a5119017b8e8d6218fa0832b09df65aae7d5a6de29a85d813da2fb
 
 ARG SYNAPSEML_VERSION=1.1.3
+ARG PYTHON_VERSION
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV SPARK_VERSION=3.5.4
@@ -41,7 +42,8 @@ RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SP
     && rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
 
 # Install image-specific Python dependencies.
-RUN conda install -y python=3 pyspark \
+RUN test -n "${PYTHON_VERSION}" \
+    && conda install -y "python=${PYTHON_VERSION}" pyspark \
     && pip install --no-cache-dir --upgrade "PyJWT>=2.12.0" \
     && conda clean --all --yes
 

--- a/tools/docker/minimal/Dockerfile
+++ b/tools/docker/minimal/Dockerfile
@@ -43,6 +43,7 @@ RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SP
 
 # Install image-specific Python dependencies.
 RUN test -n "${PYTHON_VERSION}" \
+      || (echo "PYTHON_VERSION build argument is required" >&2; exit 1) \
     && conda install -y "python=${PYTHON_VERSION}" pyspark \
     && pip install --no-cache-dir --upgrade "PyJWT>=2.12.0" \
     && conda clean --all --yes

--- a/tools/docker/minimal/Dockerfile
+++ b/tools/docker/minimal/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get -qq update \
     && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
 
-# Install conda and required dependencies
+# Install the shared conda bootstrap before image-specific packages.
 RUN curl -sSL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh \
     && bash /tmp/miniconda.sh -bfp /usr/local \
     && rm -rf /tmp/miniconda.sh \
@@ -30,8 +30,6 @@ RUN curl -sSL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64
     && conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main \
     && conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r \
     && conda update -y conda \
-    && conda install -y python=3 pyspark \
-    && pip install --upgrade "PyJWT>=2.12.0" \
     && conda clean --all --yes
 
 ENV PATH=/usr/local/bin:${PATH}
@@ -41,6 +39,11 @@ RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SP
     && tar -xzf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \
     && mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} /opt/spark \
     && rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
+
+# Install image-specific Python dependencies.
+RUN conda install -y python=3 pyspark \
+    && pip install --upgrade "PyJWT>=2.12.0" \
+    && conda clean --all --yes
 
 ENV SPARK_HOME=/opt/spark
 ENV PYTHONPATH=${SPARK_HOME}/python/:${SPARK_HOME}/python/lib/py4j*

--- a/tools/docker/minimal/Dockerfile
+++ b/tools/docker/minimal/Dockerfile
@@ -42,7 +42,7 @@ RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SP
 
 # Install image-specific Python dependencies.
 RUN conda install -y python=3 pyspark \
-    && pip install --upgrade "PyJWT>=2.12.0" \
+    && pip install --no-cache-dir --upgrade "PyJWT>=2.12.0" \
     && conda clean --all --yes
 
 ENV SPARK_HOME=/opt/spark


### PR DESCRIPTION
## Summary

- reuse identical Apt, Miniconda, and Spark layers across the Demo and Minimal images
- source both images' exact Python version from `environment.yml`
- expose BuildKit layer progress and avoid retaining Pip's download cache
- enforce the cache boundary, version wiring, and diagnostics in CI tests

## Evidence

Exact-head Azure build [232288728](https://msdata.visualstudio.com/A365/_build/results?buildId=232288728) passed BuildDocker in **10.43 minutes** and passed **65/66 jobs**. The sole failure was Fabric's workspace API returning HTTP 500 before any test ran, matching exact-master build [232106690](https://msdata.visualstudio.com/A365/_build/results?buildId=232106690).

A controlled local comparison reduced the change-specific Minimal build from **7.00 to 4.24 minutes**, with identical Conda inventories and matching smoke tests.

## Validation

- pipeline tests: 47 passed, 21 skipped
- changed Python tests pass Black
- both Dockerfiles pass `docker build --check`
- clean Demo and Minimal builds report Python 3.11.8; Minimal reuses the shared bootstrap
- extractor validated with Bash 3.2 and rejects missing or non-exact Python pins