### PR TITLE
fix: propagate LightGBM iteration failures

### DIFF
--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/TrainUtils.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/TrainUtils.scala
@@ -107,10 +107,8 @@ private[lightgbm] object TrainUtils extends Serializable {
       }
     } catch {
       case e: java.lang.Exception =>
-        log.warn("LightGBM reached early termination on one task," +
-          " stopping training on task. This message should rarely occur." +
-          " Inner exception: " + e.toString)
-        state.isFinished = true
+        log.error("LightGBM iteration failed; propagating the task failure", e)
+        throw e
     }
   }
 

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/TrainUtilsSuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/TrainUtilsSuite.scala
@@ -3,7 +3,13 @@
 
 package com.microsoft.azure.synapse.ml.lightgbm.split1
 
-import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMRegressor, NetworkManager, TrainUtils}
+import com.microsoft.azure.synapse.ml.io.http.SharedSingleton
+import com.microsoft.azure.synapse.ml.lightgbm.booster.LightGBMBooster
+import com.microsoft.azure.synapse.ml.lightgbm.{ColumnParams, LightGBMRegressor, NetworkManager, NetworkParams,
+  NetworkTopologyInfo, PartitionTaskContext, PartitionTaskTrainingState, SharedState, TaskInstrumentationMeasures,
+  TrainingContext, TrainUtils}
+import org.apache.spark.ml.linalg.SQLDataTypes
+import org.apache.spark.sql.types.{StructField, StructType}
 import org.scalatest.funsuite.AnyFunSuite
 import org.slf4j.LoggerFactory
 
@@ -42,6 +48,40 @@ class TrainUtilsSuite extends AnyFunSuite {
     "average_precision")
 
   private val tolerances = Seq(0.0, 0.25, 2.0, 25.0)
+
+  private def trainingState(booster: LightGBMBooster): PartitionTaskTrainingState = {
+    val featuresField = StructField("features", SQLDataTypes.VectorType)
+    val trainParams = new LightGBMRegressor().getTrainParams(
+      numTasks = 1,
+      featuresSchema = featuresField,
+      numTasksPerExec = 1)
+    val trainingContext = TrainingContext(
+      batchIndex = 0,
+      sharedStateSingleton = SharedSingleton(new SharedState(trainParams)),
+      schema = StructType(Seq(featuresField)),
+      numCols = 1,
+      numInitScoreClasses = 0,
+      trainingParams = trainParams,
+      networkParams = NetworkParams(12400, "127.0.0.1", 12400, barrierExecutionMode = false),
+      columnParams = ColumnParams("label", "features", None, None, None),
+      datasetParams = "",
+      featureNames = None,
+      numTasksPerExecutor = 1,
+      validationData = None,
+      serializedReferenceDataset = None,
+      partitionCounts = Some(Array(1L)))
+    val taskContext = PartitionTaskContext(
+      trainingCtx = trainingContext,
+      partitionId = 0,
+      taskId = 0L,
+      measures = new TaskInstrumentationMeasures(0),
+      networkTopologyInfo = NetworkTopologyInfo("127.0.0.1:12400", Array(0), 12400),
+      shouldExecuteTraining = true,
+      isEmptyPartition = false,
+      shouldReturnBooster = true,
+      shouldCalcValidationDataset = false)
+    PartitionTaskTrainingState(taskContext, booster)
+  }
 
   test("Improvement tolerance is symmetric across metrics and tolerance values") {
     val bestScore = 100.0
@@ -144,6 +184,21 @@ class TrainUtilsSuite extends AnyFunSuite {
     assert(!TrainUtils.shouldStopEarly(iteration = 4, bestIteration = 0, earlyStoppingRound = 5))
     assert(TrainUtils.shouldStopEarly(iteration = 5, bestIteration = 0, earlyStoppingRound = 5))
     assert(TrainUtils.shouldStopEarly(iteration = 10, bestIteration = 5, earlyStoppingRound = 5))
+  }
+
+  test("Iteration failures propagate instead of becoming early termination") {
+    val expected = new RuntimeException("native iteration failed")
+    val booster = new LightGBMBooster() {
+      override def updateOneIteration(): Boolean = throw expected
+    }
+    val state = trainingState(booster)
+
+    val actual = intercept[RuntimeException] {
+      TrainUtils.updateOneIteration(state, log)
+    }
+
+    assert(actual eq expected)
+    assert(!state.isFinished)
   }
 
   test("Early stopping parameters accept valid values and reject invalid values") {


### PR DESCRIPTION
## Related Issues/PRs

Related to #569 and #728.

This PR addresses the error-handling behavior described in those issues. It does
not attempt to resolve the underlying causes of worker or network failures.

## What changes are proposed in this pull request?

`TrainUtils.updateOneIteration` currently catches exceptions raised during a
LightGBM iteration and sets `state.isFinished = true`.

This makes an iteration failure indistinguishable from legitimate training
completion. In distributed training, if one native worker fails, peer workers
can receive errors such as:

```text
Socket recv error, Connection reset by peer
```

SynapseML then logs the exception as early termination. As a result, the fit can
return a partial model instead of reporting the underlying task failure.

This change:

- logs the iteration failure and rethrows the original exception;
- leaves `state.isFinished` unchanged when an iteration throws;
- preserves the existing behavior when LightGBM legitimately reports completion;
- allows existing Spark task and job failure handling to process the error.

It also adds a deterministic regression test using a failing booster. The test
verifies that the original exception is propagated and the training state is not
marked as finished.

## How is this patch tested?

- [x] I have written tests and confirmed the proposed bug fix works.

The focused `TrainUtilsSuite` passes, including the new regression test:

```text
Iteration failures propagate instead of becoming early termination
```

## Does this PR change any dependencies?

- [x] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following the steps below.