### PR TITLE
feat: add Python IntelliSense for generated APIs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -151,6 +151,10 @@ generatePythonDoc := {
 
 
 val packageSynapseML = TaskKey[Unit]("packageSynapseML", "package all projects into SynapseML")
+val cleanMergedPython = TaskKey[Unit]("cleanMergedPython", "clean merged Python package sources")
+cleanMergedPython := {
+  FileUtils.deleteDirectory(join(rootGenDir.value, "src", "python"))
+}
 packageSynapseML := {
   def writeSetupFileToTarget(dir: File): Unit = {
     if (!dir.exists()) {
@@ -187,7 +191,10 @@ packageSynapseML := {
          |        "Programming Language :: Python :: 3",
          |    ],
          |    zip_safe=True,
-         |    package_data={"synapseml": ["../LICENSE.txt", "../README.txt"]},
+         |    package_data={
+         |        "": ["*.pyi", "py.typed"],
+         |        "synapseml": ["../LICENSE.txt", "../README.txt"],
+         |    },
          |)
          |
          |""".stripMargin
@@ -195,6 +202,7 @@ packageSynapseML := {
   }
 
   Def.sequential(
+    cleanMergedPython,
     runTaskForAllInCompile(packagePython),
     runTaskForAllInCompile(mergePyCode)
   ).value

--- a/core/src/main/python/synapse/ml/stages/UDFTransformer.pyi
+++ b/core/src/main/python/synapse/ml/stages/UDFTransformer.pyi
@@ -1,0 +1,44 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in project root for information.
+
+from typing import Any, List, Optional
+
+from pyspark.ml.param import Param
+from pyspark.ml.util import JavaMLReadable, JavaMLWritable
+from pyspark.ml.wrapper import JavaTransformer
+from pyspark.sql.functions import UserDefinedFunction
+from synapse.ml.core.serialize.java_params_patch import ComplexParamsMixin
+
+class UDFTransformer(
+    ComplexParamsMixin,
+    JavaMLReadable,
+    JavaMLWritable,
+    JavaTransformer,
+):
+    inputCol: Param
+    inputCols: Param
+    outputCol: Param
+    udf: Param
+
+    def __init__(
+        self,
+        *,
+        inputCol: Optional[str] = ...,
+        inputCols: Optional[List[str]] = ...,
+        outputCol: Optional[str] = ...,
+        udf: Optional[UserDefinedFunction] = ...,
+    ) -> None: ...
+    def setInputCol(self, value: str) -> UDFTransformer: ...
+    def getInputCol(self) -> str: ...
+    def setInputCols(self, value: List[str]) -> UDFTransformer: ...
+    def getInputCols(self) -> List[str]: ...
+    def setOutputCol(self, value: str) -> UDFTransformer: ...
+    def getOutputCol(self) -> str: ...
+    def setUDF(self, udf: UserDefinedFunction) -> UDFTransformer: ...
+    def getUDF(self) -> UserDefinedFunction: ...
+    @classmethod
+    def read(cls) -> Any: ...
+    @staticmethod
+    def getJavaPackage() -> str: ...
+    @staticmethod
+    def _from_java(java_stage: Any) -> UDFTransformer: ...

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/codegen/DefaultParamInfo.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/codegen/DefaultParamInfo.scala
@@ -7,7 +7,9 @@ import com.microsoft.azure.synapse.ml.param._
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.param._
 
+import java.lang.reflect.{ParameterizedType, Type => JavaType}
 import scala.reflect.ClassTag
+import scala.util.Try
 
 case class ParamInfo[T <: Param[_]: ClassTag](pyType: String,
                                                pyTypeConverter: Option[String],
@@ -22,6 +24,8 @@ case class ParamInfo[T <: Param[_]: ClassTag](pyType: String,
   }
 
 }
+
+private[codegen] case class PythonTypeInfo(pyType: String, pyiType: String)
 
 object DefaultParamInfo extends Logging {
 
@@ -63,7 +67,7 @@ object DefaultParamInfo extends Logging {
     "object", null) //scalastyle:ignore null
 
   //scalastyle:off cyclomatic.complexity
-  def getGeneralParamInfo(dataType: Param[_]): ParamInfo[_] = {
+  private def generalParamInfo(dataType: Param[_]): ParamInfo[_] = {
     dataType match {
       case _: BooleanParam => BooleanInfo
       case _: IntParam => IntInfo
@@ -81,23 +85,168 @@ object DefaultParamInfo extends Logging {
       case _: TypedIntArrayParam => TypedIntArrayInfo
       case _: TypedDoubleArrayParam => TypedDoubleArrayInfo
       case _: UntypedArrayParam => UntypedArrayInfo
-      case p => {
-        logWarning(s"unsupported type $p")
-        UnknownInfo
-      }
+      case _ => UnknownInfo
     }
     //scalastyle:on cyclomatic.complexity
   }
 
-  def defaultGetParamInfo(stage: Params, p: Param[_]): ParamInfo[_] = {
-    try {
-      stage.getClass.getMethod(p.name)
-        .getAnnotatedReturnType.getType.toString match {
-        case "org.apache.spark.ml.param.Param<java.lang.String>" => StringInfo
-        case _ => getGeneralParamInfo(p)
+  def getGeneralParamInfo(dataType: Param[_]): ParamInfo[_] = {
+    val result = generalParamInfo(dataType)
+    if (result == UnknownInfo) {
+      logWarning(s"unsupported type $dataType")
+    }
+    result
+  }
+
+  private val StubTypeOverrides: Seq[(ParamInfo[_], String)] = Seq(
+    LongInfo -> "int",
+    StringArrayInfo -> "List[str]",
+    DoubleArrayInfo -> "List[float]",
+    IntArrayInfo -> "List[int]",
+    ByteArrayInfo -> "List[int]",
+    DoubleArrayArrayInfo -> "List[List[float]]",
+    StringStringMapInfo -> "Dict[str, str]",
+    StringIntMapInfo -> "Dict[str, int]",
+    ArrayMapInfo -> "List[Dict[str, Any]]",
+    TypedIntArrayInfo -> "List[int]",
+    TypedDoubleArrayInfo -> "List[float]",
+    UntypedArrayInfo -> "List[Any]",
+    UnknownInfo -> "Any"
+  )
+
+  private[codegen] def pythonTypeInfo(paramInfo: ParamInfo[_]): PythonTypeInfo = {
+    val pyiType = StubTypeOverrides.collectFirst {
+      case (info, stubType) if info.eq(paramInfo) => stubType
+    }.getOrElse(paramInfo.pyType)
+    PythonTypeInfo(paramInfo.pyType, pyiType)
+  }
+
+  private def genericTypeInfo(pyType: String, pyiType: String): PythonTypeInfo =
+    PythonTypeInfo(pyType, pyiType)
+
+  private val DirectTypeInfo: Map[Class[_], PythonTypeInfo] = Map(
+    java.lang.Boolean.TYPE -> pythonTypeInfo(BooleanInfo),
+    classOf[java.lang.Boolean] -> pythonTypeInfo(BooleanInfo),
+    java.lang.Byte.TYPE -> pythonTypeInfo(IntInfo),
+    classOf[java.lang.Byte] -> pythonTypeInfo(IntInfo),
+    java.lang.Short.TYPE -> pythonTypeInfo(IntInfo),
+    classOf[java.lang.Short] -> pythonTypeInfo(IntInfo),
+    java.lang.Integer.TYPE -> pythonTypeInfo(IntInfo),
+    classOf[java.lang.Integer] -> pythonTypeInfo(IntInfo),
+    java.lang.Long.TYPE -> pythonTypeInfo(LongInfo),
+    classOf[java.lang.Long] -> pythonTypeInfo(LongInfo),
+    java.lang.Float.TYPE -> pythonTypeInfo(FloatInfo),
+    classOf[java.lang.Float] -> pythonTypeInfo(FloatInfo),
+    java.lang.Double.TYPE -> pythonTypeInfo(DoubleInfo),
+    classOf[java.lang.Double] -> pythonTypeInfo(DoubleInfo),
+    classOf[String] -> pythonTypeInfo(StringInfo)
+  )
+
+  private val NamedTypeInfo: Map[String, PythonTypeInfo] = Map(
+    "org.apache.spark.ml.param.ParamMap" -> genericTypeInfo("ParamMap", "ParamMap"),
+    "org.apache.spark.sql.Dataset" -> genericTypeInfo("DataFrame", "DataFrame"),
+    "org.apache.spark.sql.types.DataType" -> genericTypeInfo("DataType", "DataType")
+  )
+
+  private def classInfo(clazz: Class[_]): Option[PythonTypeInfo] = {
+    DirectTypeInfo.get(clazz)
+      .orElse(NamedTypeInfo.get(clazz.getName))
+      .orElse {
+        if (clazz.isArray) {
+          val innerType = javaTypeInfo(clazz.getComponentType).map(_.pyiType).getOrElse("Any")
+          Some(genericTypeInfo("list", s"List[$innerType]"))
+        } else {
+          None
+        }
       }
-    } catch {
-      case _: Exception => getGeneralParamInfo(p)
+  }
+
+  private def javaTypeInfo(javaType: JavaType): Option[PythonTypeInfo] = {
+    javaType match {
+      case clazz: Class[_] =>
+        classInfo(clazz)
+      case parameterizedType: ParameterizedType =>
+        parameterizedInfo(parameterizedType)
+      case _ =>
+        None
+    }
+  }
+
+  private[codegen] def pythonMethodArgumentType(javaType: JavaType): String = {
+    javaType match {
+      case parameterizedType: ParameterizedType
+        if (parameterizedType.getRawType match {
+          case clazz: Class[_] => classOf[Param[_]].isAssignableFrom(clazz)
+          case _ => false
+        }) =>
+        "Param"
+      case clazz: Class[_] if classOf[Param[_]].isAssignableFrom(clazz) =>
+        "Param"
+      case _ =>
+        javaTypeInfo(javaType).map(_.pyiType).getOrElse("Any")
+    }
+  }
+
+  private def parameterizedInfo(parameterizedType: ParameterizedType): Option[PythonTypeInfo] = {
+    val rawType = parameterizedType.getRawType
+    val arguments = parameterizedType.getActualTypeArguments
+    rawType match {
+      case clazz: Class[_] if classOf[Param[_]].isAssignableFrom(clazz) =>
+        arguments.headOption.flatMap(javaTypeInfo)
+      case clazz: Class[_] if Seq(
+        "scala.collection.Seq",
+        "scala.collection.immutable.Seq",
+        "java.util.List"
+      ).contains(clazz.getName) =>
+        val innerType = arguments.headOption.flatMap(javaTypeInfo).map(_.pyiType).getOrElse("Any")
+        Some(genericTypeInfo("list", s"List[$innerType]"))
+      case clazz: Class[_] if Seq(
+        "scala.collection.Map",
+        "scala.collection.immutable.Map",
+        "java.util.Map"
+      ).contains(clazz.getName) =>
+        val keyType = arguments.headOption.flatMap(javaTypeInfo).map(_.pyiType).getOrElse("Any")
+        val valueType = arguments.drop(1).headOption.flatMap(javaTypeInfo).map(_.pyiType).getOrElse("Any")
+        Some(genericTypeInfo("dict", s"Dict[$keyType, $valueType]"))
+      case clazz: Class[_] if clazz.getName == "org.apache.spark.sql.Dataset" =>
+        Some(genericTypeInfo("DataFrame", "DataFrame"))
+      case _ =>
+        None
+    }
+  }
+
+  private def reflectedTypeInfo(stage: Params, methodName: String): Option[PythonTypeInfo] =
+    Try(stage.getClass.getMethod(methodName)).toOption.flatMap(method => javaTypeInfo(method.getGenericReturnType))
+
+  private[codegen] def defaultPythonTypeInfo(stage: Params, p: Param[_]): PythonTypeInfo = {
+    val generalInfo = generalParamInfo(p)
+    val reflectedInfo = p match {
+      case _: ServiceParam[_] =>
+        reflectedTypeInfo(stage, "get" + p.name.capitalize)
+          .orElse(reflectedTypeInfo(stage, p.name))
+      case _ if generalInfo == UnknownInfo =>
+        reflectedTypeInfo(stage, p.name)
+          .orElse(reflectedTypeInfo(stage, "get" + p.name.capitalize))
+      case _ =>
+        None
+    }
+    reflectedInfo.getOrElse(pythonTypeInfo(generalInfo))
+  }
+
+  def defaultGetParamInfo(stage: Params, p: Param[_]): ParamInfo[_] = {
+    p match {
+      case _: ServiceParam[_] =>
+        UnknownInfo
+      case _ =>
+        try {
+          stage.getClass.getMethod(p.name)
+            .getAnnotatedReturnType.getType.toString match {
+            case "org.apache.spark.ml.param.Param<java.lang.String>" => StringInfo
+            case _ => getGeneralParamInfo(p)
+          }
+        } catch {
+          case _: Exception => getGeneralParamInfo(p)
+        }
     }
   }
 

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/codegen/PyCodegen.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/codegen/PyCodegen.scala
@@ -38,11 +38,73 @@ object PyCodegen {
       |    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
       |""".stripMargin
 
+  private val OpenAICompletionStubImport: String =
+    """from synapse.ml.services.openai.OpenAICompletion import OpenAICompletion as OpenAICompletion
+      |""".stripMargin
+
+  private val StubSymbolPattern = """(?m)^(?:class|def)\s+([A-Za-z_][A-Za-z0-9_]*)\b""".r
+
   private def isOpenAICompletionStub(packageFolder: String, fileName: String): Boolean =
     packageFolder == "/services/openai" && fileName == DeprecatedOpenAICompletionFile
 
   private def initFileExtra(packageFolder: String): String =
     if (packageFolder == "/services/openai") OpenAICompletionImportHook else ""
+
+  private def initStubExtra(packageFolder: String): String =
+    if (packageFolder == "/services/openai") OpenAICompletionStubImport else ""
+
+  private def hasManualInit(conf: CodegenConfig, packageFolder: String): Boolean = {
+    val manualInit = join(conf.pySrcOverrideDir, "synapse", "ml", packageFolder, "__init__.py")
+    manualInit.isFile && readFile(manualInit).trim.nonEmpty
+  }
+
+  private def stubModuleImports(
+      dir: File,
+      packageFolder: String,
+      packageString: String): String = {
+    val stubFiles = dir.listFiles.filter(file =>
+      file.isFile &&
+        file.getName.endsWith(".pyi") &&
+        file.getName != "__init__.pyi" &&
+        !file.getName.startsWith("_")
+    ).sorted
+    val stubModules = stubFiles.map(file => getBaseName(file.getName)).toSet
+    val explicitImports = stubFiles.flatMap { file =>
+      val moduleName = getBaseName(file.getName)
+      val modulePath = s"synapse.ml$packageString.$moduleName"
+      StubSymbolPattern.findAllMatchIn(readFile(file)).map(_.group(1))
+        .filterNot(_.startsWith("_"))
+        .map(symbol => s"from $modulePath import $symbol as $symbol\n")
+    }
+    val fallbackImports = dir.listFiles.filter(file =>
+      file.isFile &&
+        file.getName.endsWith(".py") &&
+        file.getName != "__init__.py" &&
+        !file.getName.startsWith("_") &&
+        !file.getName.startsWith("test") &&
+        !stubModules.contains(getBaseName(file.getName))
+    ).sorted
+      .filterNot(file => isOpenAICompletionStub(packageFolder, file.getName))
+      .map(file => s"from synapse.ml$packageString.${getBaseName(file.getName)} import *\n")
+    (explicitImports ++ fallbackImports).mkString("")
+  }
+
+  private def makeInitStub(
+      conf: CodegenConfig,
+      dir: File,
+      packageFolder: String,
+      packageString: String): Unit = {
+    if (packageFolder.nonEmpty && !hasManualInit(conf, packageFolder)) {
+      val importStrings = if (packageFolder == "/services") {
+        dir.listFiles.filter(_.isDirectory)
+          .filter(folder => folder.getName != "langchain").sorted
+          .map(folder => s"from synapse.ml$packageString.${folder.getName} import *\n").mkString("")
+      } else {
+        stubModuleImports(dir, packageFolder, packageString)
+      }
+      writeFile(new File(dir, "__init__.pyi"), importStrings + initStubExtra(packageFolder))
+    }
+  }
 
   def generatePythonClasses(conf: CodegenConfig): Unit = {
     val instantiatedClasses = instantiateServices[PythonWrappable](conf.jarName)
@@ -74,9 +136,24 @@ object PyCodegen {
         initFile.delete()
       }
     }
+    makeInitStub(conf, dir, packageFolder, packageString)
     dir.listFiles().filter(_.isDirectory).foreach(f =>
       makeInitFiles(conf, packageFolder + "/" + f.getName)
     )
+  }
+
+  private def containsTypeStub(dir: File): Boolean =
+    Option(dir.listFiles()).exists(_.exists { file =>
+      (file.isFile && file.getName.endsWith(".pyi")) ||
+        (file.isDirectory && containsTypeStub(file))
+    })
+
+  private def generateTypingMarkers(conf: CodegenConfig): Unit = {
+    val namespaceRoot = join(conf.pySrcDir, "synapse", "ml")
+    Option(namespaceRoot.listFiles()).getOrElse(Array.empty)
+      .filter(_.isDirectory)
+      .filter(containsTypeStub)
+      .foreach(dir => writeFile(join(dir, "py.typed"), ""))
   }
 
   //noinspection ScalaStyle
@@ -139,7 +216,10 @@ object PyCodegen {
          |        "Programming Language :: Python :: 3",
          |    ],
          |    zip_safe=True,
-         |    package_data={"synapseml": ["../LICENSE.txt", "../README.txt"]},
+         |    package_data={
+         |        "": ["*.pyi", "py.typed"],
+         |        "synapseml": ["../LICENSE.txt", "../README.txt"],
+         |    },
          |    project_urls={
          |        "Website": "https://microsoft.github.io/SynapseML/",
          |        "Documentation": "https://mmlspark.blob.core.windows.net/docs/${conf.pythonizedVersion}/pyspark/index.html",
@@ -153,6 +233,7 @@ object PyCodegen {
   //scalastyle:on
 
   private[codegen] def generateInitFiles(conf: CodegenConfig): Unit = {
+    generateTypingMarkers(conf)
     makeInitFiles(conf)
     PythonInitMerger.preserve(conf)
   }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/codegen/Wrappable.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/codegen/Wrappable.scala
@@ -14,6 +14,7 @@ import org.apache.spark.ml.{Estimator, Model, Transformer}
 import scala.reflect.runtime.universe._
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.util.WeakHashMap
 
 
 trait BaseWrappable extends Params {
@@ -53,9 +54,31 @@ trait BaseWrappable extends Params {
 
 }
 
+private[codegen] object PythonStubCodegen {
+  val PythonMethodPattern =
+    """^\s*def\s+([A-Za-z_][A-Za-z0-9_]*)\(([^)]*)\)(?:\s*->\s*([^:]+))?:\s*$""".r
+
+  private val TypeInfoByStage = new WeakHashMap[Params, Map[String, PythonTypeInfo]]()
+
+  def pythonTypeInfo(stage: Params, param: Param[_]): PythonTypeInfo = synchronized {
+    val typeInfoByName = Option(TypeInfoByStage.get(stage)).getOrElse {
+      val computed = stage.params
+        .map(p => p.name -> DefaultParamInfo.defaultPythonTypeInfo(stage, p))
+        .toMap
+      TypeInfoByStage.put(stage, computed)
+      computed
+    }
+    typeInfoByName.getOrElse(param.name, DefaultParamInfo.defaultPythonTypeInfo(stage, param))
+  }
+}
+
 trait PythonWrappable extends BaseWrappable {
 
   import GenerationUtils._
+  import PythonStubCodegen.PythonMethodPattern
+
+  private def getPythonTypeInfo(p: Param[_]): PythonTypeInfo =
+    PythonStubCodegen.pythonTypeInfo(thisStage, p)
 
   def pyAdditionalMethods: String = {
     ""
@@ -86,7 +109,7 @@ trait PythonWrappable extends BaseWrappable {
   // TODO add default values
   protected lazy val pyClassDoc: String = {
     val argLines = thisStage.params.map { p =>
-      s"""${p.name} (${getParamInfo(p).pyType}): ${p.doc}"""
+      s"""${p.name} (${getPythonTypeInfo(p).pyType}): ${p.doc}"""
     }.mkString("\n")
     s"""|"\""
         |Args:
@@ -276,6 +299,158 @@ trait PythonWrappable extends BaseWrappable {
   protected def pyParamsGetters: String =
     thisStage.params.map(pyParamGetter).mkString("\n")
 
+  private def pyStubOptionalType(pyiType: String): String = {
+    if (pyiType == "Any") "Any" else s"Optional[$pyiType]"
+  }
+
+  private def pyStubParamArgs(p: Param[_]): Seq[String] = {
+    val pyiType = getPythonTypeInfo(p).pyiType
+    (p, thisStage.getDefault(p)) match {
+      case (_: ServiceParam[_], _) =>
+        Seq(
+          s"${p.name}: ${pyStubOptionalType(pyiType)} = ...",
+          s"${p.name}Col: Optional[str] = ..."
+        )
+      case (_: ComplexParam[_], _) | (_, None) =>
+        Seq(s"${p.name}: ${pyStubOptionalType(pyiType)} = ...")
+      case _ =>
+        Seq(s"${p.name}: $pyiType = ...")
+    }
+  }
+
+  private def pyStubParamsArgs: Seq[String] =
+    thisStage.params.flatMap(pyStubParamArgs)
+
+  private def pyStubKeywordOnlyMethod(
+      methodName: String,
+      args: Seq[String],
+      returnType: String,
+      fluent: Boolean = false): String = {
+    val selfArgument = if (fluent) "self: _T" else "self"
+    if (args.isEmpty) {
+      s"def $methodName($selfArgument) -> $returnType: ..."
+    } else {
+      s"""|def $methodName(
+          |    $selfArgument,
+          |    *,
+          |${indent(args.mkString(",\n"), 1)}
+          |) -> $returnType: ...""".stripMargin
+    }
+  }
+
+  private def pyStubInitFunc: String =
+    pyStubKeywordOnlyMethod(
+      "__init__",
+      Seq("java_obj: Any = ...") ++ pyStubParamsArgs,
+      "None"
+    )
+
+  private def pyStubSetParamsFunc: String =
+    pyStubKeywordOnlyMethod("setParams", pyStubParamsArgs, "_T", fluent = true)
+
+  private def pyStubParamDefinition(p: Param[_]): String =
+    s"${p.name}: Param"
+
+  private def pyStubParamSetter(p: Param[_]): String = {
+    val capName = p.name.capitalize
+    val pyiType = getPythonTypeInfo(p).pyiType
+    p match {
+      case _: ServiceParam[_] =>
+        s"""|def set$capName(self: _T, value: $pyiType) -> _T: ...
+            |def set${capName}Col(self: _T, value: str) -> _T: ...""".stripMargin
+      case _ =>
+        s"def set$capName(self: _T, value: $pyiType) -> _T: ..."
+    }
+  }
+
+  private def pyStubParamGetter(p: Param[_]): String = {
+    val capName = p.name.capitalize
+    s"def get$capName(self) -> ${getPythonTypeInfo(p).pyiType}: ..."
+  }
+
+  private def pyStubAdditionalArgument(
+      argument: String,
+      fluent: Boolean,
+      inferredType: Option[String]): String = {
+    val trimmed = argument.trim
+    if (trimmed == "self" && fluent) {
+      "self: _T"
+    } else if (trimmed == "self" || trimmed == "cls") {
+      trimmed
+    } else {
+      val hasDefault = trimmed.contains("=")
+      val argumentParts = trimmed.split("=", 2).map(_.trim)
+      val withoutDefault = argumentParts.head
+      val typedArgument = if (withoutDefault.contains(":")) {
+        withoutDefault
+      } else {
+        val argumentType = inferredType.getOrElse("Any")
+        val optionalType =
+          if (argumentParts.lift(1).contains("None") && argumentType != "Any") {
+            s"Optional[$argumentType]"
+          } else {
+            argumentType
+          }
+        s"$withoutDefault: $optionalType"
+      }
+      if (hasDefault) s"$typedArgument = ..." else typedArgument
+    }
+  }
+
+  private def pyStubAdditionalArgumentTypes(methodName: String, argumentCount: Int): Seq[String] = {
+    thisStage.getClass.getMethods
+      .filter(method => method.getName == methodName && method.getParameterCount == argumentCount)
+      .sortBy(_.toGenericString)
+      .headOption
+      .map(_.getGenericParameterTypes.toSeq.map(DefaultParamInfo.pythonMethodArgumentType))
+      .getOrElse(Seq.fill(argumentCount)("Any"))
+  }
+
+  private def isFluentStubMethod(methodName: String): Boolean =
+    methodName.startsWith("set") || methodName == "copy"
+
+  private def pyStubAdditionalReturnType(
+      methodName: String,
+      returnType: String,
+      fluent: Boolean): String = {
+    Option(returnType).map(_.trim).filter(_.nonEmpty).getOrElse {
+      if (fluent) "_T"
+      else if (methodName == "clear") "None"
+      else "Any"
+    }
+  }
+
+  private def pyStubAdditionalMethods: String = {
+    pyAdditionalMethods.split("\n").flatMap {
+      case PythonMethodPattern(methodName, args, returnType) if !methodName.startsWith("_") =>
+        val fluent = isFluentStubMethod(methodName)
+        val methodArgs = args.split(",").filter(_.trim.nonEmpty)
+        val valueArgCount = methodArgs.count(arg => !Set("self", "cls").contains(arg.trim))
+        val inferredTypes = pyStubAdditionalArgumentTypes(methodName, valueArgCount).iterator
+        val typedArgs = methodArgs.map { argument =>
+          val inferredType =
+            if (Set("self", "cls").contains(argument.trim)) None
+            else Some(inferredTypes.next())
+          pyStubAdditionalArgument(argument, fluent, inferredType)
+        }.mkString(", ")
+        val typedReturn = pyStubAdditionalReturnType(methodName, returnType, fluent)
+        Some(s"def $methodName($typedArgs) -> $typedReturn: ...")
+      case _ =>
+        None
+    }.distinct.mkString("\n")
+  }
+
+  private def pyStubExtraEstimatorMethods: String = {
+    thisStage match {
+      case _: Estimator[_] =>
+        val modelName = companionModelClassName.split(".".toCharArray).last
+        s"""|def _create_model(self, java_model: Any) -> $modelName: ...
+            |def _fit(self, dataset: DataFrame) -> $modelName: ...""".stripMargin
+      case _ =>
+        ""
+    }
+  }
+
   def pyInitFunc(): String = {
     s"""
        |@keyword_only
@@ -380,6 +555,53 @@ trait PythonWrappable extends BaseWrappable {
   }
   //scalastyle:on method.length
 
+  private def pythonStubClass(): String = {
+    val paramDefinitions = thisStage.params.map(pyStubParamDefinition).mkString("\n")
+    val paramSetters = thisStage.params.map(pyStubParamSetter).mkString("\n")
+    val paramGetters = thisStage.params.map(pyStubParamGetter).mkString("\n")
+    s"""|$copyrightLines
+        |
+        |from typing import Any, Dict, List, Optional, TypeVar
+        |
+        |from pyspark.ml.evaluation import JavaEvaluator
+        |from pyspark.ml.param import Param, ParamMap
+        |from pyspark.ml.util import JavaMLReadable, JavaMLWritable
+        |from pyspark.ml.wrapper import JavaEstimator, JavaModel, JavaTransformer
+        |from pyspark.sql import DataFrame
+        |from pyspark.sql.types import DataType
+        |from synapse.ml.core.serialize.java_params_patch import ComplexParamsMixin
+        |$pyExtraEstimatorImports
+        |
+        |_T = TypeVar("_T", bound="$pyClassName")
+        |
+        |class $pyClassName(${pyInheritedClasses.mkString(", ")}):
+        |${indent(pyClassDoc, 1)}
+        |
+        |${indent(paramDefinitions, 1)}
+        |
+        |${indent(pyStubInitFunc, 1)}
+        |
+        |${indent(pyStubSetParamsFunc, 1)}
+        |
+        |    @classmethod
+        |    def read(cls) -> Any: ...
+        |
+        |    @staticmethod
+        |    def getJavaPackage() -> str: ...
+        |
+        |    @staticmethod
+        |    def _from_java(java_stage: Any) -> $pyClassName: ...
+        |
+        |${indent(paramSetters, 1)}
+        |
+        |${indent(paramGetters, 1)}
+        |
+        |${indent(pyStubExtraEstimatorMethods, 1)}
+        |
+        |${indent(pyStubAdditionalMethods, 1)}
+        |""".stripMargin
+  }
+
   def makePyFile(conf: CodegenConfig): Unit = {
     val importPath = thisStage.getClass.getName.split(".".toCharArray).dropRight(1)
     val srcFolders = importPath.mkString(".")
@@ -389,6 +611,9 @@ trait PythonWrappable extends BaseWrappable {
     Files.write(
       FileUtilities.join(srcDir, pyClassName + ".py").toPath,
       pythonClass().getBytes(StandardCharsets.UTF_8))
+    Files.write(
+      FileUtilities.join(srcDir, pyClassName + ".pyi").toPath,
+      pythonStubClass().getBytes(StandardCharsets.UTF_8))
   }
 
 }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/codegen/PyCodegenSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/codegen/PyCodegenSuite.scala
@@ -17,58 +17,73 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.zip.ZipFile
 
-private class TypedPythonStage(override val uid: String = "typedPythonStage")
-  extends Transformer with Wrappable {
+// Keep PipelineStage fixtures nested so production-stage discovery ignores test-only classes.
+private[codegen] object PyCodegenFixtures {
 
-  val count = new DoubleParam(this, "count", "numeric value")
-  val labels = new StringArrayParam(this, "labels", "labels")
-  val model = new com.microsoft.azure.synapse.ml.param.ServiceParam[String](
-    this, "model", "model name")
-  val text = new Param[String](this, "text", "text value")
+  class TypedPythonStage(override val uid: String = "typedPythonStage")
+    extends Transformer with Wrappable {
 
-  def getModel: String = ""
-  def setAlias(value: String): this.type = this
+    override protected lazy val classNameHelper: String = "TypedPythonStage"
 
-  override def pyAdditionalMethods: String =
-    super.pyAdditionalMethods +
-      """|def setAlias(self, value):
-         |    return self
-         |
-         |def clear(self, param):
-         |    return None
-         |
-         |def copy(self, extra=None):
-         |    return self
-         |""".stripMargin
+    val count = new DoubleParam(this, "count", "numeric value")
+    val labels = new StringArrayParam(this, "labels", "labels")
+    val model = new com.microsoft.azure.synapse.ml.param.ServiceParam[String](
+      this, "model", "model name")
+    val text = new Param[String](this, "text", "text value")
 
-  override def transform(dataset: Dataset[_]): DataFrame = dataset.toDF()
+    def getModel: String = ""
+    def setAlias(value: String): this.type = this
 
-  override def transformSchema(schema: StructType): StructType = schema
+    override def pyAdditionalMethods: String =
+      super.pyAdditionalMethods +
+        """|def setAlias(self, value):
+           |    return self
+           |
+           |def clear(self, param):
+           |    return None
+           |
+           |def copy(self, extra=None):
+           |    return self
+           |""".stripMargin
 
-  override def copy(extra: ParamMap): TypedPythonStage = defaultCopy(extra)
-}
+    override def transform(dataset: Dataset[_]): DataFrame = dataset.toDF()
 
-private class TypedPythonModel(override val uid: String = "typedPythonModel")
-  extends Model[TypedPythonModel] with Wrappable {
+    override def transformSchema(schema: StructType): StructType = schema
 
-  override def transform(dataset: Dataset[_]): DataFrame = dataset.toDF()
+    override def copy(extra: ParamMap): TypedPythonStage = defaultCopy(extra)
+  }
 
-  override def transformSchema(schema: StructType): StructType = schema
+  class TypedPythonModel(override val uid: String = "typedPythonModel")
+    extends Model[TypedPythonModel] with Wrappable {
 
-  override def copy(extra: ParamMap): TypedPythonModel = defaultCopy(extra)
-}
+    override protected lazy val classNameHelper: String = "TypedPythonModel"
 
-private class TypedPythonEstimator(override val uid: String = "typedPythonEstimator")
-  extends Estimator[TypedPythonModel] with Wrappable {
+    override def transform(dataset: Dataset[_]): DataFrame = dataset.toDF()
 
-  override def fit(dataset: Dataset[_]): TypedPythonModel = new TypedPythonModel()
+    override def transformSchema(schema: StructType): StructType = schema
 
-  override def transformSchema(schema: StructType): StructType = schema
+    override def copy(extra: ParamMap): TypedPythonModel = defaultCopy(extra)
+  }
 
-  override def copy(extra: ParamMap): TypedPythonEstimator = defaultCopy(extra)
+  class TypedPythonEstimator(override val uid: String = "typedPythonEstimator")
+    extends Estimator[TypedPythonModel] with Wrappable {
+
+    override protected lazy val classNameHelper: String = "TypedPythonEstimator"
+
+    override protected def companionModelClassName: String =
+      "com.microsoft.azure.synapse.ml.codegen.TypedPythonModel"
+
+    override def fit(dataset: Dataset[_]): TypedPythonModel = new TypedPythonModel()
+
+    override def transformSchema(schema: StructType): StructType = schema
+
+    override def copy(extra: ParamMap): TypedPythonEstimator = defaultCopy(extra)
+  }
 }
 
 class PyCodegenSuite extends AnyFunSuite {
+
+  import PyCodegenFixtures._
 
   private def pythonExecutable: String =
     if (System.getProperty("os.name").toLowerCase.contains("windows")) "python" else "python3"

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/codegen/PyCodegenSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/codegen/PyCodegenSuite.scala
@@ -4,12 +4,69 @@
 package com.microsoft.azure.synapse.ml.codegen
 
 import org.apache.commons.io.{FileUtils, IOUtils}
+import org.apache.spark.ml.{Estimator, Model, Transformer}
+import org.apache.spark.ml.param.{DoubleParam, Param, ParamMap, StringArrayParam}
+import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.types.StructType
 import org.scalatest.funsuite.AnyFunSuite
+import spray.json.DefaultJsonProtocol._
 
 import java.io.File
+import java.lang.reflect.Modifier
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.zip.ZipFile
+
+private class TypedPythonStage(override val uid: String = "typedPythonStage")
+  extends Transformer with Wrappable {
+
+  val count = new DoubleParam(this, "count", "numeric value")
+  val labels = new StringArrayParam(this, "labels", "labels")
+  val model = new com.microsoft.azure.synapse.ml.param.ServiceParam[String](
+    this, "model", "model name")
+  val text = new Param[String](this, "text", "text value")
+
+  def getModel: String = ""
+  def setAlias(value: String): this.type = this
+
+  override def pyAdditionalMethods: String =
+    super.pyAdditionalMethods +
+      """|def setAlias(self, value):
+         |    return self
+         |
+         |def clear(self, param):
+         |    return None
+         |
+         |def copy(self, extra=None):
+         |    return self
+         |""".stripMargin
+
+  override def transform(dataset: Dataset[_]): DataFrame = dataset.toDF()
+
+  override def transformSchema(schema: StructType): StructType = schema
+
+  override def copy(extra: ParamMap): TypedPythonStage = defaultCopy(extra)
+}
+
+private class TypedPythonModel(override val uid: String = "typedPythonModel")
+  extends Model[TypedPythonModel] with Wrappable {
+
+  override def transform(dataset: Dataset[_]): DataFrame = dataset.toDF()
+
+  override def transformSchema(schema: StructType): StructType = schema
+
+  override def copy(extra: ParamMap): TypedPythonModel = defaultCopy(extra)
+}
+
+private class TypedPythonEstimator(override val uid: String = "typedPythonEstimator")
+  extends Estimator[TypedPythonModel] with Wrappable {
+
+  override def fit(dataset: Dataset[_]): TypedPythonModel = new TypedPythonModel()
+
+  override def transformSchema(schema: StructType): StructType = schema
+
+  override def copy(extra: ParamMap): TypedPythonEstimator = defaultCopy(extra)
+}
 
 class PyCodegenSuite extends AnyFunSuite {
 
@@ -38,6 +95,9 @@ class PyCodegenSuite extends AnyFunSuite {
 
   private def initFile(base: File, packageFolder: String): File =
     new File(packageDir(base, packageFolder), "__init__.py")
+
+  private def initStubFile(base: File, packageFolder: String): File =
+    new File(packageDir(base, packageFolder), "__init__.pyi")
 
   private def writeUtf8(file: File, content: String): Unit = {
     file.getParentFile.mkdirs()
@@ -111,17 +171,83 @@ class PyCodegenSuite extends AnyFunSuite {
     }
   }
 
+  private def repositoryRoot(candidate: File): File = {
+    if (new File(candidate, "build.sbt").isFile && new File(candidate, "core").isDirectory) candidate
+    else Option(candidate.getParentFile).map(repositoryRoot)
+      .getOrElse(fail(s"Could not find repository root from ${System.getProperty("user.dir")}"))
+  }
+
+  private def aggregateBuildFile: File =
+    new File(repositoryRoot(new File(System.getProperty("user.dir"))), "build.sbt")
+
   private def aggregatePackageDiscovery(): String = {
-    def repositoryRoot(candidate: File): File = {
-      if (new File(candidate, "build.sbt").isFile && new File(candidate, "core").isDirectory) candidate
-      else Option(candidate.getParentFile).map(repositoryRoot)
-        .getOrElse(fail(s"Could not find repository root from ${System.getProperty("user.dir")}"))
-    }
-    val buildFile = new File(repositoryRoot(new File(System.getProperty("user.dir"))), "build.sbt")
-    val lines = readUtf8(buildFile).split("\n")
+    val lines = readUtf8(aggregateBuildFile).split("\n")
       .filter(_.contains("|    packages=find_namespace_packages("))
     assert(lines.length === 1)
     lines.head.trim.stripPrefix("|    packages=").stripSuffix(",")
+  }
+
+  private def aggregatePackageData(): String = {
+    val content = readUtf8(aggregateBuildFile)
+    val pattern = """(?s)\|\s+package_data=(\{.*?\}),\n\s+\|\)""".r
+    pattern.findFirstMatchIn(content).map(_.group(1).replaceAllLiterally("|", ""))
+      .getOrElse(fail("Could not find aggregate package_data in build.sbt"))
+  }
+
+  test("stub helpers do not add abstract state to the public PythonWrappable trait") {
+    val abstractMethods = classOf[PythonWrappable].getDeclaredMethods
+      .filter(method => Modifier.isAbstract(method.getModifiers))
+    assert(abstractMethods.isEmpty, abstractMethods.map(_.getName).mkString(", "))
+  }
+
+  test("generated wrappers include typed constructor, param, and method stubs") {
+    withTempDir { root =>
+      val conf = codegenConfig(root)
+      val stage = new TypedPythonStage
+
+      stage.makePyFile(conf)
+
+      val folder = "/codegen"
+      val runtimeFile = new File(packageDir(conf.pySrcDir, folder), "TypedPythonStage.py")
+      val stubFile = new File(packageDir(conf.pySrcDir, folder), "TypedPythonStage.pyi")
+      val stub = readUtf8(stubFile)
+
+      assert(runtimeFile.isFile)
+      assert(stubFile.isFile)
+      assert(stub.contains("class TypedPythonStage("))
+      assert(stub.contains("count: Param"))
+      assert(stub.contains("count: Optional[float] = ..."))
+      assert(stub.contains("labels: Optional[List[str]] = ..."))
+      assert(stub.contains("model: Optional[str] = ..."))
+      assert(stub.contains("modelCol: Optional[str] = ..."))
+      assert(stub.contains("""_T = TypeVar("_T", bound="TypedPythonStage")"""))
+      assert(stub.contains("def setCount(self: _T, value: float) -> _T: ..."))
+      assert(stub.contains("def getText(self) -> str: ..."))
+      assert(stub.contains("def setAlias(self: _T, value: str) -> _T: ..."))
+      assert(stub.contains("def clear(self, param: Param) -> None: ..."))
+      assert(stub.contains(
+        "def copy(self: _T, extra: Optional[ParamMap] = ...) -> _T: ..."))
+      assertPythonCompiles(stubFile)
+    }
+  }
+
+  test("generated estimator stubs preserve companion model return types") {
+    withTempDir { root =>
+      val conf = codegenConfig(root)
+
+      new TypedPythonModel().makePyFile(conf)
+      new TypedPythonEstimator().makePyFile(conf)
+
+      val stubFile = new File(packageDir(conf.pySrcDir, "/codegen"), "TypedPythonEstimator.pyi")
+      val stub = readUtf8(stubFile)
+      assert(stub.contains(
+        "from synapse.ml.codegen.TypedPythonModel import TypedPythonModel"))
+      assert(stub.contains(
+        "def _create_model(self, java_model: Any) -> TypedPythonModel: ..."))
+      assert(stub.contains(
+        "def _fit(self, dataset: DataFrame) -> TypedPythonModel: ..."))
+      assertPythonCompiles(stubFile)
+    }
   }
 
   test("nested init keeps UTF-8 manual content after deterministic generated imports") {
@@ -202,9 +328,32 @@ class PyCodegenSuite extends AnyFunSuite {
       assert(generated.indexOf(hook) < generated.indexOf(manual))
       assert(occurrences(generated, hook) === 1)
       assert(occurrences(generated, manual) === 1)
+      assert(!initStubFile(conf.pySrcDir, folder).exists())
 
       PyCodegen.generateInitFiles(conf)
       assert(Files.readAllBytes(output.toPath).sameElements(first))
+    }
+  }
+
+  test("OpenAI init stub exports generated classes and the deprecated compatibility class") {
+    withTempDir { root =>
+      val conf = codegenConfig(root)
+      val folder = "/services/openai"
+      addModule(conf, folder, "OpenAIPrompt.py")
+      addModule(conf, folder, "OpenAICompletion.py")
+      writeUtf8(
+        new File(packageDir(conf.pySrcDir, folder), "OpenAIPrompt.pyi"),
+        "class OpenAIPrompt: ...\n"
+      )
+
+      PyCodegen.generateInitFiles(conf)
+
+      val stub = readUtf8(initStubFile(conf.pySrcDir, folder))
+      assert(stub.contains(
+        "from synapse.ml.services.openai.OpenAIPrompt import OpenAIPrompt as OpenAIPrompt"))
+      assert(stub.contains(
+        "from synapse.ml.services.openai.OpenAICompletion import OpenAICompletion as OpenAICompletion"))
+      assert(!stub.contains("OpenAICompletion import *"))
     }
   }
 
@@ -215,6 +364,8 @@ class PyCodegenSuite extends AnyFunSuite {
       ensurePackage(conf, folder)
       addModule(conf, folder, "Zulu.py")
       addModule(conf, folder, "Alpha.py")
+      writeUtf8(new File(packageDir(conf.pySrcDir, folder), "Zulu.pyi"), "class Zulu: ...\n")
+      writeUtf8(new File(packageDir(conf.pySrcDir, folder), "Alpha.pyi"), "class Alpha: ...\n")
 
       PyCodegen.generateInitFiles(conf)
 
@@ -227,9 +378,31 @@ class PyCodegenSuite extends AnyFunSuite {
       assert(generated.indexOf(alphaImport) < generated.indexOf(zuluImport))
       assert(occurrences(generated, alphaImport) === 1)
       assert(occurrences(generated, zuluImport) === 1)
+      val stubOutput = initStubFile(conf.pySrcDir, folder)
+      val firstStub = Files.readAllBytes(stubOutput.toPath)
+      val stub = new String(firstStub, StandardCharsets.UTF_8)
+      val alphaStubImport = "from synapse.ml.plain.Alpha import Alpha as Alpha"
+      val zuluStubImport = "from synapse.ml.plain.Zulu import Zulu as Zulu"
+      assert(stub.indexOf(alphaStubImport) >= 0)
+      assert(stub.indexOf(alphaStubImport) < stub.indexOf(zuluStubImport))
 
       PyCodegen.generateInitFiles(conf)
       assert(Files.readAllBytes(output.toPath).sameElements(first))
+      assert(Files.readAllBytes(stubOutput.toPath).sameElements(firstStub))
+    }
+  }
+
+  test("services init stub mirrors the runtime langchain exclusion") {
+    withTempDir { root =>
+      val conf = codegenConfig(root)
+      ensurePackage(conf, "/services/openai")
+      ensurePackage(conf, "/services/langchain")
+
+      PyCodegen.generateInitFiles(conf)
+
+      val stub = readUtf8(initStubFile(conf.pySrcDir, "/services"))
+      assert(stub.contains("from synapse.ml.services.openai import *"))
+      assert(!stub.contains("langchain"))
     }
   }
 
@@ -357,12 +530,17 @@ class PyCodegenSuite extends AnyFunSuite {
       val manual = "wheel_marker = \"Grüße 雪\"\n"
       addManualInit(conf, "", manual)
       addModule(conf, "/nested", "Widget.py")
+      writeUtf8(new File(packageDir(conf.pySrcDir, "/nested"), "Widget.pyi"), "class Widget: ...\n")
       PyCodegen.generatePyPackageData(conf)
       PyCodegen.generateInitFiles(conf)
 
       val wheel = buildWheel(conf.pySrcDir, new File(conf.targetDir, "wheel-test"))
       assert(wheelEntryContent(wheel, "synapse/ml/__init__.py").contains(manual))
+      assert(wheelEntryContent(wheel, "synapse/ml/py.typed").isEmpty)
       assert(wheelEntryContent(wheel, "synapse/ml/nested/__init__.py").nonEmpty)
+      assert(wheelEntryContent(wheel, "synapse/ml/nested/__init__.pyi").nonEmpty)
+      assert(wheelEntryContent(wheel, "synapse/ml/nested/py.typed").nonEmpty)
+      assert(wheelEntryContent(wheel, "synapse/ml/nested/Widget.pyi").nonEmpty)
     }
   }
 
@@ -373,14 +551,24 @@ class PyCodegenSuite extends AnyFunSuite {
       val manual = "aggregate_marker = \"café 雪\"\n"
       writeUtf8(new File(sourceDir, "synapse/ml/__init__.py"), manual)
       writeUtf8(new File(sourceDir, "synapse/ml/nested/__init__.py"), "")
+      writeUtf8(
+        new File(sourceDir, "synapse/ml/nested/__init__.pyi"),
+        "from .Widget import Widget as Widget\n"
+      )
+      writeUtf8(new File(sourceDir, "synapse/ml/nested/py.typed"), "")
+      writeUtf8(new File(sourceDir, "synapse/ml/nested/Widget.pyi"), "class Widget: ...\n")
       val setup = "from setuptools import setup, find_namespace_packages\n" +
         "setup(name=\"aggregate-wheel-test\", version=\"1.0.0\", packages=" +
-        aggregatePackageDiscovery() + ")\n"
+        aggregatePackageDiscovery() + ", package_data=" + aggregatePackageData() + ")\n"
       writeUtf8(new File(sourceDir, "setup.py"), setup)
 
       val wheel = buildWheel(sourceDir, wheelDir)
       assert(wheelEntryContent(wheel, "synapse/ml/__init__.py").contains(manual))
+      assert(wheelEntryContent(wheel, "synapse/ml/py.typed").isEmpty)
       assert(wheelEntryContent(wheel, "synapse/ml/nested/__init__.py").nonEmpty)
+      assert(wheelEntryContent(wheel, "synapse/ml/nested/__init__.pyi").nonEmpty)
+      assert(wheelEntryContent(wheel, "synapse/ml/nested/py.typed").nonEmpty)
+      assert(wheelEntryContent(wheel, "synapse/ml/nested/Widget.pyi").nonEmpty)
     }
   }
 }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/codegen/VerifyDefaultParamInfo.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/codegen/VerifyDefaultParamInfo.scala
@@ -4,8 +4,10 @@
 package com.microsoft.azure.synapse.ml.codegen
 
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import com.microsoft.azure.synapse.ml.param.ServiceParam
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.util.Identifiable
+import spray.json.DefaultJsonProtocol._
 
 class VerifyDefaultParamInfo extends TestBase {
 
@@ -47,5 +49,37 @@ class VerifyDefaultParamInfo extends TestBase {
     assert(DefaultParamInfo.StringStringMapInfo.pyType === "dict")
     assert(DefaultParamInfo.StringInfo.pyType === "str")
     assert(DefaultParamInfo.UnknownInfo.pyType === "object")
+  }
+
+  test("ParamInfo instances publish precise stub types") {
+    assert(DefaultParamInfo.pythonTypeInfo(DefaultParamInfo.LongInfo).pyiType === "int")
+    assert(DefaultParamInfo.pythonTypeInfo(DefaultParamInfo.StringArrayInfo).pyiType === "List[str]")
+    assert(DefaultParamInfo.pythonTypeInfo(DefaultParamInfo.DoubleArrayInfo).pyiType === "List[float]")
+    assert(DefaultParamInfo.pythonTypeInfo(DefaultParamInfo.StringStringMapInfo).pyiType === "Dict[str, str]")
+    assert(DefaultParamInfo.pythonTypeInfo(DefaultParamInfo.UnknownInfo).pyiType === "Any")
+  }
+
+  test("ServiceParam types are inferred from their scalar getters without adding converters") {
+    class ServiceParams extends Params {
+      override val uid: String = Identifiable.randomUID("ServiceParams")
+      val temperature = new ServiceParam[Double](this, "temperature", "temperature")
+      val model = new ServiceParam[String](this, "model", "model")
+
+      def getTemperature: Double = 0.0
+      def getModel: String = ""
+
+      override def copy(extra: ParamMap): Params = this
+    }
+
+    val params = new ServiceParams
+    val temperatureType = DefaultParamInfo.defaultPythonTypeInfo(params, params.temperature)
+    val modelType = DefaultParamInfo.defaultPythonTypeInfo(params, params.model)
+    val temperatureInfo = DefaultParamInfo.defaultGetParamInfo(params, params.temperature)
+    val modelInfo = DefaultParamInfo.defaultGetParamInfo(params, params.model)
+
+    assert(temperatureType.pyiType === "float")
+    assert(modelType.pyiType === "str")
+    assert(temperatureInfo.pyTypeConverter.isEmpty)
+    assert(modelInfo.pyTypeConverter.isEmpty)
   }
 }

--- a/docs/Get Started/Install SynapseML.md
+++ b/docs/Get Started/Install SynapseML.md
@@ -113,6 +113,11 @@ python -m pip install "synapseml==1.1.3" "pyspark>=4.0.1,<4.1"
 python -m pip install "synapseml==1.1.3" "pyspark>=3.5,<3.6"
 ```
 
+SynapseML wheels include PEP 561 type information for generated Python APIs.
+Editors such as VS Code with Pylance can therefore suggest transformer
+constructor parameters, setters, getters, and their types automatically when
+the editor is using the same Python environment where SynapseML is installed.
+
 ```python
 from pyspark.sql import SparkSession
 


### PR DESCRIPTION
## Related Issues/PRs

Closes #1013.

## What changes are proposed in this pull request?

SynapseML's generated Python wrappers expose runtime keyword names, but they do
not currently ship PEP 561 typing metadata. Editors therefore infer many
setters and optional parameters as `Unknown`, and package-level class discovery
is inconsistent.

This PR:

- generates adjacent `.pyi` files for generated transformers, estimators, and
  models, including typed constructors, `setParams`, Params, setters, getters,
  estimator model returns, and Python-only generated methods;
- infers precise scalar and collection types, including OpenAI
  `ServiceParam` values such as `concurrency`, `temperature`, and
  `deploymentName`, without changing runtime converters or the public
  `ParamInfo` JVM shape;
- generates explicit package stub exports and PEP 561 markers in
  component-owned namespace subpackages, and packages them in both component
  and aggregate wheels;
- adds a manual stub for the exceptional `UDFTransformer` wrapper, which does
  not inherit its generated base class;
- cleans the aggregate Python merge directory before packaging so removed
  generated files cannot survive into later wheels; and
- documents automatic Pylance/editor support after wheel installation.

The generated runtime `.py` execution structure remains unchanged; only
documentation type labels become more precise.

## How is this patch tested?

- [x] I have written tests and confirmed the proposed feature works.

Validation on the final rebased commit:

- 24 focused Scala codegen and type-inference tests passed.
- The full `com.microsoft.azure.synapse.ml.core.**` selector passed, including
  the production-stage discovery suite that caught test-only fixture leakage.
- Aggregate `compile`, `Test / compile`, `scalastyle`, and
  `Test / scalastyle` passed across all six modules.
- `black==22.3.0 --check` and `git diff --check` passed.
- Full codegen succeeded for core, deep-learning, cognitive, VW, LightGBM,
  and OpenCV.
- `packageSynapseML` produced an installable aggregate wheel containing 221
  `.pyi` files and 17 namespace-safe `py.typed` markers.
- Pyright reported zero errors for representative APIs, every generated class
  stub, and 140 package-level exports; the same stubs also passed with a
  Python 3.8 target.
- Negative Pyright coverage rejected 10 invalid constructor/setter calls with
  the expected types.
- Jedi resolved OpenAI classes and method completions, and reported all 73
  `OpenAIPrompt` constructor parameters including `concurrency`.
- The installed wheel imported successfully, and no `.pyi` file was loaded by
  the Python runtime.
- The public `PythonWrappable` trait has no new abstract JVM members compared
  with the target-branch binary surface.
- Normalized AST comparison found zero execution-structure differences across
  all 310 generated runtime `.py` files.
- Alternating cold import measurements showed no runtime regression
  (typed median 1.495s vs. baseline 1.521s). Comparable dirty-worktree codegen
  was within local noise (60.06s vs. 58.89s).
- Azure build
  [232486498](https://msdata.visualstudio.com/A365/_build/results?buildId=232486498)
  passed 76 checks, including `UnitTests core`. Its only failed job is the
  unrelated Fabric E2E cleanup, which aborted before running tests because
  `GET https://api.fabric.microsoft.com/v1/workspaces` returned HTTP 500 on
  both the initial run and a failed-job-only retry.

## Does this PR change any dependencies?

- [x] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No new transformer API is added. Installation documentation is updated.
- [ ] Yes. Make sure you have added samples following below steps.
