### PR TITLE
chore: simplify CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,10 +1,1 @@
-# For general updates to the library
 *                @ranadeepsingh @BrendanWalsh
-
-# Markus' Areas
-vw/              @eisber
-isolationforest/ @eisber
-recommendation/  @eisber
-
-# Scott's Areas
-lightgbm/        @svotaw


### PR DESCRIPTION
## Related Issues/PRs

None.

## What changes are proposed in this pull request?

Replace all path-specific `CODEOWNERS` entries with one repository-wide rule
assigning `@ranadeepsingh` and `@BrendanWalsh`.

## How is this patch tested?

- [x] Confirmed `CODEOWNERS` contains exactly the requested newline-terminated rule.
- [x] No automated tests are needed for this metadata-only change.

## Does this PR change any dependencies?

- [x] No.
- [ ] Yes.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No.
- [ ] Yes.
