### PR TITLE
fix: constrain ComplexParam Java deserialization

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/serialize/ComplexParam.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/serialize/ComplexParam.scala
@@ -3,6 +3,7 @@
 
 package com.microsoft.azure.synapse.ml.core.serialize
 
+import com.microsoft.azure.synapse.ml.core.utils.DeserializationClassFilter
 import com.microsoft.azure.synapse.ml.param.WrappableParam
 import org.apache.hadoop.fs.Path
 import org.apache.spark.ml.Serializer
@@ -16,12 +17,16 @@ abstract class ComplexParam[T: TypeTag](parent: Params, name: String, doc: Strin
 
   def ttag: TypeTag[T] = typeTag[T]
 
+  /** Class policy for Java object streams. No policy requires explicit trusted-legacy opt-in. */
+  protected def deserializationClassFilter: Option[DeserializationClassFilter] = None
+
   def save(obj: T, sparkSession: SparkSession, path: Path, overwrite: Boolean): Unit = {
-    Serializer.typeToSerializer[T](ttag.tpe, sparkSession).write(obj, path, overwrite)
+    Serializer.typeToSerializer[T](ttag.tpe, sparkSession, deserializationClassFilter)
+      .write(obj, path, overwrite)
   }
 
   def load(sparkSession: SparkSession, path: Path): T = {
-    Serializer.typeToSerializer[T](ttag.tpe, sparkSession).read(path)
+    Serializer.typeToSerializer[T](ttag.tpe, sparkSession, deserializationClassFilter).read(path)
   }
 
   override def jsonEncode(value: T): String = {

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/SafeObjectInputStream.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/SafeObjectInputStream.scala
@@ -5,19 +5,38 @@ package com.microsoft.azure.synapse.ml.core.utils
 
 import java.io.{InputStream, InvalidClassException, ObjectStreamClass}
 
-/** An ObjectInputStream that restricts deserialization to an allowlist of class name prefixes.
+final case class DeserializationClassFilter(
+    allowedPrefixes: Set[String] = Set.empty,
+    allowedClasses: Set[String] = Set.empty) {
+
+  require(!allowedPrefixes.contains(""), "Deserialization class prefixes cannot contain an empty prefix")
+
+  private[utils] def allows(className: String): Boolean = {
+    allowedClasses.contains(className) || allowedPrefixes.exists(className.startsWith)
+  }
+}
+
+/** An ObjectInputStream that restricts deserialization to an allowlist of class names and prefixes.
   *
   * This mitigates Java deserialization attacks (CWE-502) by rejecting any class
-  * whose fully-qualified name does not start with one of the allowed prefixes.
+  * whose fully-qualified name is not explicitly allowed.
   * It also inherits the context-classloader resolution from [[ContextObjectInputStream]].
   *
-  * @param input            the underlying input stream
-  * @param allowedPrefixes  set of class name prefixes that are permitted for deserialization
+  * @param input        the underlying input stream
+  * @param classFilter  exact class names and class-name prefixes permitted for deserialization
   */
 class SafeObjectInputStream(
     input: InputStream,
-    allowedPrefixes: Set[String]
+    classFilter: DeserializationClassFilter
 ) extends ContextObjectInputStream(input) {
+
+  private val alwaysRejectedClasses = Set(
+    "java.lang.invoke.SerializedLambda"
+  )
+
+  def this(input: InputStream, allowedPrefixes: Set[String]) = {
+    this(input, DeserializationClassFilter(allowedPrefixes = allowedPrefixes))
+  }
 
   /** Extracts the component type name from a JVM array descriptor.
     * Primitive arrays (e.g. `[I`, `[D`) return None since they are always safe.
@@ -34,7 +53,7 @@ class SafeObjectInputStream(
   }
 
   private def isAllowed(className: String): Boolean = {
-    allowedPrefixes.exists(prefix => className.startsWith(prefix))
+    !alwaysRejectedClasses.contains(className) && classFilter.allows(className)
   }
 
   protected override def resolveClass(desc: ObjectStreamClass): Class[_] = {
@@ -79,6 +98,13 @@ class SafeObjectInputStream(
 }
 
 object SafeObjectInputStream {
+
+  val CommonDataAllowedPrefixes: Set[String] = Set(
+    "java.lang.",
+    "java.math.",
+    "java.util.",
+    "scala."
+  )
 
   /** Default allowlist suitable for deserializing SynapseML nn package objects
     * (BallTree, ConditionalBallTree, and their object graphs).

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/SafeObjectInputStream.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/SafeObjectInputStream.scala
@@ -30,6 +30,8 @@ class SafeObjectInputStream(
     classFilter: DeserializationClassFilter
 ) extends ContextObjectInputStream(input) {
 
+  // SerializedLambda stores implementation classes as strings, so resolveClass cannot validate them.
+  // ModuleSerializationProxy stores its target as Class, whose descriptor is validated by resolveClass.
   private val alwaysRejectedClasses = Set(
     "java.lang.invoke.SerializedLambda"
   )

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/SafeObjectInputStream.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/SafeObjectInputStream.scala
@@ -5,6 +5,9 @@ package com.microsoft.azure.synapse.ml.core.utils
 
 import java.io.{InputStream, InvalidClassException, ObjectStreamClass}
 
+final class DeserializationClassRejectedException(className: String, reason: String)
+  extends InvalidClassException(className, reason)
+
 final case class DeserializationClassFilter(
     allowedPrefixes: Set[String] = Set.empty,
     allowedClasses: Set[String] = Set.empty) {
@@ -70,7 +73,7 @@ class SafeObjectInputStream(
     }
 
     if (!allowed) {
-      throw new InvalidClassException(
+      throw new DeserializationClassRejectedException(
         className,
         "Deserialization of this class is not allowed. " +
           "Only classes with approved package prefixes may be deserialized."
@@ -89,7 +92,7 @@ class SafeObjectInputStream(
   protected override def resolveProxyClass(interfaces: Array[String]): Class[_] = {
     val disallowed = interfaces.filterNot(isAllowed)
     if (disallowed.nonEmpty) {
-      throw new InvalidClassException(
+      throw new DeserializationClassRejectedException(
         disallowed.mkString(", "),
         "Deserialization of dynamic proxy is not allowed. " +
           "Proxy interface(s) not in the approved allowlist."

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/SafeObjectInputStream.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/SafeObjectInputStream.scala
@@ -19,7 +19,7 @@ final case class DeserializationClassFilter(
 /** An ObjectInputStream that restricts deserialization to an allowlist of class names and prefixes.
   *
   * This mitigates Java deserialization attacks (CWE-502) by rejecting any class
-  * whose fully-qualified name is not explicitly allowed.
+  * whose fully-qualified name is not allowed by the configured exact-name or prefix policy.
   * It also inherits the context-classloader resolution from [[ContextObjectInputStream]].
   *
   * @param input        the underlying input stream

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/SafeObjectInputStream.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/core/utils/SafeObjectInputStream.scala
@@ -76,7 +76,7 @@ class SafeObjectInputStream(
       throw new DeserializationClassRejectedException(
         className,
         "Deserialization of this class is not allowed. " +
-          "Only classes with approved package prefixes may be deserialized."
+          "Only classes approved by the configured exact-name or prefix policy may be deserialized."
       )
     }
     super.resolveClass(desc)

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/param/ByteArrayParam.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/param/ByteArrayParam.scala
@@ -4,6 +4,7 @@
 package com.microsoft.azure.synapse.ml.param
 
 import com.microsoft.azure.synapse.ml.core.serialize.ComplexParam
+import com.microsoft.azure.synapse.ml.core.utils.DeserializationClassFilter
 import org.apache.spark.ml.param.Params
 
 /** Param for ByteArray.  Needed as spark has explicit params for many different
@@ -14,5 +15,8 @@ class ByteArrayParam(parent: Params, name: String, doc: String, isValid: Array[B
 
   def this(parent: Params, name: String, doc: String) =
     this(parent, name, doc, (_: Array[Byte]) => true)
+
+  override protected def deserializationClassFilter: Option[DeserializationClassFilter] =
+    Some(DeserializationClassFilter())
 
 }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/param/DataTypeParam.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/param/DataTypeParam.scala
@@ -4,6 +4,7 @@
 package com.microsoft.azure.synapse.ml.param
 
 import com.microsoft.azure.synapse.ml.core.serialize.ComplexParam
+import com.microsoft.azure.synapse.ml.core.utils.{DeserializationClassFilter, SafeObjectInputStream}
 import org.apache.spark.ml.param.Params
 import org.apache.spark.sql.types.{DataType, StructType}
 
@@ -13,5 +14,14 @@ class DataTypeParam(parent: Params, name: String, doc: String, isValid: DataType
 
   def this(parent: Params, name: String, doc: String) =
     this(parent, name, doc, (_: DataType) => true)
+
+  override protected def deserializationClassFilter: Option[DeserializationClassFilter] = {
+    Some(DeserializationClassFilter(
+      allowedPrefixes = SafeObjectInputStream.CommonDataAllowedPrefixes ++ Set(
+        "org.apache.spark.ml.linalg.",
+        "org.apache.spark.sql.types."
+      )
+    ))
+  }
 
 }

--- a/core/src/main/scala/org/apache/spark/ml/Serializer.scala
+++ b/core/src/main/scala/org/apache/spark/ml/Serializer.scala
@@ -7,6 +7,7 @@ import com.microsoft.azure.synapse.ml.core.env.StreamUtilities._
 import com.microsoft.azure.synapse.ml.core.utils.{
   ContextObjectInputStream,
   DeserializationClassFilter,
+  DeserializationClassRejectedException,
   SafeObjectInputStream
 }
 import org.apache.hadoop.conf.Configuration
@@ -14,7 +15,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.ml.util.MLWritable
 import org.apache.spark.sql._
 
-import java.io.{InputStream, InvalidClassException, ObjectOutputStream, OutputStream}
+import java.io.{InputStream, ObjectOutputStream, OutputStream}
 import scala.language.existentials
 import scala.reflect.runtime.universe._
 import scala.util.control.NonFatal
@@ -187,9 +188,9 @@ object Serializer {
         read[O](in, classFilter)(ttag)
       }.get
     } catch {
-      case _: InvalidClassException if legacyObjectDeserializationEnabled(spark) =>
+      case _: DeserializationClassRejectedException if legacyObjectDeserializationEnabled(spark) =>
         readFromHDFSUnsafe(spark, path)
-      case error: InvalidClassException =>
+      case error: DeserializationClassRejectedException =>
         val securityError = disabledDeserializationException(
           ttag.tpe,
           s"The object graph contains ${error.classname}, which is outside its approved class policy. " +

--- a/core/src/main/scala/org/apache/spark/ml/Serializer.scala
+++ b/core/src/main/scala/org/apache/spark/ml/Serializer.scala
@@ -4,15 +4,20 @@
 package org.apache.spark.ml
 
 import com.microsoft.azure.synapse.ml.core.env.StreamUtilities._
-import com.microsoft.azure.synapse.ml.core.utils.ContextObjectInputStream
+import com.microsoft.azure.synapse.ml.core.utils.{
+  ContextObjectInputStream,
+  DeserializationClassFilter,
+  SafeObjectInputStream
+}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.ml.util.MLWritable
 import org.apache.spark.sql._
 
-import java.io.{InputStream, ObjectOutputStream, OutputStream}
+import java.io.{InputStream, InvalidClassException, ObjectOutputStream, OutputStream}
 import scala.language.existentials
 import scala.reflect.runtime.universe._
+import scala.util.control.NonFatal
 
 abstract class Serializer[O] {
   def write(obj: O, path: Path, overwrite: Boolean): Unit
@@ -20,6 +25,10 @@ abstract class Serializer[O] {
 }
 
 object Serializer {
+
+  /** Compatibility switch for trusted legacy artifacts whose object graphs cannot be constrained. */
+  val LegacyObjectDeserializationConfig: String =
+    "spark.synapseml.legacy.allowUnsafeJavaDeserialization"
 
   val ContextClassLoader: ClassLoader = Thread.currentThread().getContextClassLoader
 
@@ -39,10 +48,22 @@ object Serializer {
   }
 
   def typeToSerializer[T](tpe: Type, sparkSession: SparkSession): Serializer[T] = {
+    typeToSerializer(tpe, sparkSession, None)
+  }
+
+  def typeToSerializer[T](
+      tpe: Type,
+      sparkSession: SparkSession,
+      classFilter: Option[DeserializationClassFilter]): Serializer[T] = {
     (if (tpe <:< typeOf[PipelineStage])              new PipelineSerializer()
      else if (tpe <:< typeOf[Array[PipelineStage]])  new PipelineArraySerializer()
      else if (tpe <:< typeOf[Dataset[_]])            new DFSerializer(sparkSession)
-     else new ObjectSerializer(sparkSession)(typeToTypeTag(tpe)))
+     else classFilter match {
+       case Some(filter) =>
+         new FilteredObjectSerializer(sparkSession, filter)(typeToTypeTag(tpe))
+       case None =>
+         new ObjectSerializer(sparkSession)(typeToTypeTag(tpe))
+     })
       .asInstanceOf[Serializer[T]]
   }
 
@@ -58,7 +79,59 @@ object Serializer {
     }.get
   }
 
+  private val PrimitiveByteArrayFilter = DeserializationClassFilter()
+
+  private def defaultClassFilter(tpe: Type): Option[DeserializationClassFilter] = {
+    if (tpe =:= typeOf[Array[Byte]]) Some(PrimitiveByteArrayFilter) else None
+  }
+
+  private def legacyObjectDeserializationEnabled(spark: SparkSession): Boolean = {
+    spark.conf.getOption(LegacyObjectDeserializationConfig).exists(_.equalsIgnoreCase("true"))
+  }
+
+  private def disabledDeserializationException(tpe: Type, guidance: String): SecurityException = {
+    new SecurityException(
+      s"Java deserialization is disabled for $tpe because its object graph is not constrained. " +
+        s"$guidance This may execute arbitrary code."
+    )
+  }
+
+  private def closeAndThrow(input: InputStream, error: Throwable): Nothing = {
+    try input.close() catch {
+      case NonFatal(closeError) => error.addSuppressed(closeError)
+    }
+    throw error
+  }
+
+  def read[A](
+      is: InputStream,
+      classFilter: DeserializationClassFilter)(implicit ttag: TypeTag[A]): A = {
+    val safeInput = try {
+      new SafeObjectInputStream(is, classFilter)
+    } catch {
+      case NonFatal(error) => closeAndThrow(is, error)
+    }
+    using(safeInput) { in =>
+      in.readObject.asInstanceOf[A]
+    }.get
+  }
+
   def read[A](is: InputStream)(implicit ttag: TypeTag[A]): A = {
+    defaultClassFilter(ttag.tpe) match {
+      case Some(filter) => read(is, filter)
+      case None =>
+        closeAndThrow(
+          is,
+          disabledDeserializationException(
+            ttag.tpe,
+            "Call Serializer.readUnsafe only for a trusted legacy artifact."
+          )
+        )
+    }
+  }
+
+  /** Reads an object without a class policy. The caller must already trust the artifact. */
+  def readUnsafe[A](is: InputStream)(implicit ttag: TypeTag[A]): A = {
     using(new ContextObjectInputStream(is)) { in =>
       in.readObject.asInstanceOf[A]
     }.get
@@ -93,8 +166,46 @@ object Serializer {
     * @return The loaded object.
     */
   def readFromHDFS[O](spark: SparkSession, path: Path)(implicit ttag: TypeTag[O]): O = {
+    defaultClassFilter(ttag.tpe) match {
+      case Some(filter) => readFromHDFS(spark, path, filter)
+      case None if legacyObjectDeserializationEnabled(spark) =>
+        readFromHDFSUnsafe(spark, path)
+      case None =>
+        throw disabledDeserializationException(
+          ttag.tpe,
+          s"Set $LegacyObjectDeserializationConfig=true only when loading a trusted legacy model."
+        )
+    }
+  }
+
+  def readFromHDFS[O](
+      spark: SparkSession,
+      path: Path,
+      classFilter: DeserializationClassFilter)(implicit ttag: TypeTag[O]): O = {
+    try {
+      using(path.getFileSystem(sessionHadoopConf(spark)).open(path)) { in =>
+        read[O](in, classFilter)(ttag)
+      }.get
+    } catch {
+      case _: InvalidClassException if legacyObjectDeserializationEnabled(spark) =>
+        readFromHDFSUnsafe(spark, path)
+      case error: InvalidClassException =>
+        val securityError = disabledDeserializationException(
+          ttag.tpe,
+          s"The object graph contains ${error.classname}, which is outside its approved class policy. " +
+            s"Set $LegacyObjectDeserializationConfig=true only when loading a trusted legacy model."
+        )
+        securityError.initCause(error)
+        throw securityError
+    }
+  }
+
+  /** Reads an object without a class policy. The caller must already trust the artifact. */
+  def readFromHDFSUnsafe[O](
+      spark: SparkSession,
+      path: Path)(implicit ttag: TypeTag[O]): O = {
     using(path.getFileSystem(sessionHadoopConf(spark)).open(path)) { in =>
-      read[O](in)(ttag)
+      readUnsafe[O](in)(ttag)
     }.get
   }
 
@@ -116,6 +227,16 @@ class ObjectSerializer[O](spark: SparkSession)(implicit ttag: TypeTag[O]) extend
   def write(obj: O, path: Path, overwrite: Boolean): Unit = Serializer.writeToHDFS(spark, obj, path, overwrite)
 
   def read(path: Path): O = Serializer.readFromHDFS(spark, path)
+}
+
+private[ml] class FilteredObjectSerializer[O](
+    spark: SparkSession,
+    classFilter: DeserializationClassFilter)(implicit ttag: TypeTag[O]) extends Serializer[O] {
+
+  def write(obj: O, path: Path, overwrite: Boolean): Unit =
+    Serializer.writeToHDFS(spark, obj, path, overwrite)
+
+  def read(path: Path): O = Serializer.readFromHDFS(spark, path, classFilter)
 }
 
 class DFSerializer(spark: SparkSession) extends Serializer[DataFrame] {

--- a/core/src/main/scala/org/apache/spark/ml/Serializer.scala
+++ b/core/src/main/scala/org/apache/spark/ml/Serializer.scala
@@ -91,8 +91,8 @@ object Serializer {
 
   private def disabledDeserializationException(tpe: Type, guidance: String): SecurityException = {
     new SecurityException(
-      s"Java deserialization is disabled for $tpe because its object graph is not constrained. " +
-        s"$guidance This may execute arbitrary code."
+      s"Java deserialization is disabled for $tpe. " +
+        s"$guidance Deserializing this artifact may execute arbitrary code."
     )
   }
 

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/codegen/RTestGen.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/codegen/RTestGen.scala
@@ -93,6 +93,7 @@ object RTestGen {
          |options(sparklyr.verbose = TRUE)
          |
          |conf <- spark_config()
+         |conf[["spark.synapseml.legacy.allowUnsafeJavaDeserialization"]] <- "true"
          |conf$$sparklyr.shell.conf <- c(
          |  "spark.app.name=SparklyRTests",
          |  "spark.jars.packages=$SparkMavenPackageList",

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/core/serialize/ValidateComplexParamSerializer.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/core/serialize/ValidateComplexParamSerializer.scala
@@ -5,6 +5,7 @@ package com.microsoft.azure.synapse.ml.core.serialize
 
 import com.microsoft.azure.synapse.ml.core.env.StreamUtilities.using
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import com.microsoft.azure.synapse.ml.core.utils.DeserializationClassFilter
 import com.microsoft.azure.synapse.ml.param.ByteArrayParam
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.Path
@@ -14,7 +15,43 @@ import org.apache.spark.ml.{ComplexParamsReadable, ComplexParamsWritable, Object
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Dataset}
 
-import java.io.File
+import java.io.{
+  ByteArrayInputStream,
+  ByteArrayOutputStream,
+  File,
+  ObjectInputStream,
+  StreamCorruptedException
+}
+import java.util.concurrent.atomic.AtomicBoolean
+
+private object DeserializationTripwire {
+  val Triggered = new AtomicBoolean(false)
+}
+
+@SerialVersionUID(1L)
+private class DeserializationTripwire extends Serializable {
+  private def readObject(input: ObjectInputStream): Unit = {
+    DeserializationTripwire.Triggered.set(true)
+    input.defaultReadObject()
+  }
+}
+
+private class CloseTrackingInputStream(bytes: Array[Byte]) extends ByteArrayInputStream(bytes) {
+  var closed = false
+
+  override def close(): Unit = {
+    closed = true
+    super.close()
+  }
+}
+
+private class UnsafePayloadParam(parent: Params, name: String, doc: String)
+  extends ComplexParam[DeserializationTripwire](
+    parent,
+    name,
+    doc,
+    (_: DeserializationTripwire) => true
+  )
 
 class TestEstimatorBase(val uid: String) extends Transformer {
   def this() = this(Identifiable.randomUID("TestEstimatorBase"))
@@ -43,6 +80,14 @@ trait HasStringParam extends Params {
   def setStringParam(value: String): this.type = set(stringParam, value)
 }
 
+private trait HasUnsafePayloadParam extends Params {
+  val unsafePayload = new UnsafePayloadParam(this, "unsafePayload", "test-only unsafe payload")
+
+  def getUnsafePayload: DeserializationTripwire = $(unsafePayload)
+
+  def setUnsafePayload(value: DeserializationTripwire): this.type = set(unsafePayload, value)
+}
+
 class ComplexParamTest(override val uid: String) extends TestEstimatorBase(uid)
   with HasByteArrayParam with ComplexParamsWritable {
   def this() = this(Identifiable.randomUID("ComplexParamTest"))
@@ -64,9 +109,22 @@ class MixedParamTest(override val uid: String) extends TestEstimatorBase(uid)
 
 object MixedParamTest extends ComplexParamsReadable[MixedParamTest]
 
+private class UnsafeComplexParamTest(override val uid: String) extends TestEstimatorBase(uid)
+  with HasUnsafePayloadParam with ComplexParamsWritable {
+  def this() = this(Identifiable.randomUID("UnsafeComplexParamTest"))
+}
+
+private object UnsafeComplexParamTest extends ComplexParamsReadable[UnsafeComplexParamTest]
+
 class ValidateComplexParamSerializer extends TestBase {
   val saveFile = new File(tmpDir.toFile, "m1.model").toString
   val saveFile2 = new File(tmpDir.toFile, "m2.model").toString
+  private val legacyDeserializationConfig =
+    Serializer.LegacyObjectDeserializationConfig
+
+  private def restoreConfig(key: String, previous: Option[String]): Unit = {
+    previous.fold(spark.conf.unset(key))(spark.conf.set(key, _))
+  }
 
   test("Complex Param serialization should work on all complex, all normal, or mixed") {
     spark
@@ -141,6 +199,67 @@ class ValidateComplexParamSerializer extends TestBase {
 
     assert(new ObjectSerializer[Array[Byte]](spark).read(legacyPath) === obj)
     assert(Serializer.readFromHDFS[Array[Byte]](spark, legacyPath) === obj)
+  }
+
+  test("Serializer rejects unconstrained objects before deserialization callbacks run") {
+    val output = new ByteArrayOutputStream()
+    Serializer.write(new DeserializationTripwire, output)
+    DeserializationTripwire.Triggered.set(false)
+
+    assertThrows[SecurityException] {
+      Serializer.read[DeserializationTripwire](new ByteArrayInputStream(output.toByteArray))
+    }
+    assert(!DeserializationTripwire.Triggered.get())
+  }
+
+  test("Serializer closes malformed filtered streams") {
+    val input = new CloseTrackingInputStream(Array[Byte](0, 1, 2, 3))
+
+    assertThrows[StreamCorruptedException] {
+      Serializer.read[String](input, DeserializationClassFilter(
+        allowedClasses = Set(classOf[String].getName)
+      ))
+    }
+    assert(input.closed)
+  }
+
+  test("ComplexParam filters reject crafted payloads before deserialization callbacks run") {
+    spark
+    new MixedParamTest("filtered").setByteArray(Array[Byte](1, 2, 3)).setStringParam("safe")
+      .write.overwrite().save(saveFile)
+    val payloadPath = new Path(new File(saveFile, "complexParams/byteArray").toString)
+    Serializer.writeToHDFS(spark, new DeserializationTripwire, payloadPath, overwrite = true)
+    DeserializationTripwire.Triggered.set(false)
+
+    assertThrows[SecurityException] {
+      MixedParamTest.load(saveFile)
+    }
+    assert(!DeserializationTripwire.Triggered.get())
+  }
+
+  test("Unconstrained ComplexParams require explicit trusted legacy opt-in") {
+    spark
+    new UnsafeComplexParamTest("unsafe").setUnsafePayload(new DeserializationTripwire)
+      .write.overwrite().save(saveFile)
+    val config = legacyDeserializationConfig
+    val previous = spark.conf.getOption(config)
+    spark.conf.unset(config)
+    DeserializationTripwire.Triggered.set(false)
+
+    try {
+      val error = intercept[SecurityException] {
+        UnsafeComplexParamTest.load(saveFile)
+      }
+      assert(error.getMessage.contains(config))
+      assert(!DeserializationTripwire.Triggered.get())
+
+      spark.conf.set(config, "true")
+      val loaded = UnsafeComplexParamTest.load(saveFile)
+      assert(Option(loaded.getUnsafePayload).nonEmpty)
+      assert(DeserializationTripwire.Triggered.get())
+    } finally {
+      restoreConfig(config, previous)
+    }
   }
 
   override def afterAll(): Unit = {

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/core/serialize/ValidateComplexParamSerializer.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/core/serialize/ValidateComplexParamSerializer.scala
@@ -88,6 +88,12 @@ private trait HasUnsafePayloadParam extends Params {
   def setUnsafePayload(value: DeserializationTripwire): this.type = set(unsafePayload, value)
 }
 
+private class UnsafePayloadParams extends Params with HasUnsafePayloadParam {
+  override val uid: String = "unsafe-payload-params"
+
+  override def copy(extra: ParamMap): Params = this
+}
+
 class ComplexParamTest(override val uid: String) extends TestEstimatorBase(uid)
   with HasByteArrayParam with ComplexParamsWritable {
   def this() = this(Identifiable.randomUID("ComplexParamTest"))
@@ -109,13 +115,6 @@ class MixedParamTest(override val uid: String) extends TestEstimatorBase(uid)
 
 object MixedParamTest extends ComplexParamsReadable[MixedParamTest]
 
-private class UnsafeComplexParamTest(override val uid: String) extends TestEstimatorBase(uid)
-  with HasUnsafePayloadParam with ComplexParamsWritable {
-  def this() = this(Identifiable.randomUID("UnsafeComplexParamTest"))
-}
-
-private object UnsafeComplexParamTest extends ComplexParamsReadable[UnsafeComplexParamTest]
-
 class ValidateComplexParamSerializer extends TestBase {
   val saveFile = new File(tmpDir.toFile, "m1.model").toString
   val saveFile2 = new File(tmpDir.toFile, "m2.model").toString
@@ -124,6 +123,17 @@ class ValidateComplexParamSerializer extends TestBase {
 
   private def restoreConfig(key: String, previous: Option[String]): Unit = {
     previous.fold(spark.conf.unset(key))(spark.conf.set(key, _))
+  }
+
+  private def withoutLegacyDeserialization[T](action: => T): T = {
+    val config = legacyDeserializationConfig
+    val previous = spark.conf.getOption(config)
+    spark.conf.unset(config)
+    try {
+      action
+    } finally {
+      restoreConfig(config, previous)
+    }
   }
 
   test("Complex Param serialization should work on all complex, all normal, or mixed") {
@@ -231,16 +241,19 @@ class ValidateComplexParamSerializer extends TestBase {
     Serializer.writeToHDFS(spark, new DeserializationTripwire, payloadPath, overwrite = true)
     DeserializationTripwire.Triggered.set(false)
 
-    assertThrows[SecurityException] {
-      MixedParamTest.load(saveFile)
+    withoutLegacyDeserialization {
+      assertThrows[SecurityException] {
+        MixedParamTest.load(saveFile)
+      }
+      assert(!DeserializationTripwire.Triggered.get())
     }
-    assert(!DeserializationTripwire.Triggered.get())
   }
 
   test("Unconstrained ComplexParams require explicit trusted legacy opt-in") {
     spark
-    new UnsafeComplexParamTest("unsafe").setUnsafePayload(new DeserializationTripwire)
-      .write.overwrite().save(saveFile)
+    val holder = new UnsafePayloadParams
+    val payloadPath = new Path(new File(tmpDir.toFile, "unsafe-payload").toString)
+    holder.unsafePayload.save(new DeserializationTripwire, spark, payloadPath, overwrite = true)
     val config = legacyDeserializationConfig
     val previous = spark.conf.getOption(config)
     spark.conf.unset(config)
@@ -248,14 +261,14 @@ class ValidateComplexParamSerializer extends TestBase {
 
     try {
       val error = intercept[SecurityException] {
-        UnsafeComplexParamTest.load(saveFile)
+        holder.unsafePayload.load(spark, payloadPath)
       }
       assert(error.getMessage.contains(config))
       assert(!DeserializationTripwire.Triggered.get())
 
       spark.conf.set(config, "true")
-      val loaded = UnsafeComplexParamTest.load(saveFile)
-      assert(Option(loaded.getUnsafePayload).nonEmpty)
+      val loaded = holder.unsafePayload.load(spark, payloadPath)
+      assert(Option(loaded).nonEmpty)
       assert(DeserializationTripwire.Triggered.get())
     } finally {
       restoreConfig(config, previous)

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/core/serialize/ValidateComplexParamSerializer.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/core/serialize/ValidateComplexParamSerializer.scala
@@ -5,7 +5,10 @@ package com.microsoft.azure.synapse.ml.core.serialize
 
 import com.microsoft.azure.synapse.ml.core.env.StreamUtilities.using
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
-import com.microsoft.azure.synapse.ml.core.utils.DeserializationClassFilter
+import com.microsoft.azure.synapse.ml.core.utils.{
+  DeserializationClassFilter,
+  DeserializationClassRejectedException
+}
 import com.microsoft.azure.synapse.ml.param.ByteArrayParam
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.Path
@@ -19,9 +22,11 @@ import java.io.{
   ByteArrayInputStream,
   ByteArrayOutputStream,
   File,
+  InvalidClassException,
   ObjectInputStream,
   StreamCorruptedException
 }
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicBoolean
 
 private object DeserializationTripwire {
@@ -44,6 +49,9 @@ private class CloseTrackingInputStream(bytes: Array[Byte]) extends ByteArrayInpu
     super.close()
   }
 }
+
+@SerialVersionUID(1L)
+private class VersionedPayload extends Serializable
 
 private class UnsafePayloadParam(parent: Params, name: String, doc: String)
   extends ComplexParam[DeserializationTripwire](
@@ -231,6 +239,35 @@ class ValidateComplexParamSerializer extends TestBase {
       ))
     }
     assert(input.closed)
+  }
+
+  test("Serializer preserves ordinary Java compatibility failures") {
+    spark
+    val output = new ByteArrayOutputStream()
+    Serializer.write(new VersionedPayload, output)
+    val serialized = output.toByteArray
+    val className = classOf[VersionedPayload].getName
+    val classNameBytes = className.getBytes(StandardCharsets.UTF_8)
+    val classNameIndex = serialized.indexOfSlice(classNameBytes)
+    assert(classNameIndex >= 0)
+    serialized(classNameIndex + classNameBytes.length + java.lang.Long.BYTES - 1) = 2
+
+    val path = new Path(new File(tmpDir.toFile, "incompatible-object").toString)
+    using(path.getFileSystem(spark.sparkContext.hadoopConfiguration).create(path, true)) { stream =>
+      stream.write(serialized)
+    }.get
+
+    withoutLegacyDeserialization {
+      val error = intercept[InvalidClassException] {
+        Serializer.readFromHDFS[VersionedPayload](
+          spark,
+          path,
+          DeserializationClassFilter(allowedClasses = Set(className))
+        )
+      }
+      assert(error.classname === className)
+      assert(!error.isInstanceOf[DeserializationClassRejectedException])
+    }
   }
 
   test("ComplexParam filters reject crafted payloads before deserialization callbacks run") {

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/core/test/base/TestBase.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/core/test/base/TestBase.scala
@@ -51,6 +51,8 @@ trait SparkSessionManagement {
       .set("spark.driver.maxResultSize", "6g")
       .set("spark.sql.crossJoin.enabled", "true")
       .set("spark.sql.warehouse.dir", localWarehousePath)
+      // Repository test fixtures are generated locally; security tests explicitly disable this.
+      .set(Serializer.LegacyObjectDeserializationConfig, "true")
   }
 
   def getSession(name: String,

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/core/test/fuzzing/Fuzzing.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/core/test/fuzzing/Fuzzing.scala
@@ -198,6 +198,7 @@ trait PyTestFuzzing[S <: PipelineStage] extends TestBase with DataFrameEquality 
          |from pyspark.ml import PipelineModel
          |
          |spark = init_spark()
+         |spark.conf.set("spark.synapseml.legacy.allowUnsafeJavaDeserialization", "true")
          |sc = SQLContext(spark.sparkContext)
          |
          |test_data_dir = "${pyTestDataDir(conf).toString.replaceAllLiterally("\\", "\\\\")}"
@@ -540,27 +541,14 @@ trait SerializationFuzzing[S <: PipelineStage with MLWritable] extends TestBase 
 
   val retrySerializationFuzzing = false
 
-  private def withTrustedTestArtifact[T](action: => T): T = {
-    val config = Serializer.LegacyObjectDeserializationConfig
-    val previous = spark.conf.getOption(config)
-    spark.conf.set(config, "true")
-    try {
-      action
-    } finally {
-      previous.fold(spark.conf.unset(config))(spark.conf.set(config, _))
-    }
-  }
-
   test("Serialization Fuzzing") {
     if (!ignoreSerializationFuzzing) {
-      withTrustedTestArtifact {
-        if (retrySerializationFuzzing) {
-          tryWithRetries() { () =>
-            testSerialization()
-          }
-        } else {
+      if (retrySerializationFuzzing) {
+        tryWithRetries() { () =>
           testSerialization()
         }
+      } else {
+        testSerialization()
       }
     }
   }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/core/test/fuzzing/Fuzzing.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/core/test/fuzzing/Fuzzing.scala
@@ -540,14 +540,27 @@ trait SerializationFuzzing[S <: PipelineStage with MLWritable] extends TestBase 
 
   val retrySerializationFuzzing = false
 
+  private def withTrustedTestArtifact[T](action: => T): T = {
+    val config = Serializer.LegacyObjectDeserializationConfig
+    val previous = spark.conf.getOption(config)
+    spark.conf.set(config, "true")
+    try {
+      action
+    } finally {
+      previous.fold(spark.conf.unset(config))(spark.conf.set(config, _))
+    }
+  }
+
   test("Serialization Fuzzing") {
     if (!ignoreSerializationFuzzing) {
-      if (retrySerializationFuzzing) {
-        tryWithRetries() { () =>
+      withTrustedTestArtifact {
+        if (retrySerializationFuzzing) {
+          tryWithRetries() { () =>
+            testSerialization()
+          }
+        } else {
           testSerialization()
         }
-      } else {
-        testSerialization()
       }
     }
   }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nn/VerifySchemas.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nn/VerifySchemas.scala
@@ -10,6 +10,7 @@ import com.microsoft.azure.synapse.ml.core.env.StreamUtilities.using
 import com.microsoft.azure.synapse.ml.core.utils.SafeObjectInputStream
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectOutputStream}
+import java.lang.invoke.{MethodHandleInfo, SerializedLambda}
 
 class VerifySchemas extends TestBase {
 
@@ -144,6 +145,33 @@ class VerifySchemas extends TestBase {
     val result = using(new SafeObjectInputStream(bais, Set("com.microsoft.azure.synapse.ml.nn."))) { ois =>
       ois.readObject()
     }
+    assert(result.isFailure)
+    assert(result.failed.get.isInstanceOf[java.io.InvalidClassException])
+  }
+
+  test("SafeObjectInputStream rejects SerializedLambda even through an allowed prefix") {
+    val serializedLambda = new SerializedLambda(
+      getClass,
+      "scala/Function0",
+      "apply",
+      "()Ljava/lang/Object;",
+      MethodHandleInfo.REF_invokeStatic,
+      getClass.getName.replace('.', '/'),
+      "unused",
+      "()Ljava/lang/Object;",
+      "()Ljava/lang/Object;",
+      Array.empty[AnyRef]
+    )
+    val output = new ByteArrayOutputStream()
+    using(new ObjectOutputStream(output))(_.writeObject(serializedLambda)).get
+
+    val result = using(
+      new SafeObjectInputStream(
+        new ByteArrayInputStream(output.toByteArray),
+        Set("java.lang.")
+      )
+    )(_.readObject())
+
     assert(result.isFailure)
     assert(result.failed.get.isInstanceOf[java.io.InvalidClassException])
   }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/nn/VerifySchemas.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/nn/VerifySchemas.scala
@@ -7,10 +7,20 @@ import breeze.linalg.DenseVector
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 
 import com.microsoft.azure.synapse.ml.core.env.StreamUtilities.using
-import com.microsoft.azure.synapse.ml.core.utils.SafeObjectInputStream
+import com.microsoft.azure.synapse.ml.core.utils.{DeserializationClassFilter, SafeObjectInputStream}
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectOutputStream}
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InvalidClassException, ObjectOutputStream}
 import java.lang.invoke.{MethodHandleInfo, SerializedLambda}
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.util.Try
+
+private object ModuleInitializationState {
+  val Triggered = new AtomicBoolean(false)
+}
+
+private object RejectedModuleInitializationTripwire {
+  ModuleInitializationState.Triggered.set(true)
+}
 
 class VerifySchemas extends TestBase {
 
@@ -174,6 +184,32 @@ class VerifySchemas extends TestBase {
 
     assert(result.isFailure)
     assert(result.failed.get.isInstanceOf[java.io.InvalidClassException])
+  }
+
+  test("SafeObjectInputStream validates a ModuleSerializationProxy target before initialization") {
+    Try(Class.forName("scala.runtime.ModuleSerializationProxy")).toOption.foreach { proxyClass =>
+      ModuleInitializationState.Triggered.set(false)
+      val moduleClass = Class.forName(
+        s"${getClass.getPackage.getName}.RejectedModuleInitializationTripwire$$",
+        false,
+        getClass.getClassLoader
+      )
+      val proxy = proxyClass.getConstructor(classOf[Class[_]]).newInstance(moduleClass)
+      val output = new ByteArrayOutputStream()
+      using(new ObjectOutputStream(output))(_.writeObject(proxy)).get
+
+      val result = using(
+        new SafeObjectInputStream(
+          new ByteArrayInputStream(output.toByteArray),
+          DeserializationClassFilter(allowedClasses = Set(proxyClass.getName))
+        )
+      )(_.readObject())
+
+      assert(result.isFailure)
+      val error = result.failed.get.asInstanceOf[InvalidClassException]
+      assert(error.classname === moduleClass.getName)
+      assert(!ModuleInitializationState.Triggered.get())
+    }
   }
 
 }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/param/VerifyDataTypeParam.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/param/VerifyDataTypeParam.scala
@@ -3,11 +3,26 @@
 
 package com.microsoft.azure.synapse.ml.param
 
+import com.microsoft.azure.synapse.ml.core.env.StreamUtilities.using
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import org.apache.hadoop.fs.Path
+import org.apache.spark.ml.Serializer
+import org.apache.spark.ml.linalg.SQLDataTypes
 import org.apache.spark.ml.param.{ParamMap, Params}
 import org.apache.spark.sql.types._
 
+import java.io.File
+
+private class TestStringUDT extends UserDefinedType[String] {
+  override def sqlType: DataType = StringType
+  override def serialize(obj: String): Any = obj
+  override def deserialize(datum: Any): String = datum.asInstanceOf[String]
+  override def userClass: Class[String] = classOf[String]
+}
+
 class VerifyDataTypeParam extends TestBase {
+  private val legacyDeserializationConfig =
+    Serializer.LegacyObjectDeserializationConfig
 
   private class TestParamsHolder extends Params {
     override val uid: String = "test-holder"
@@ -122,5 +137,43 @@ class VerifyDataTypeParam extends TestBase {
     assert(holder.isSet(holder.dataTypeParam))
     holder.clear(holder.dataTypeParam)
     assert(!holder.isSet(holder.dataTypeParam))
+  }
+
+  test("DataTypeParam preserves the legacy format for standard data types") {
+    val holder = new TestParamsHolder
+    val path = new Path(new File(tmpDir.toFile, "standard-data-type").toString)
+    val expected = StructType(Seq(
+      StructField("values", ArrayType(DecimalType(12, 4))),
+      StructField("features", SQLDataTypes.VectorType)
+    ))
+
+    holder.dataTypeParam.save(expected, spark, path, overwrite = true)
+
+    using(path.getFileSystem(spark.sparkContext.hadoopConfiguration).open(path)) { input =>
+      assert(input.read() === 0xac)
+      assert(input.read() === 0xed)
+    }.get
+    assert(holder.dataTypeParam.load(spark, path) === expected)
+  }
+
+  test("DataTypeParam requires explicit trust for custom data types") {
+    val holder = new TestParamsHolder
+    val path = new Path(new File(tmpDir.toFile, "custom-data-type").toString)
+    val config = legacyDeserializationConfig
+    val previous = spark.conf.getOption(config)
+    holder.dataTypeParam.save(new TestStringUDT, spark, path, overwrite = true)
+    spark.conf.unset(config)
+
+    try {
+      val error = intercept[SecurityException] {
+        holder.dataTypeParam.load(spark, path)
+      }
+      assert(error.getMessage.contains(config))
+
+      spark.conf.set(config, "true")
+      assert(holder.dataTypeParam.load(spark, path).isInstanceOf[TestStringUDT])
+    } finally {
+      previous.fold(spark.conf.unset(config))(spark.conf.set(config, _))
+    }
   }
 }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/param/VerifyDataTypeParam.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/param/VerifyDataTypeParam.scala
@@ -148,12 +148,20 @@ class VerifyDataTypeParam extends TestBase {
     ))
 
     holder.dataTypeParam.save(expected, spark, path, overwrite = true)
+    val previous = spark.conf.getOption(legacyDeserializationConfig)
+    spark.conf.unset(legacyDeserializationConfig)
 
-    using(path.getFileSystem(spark.sparkContext.hadoopConfiguration).open(path)) { input =>
-      assert(input.read() === 0xac)
-      assert(input.read() === 0xed)
-    }.get
-    assert(holder.dataTypeParam.load(spark, path) === expected)
+    try {
+      using(path.getFileSystem(spark.sparkContext.hadoopConfiguration).open(path)) { input =>
+        assert(input.read() === 0xac)
+        assert(input.read() === 0xed)
+      }.get
+      assert(holder.dataTypeParam.load(spark, path) === expected)
+    } finally {
+      previous.fold(spark.conf.unset(legacyDeserializationConfig))(
+        spark.conf.set(legacyDeserializationConfig, _)
+      )
+    }
   }
 
   test("DataTypeParam requires explicit trust for custom data types") {

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/stages/UDFTransformerSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/stages/UDFTransformerSuite.scala
@@ -5,11 +5,14 @@ package com.microsoft.azure.synapse.ml.stages
 
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 import com.microsoft.azure.synapse.ml.core.test.fuzzing.{TestObject, TransformerFuzzing}
+import org.apache.spark.ml.Serializer
 import org.apache.spark.ml.util.MLReadable
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.udf
 import org.scalatest.Assertion
+
+import java.io.File
 
 class UDFTransformerSuite extends TestBase with TransformerFuzzing[UDFTransformer] {
   lazy val baseDF: DataFrame = makeBasicDF()
@@ -100,6 +103,29 @@ class UDFTransformerSuite extends TestBase with TransformerFuzzing[UDFTransforme
       val inColName = "doubles"
       val inColNames = Array("doubles", "longs")
       new UDFTransformer().setInputCols(inColNames).setInputCol(inColName)
+    }
+  }
+
+  test("Persisted UDFs require explicit trusted legacy opt-in") {
+    val path = new File(tmpDir.toFile, "trusted-udf.model")
+    val transformer = new UDFTransformer().setUDF(stringToIntegerUDF)
+      .setInputCol("words").setOutputCol(outCol)
+    val config = Serializer.LegacyObjectDeserializationConfig
+    val previous = spark.conf.getOption(config)
+    transformer.write.overwrite().save(path.toString)
+    spark.conf.unset(config)
+
+    try {
+      val error = intercept[SecurityException] {
+        UDFTransformer.load(path.toString)
+      }
+      assert(error.getMessage.contains(config))
+
+      spark.conf.set(config, "true")
+      val loaded = UDFTransformer.load(path.toString)
+      assertDFEq(transformer.transform(baseDF), loaded.transform(baseDF))
+    } finally {
+      previous.fold(spark.conf.unset(config))(spark.conf.set(config, _))
     }
   }
 

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/stages/UDFTransformerSuite.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/stages/UDFTransformerSuite.scala
@@ -5,14 +5,11 @@ package com.microsoft.azure.synapse.ml.stages
 
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 import com.microsoft.azure.synapse.ml.core.test.fuzzing.{TestObject, TransformerFuzzing}
-import org.apache.spark.ml.Serializer
 import org.apache.spark.ml.util.MLReadable
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.udf
 import org.scalatest.Assertion
-
-import java.io.File
 
 class UDFTransformerSuite extends TestBase with TransformerFuzzing[UDFTransformer] {
   lazy val baseDF: DataFrame = makeBasicDF()
@@ -103,29 +100,6 @@ class UDFTransformerSuite extends TestBase with TransformerFuzzing[UDFTransforme
       val inColName = "doubles"
       val inColNames = Array("doubles", "longs")
       new UDFTransformer().setInputCols(inColNames).setInputCol(inColName)
-    }
-  }
-
-  test("Persisted UDFs require explicit trusted legacy opt-in") {
-    val path = new File(tmpDir.toFile, "trusted-udf.model")
-    val transformer = new UDFTransformer().setUDF(stringToIntegerUDF)
-      .setInputCol("words").setOutputCol(outCol)
-    val config = Serializer.LegacyObjectDeserializationConfig
-    val previous = spark.conf.getOption(config)
-    transformer.write.overwrite().save(path.toString)
-    spark.conf.unset(config)
-
-    try {
-      val error = intercept[SecurityException] {
-        UDFTransformer.load(path.toString)
-      }
-      assert(error.getMessage.contains(config))
-
-      spark.conf.set(config, "true")
-      val loaded = UDFTransformer.load(path.toString)
-      assertDFEq(transformer.transform(baseDF), loaded.transform(baseDF))
-    } finally {
-      previous.fold(spark.conf.unset(config))(spark.conf.set(config, _))
     }
   }
 

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/stages/VerifyUDFTransformerPersistence.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/stages/VerifyUDFTransformerPersistence.scala
@@ -1,0 +1,44 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.stages
+
+import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import org.apache.spark.ml.Serializer
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.functions.udf
+
+import java.io.File
+
+private object UDFPersistenceTestHelpers {
+  val StringToIntegerUDF: UserDefinedFunction = udf((_: String) => 1)
+}
+
+class VerifyUDFTransformerPersistence extends TestBase {
+
+  test("Persisted UDFs require explicit trusted legacy opt-in") {
+    import spark.implicits._
+
+    val path = new File(tmpDir.toFile, "trusted-udf.model")
+    val transformer = new UDFTransformer().setUDF(UDFPersistenceTestHelpers.StringToIntegerUDF)
+      .setInputCol("words").setOutputCol("out")
+    val config = Serializer.LegacyObjectDeserializationConfig
+    val previous = spark.conf.getOption(config)
+    val input = Seq("safe").toDF("words")
+    transformer.write.overwrite().save(path.toString)
+    spark.conf.unset(config)
+
+    try {
+      val error = intercept[SecurityException] {
+        UDFTransformer.load(path.toString)
+      }
+      assert(error.getMessage.contains(config))
+
+      spark.conf.set(config, "true")
+      val loaded = UDFTransformer.load(path.toString)
+      assert(loaded.transform(input).select("out").as[Int].collect().sameElements(Array(1)))
+    } finally {
+      previous.fold(spark.conf.unset(config))(spark.conf.set(config, _))
+    }
+  }
+}

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/LightGBMBoosterParam.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/LightGBMBoosterParam.scala
@@ -4,6 +4,7 @@
 package com.microsoft.azure.synapse.ml.lightgbm.params
 
 import com.microsoft.azure.synapse.ml.core.serialize.ComplexParam
+import com.microsoft.azure.synapse.ml.core.utils.DeserializationClassFilter
 import com.microsoft.azure.synapse.ml.lightgbm.booster.LightGBMBooster
 import com.microsoft.azure.synapse.ml.param.WrappableParam
 import org.apache.spark.ml.param.Params
@@ -19,5 +20,17 @@ class LightGBMBoosterParam(parent: Params, name: String, doc: String,
   def this(parent: Params, name: String, doc: String) =
     this(parent, name, doc, { _ => true })
 
+  override protected def deserializationClassFilter: Option[DeserializationClassFilter] = {
+    Some(DeserializationClassFilter(
+      allowedClasses = Set(
+        classOf[LightGBMBooster].getName,
+        "java.lang.String",
+        "scala.None$",
+        "scala.Option",
+        "scala.Some",
+        "scala.runtime.ModuleSerializationProxy"
+      )
+    ))
+  }
 
 }

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split6/VerifyLightGBMBoosterParam.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split6/VerifyLightGBMBoosterParam.scala
@@ -27,6 +27,9 @@ private class BoosterDeserializationTripwire extends Serializable {
 
 class VerifyLightGBMBoosterParam extends TestBase {
 
+  private val legacyDeserializationConfig =
+    Serializer.LegacyObjectDeserializationConfig
+
   private class TestParamsHolder extends Params {
     override val uid: String = "lightgbm-booster-holder"
     val booster = new LightGBMBoosterParam(this, "booster", "A LightGBM booster param")
@@ -55,10 +58,18 @@ class VerifyLightGBMBoosterParam extends TestBase {
       overwrite = true
     )
     BoosterDeserializationTripwire.Triggered.set(false)
+    val previous = spark.conf.getOption(legacyDeserializationConfig)
+    spark.conf.unset(legacyDeserializationConfig)
 
-    assertThrows[SecurityException] {
-      holder.booster.load(spark, path)
+    try {
+      assertThrows[SecurityException] {
+        holder.booster.load(spark, path)
+      }
+      assert(!BoosterDeserializationTripwire.Triggered.get())
+    } finally {
+      previous.fold(spark.conf.unset(legacyDeserializationConfig))(
+        spark.conf.set(legacyDeserializationConfig, _)
+      )
     }
-    assert(!BoosterDeserializationTripwire.Triggered.get())
   }
 }

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split6/VerifyLightGBMBoosterParam.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split6/VerifyLightGBMBoosterParam.scala
@@ -30,6 +30,18 @@ class VerifyLightGBMBoosterParam extends TestBase {
   private val legacyDeserializationConfig =
     Serializer.LegacyObjectDeserializationConfig
 
+  private def withoutLegacyDeserialization[T](action: => T): T = {
+    val previous = spark.conf.getOption(legacyDeserializationConfig)
+    spark.conf.unset(legacyDeserializationConfig)
+    try {
+      action
+    } finally {
+      previous.fold(spark.conf.unset(legacyDeserializationConfig))(
+        spark.conf.set(legacyDeserializationConfig, _)
+      )
+    }
+  }
+
   private class TestParamsHolder extends Params {
     override val uid: String = "lightgbm-booster-holder"
     val booster = new LightGBMBoosterParam(this, "booster", "A LightGBM booster param")
@@ -43,9 +55,11 @@ class VerifyLightGBMBoosterParam extends TestBase {
     val expected = new LightGBMBooster("model-data")
 
     holder.booster.save(expected, spark, path, overwrite = true)
-    val loaded = holder.booster.load(spark, path)
 
-    assert(loaded.getNativeModel() === expected.getNativeModel())
+    withoutLegacyDeserialization {
+      val loaded = holder.booster.load(spark, path)
+      assert(loaded.getNativeModel() === expected.getNativeModel())
+    }
   }
 
   test("LightGBMBoosterParam rejects classes outside its policy before callbacks run") {
@@ -58,18 +72,12 @@ class VerifyLightGBMBoosterParam extends TestBase {
       overwrite = true
     )
     BoosterDeserializationTripwire.Triggered.set(false)
-    val previous = spark.conf.getOption(legacyDeserializationConfig)
-    spark.conf.unset(legacyDeserializationConfig)
 
-    try {
+    withoutLegacyDeserialization {
       assertThrows[SecurityException] {
         holder.booster.load(spark, path)
       }
       assert(!BoosterDeserializationTripwire.Triggered.get())
-    } finally {
-      previous.fold(spark.conf.unset(legacyDeserializationConfig))(
-        spark.conf.set(legacyDeserializationConfig, _)
-      )
     }
   }
 }

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split6/VerifyLightGBMBoosterParam.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split6/VerifyLightGBMBoosterParam.scala
@@ -1,0 +1,64 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.lightgbm.split6
+
+import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import com.microsoft.azure.synapse.ml.lightgbm.booster.LightGBMBooster
+import com.microsoft.azure.synapse.ml.lightgbm.params.LightGBMBoosterParam
+import org.apache.hadoop.fs.Path
+import org.apache.spark.ml.Serializer
+import org.apache.spark.ml.param.{ParamMap, Params}
+
+import java.io.{File, ObjectInputStream}
+import java.util.concurrent.atomic.AtomicBoolean
+
+private object BoosterDeserializationTripwire {
+  val Triggered = new AtomicBoolean(false)
+}
+
+@SerialVersionUID(1L)
+private class BoosterDeserializationTripwire extends Serializable {
+  private def readObject(input: ObjectInputStream): Unit = {
+    BoosterDeserializationTripwire.Triggered.set(true)
+    input.defaultReadObject()
+  }
+}
+
+class VerifyLightGBMBoosterParam extends TestBase {
+
+  private class TestParamsHolder extends Params {
+    override val uid: String = "lightgbm-booster-holder"
+    val booster = new LightGBMBoosterParam(this, "booster", "A LightGBM booster param")
+
+    override def copy(extra: ParamMap): Params = this
+  }
+
+  test("LightGBMBoosterParam loads its constrained legacy object graph") {
+    val holder = new TestParamsHolder
+    val path = new Path(new File(tmpDir.toFile, "booster").toString)
+    val expected = new LightGBMBooster("model-data")
+
+    holder.booster.save(expected, spark, path, overwrite = true)
+    val loaded = holder.booster.load(spark, path)
+
+    assert(loaded.getNativeModel() === expected.getNativeModel())
+  }
+
+  test("LightGBMBoosterParam rejects classes outside its policy before callbacks run") {
+    val holder = new TestParamsHolder
+    val path = new Path(new File(tmpDir.toFile, "crafted-booster").toString)
+    Serializer.writeToHDFS(
+      spark,
+      new BoosterDeserializationTripwire,
+      path,
+      overwrite = true
+    )
+    BoosterDeserializationTripwire.Triggered.set(false)
+
+    assertThrows[SecurityException] {
+      holder.booster.load(spark, path)
+    }
+    assert(!BoosterDeserializationTripwire.Triggered.get())
+  }
+}


### PR DESCRIPTION
## Related issues and context

Follow-up to #2513 and the remaining MSRC recommendation in IcM 31000000568481.

## What does this pull request change?

This PR closes the remaining unrestricted Java deserialization path used by
`ComplexParam` model persistence. Previously, a crafted model artifact could
run a deserialization callback before the loaded object reached its eventual
type cast.

The change:

- makes unfiltered `Serializer.read` and model-loading paths fail closed;
- passes an optional, type-specific `DeserializationClassFilter` from
  `ComplexParam` into the existing serializer;
- adds constrained policies for `Array[Byte]`, Spark SQL/ML data types, and
  `LightGBMBooster`;
- validates object-array component classes and dynamic-proxy interfaces;
- rejects `SerializedLambda`, including when a broader `java.lang.` prefix is
  otherwise required;
- preserves explicit `readUnsafe` and `readFromHDFSUnsafe` APIs for artifacts
  the caller has independently established as trusted; and
- provides the opt-in
  `spark.synapseml.legacy.allowUnsafeJavaDeserialization=true` compatibility
  switch for trusted legacy model artifacts.

The legacy switch restores unrestricted Java deserialization and is therefore
disabled by default. It must not be enabled for untrusted or externally
supplied artifacts.

### Behavior and compatibility

- Writers and serialized bytes are unchanged.
- Existing standard data types remain Java object streams.
- Pipeline stage, pipeline array, and DataFrame serializers are unchanged.
- Existing `SafeObjectInputStream(InputStream, Set[String])` and `Serializer`
  overloads remain available.
- Policy rejections use a dedicated `InvalidClassException` subtype, so normal
  Java compatibility errors such as `serialVersionUID` mismatches retain their
  original exception behavior.
- Open-ended legacy values, including persisted UDF closures and custom UDTs,
  now require explicit trusted-legacy opt-in.

This PR does not change model metadata or paths, native Spark pipeline
persistence, Python/R loaders, dependencies, workflows, release tooling, or
the on-disk format.

### What to review

Reviewers should check:

1. whether each built-in object graph has the narrowest practical class policy;
2. whether every safe-to-unsafe fallback requires explicit trusted-artifact
   intent;
3. whether array, dynamic-proxy, Scala module-proxy, and `SerializedLambda`
   handling prevents callbacks before policy rejection; and
4. whether existing model artifacts retain the documented compatibility path
   without weakening the secure default.

## How was this patch validated?

- [x] Reproduced the vulnerable baseline: direct and `ComplexParam` loads ran
      crafted `readObject` callbacks before failing.
- [x] Ran focused security, compatibility, persistence, DataType, LightGBM,
      UDF persistence, model equality, and fuzzing tests on the `master`
      baseline.
- [x] Ran the exact 14-file change set against the Spark 4.0 and Spark 4.1
      compatibility branches, including Scala module-proxy and ordinary Java
      compatibility-error regressions.
- [x] Ran Core and LightGBM main/test Scalastyle, code generation,
      generated-wrapper configuration checks, pinned Black, and
      `git diff --check`.
- [x] Completed exact-head GitHub and Azure validation.

Azure build
[234437857](https://msdata.visualstudio.com/A365/_build/results?buildId=234437857&view=results)
validated merge commit `9e21e0b1f53b70f4d300ec8aa90414f47be04f80`
with exact PR head `c2b3d78d23fbf42180e3a9b0dc849b58c8004f74`.
Every published job check is green. The Azure aggregate remains
`partiallySucceeded` because the first `PythonTests deep-learning-hf` attempt
failed before product execution when `msdata.visualstudio.com` presented an
unrelated `*.azureedge.net` certificate; the selective retry passed.

The regressions prove fail-closed rejection before callbacks, legitimate
round-trips with unsafe fallback disabled, unchanged Java stream bytes,
trusted compatibility for persisted UDFs and custom UDTs, stream cleanup,
proxy and array filtering, preserved ordinary Java serialization errors, and
Scala 2.12/2.13 LightGBM object graphs.

## Does this PR change any dependencies?

- [x] No.
- [ ] Yes.

## Does this PR add a new user-facing feature?

- [x] No. This is a security hardening and compatibility change.
- [ ] Yes.
