### PR TITLE
fix: refresh Fabric authentication during AI Functions retries

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/CognitiveServiceBase.scala
@@ -329,6 +329,8 @@ object URLEncodingUtils {
 }
 
 private[ml] object ServiceAuthHeaders {
+  private[ml] case class Resolution(headers: Map[String, String], usesFabricFallback: Boolean)
+
   private[ml] def nonBlank(value: String): Boolean = value != null && value.trim.nonEmpty
 
   // Normalize a header map from any caller (a writer-supplied java.util.HashMap included) into a
@@ -360,15 +362,15 @@ private[ml] object ServiceAuthHeaders {
       .headOption
       .map { case (_, value) => canonicalName -> value }
 
-  def build(subscriptionKey: Option[String],
-            subscriptionKeyHeaderName: String,
-            aadHeaderName: String,
-            aadToken: Option[String],
-            customAuthHeader: Option[String],
-            customHeaders: Option[Map[String, String]],
-            fabricFallbackAuthHeader: => Option[String],
-            telemHeaders: Option[Map[String, String]],
-            contentType: Option[String]): Map[String, String] = {
+  def resolve(subscriptionKey: Option[String],
+              subscriptionKeyHeaderName: String,
+              aadHeaderName: String,
+              aadToken: Option[String],
+              customAuthHeader: Option[String],
+              customHeaders: Option[Map[String, String]],
+              fabricFallbackAuthHeader: => Option[String],
+              telemHeaders: Option[Map[String, String]],
+              contentType: Option[String]): Resolution = {
     val providedCustomHeaders = sanitizeHeaderMap(customHeaders)
 
     // Header names that carry credentials in this context, compared case-insensitively.
@@ -383,13 +385,18 @@ private[ml] object ServiceAuthHeaders {
     // higher-priority source above is absent. A fallback that acquires a token (and may throw) is
     // therefore never run while a subscription key, AAD token, explicit custom-auth header, or an
     // embedded customHeaders credential is present.
-    val authHeader: Option[(String, String)] = subscriptionKey.filter(nonBlank)
+    val explicitAuthHeader: Option[(String, String)] = subscriptionKey.filter(nonBlank)
       .map(value => subscriptionKeyHeaderName -> value)
       .orElse(aadToken.filter(nonBlank).map(value => aadHeaderName -> ("Bearer " + value)))
       .orElse(customAuthHeader.filter(nonBlank).map(value => aadHeaderName -> value))
       .orElse(embeddedCredential(providedCustomHeaders, subscriptionKeyHeaderName))
       .orElse(embeddedCredential(providedCustomHeaders, aadHeaderName))
-      .orElse(fabricFallbackAuthHeader.filter(nonBlank).map(value => aadHeaderName -> value))
+    val fabricAuthHeader = if (explicitAuthHeader.isDefined) {
+      None
+    } else {
+      fabricFallbackAuthHeader.filter(nonBlank).map(value => aadHeaderName -> value)
+    }
+    val authHeader = explicitAuthHeader.orElse(fabricAuthHeader)
 
     // Generic headers never carry auth: strip api-key/Authorization entries (any casing) so they
     // can neither override the resolved credential nor duplicate it under a different case.
@@ -412,7 +419,30 @@ private[ml] object ServiceAuthHeaders {
     }
     contentType.filterNot(StringUtils.isEmpty).foreach(value => headers += ("Content-Type" -> value))
 
-    new scala.collection.immutable.TreeMap[String, String]() ++ headers
+    Resolution(
+      new scala.collection.immutable.TreeMap[String, String]() ++ headers,
+      usesFabricFallback = fabricAuthHeader.isDefined)
+  }
+
+  def build(subscriptionKey: Option[String],
+            subscriptionKeyHeaderName: String,
+            aadHeaderName: String,
+            aadToken: Option[String],
+            customAuthHeader: Option[String],
+            customHeaders: Option[Map[String, String]],
+            fabricFallbackAuthHeader: => Option[String],
+            telemHeaders: Option[Map[String, String]],
+            contentType: Option[String]): Map[String, String] = {
+    resolve(
+      subscriptionKey,
+      subscriptionKeyHeaderName,
+      aadHeaderName,
+      aadToken,
+      customAuthHeader,
+      customHeaders,
+      fabricFallbackAuthHeader,
+      telemHeaders,
+      contentType).headers
   }
 }
 
@@ -503,12 +533,22 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
     getValueOpt(row, customHeaders)
   }
 
+  protected def supportsImplicitFabricAuthRetry: Boolean = false
+
   protected def addHeaders(req: HttpRequestBase,
                            row: Row,
                            addContentType: Boolean = true): Unit = {
 
-    val headers = getHeaders(row, addContentType)
-    headers.foreach { case (headerName, headerValue) => req.addHeader(headerName, headerValue) }
+    val resolution = resolveServiceAuthHeaders(row, addContentType, getFabricFallbackAuthHeader(row))
+    req.removeHeaders(HTTPRequestData.FabricAuthMarkerHeader)
+    resolution.headers.foreach { case (headerName, headerValue) =>
+      if (!HTTPRequestData.isFabricAuthMarker(headerName)) {
+        req.addHeader(headerName, headerValue)
+      }
+    }
+    if (resolution.usesFabricFallback && supportsImplicitFabricAuthRetry) {
+      req.addHeader(HTTPRequestData.FabricAuthMarkerHeader, "true")
+    }
   }
 
   // Returns a list of key-value pairs representing the headers
@@ -523,7 +563,14 @@ trait HasCognitiveServiceInput extends HasURL with HasSubscriptionKey with HasAA
   private[ml] def buildServiceAuthHeaders(row: Row,
                                           addContentType: Boolean,
                                           fabricFallbackAuthHeader: => Option[String]): Map[String, String] = {
-    ServiceAuthHeaders.build(
+    resolveServiceAuthHeaders(row, addContentType, fabricFallbackAuthHeader).headers
+  }
+
+  private def resolveServiceAuthHeaders(
+      row: Row,
+      addContentType: Boolean,
+      fabricFallbackAuthHeader: => Option[String]): ServiceAuthHeaders.Resolution = {
+    ServiceAuthHeaders.resolve(
       getValueOpt(row, subscriptionKey),
       subscriptionKeyHeaderName,
       aadHeaderName,

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -577,6 +577,16 @@ trait HasOpenAIFabricHeaders extends HasCognitiveServiceInput {
     runningOnFabric && usingDefaultOpenAIEndpoint && !hasCustomUrlRoot
   }
 
+  override protected def supportsImplicitFabricAuthRetry: Boolean = usingImplicitFabricEndpoint
+
+  abstract override protected def getFabricFallbackAuthHeader(row: Row): Option[String] = {
+    if (usingImplicitFabricEndpoint) {
+      super.getFabricFallbackAuthHeader(row)
+    } else {
+      None
+    }
+  }
+
   abstract override protected def getCustomHeaders(row: Row): Option[Map[String, String]] = {
     val headers = super.getCustomHeaders(row)
     if (usingImplicitFabricEndpoint) {

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricAuthRetrySuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricAuthRetrySuite.scala
@@ -1,0 +1,61 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.services.openai
+
+import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import com.microsoft.azure.synapse.ml.io.http.HTTPRequestData
+import org.apache.http.client.methods.HttpPost
+import org.apache.spark.sql.Row
+
+class OpenAIFabricAuthRetrySuite extends TestBase {
+
+  private class AuthProvenanceProbe(fallbackAuthHeader: Option[String]) extends OpenAIChatCompletion {
+    var fallbackCalls = 0
+
+    override protected[openai] def runningOnFabric: Boolean = true
+
+    override protected[openai] def usingDefaultOpenAIEndpoint: Boolean = true
+
+    override protected def getFabricFallbackAuthHeader(row: Row): Option[String] = {
+      fallbackCalls += 1
+      fallbackAuthHeader
+    }
+
+    def requestData: HTTPRequestData = {
+      val request = new HttpPost("https://example.test/openai")
+      addHeaders(request, Row.empty, addContentType = false)
+      new HTTPRequestData(request)
+    }
+  }
+
+  test("only implicit Fabric authentication marks a request for refresh") {
+    val implicitProbe = new AuthProvenanceProbe(Some("MwcToken implicit"))
+    val implicitRequestData = implicitProbe.requestData
+    val implicitHttpRequest = implicitRequestData.toHTTPCore
+
+    assert(implicitProbe.fallbackCalls === 1)
+    assert(implicitRequestData.usesFabricAuth)
+    assert(implicitHttpRequest.getFirstHeader("Authorization").getValue === "MwcToken implicit")
+    assert(Option(implicitHttpRequest.getFirstHeader(HTTPRequestData.FabricAuthMarkerHeader)).isEmpty)
+
+    val explicitProbe = new AuthProvenanceProbe(Some("MwcToken implicit"))
+      .setCustomAuthHeader("MwcToken explicit")
+      .setCustomHeaders(Map(HTTPRequestData.FabricAuthMarkerHeader -> "true"))
+      .asInstanceOf[AuthProvenanceProbe]
+    val explicitRequestData = explicitProbe.requestData
+
+    assert(explicitProbe.fallbackCalls === 0)
+    assert(!explicitRequestData.usesFabricAuth)
+    assert(explicitRequestData.toHTTPCore.getFirstHeader("Authorization").getValue === "MwcToken explicit")
+
+    val apiKeyProbe = new AuthProvenanceProbe(Some("MwcToken implicit"))
+      .setSubscriptionKey("explicit-key")
+      .asInstanceOf[AuthProvenanceProbe]
+    val apiKeyRequestData = apiKeyProbe.requestData
+
+    assert(apiKeyProbe.fallbackCalls === 0)
+    assert(!apiKeyRequestData.usesFabricAuth)
+    assert(apiKeyRequestData.toHTTPCore.getFirstHeader("api-key").getValue === "explicit-key")
+  }
+}

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
@@ -4,10 +4,8 @@
 package com.microsoft.azure.synapse.ml.services.openai
 
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
-import com.microsoft.azure.synapse.ml.io.http.HTTPRequestData
 import com.microsoft.azure.synapse.ml.logging.common.PlatformDetails
 import com.microsoft.azure.synapse.ml.services.HasCognitiveServiceInput
-import org.apache.http.client.methods.HttpPost
 import org.apache.spark.sql.Row
 import spray.json._
 
@@ -59,25 +57,6 @@ class OpenAIFabricHeadersSuite extends TestBase {
       override protected val isFabric: Boolean,
       override protected val usesDefaultEndpoint: Boolean)
     extends OpenAIResponses with InspectableFabricHeaders
-
-  private class AuthProvenanceProbe(fallbackAuthHeader: Option[String]) extends OpenAIChatCompletion {
-    var fallbackCalls = 0
-
-    override protected[openai] def runningOnFabric: Boolean = true
-
-    override protected[openai] def usingDefaultOpenAIEndpoint: Boolean = true
-
-    override protected def getFabricFallbackAuthHeader(row: Row): Option[String] = {
-      fallbackCalls += 1
-      fallbackAuthHeader
-    }
-
-    def requestData: HTTPRequestData = {
-      val request = new HttpPost("https://example.test/openai")
-      addHeaders(request, Row.empty, addContentType = false)
-      new HTTPRequestData(request)
-    }
-  }
 
   private def transformers(
       isFabric: Boolean,
@@ -180,35 +159,5 @@ class OpenAIFabricHeadersSuite extends TestBase {
     assert(headers.keys.forall(_ != null))
     assert(headers.values.forall(_ != null))
     assert(!headers.contains("Other"))
-  }
-
-  test("only implicit Fabric authentication marks a request for refresh") {
-    val implicitProbe = new AuthProvenanceProbe(Some("MwcToken implicit"))
-    val implicitRequestData = implicitProbe.requestData
-    val implicitHttpRequest = implicitRequestData.toHTTPCore
-
-    assert(implicitProbe.fallbackCalls === 1)
-    assert(implicitRequestData.usesFabricAuth)
-    assert(implicitHttpRequest.getFirstHeader("Authorization").getValue === "MwcToken implicit")
-    assert(Option(implicitHttpRequest.getFirstHeader(HTTPRequestData.FabricAuthMarkerHeader)).isEmpty)
-
-    val explicitProbe = new AuthProvenanceProbe(Some("MwcToken implicit"))
-      .setCustomAuthHeader("MwcToken explicit")
-      .setCustomHeaders(Map(HTTPRequestData.FabricAuthMarkerHeader -> "true"))
-      .asInstanceOf[AuthProvenanceProbe]
-    val explicitRequestData = explicitProbe.requestData
-
-    assert(explicitProbe.fallbackCalls === 0)
-    assert(!explicitRequestData.usesFabricAuth)
-    assert(explicitRequestData.toHTTPCore.getFirstHeader("Authorization").getValue === "MwcToken explicit")
-
-    val apiKeyProbe = new AuthProvenanceProbe(Some("MwcToken implicit"))
-      .setSubscriptionKey("explicit-key")
-      .asInstanceOf[AuthProvenanceProbe]
-    val apiKeyRequestData = apiKeyProbe.requestData
-
-    assert(apiKeyProbe.fallbackCalls === 0)
-    assert(!apiKeyRequestData.usesFabricAuth)
-    assert(apiKeyRequestData.toHTTPCore.getFirstHeader("api-key").getValue === "explicit-key")
   }
 }

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIFabricHeadersSuite.scala
@@ -4,8 +4,10 @@
 package com.microsoft.azure.synapse.ml.services.openai
 
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import com.microsoft.azure.synapse.ml.io.http.HTTPRequestData
 import com.microsoft.azure.synapse.ml.logging.common.PlatformDetails
 import com.microsoft.azure.synapse.ml.services.HasCognitiveServiceInput
+import org.apache.http.client.methods.HttpPost
 import org.apache.spark.sql.Row
 import spray.json._
 
@@ -57,6 +59,25 @@ class OpenAIFabricHeadersSuite extends TestBase {
       override protected val isFabric: Boolean,
       override protected val usesDefaultEndpoint: Boolean)
     extends OpenAIResponses with InspectableFabricHeaders
+
+  private class AuthProvenanceProbe(fallbackAuthHeader: Option[String]) extends OpenAIChatCompletion {
+    var fallbackCalls = 0
+
+    override protected[openai] def runningOnFabric: Boolean = true
+
+    override protected[openai] def usingDefaultOpenAIEndpoint: Boolean = true
+
+    override protected def getFabricFallbackAuthHeader(row: Row): Option[String] = {
+      fallbackCalls += 1
+      fallbackAuthHeader
+    }
+
+    def requestData: HTTPRequestData = {
+      val request = new HttpPost("https://example.test/openai")
+      addHeaders(request, Row.empty, addContentType = false)
+      new HTTPRequestData(request)
+    }
+  }
 
   private def transformers(
       isFabric: Boolean,
@@ -159,5 +180,35 @@ class OpenAIFabricHeadersSuite extends TestBase {
     assert(headers.keys.forall(_ != null))
     assert(headers.values.forall(_ != null))
     assert(!headers.contains("Other"))
+  }
+
+  test("only implicit Fabric authentication marks a request for refresh") {
+    val implicitProbe = new AuthProvenanceProbe(Some("MwcToken implicit"))
+    val implicitRequestData = implicitProbe.requestData
+    val implicitHttpRequest = implicitRequestData.toHTTPCore
+
+    assert(implicitProbe.fallbackCalls === 1)
+    assert(implicitRequestData.usesFabricAuth)
+    assert(implicitHttpRequest.getFirstHeader("Authorization").getValue === "MwcToken implicit")
+    assert(Option(implicitHttpRequest.getFirstHeader(HTTPRequestData.FabricAuthMarkerHeader)).isEmpty)
+
+    val explicitProbe = new AuthProvenanceProbe(Some("MwcToken implicit"))
+      .setCustomAuthHeader("MwcToken explicit")
+      .setCustomHeaders(Map(HTTPRequestData.FabricAuthMarkerHeader -> "true"))
+      .asInstanceOf[AuthProvenanceProbe]
+    val explicitRequestData = explicitProbe.requestData
+
+    assert(explicitProbe.fallbackCalls === 0)
+    assert(!explicitRequestData.usesFabricAuth)
+    assert(explicitRequestData.toHTTPCore.getFirstHeader("Authorization").getValue === "MwcToken explicit")
+
+    val apiKeyProbe = new AuthProvenanceProbe(Some("MwcToken implicit"))
+      .setSubscriptionKey("explicit-key")
+      .asInstanceOf[AuthProvenanceProbe]
+    val apiKeyRequestData = apiKeyProbe.requestData
+
+    assert(apiKeyProbe.fallbackCalls === 0)
+    assert(!apiKeyRequestData.usesFabricAuth)
+    assert(apiKeyRequestData.toHTTPCore.getFirstHeader("api-key").getValue === "explicit-key")
   }
 }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/fabric/FabricClient.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/fabric/FabricClient.scala
@@ -7,7 +7,7 @@ import spray.json.DefaultJsonProtocol.{StringJsonFormat, mapFormat}
 import spray.json._
 
 import java.net.{MalformedURLException, URI, URL}
-import java.util.UUID
+import java.util.{Locale, UUID}
 import scala.collection.concurrent.TrieMap
 import scala.io.Source
 import scala.util.control.NonFatal
@@ -22,6 +22,7 @@ object FabricClient extends RESTUtils {
   private val SparkConfPath = "/opt/spark/conf/spark-defaults.conf";
   private val ClusterInfoPath = "/opt/health-agent/conf/cluster-info.json";
   private val CognitiveMwcRefreshLocks = TrieMap.empty[(String, String), AnyRef]
+  private val AmbiguousPathEncoding = "(?i)%(?:25)*(?:2e|2f|5c)".r
 
   lazy val CapacityID: Option[String] = getCapacityID;
   lazy val WorkspaceID: Option[String] = getWorkspaceID;
@@ -220,11 +221,13 @@ object FabricClient extends RESTUtils {
   }
 
   private def trustedPath(rawPath: String): Option[String] = {
-    val lowerPath = rawPath.toLowerCase
-    val hasAmbiguousEncoding = Seq("%2e", "%2f", "%5c").exists(lowerPath.contains)
-    val normalizedPath = rawPath.replaceAll("/+", "/")
-    val hasDotSegment = normalizedPath.split("/", -1).exists(segment => segment == "." || segment == "..")
-    if (hasAmbiguousEncoding || rawPath.contains("\\") || hasDotSegment) None else Some(normalizedPath)
+    Option(rawPath).flatMap { path =>
+      val lowerPath = path.toLowerCase(Locale.ROOT)
+      val hasAmbiguousEncoding = AmbiguousPathEncoding.findFirstIn(lowerPath).nonEmpty
+      val normalizedPath = path.replaceAll("/+", "/")
+      val hasDotSegment = normalizedPath.split("/", -1).exists(segment => segment == "." || segment == "..")
+      if (hasAmbiguousEncoding || path.contains("\\") || hasDotSegment) None else Some(normalizedPath)
+    }
   }
 
   private[ml] def isOpenAIEndpoint(requestUrl: String): Boolean = {
@@ -239,13 +242,25 @@ object FabricClient extends RESTUtils {
     val workspaceId = WorkspaceID.getOrElse("")
     val artifactId = ArtifactID.getOrElse("")
     val refreshLock = CognitiveMwcRefreshLocks.getOrElseUpdate((workspaceId, artifactId), new Object())
+    refreshAuthHeader(
+      rejectedAuthHeader,
+      refreshLock,
+      () => TokenLibrary.getCognitiveMwcTokenAuthHeader(workspaceId, artifactId),
+      () => TokenLibrary.invalidateSparkMwcToken(workspaceId, artifactId))
+  }
+
+  private[ml] def refreshAuthHeader(
+      rejectedAuthHeader: String,
+      refreshLock: AnyRef,
+      getCurrentAuthHeader: () => String,
+      invalidateAuthHeader: () => Unit): String = {
     refreshLock.synchronized {
-      val currentAuthHeader = TokenLibrary.getCognitiveMwcTokenAuthHeader(workspaceId, artifactId)
+      val currentAuthHeader = getCurrentAuthHeader()
       if (currentAuthHeader != rejectedAuthHeader) {
         currentAuthHeader
       } else {
-        TokenLibrary.invalidateSparkMwcToken(workspaceId, artifactId)
-        TokenLibrary.getCognitiveMwcTokenAuthHeader(workspaceId, artifactId)
+        invalidateAuthHeader()
+        getCurrentAuthHeader()
       }
     }
   }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/fabric/FabricClient.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/fabric/FabricClient.scala
@@ -6,9 +6,11 @@ package com.microsoft.azure.synapse.ml.fabric
 import spray.json.DefaultJsonProtocol.{StringJsonFormat, mapFormat}
 import spray.json._
 
-import java.net.{MalformedURLException, URL}
+import java.net.{MalformedURLException, URI, URL}
 import java.util.UUID
+import scala.collection.concurrent.TrieMap
 import scala.io.Source
+import scala.util.control.NonFatal
 
 object FabricClient extends RESTUtils {
   private val WorkloadEndpointTypeML = "ML";
@@ -19,6 +21,7 @@ object FabricClient extends RESTUtils {
   private val ContextFilePath = "/home/trusted-service-user/.trident-context";
   private val SparkConfPath = "/opt/spark/conf/spark-defaults.conf";
   private val ClusterInfoPath = "/opt/health-agent/conf/cluster-info.json";
+  private val CognitiveMwcRefreshLocks = TrieMap.empty[(String, String), AnyRef]
 
   lazy val CapacityID: Option[String] = getCapacityID;
   lazy val WorkspaceID: Option[String] = getWorkspaceID;
@@ -194,5 +197,56 @@ object FabricClient extends RESTUtils {
 
   def getCognitiveMWCTokenAuthHeader: String = {
     TokenLibrary.getCognitiveMwcTokenAuthHeader(WorkspaceID.getOrElse(""), ArtifactID.getOrElse(""))
+  }
+
+  private[ml] def isEndpointUnder(requestUrl: String, endpointRoot: String): Boolean = {
+    try {
+      val request = new URL(requestUrl)
+      val root = new URL(endpointRoot)
+      val requestPort = if (request.getPort >= 0) request.getPort else request.getDefaultPort
+      val rootPort = if (root.getPort >= 0) root.getPort else root.getDefaultPort
+      val requestPath = trustedPath(new URI(requestUrl).getRawPath)
+      val rootPath = trustedPath(new URI(endpointRoot).getRawPath)
+      requestPath.exists(path =>
+        rootPath.exists(rootPrefix =>
+          request.getProtocol.equalsIgnoreCase("https") &&
+            root.getProtocol.equalsIgnoreCase("https") &&
+            request.getHost.equalsIgnoreCase(root.getHost) &&
+            requestPort == rootPort &&
+            path.startsWith(rootPrefix)))
+    } catch {
+      case _: MalformedURLException | _: java.net.URISyntaxException => false
+    }
+  }
+
+  private def trustedPath(rawPath: String): Option[String] = {
+    val lowerPath = rawPath.toLowerCase
+    val hasAmbiguousEncoding = Seq("%2e", "%2f", "%5c").exists(lowerPath.contains)
+    val normalizedPath = rawPath.replaceAll("/+", "/")
+    val hasDotSegment = normalizedPath.split("/", -1).exists(segment => segment == "." || segment == "..")
+    if (hasAmbiguousEncoding || rawPath.contains("\\") || hasDotSegment) None else Some(normalizedPath)
+  }
+
+  private[ml] def isOpenAIEndpoint(requestUrl: String): Boolean = {
+    try {
+      isEndpointUnder(requestUrl, MLWorkloadEndpointOpenAI)
+    } catch {
+      case NonFatal(_) => false
+    }
+  }
+
+  def refreshCognitiveMWCTokenAuthHeader(rejectedAuthHeader: String): String = {
+    val workspaceId = WorkspaceID.getOrElse("")
+    val artifactId = ArtifactID.getOrElse("")
+    val refreshLock = CognitiveMwcRefreshLocks.getOrElseUpdate((workspaceId, artifactId), new Object())
+    refreshLock.synchronized {
+      val currentAuthHeader = TokenLibrary.getCognitiveMwcTokenAuthHeader(workspaceId, artifactId)
+      if (currentAuthHeader != rejectedAuthHeader) {
+        currentAuthHeader
+      } else {
+        TokenLibrary.invalidateSparkMwcToken(workspaceId, artifactId)
+        TokenLibrary.getCognitiveMwcTokenAuthHeader(workspaceId, artifactId)
+      }
+    }
   }
 }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/fabric/TokenLibrary.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/fabric/TokenLibrary.scala
@@ -66,6 +66,9 @@ object TokenLibrary {
       case _: ReflectiveOperationException | _: SecurityException |
            _: LinkageError | _: IllegalArgumentException =>
         fallback
+      case error: RuntimeException
+          if error.getClass.getName == "java.lang.reflect.InaccessibleObjectException" =>
+        fallback
     }
   }
 
@@ -79,7 +82,6 @@ object TokenLibrary {
         (cls.getMethods ++ cls.getDeclaredMethods)
           .find(method => method.getName == methodName && method.getParameterCount == parameterCount)
           .map { method =>
-            method.setAccessible(true)
             module -> method
           }
       }
@@ -122,11 +124,17 @@ object TokenLibrary {
           case path: String => Some(Paths.get(path))
           case _ => None
         }
-        tokenPath.exists { path =>
-          Files.deleteIfExists(path)
-          true
-        }
+        tokenPath.exists(deleteTokenPath)
       }
+    }
+  }
+
+  private[ml] def deleteTokenPath(path: Path): Boolean = {
+    try {
+      Files.deleteIfExists(path)
+      true
+    } catch {
+      case _: java.io.IOException | _: SecurityException => false
     }
   }
 

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/fabric/TokenLibrary.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/fabric/TokenLibrary.scala
@@ -59,11 +59,21 @@ object TokenLibrary {
       .asInstanceOf[String]
   }
 
-  private def objectMethod(classNames: Seq[String],
-                           methodName: String,
-                           parameterCount: Int): Option[(AnyRef, java.lang.reflect.Method)] = {
+  private def reflectionOrElse[T](fallback: => T)(operation: => T): T = {
+    try {
+      operation
+    } catch {
+      case _: ReflectiveOperationException | _: SecurityException |
+           _: LinkageError | _: IllegalArgumentException =>
+        fallback
+    }
+  }
+
+  private[ml] def objectMethod(classNames: Seq[String],
+                               methodName: String,
+                               parameterCount: Int): Option[(AnyRef, java.lang.reflect.Method)] = {
     classNames.iterator.flatMap { className =>
-      try {
+      reflectionOrElse(Option.empty[(AnyRef, java.lang.reflect.Method)]) {
         val cls = Class.forName(className)
         val module = cls.getField("MODULE$").get(null).asInstanceOf[AnyRef] //scalastyle:ignore null
         (cls.getMethods ++ cls.getDeclaredMethods)
@@ -72,49 +82,60 @@ object TokenLibrary {
             method.setAccessible(true)
             module -> method
           }
-      } catch {
-        case _: ClassNotFoundException | _: NoSuchFieldException => None
       }
     }.take(1).toSeq.headOption
   }
 
   private def invalidateWithRuntimeApi(workspaceId: String, artifactId: String): Boolean = {
     objectMethod(Seq(TokenLibraryClass), "invalidateMwcToken", 4).exists { case (module, method) =>
-      method.invoke(
-        module,
-        workspaceId,
-        artifactId,
-        Int.box(SparkTokenVersion),
-        SparkWorkloadType)
-      true
+      reflectionOrElse(false) {
+        method.invoke(
+          module,
+          workspaceId,
+          artifactId,
+          Int.box(SparkTokenVersion),
+          SparkWorkloadType)
+        true
+      }
     }
   }
 
   private def nfsCacheKey(cacheKey: String): String = {
     objectMethod(NfsCacheClasses, "getNFSCacheKey", 1)
-      .map { case (module, method) => method.invoke(module, cacheKey).asInstanceOf[String] }
+      .flatMap { case (module, method) =>
+        reflectionOrElse(Option.empty[String]) {
+          method.invoke(module, cacheKey) match {
+            case resolved: String => Some(resolved)
+            case _ => None
+          }
+        }
+      }
       .getOrElse(cacheKey)
   }
 
   private def deleteNfsToken(resolvedCacheKey: String): Boolean = {
     objectMethod(NfsCacheClasses, "getNFSTokenFilePath", 1).exists { case (module, method) =>
-      val tokenPath = method.invoke(module, resolvedCacheKey) match {
-        case path: Path => path
-        case file: File => file.toPath
-        case path: String => Paths.get(path)
-        case other =>
-          throw new IllegalStateException(
-            s"Unsupported Fabric token cache path type: ${Option(other).map(_.getClass.getName).orNull}")
+      reflectionOrElse(false) {
+        val tokenPath = method.invoke(module, resolvedCacheKey) match {
+          case path: Path => Some(path)
+          case file: File => Some(file.toPath)
+          case path: String => Some(Paths.get(path))
+          case _ => None
+        }
+        tokenPath.exists { path =>
+          Files.deleteIfExists(path)
+          true
+        }
       }
-      Files.deleteIfExists(tokenPath)
-      true
     }
   }
 
   private def clearInMemoryTokenCache(): Boolean = {
     objectMethod(InMemoryCacheClasses, "clear", 0).exists { case (module, method) =>
-      method.invoke(module)
-      true
+      reflectionOrElse(false) {
+        method.invoke(module)
+        true
+      }
     }
   }
 

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/fabric/TokenLibrary.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/fabric/TokenLibrary.scala
@@ -3,10 +3,26 @@
 
 package com.microsoft.azure.synapse.ml.fabric
 
+import java.io.File
+import java.nio.file.{Files, Path, Paths}
 import scala.reflect.runtime.currentMirror
 import scala.reflect.runtime.universe._
 
 object TokenLibrary {
+  private val TokenLibraryClass = "com.microsoft.azure.trident.tokenlibrary.TokenLibrary$"
+  private val InMemoryCacheClasses = Seq(
+    "com.microsoft.azure.trident.tokenlibrary.InMemoryCacheClient$",
+    "com.microsoft.azure.trident.tokenlibrary.cache.InMemoryCacheClient$",
+    "com.microsoft.fabric.tokenlibrary.InMemoryCacheClient$",
+    "com.microsoft.fabric.tokenlibrary.cache.InMemoryCacheClient$")
+  private val NfsCacheClasses = Seq(
+    "com.microsoft.azure.trident.tokenlibrary.NFSCache$",
+    "com.microsoft.azure.trident.tokenlibrary.cache.NFSCache$",
+    "com.microsoft.fabric.tokenlibrary.NFSCache$",
+    "com.microsoft.fabric.tokenlibrary.cache.NFSCache$")
+  private val SparkTokenVersion = 2
+  private val SparkWorkloadType = "SparkCore"
+
   def getAccessToken: String = {
     val objectName = "com.microsoft.azure.trident.tokenlibrary.TokenLibrary"
     val mirror = currentMirror
@@ -39,10 +55,91 @@ object TokenLibrary {
       m.asMethod.paramLists.flatten.map(_.typeSignature).zip(argTypes).forall { case (a, b) => a =:= b }
     }.getOrElse(throw new NoSuchMethodException(s"Method $methodName with argument type not found"))
     val methodMirror = mirror.reflect(obj).reflectMethod(selectedMethodSymbol.asMethod)
-    methodMirror(workspaceId, artifactId, 2, "SparkCore")
+    methodMirror(workspaceId, artifactId, SparkTokenVersion, SparkWorkloadType)
       .asInstanceOf[String]
   }
 
+  private def objectMethod(classNames: Seq[String],
+                           methodName: String,
+                           parameterCount: Int): Option[(AnyRef, java.lang.reflect.Method)] = {
+    classNames.iterator.flatMap { className =>
+      try {
+        val cls = Class.forName(className)
+        val module = cls.getField("MODULE$").get(null).asInstanceOf[AnyRef] //scalastyle:ignore null
+        (cls.getMethods ++ cls.getDeclaredMethods)
+          .find(method => method.getName == methodName && method.getParameterCount == parameterCount)
+          .map { method =>
+            method.setAccessible(true)
+            module -> method
+          }
+      } catch {
+        case _: ClassNotFoundException | _: NoSuchFieldException => None
+      }
+    }.toSeq.headOption
+  }
+
+  private def invalidateWithRuntimeApi(workspaceId: String, artifactId: String): Boolean = {
+    objectMethod(Seq(TokenLibraryClass), "invalidateMwcToken", 4).exists { case (module, method) =>
+      method.invoke(
+        module,
+        workspaceId,
+        artifactId,
+        Int.box(SparkTokenVersion),
+        SparkWorkloadType)
+      true
+    }
+  }
+
+  private def nfsCacheKey(cacheKey: String): String = {
+    objectMethod(NfsCacheClasses, "getNFSCacheKey", 1)
+      .map { case (module, method) => method.invoke(module, cacheKey).asInstanceOf[String] }
+      .getOrElse(cacheKey)
+  }
+
+  private def deleteNfsToken(resolvedCacheKey: String): Boolean = {
+    objectMethod(NfsCacheClasses, "getNFSTokenFilePath", 1).exists { case (module, method) =>
+      val tokenPath = method.invoke(module, resolvedCacheKey) match {
+        case path: Path => path
+        case file: File => file.toPath
+        case path: String => Paths.get(path)
+        case other =>
+          throw new IllegalStateException(
+            s"Unsupported Fabric token cache path type: ${Option(other).map(_.getClass.getName).orNull}")
+      }
+      Files.deleteIfExists(tokenPath)
+      true
+    }
+  }
+
+  private def clearInMemoryTokenCache(): Boolean = {
+    objectMethod(InMemoryCacheClasses, "clear", 0).exists { case (module, method) =>
+      method.invoke(module)
+      true
+    }
+  }
+
+  private[ml] def invalidateSparkMwcTokenCaches(
+      cacheKey: String,
+      encodeNfsCacheKey: String => String,
+      deleteNfsCacheEntry: String => Boolean,
+      clearInMemoryCache: () => Boolean): Unit = {
+    val deletedNfsToken = deleteNfsCacheEntry(encodeNfsCacheKey(cacheKey))
+    val clearedInMemoryToken = clearInMemoryCache()
+    if (!deletedNfsToken && !clearedInMemoryToken) {
+      throw new NoSuchMethodException("Fabric runtime does not expose MWC token cache invalidation.")
+    }
+  }
+
+  def invalidateSparkMwcToken(workspaceId: String, artifactId: String): Unit = {
+    if (!invalidateWithRuntimeApi(workspaceId, artifactId)) {
+      val cacheKey = workspaceId + artifactId + SparkTokenVersion + SparkWorkloadType
+      invalidateSparkMwcTokenCaches(
+        cacheKey,
+        nfsCacheKey,
+        deleteNfsToken,
+        () => clearInMemoryTokenCache())
+    }
+  }
 
   def getMLWorkloadAADAuthHeader: String = "Bearer " + getAccessToken
 

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/fabric/TokenLibrary.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/fabric/TokenLibrary.scala
@@ -75,7 +75,7 @@ object TokenLibrary {
       } catch {
         case _: ClassNotFoundException | _: NoSuchFieldException => None
       }
-    }.toSeq.headOption
+    }.take(1).toSeq.headOption
   }
 
   private def invalidateWithRuntimeApi(workspaceId: String, artifactId: String): Boolean = {

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPClients.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPClients.scala
@@ -169,6 +169,28 @@ object HandlingUtils extends SparkLogging {
   private def capacityLimitExceeded(response: CloseableHttpResponse): Boolean =
     responseBodyForInspection(response).exists(_.contains("CapacityLimitExceeded"))
 
+  private[ml] def previewMessage(previewRequest: HttpRequestBase): String = {
+    try {
+      previewRequest match {
+        case request: HttpPost =>
+          Option(request.getEntity).map { entity =>
+            Try {
+              val input = entity.getContent
+              try {
+                IOUtils.toString(input, "UTF-8")
+              } finally {
+                input.close()
+              }
+            }.getOrElse("")
+          }.getOrElse("")
+        case request =>
+          request.getURI.toString
+      }
+    } finally {
+      previewRequest.releaseConnection()
+    }
+  }
+
   //scalastyle:off cyclomatic.complexity
   //scalastyle:off method.length
   private[ml] def sendWithRetries(client: CloseableHttpClient,
@@ -381,12 +403,7 @@ object HandlingUtils extends SparkLogging {
   def advanced(retryTimes: Int*)(client: CloseableHttpClient,
                                  request: HTTPRequestData): HTTPResponseData = {
     try {
-      val previewRequest = request.toHTTPCore
-      val message = previewRequest match {
-        case r: HttpPost => Try(IOUtils.toString(r.getEntity.getContent, "UTF-8")).getOrElse("")
-        case r => r.getURI
-      }
-      previewRequest.releaseConnection()
+      val message = previewMessage(request.toHTTPCore)
       SynapseMLLogging.logDebug(s"sending $message")
       val start = System.currentTimeMillis()
       val usesTrustedFabricAuth = request.usesFabricAuth &&

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPClients.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPClients.scala
@@ -122,45 +122,41 @@ object HandlingUtils extends SparkLogging {
 
   private[ml] def responseBodyForInspection(response: CloseableHttpResponse): Option[String] = {
     Option(response.getEntity).flatMap { entity =>
-      if (entity.getContentLength > MaxResponseInspectionBytes) {
-        None
-      } else {
-        val output = new ByteArrayOutputStream()
-        var input = Option.empty[InputStream]
-        var keepInputOpen = false
-        try {
-          val responseInput = entity.getContent
-          input = Some(responseInput)
-          IOUtils.copyLarge(responseInput, output, 0, MaxResponseInspectionBytes + 1)
-          val bytes = output.toByteArray
-          if (bytes.length > MaxResponseInspectionBytes) {
-            replayResponseEntity(response, entity, bytes, responseInput)
-            keepInputOpen = true
-            None
-          } else {
-            val bufferedEntity = new ByteArrayEntity(bytes)
-            copyResponseEntityMetadata(entity, bufferedEntity)
-            response.setEntity(bufferedEntity)
-            Some(new String(bytes, StandardCharsets.UTF_8))
-          }
-        } catch {
-          case NonFatal(error) =>
-            logWarning("Could not inspect the HTTP response body; preserving it for retry handling.", error)
-            input.foreach { responseInput =>
-              try {
-                replayResponseEntity(response, entity, output.toByteArray, responseInput)
-                keepInputOpen = true
-              } catch {
-                case NonFatal(replayError) =>
-                  error.addSuppressed(replayError)
-                  logWarning("Could not reconstruct the partially inspected HTTP response body.", replayError)
-              }
+      val output = new ByteArrayOutputStream()
+      var input = Option.empty[InputStream]
+      var keepInputOpen = false
+      try {
+        val responseInput = entity.getContent
+        input = Some(responseInput)
+        IOUtils.copyLarge(responseInput, output, 0, MaxResponseInspectionBytes + 1)
+        val bytes = output.toByteArray
+        if (bytes.length > MaxResponseInspectionBytes) {
+          replayResponseEntity(response, entity, bytes, responseInput)
+          keepInputOpen = true
+          Some(new String(bytes, 0, MaxResponseInspectionBytes.toInt, StandardCharsets.UTF_8))
+        } else {
+          val bufferedEntity = new ByteArrayEntity(bytes)
+          copyResponseEntityMetadata(entity, bufferedEntity)
+          response.setEntity(bufferedEntity)
+          Some(new String(bytes, StandardCharsets.UTF_8))
+        }
+      } catch {
+        case NonFatal(error) =>
+          logWarning("Could not inspect the HTTP response body; preserving it for retry handling.", error)
+          input.foreach { responseInput =>
+            try {
+              replayResponseEntity(response, entity, output.toByteArray, responseInput)
+              keepInputOpen = true
+            } catch {
+              case NonFatal(replayError) =>
+                error.addSuppressed(replayError)
+                logWarning("Could not reconstruct the partially inspected HTTP response body.", replayError)
             }
-            None
-        } finally {
-          if (!keepInputOpen) {
-            input.foreach(closeInspectionInput)
           }
+          None
+      } finally {
+        if (!keepInputOpen) {
+          input.foreach(closeInspectionInput)
         }
       }
     }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPClients.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPClients.scala
@@ -3,6 +3,7 @@
 
 package com.microsoft.azure.synapse.ml.io.http
 
+import com.microsoft.azure.synapse.ml.fabric.FabricClient
 import com.microsoft.azure.synapse.ml.logging.SynapseMLLogging
 import org.apache.commons.io.IOUtils
 import org.apache.http.client.config.RequestConfig
@@ -193,17 +194,158 @@ object HandlingUtils extends SparkLogging {
   //scalastyle:on method.length
   //scalastyle:on cyclomatic.complexity
 
+  //scalastyle:off cyclomatic.complexity
+  //scalastyle:off method.length
+  //scalastyle:off magic.number
+  private[ml] def sendWithFabricAuthRetries(
+      client: CloseableHttpClient,
+      requestData: HTTPRequestData,
+      retriesLeft: Array[Int],
+      extraCodesToRetry: Set[Int] = Set(),
+      getAuthHeader: () => String = () => FabricClient.getCognitiveMWCTokenAuthHeader,
+      refreshAuthHeader: String => String = FabricClient.refreshCognitiveMWCTokenAuthHeader,
+      backoff429Ms: Long = 0,
+      authRetryUsed: Boolean = false,
+      authOverride: Option[String] = None): (CloseableHttpResponse, HttpRequestBase) = {
+    val request = requestData.toHTTPCore
+    val authHeader = authOverride.getOrElse(getAuthHeader())
+    request.setHeader("Authorization", authHeader)
+    var executingRequest = true
+    try {
+      val response = client.execute(request)
+      executingRequest = false
+      val code = response.getStatusLine.getStatusCode
+      val capacityLimitExceeded = if (code == 429) {
+        val maxInspectionBytes = 1024 * 1024L
+        Option(response.getEntity).exists { entity =>
+          if (entity.getContentLength > maxInspectionBytes) {
+            false
+          } else {
+            response.setEntity(new BufferedHttpEntity(entity))
+            Option(response.getEntity)
+              .flatMap(e => Try(IOUtils.toString(e.getContent, "UTF-8")).toOption)
+              .exists(_.contains("CapacityLimitExceeded"))
+          }
+        }
+      } else {
+        false
+      }
+
+      val successful = Set(200, 201, 202)(code)
+      val retryable = if (code == 429) {
+        !capacityLimitExceeded
+      } else if (code == 401) {
+        false
+      } else if (extraCodesToRetry(code)) {
+        true
+      } else {
+        !code.toString.startsWith("4")
+      }
+
+      if (code == 401 && !authRetryUsed) {
+        response.close()
+        request.releaseConnection()
+        val refreshedAuthHeader = refreshAuthHeader(authHeader)
+        sendWithFabricAuthRetries(
+          client,
+          requestData,
+          retriesLeft,
+          extraCodesToRetry,
+          getAuthHeader,
+          refreshAuthHeader,
+          backoff429Ms,
+          authRetryUsed = true,
+          authOverride = Some(refreshedAuthHeader))
+      } else if (successful || !retryable || retriesLeft.isEmpty) {
+        if (capacityLimitExceeded) {
+          logWarning(s"Capacity limit exceeded (non-retryable 429) on ${request.getURI}")
+        }
+        response -> request
+      } else {
+        val retryAfterMs = if (code == 429) {
+          Option(response.getFirstHeader("Retry-After"))
+            .flatMap(h => Try(h.getValue.toLong * 1000).toOption)
+            .filter(_ >= 0)
+            .map(math.min(_, MaxBackoffMs))
+        } else {
+          None
+        }
+        response.close()
+        request.releaseConnection()
+        if (code == 429) {
+          val baseBackoff = retryAfterMs.getOrElse {
+            val current = math.max(backoff429Ms, retriesLeft.head.toLong)
+            math.min(current * 2, MaxBackoffMs)
+          }
+          val jitter = Random.nextInt(math.max((baseBackoff / 10).toInt, 1))
+          Thread.sleep(math.min(baseBackoff + jitter, MaxBackoffMs))
+          sendWithFabricAuthRetries(
+            client,
+            requestData,
+            retriesLeft,
+            extraCodesToRetry,
+            getAuthHeader,
+            refreshAuthHeader,
+            baseBackoff,
+            authRetryUsed)
+        } else {
+          Thread.sleep(retriesLeft.head.toLong)
+          sendWithFabricAuthRetries(
+            client,
+            requestData,
+            retriesLeft.tail,
+            extraCodesToRetry,
+            getAuthHeader,
+            refreshAuthHeader,
+            authRetryUsed = authRetryUsed)
+        }
+      }
+    } catch {
+      case e: java.io.IOException if executingRequest =>
+        request.releaseConnection()
+        if (retriesLeft.isEmpty) {
+          throw e
+        }
+        logError("Encountering a connection error", e)
+        Thread.sleep(retriesLeft.head.toLong)
+        sendWithFabricAuthRetries(
+          client,
+          requestData,
+          retriesLeft.tail,
+          extraCodesToRetry,
+          getAuthHeader,
+          refreshAuthHeader,
+          backoff429Ms,
+          authRetryUsed)
+    }
+  }
+  //scalastyle:on magic.number
+  //scalastyle:on method.length
+  //scalastyle:on cyclomatic.complexity
+
   def advanced(retryTimes: Int*)(client: CloseableHttpClient,
                                  request: HTTPRequestData): HTTPResponseData = {
     try {
-      val req = request.toHTTPCore
-      val message = req match {
+      val previewRequest = request.toHTTPCore
+      val message = previewRequest match {
         case r: HttpPost => Try(IOUtils.toString(r.getEntity.getContent, "UTF-8")).getOrElse("")
         case r => r.getURI
       }
+      previewRequest.releaseConnection()
       SynapseMLLogging.logDebug(s"sending $message")
       val start = System.currentTimeMillis()
-      val resp = sendWithRetries(client, req, retryTimes.toArray)
+      val usesTrustedFabricAuth = request.usesFabricAuth &&
+        FabricClient.isOpenAIEndpoint(request.requestLine.uri)
+      val (resp, req) = if (usesTrustedFabricAuth) {
+        sendWithFabricAuthRetries(
+          client,
+          request,
+          retryTimes.toArray,
+          authOverride = request.authorizationHeader)
+      } else {
+        val httpRequest = request.toHTTPCore
+        sendWithRetries(client, httpRequest, retryTimes.toArray) -> httpRequest
+      }
       SynapseMLLogging.logMessage(
         s"finished sending to ${req.getURI} took (${System.currentTimeMillis() - start}ms)")
       val respData = convertAndClose(resp)

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPClients.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPClients.scala
@@ -8,7 +8,7 @@ import com.microsoft.azure.synapse.ml.logging.SynapseMLLogging
 import org.apache.commons.io.IOUtils
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.client.methods.{CloseableHttpResponse, HttpPost, HttpRequestBase}
-import org.apache.http.entity.BufferedHttpEntity
+import org.apache.http.entity.{BasicHttpEntity, ByteArrayEntity}
 import org.apache.http.impl.client.{CloseableHttpClient, HttpClientBuilder}
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager
 import org.apache.spark.injections.UDFUtils
@@ -16,6 +16,8 @@ import org.apache.spark.internal.{Logging => SparkLogging}
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.types.StringType
 
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, SequenceInputStream}
+import java.nio.charset.StandardCharsets
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, blocking}
 import scala.util.{Random, Try}
@@ -88,6 +90,48 @@ object HandlingUtils extends SparkLogging {
   }
 
   private val MaxBackoffMs: Long = 60000L // 1 minute cap for 429 backoff
+  private val MaxResponseInspectionBytes = 1024 * 1024L
+
+  private def responseBodyForInspection(response: CloseableHttpResponse): Option[String] = {
+    Option(response.getEntity).flatMap { entity =>
+      if (entity.getContentLength > MaxResponseInspectionBytes) {
+        None
+      } else {
+        val output = new ByteArrayOutputStream()
+        val input = entity.getContent
+        var keepInputOpen = false
+        try {
+          IOUtils.copyLarge(input, output, 0, MaxResponseInspectionBytes + 1)
+          val bytes = output.toByteArray
+          if (bytes.length > MaxResponseInspectionBytes) {
+            val replayEntity = new BasicHttpEntity()
+            replayEntity.setContent(new SequenceInputStream(new ByteArrayInputStream(bytes), input))
+            replayEntity.setContentLength(entity.getContentLength)
+            Option(entity.getContentEncoding).foreach(replayEntity.setContentEncoding)
+            Option(entity.getContentType).foreach(replayEntity.setContentType)
+            replayEntity.setChunked(entity.isChunked)
+            response.setEntity(replayEntity)
+            keepInputOpen = true
+            None
+          } else {
+            val bufferedEntity = new ByteArrayEntity(bytes)
+            Option(entity.getContentEncoding).foreach(bufferedEntity.setContentEncoding)
+            Option(entity.getContentType).foreach(bufferedEntity.setContentType)
+            bufferedEntity.setChunked(entity.isChunked)
+            response.setEntity(bufferedEntity)
+            Some(new String(bytes, StandardCharsets.UTF_8))
+          }
+        } finally {
+          if (!keepInputOpen) {
+            input.close()
+          }
+        }
+      }
+    }
+  }
+
+  private def capacityLimitExceeded(response: CloseableHttpResponse): Boolean =
+    responseBodyForInspection(response).exists(_.contains("CapacityLimitExceeded"))
 
   //scalastyle:off cyclomatic.complexity
   //scalastyle:off method.length
@@ -107,19 +151,7 @@ object HandlingUtils extends SparkLogging {
         case 202 => true
         case 429 =>
           // Inspect body to distinguish capacity errors from transient rate limits.
-          // Guard with Content-Length cap to avoid buffering unexpectedly large payloads.
-          val MaxInspectionBytes = 1024 * 1024L
-          val bodyStr = Option(response.getEntity).flatMap { entity =>
-            val contentLength = entity.getContentLength
-            if (contentLength > MaxInspectionBytes) {
-              None
-            } else {
-              response.setEntity(new BufferedHttpEntity(entity))
-              Option(response.getEntity)
-                .flatMap(e => Try(IOUtils.toString(e.getContent, "UTF-8")).toOption)
-            }
-          }.getOrElse("")
-          if (bodyStr.contains("CapacityLimitExceeded")) {
+          if (capacityLimitExceeded(response)) {
             // Fabric capacity-exceeded 429s are NOT transient rate limits —
             // retrying will not help and causes hangs
             logWarning(s"Capacity limit exceeded (non-retryable 429) on ${request.getURI}")
@@ -209,31 +241,18 @@ object HandlingUtils extends SparkLogging {
       authOverride: Option[String] = None): (CloseableHttpResponse, HttpRequestBase) = {
     val request = requestData.toHTTPCore
     val authHeader = authOverride.getOrElse(getAuthHeader())
+    request.removeHeaders("Authorization")
     request.setHeader("Authorization", authHeader)
     var executingRequest = true
     try {
       val response = client.execute(request)
       executingRequest = false
       val code = response.getStatusLine.getStatusCode
-      val capacityLimitExceeded = if (code == 429) {
-        val maxInspectionBytes = 1024 * 1024L
-        Option(response.getEntity).exists { entity =>
-          if (entity.getContentLength > maxInspectionBytes) {
-            false
-          } else {
-            response.setEntity(new BufferedHttpEntity(entity))
-            Option(response.getEntity)
-              .flatMap(e => Try(IOUtils.toString(e.getContent, "UTF-8")).toOption)
-              .exists(_.contains("CapacityLimitExceeded"))
-          }
-        }
-      } else {
-        false
-      }
+      val capacityLimitExceededResponse = code == 429 && capacityLimitExceeded(response)
 
       val successful = Set(200, 201, 202)(code)
       val retryable = if (code == 429) {
-        !capacityLimitExceeded
+        !capacityLimitExceededResponse
       } else if (code == 401) {
         false
       } else if (extraCodesToRetry(code)) {
@@ -257,7 +276,7 @@ object HandlingUtils extends SparkLogging {
           authRetryUsed = true,
           authOverride = Some(refreshedAuthHeader))
       } else if (successful || !retryable || retriesLeft.isEmpty) {
-        if (capacityLimitExceeded) {
+        if (capacityLimitExceededResponse) {
           logWarning(s"Capacity limit exceeded (non-retryable 429) on ${request.getURI}")
         }
         response -> request
@@ -282,7 +301,7 @@ object HandlingUtils extends SparkLogging {
           sendWithFabricAuthRetries(
             client,
             requestData,
-            retriesLeft,
+            retriesLeft.tail,
             extraCodesToRetry,
             getAuthHeader,
             refreshAuthHeader,

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPClients.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPClients.scala
@@ -403,8 +403,7 @@ object HandlingUtils extends SparkLogging {
   def advanced(retryTimes: Int*)(client: CloseableHttpClient,
                                  request: HTTPRequestData): HTTPResponseData = {
     try {
-      val message = previewMessage(request.toHTTPCore)
-      SynapseMLLogging.logDebug(s"sending $message")
+      SynapseMLLogging.logDebug(s"sending ${previewMessage(request.toHTTPCore)}")
       val start = System.currentTimeMillis()
       val usesTrustedFabricAuth = request.usesFabricAuth &&
         FabricClient.isOpenAIEndpoint(request.requestLine.uri)

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPClients.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPClients.scala
@@ -6,9 +6,10 @@ package com.microsoft.azure.synapse.ml.io.http
 import com.microsoft.azure.synapse.ml.fabric.FabricClient
 import com.microsoft.azure.synapse.ml.logging.SynapseMLLogging
 import org.apache.commons.io.IOUtils
+import org.apache.http.HttpEntity
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.client.methods.{CloseableHttpResponse, HttpPost, HttpRequestBase}
-import org.apache.http.entity.{BasicHttpEntity, ByteArrayEntity}
+import org.apache.http.entity.{AbstractHttpEntity, BasicHttpEntity, ByteArrayEntity}
 import org.apache.http.impl.client.{CloseableHttpClient, HttpClientBuilder}
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager
 import org.apache.spark.injections.UDFUtils
@@ -16,11 +17,12 @@ import org.apache.spark.internal.{Logging => SparkLogging}
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.types.StringType
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, SequenceInputStream}
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, SequenceInputStream}
 import java.nio.charset.StandardCharsets
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, blocking}
 import scala.util.{Random, Try}
+import scala.util.control.NonFatal
 
 trait Handler {
 
@@ -92,38 +94,72 @@ object HandlingUtils extends SparkLogging {
   private val MaxBackoffMs: Long = 60000L // 1 minute cap for 429 backoff
   private val MaxResponseInspectionBytes = 1024 * 1024L
 
-  private def responseBodyForInspection(response: CloseableHttpResponse): Option[String] = {
+  private def copyResponseEntityMetadata(source: HttpEntity, target: AbstractHttpEntity): Unit = {
+    Option(source.getContentEncoding).foreach(target.setContentEncoding)
+    Option(source.getContentType).foreach(target.setContentType)
+    target.setChunked(source.isChunked)
+  }
+
+  private def replayResponseEntity(response: CloseableHttpResponse,
+                                   source: HttpEntity,
+                                   bytes: Array[Byte],
+                                   input: InputStream): Unit = {
+    val replay = new BasicHttpEntity()
+    replay.setContent(new SequenceInputStream(new ByteArrayInputStream(bytes), input))
+    replay.setContentLength(source.getContentLength)
+    copyResponseEntityMetadata(source, replay)
+    response.setEntity(replay)
+  }
+
+  private def closeInspectionInput(input: InputStream): Unit = {
+    try {
+      input.close()
+    } catch {
+      case NonFatal(error) =>
+        logWarning("Could not close the HTTP response inspection stream.", error)
+    }
+  }
+
+  private[ml] def responseBodyForInspection(response: CloseableHttpResponse): Option[String] = {
     Option(response.getEntity).flatMap { entity =>
       if (entity.getContentLength > MaxResponseInspectionBytes) {
         None
       } else {
         val output = new ByteArrayOutputStream()
-        val input = entity.getContent
+        var input = Option.empty[InputStream]
         var keepInputOpen = false
         try {
-          IOUtils.copyLarge(input, output, 0, MaxResponseInspectionBytes + 1)
+          val responseInput = entity.getContent
+          input = Some(responseInput)
+          IOUtils.copyLarge(responseInput, output, 0, MaxResponseInspectionBytes + 1)
           val bytes = output.toByteArray
           if (bytes.length > MaxResponseInspectionBytes) {
-            val replayEntity = new BasicHttpEntity()
-            replayEntity.setContent(new SequenceInputStream(new ByteArrayInputStream(bytes), input))
-            replayEntity.setContentLength(entity.getContentLength)
-            Option(entity.getContentEncoding).foreach(replayEntity.setContentEncoding)
-            Option(entity.getContentType).foreach(replayEntity.setContentType)
-            replayEntity.setChunked(entity.isChunked)
-            response.setEntity(replayEntity)
+            replayResponseEntity(response, entity, bytes, responseInput)
             keepInputOpen = true
             None
           } else {
             val bufferedEntity = new ByteArrayEntity(bytes)
-            Option(entity.getContentEncoding).foreach(bufferedEntity.setContentEncoding)
-            Option(entity.getContentType).foreach(bufferedEntity.setContentType)
-            bufferedEntity.setChunked(entity.isChunked)
+            copyResponseEntityMetadata(entity, bufferedEntity)
             response.setEntity(bufferedEntity)
             Some(new String(bytes, StandardCharsets.UTF_8))
           }
+        } catch {
+          case NonFatal(error) =>
+            logWarning("Could not inspect the HTTP response body; preserving it for retry handling.", error)
+            input.foreach { responseInput =>
+              try {
+                replayResponseEntity(response, entity, output.toByteArray, responseInput)
+                keepInputOpen = true
+              } catch {
+                case NonFatal(replayError) =>
+                  error.addSuppressed(replayError)
+                  logWarning("Could not reconstruct the partially inspected HTTP response body.", replayError)
+              }
+            }
+            None
         } finally {
           if (!keepInputOpen) {
-            input.close()
+            input.foreach(closeInspectionInput)
           }
         }
       }

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPSchema.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPSchema.scala
@@ -166,6 +166,12 @@ case class HTTPRequestData(requestLine: RequestLineData,
                            headers: Array[HeaderData],
                            entity: Option[EntityData]) {
 
+  private[ml] def usesFabricAuth: Boolean =
+    headers.exists(h => HTTPRequestData.isFabricAuthMarker(h.name))
+
+  private[ml] def authorizationHeader: Option[String] =
+    headers.find(_.name.equalsIgnoreCase("Authorization")).map(_.value)
+
   def this(r: HttpRequestBase) = {
     this(new RequestLineData(r.getRequestLine),
       r.getAllHeaders.map(new HeaderData(_)),
@@ -197,7 +203,7 @@ case class HTTPRequestData(requestLine: RequestLineData,
     request.setURI(new URI(requestLine.uri))
     requestLine.protocolVersion.foreach(pv =>
       request.setProtocolVersion(pv.toHTTPCore))
-    request.setHeaders(headers.map(_.toHTTPCore) ++
+    request.setHeaders(headers.filterNot(h => HTTPRequestData.isFabricAuthMarker(h.name)).map(_.toHTTPCore) ++
       Array(new BasicHeader(
         "User-Agent", s"synapseml/${BuildInfo.version}${HeaderValues.PlatformInfo}")))
     request
@@ -206,6 +212,11 @@ case class HTTPRequestData(requestLine: RequestLineData,
 }
 
 object HTTPRequestData extends SparkBindings[HTTPRequestData] {
+  private[ml] val FabricAuthMarkerHeader = "X-SynapseML-Implicit-Fabric-Auth"
+
+  private[ml] def isFabricAuthMarker(headerName: String): Boolean =
+    FabricAuthMarkerHeader.equalsIgnoreCase(headerName)
+
   def fromHTTPExchange(httpEx: HttpExchange): HTTPRequestData = {
     val requestHeaders = httpEx.getRequestHeaders
     val isChunked = Option(requestHeaders.getFirst("Transfer-Encoding") == "chunked").getOrElse(false)

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPSchema.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPSchema.scala
@@ -167,10 +167,13 @@ case class HTTPRequestData(requestLine: RequestLineData,
                            entity: Option[EntityData]) {
 
   private[ml] def usesFabricAuth: Boolean =
-    headers.exists(h => HTTPRequestData.isFabricAuthMarker(h.name))
+    headers.exists(h =>
+      HTTPRequestData.isFabricAuthMarker(h.name) &&
+        Option(h.value).exists(_.equalsIgnoreCase("true"))) &&
+      authorizationHeader.exists(HTTPRequestData.isCognitiveMwcAuthHeader)
 
   private[ml] def authorizationHeader: Option[String] =
-    headers.find(_.name.equalsIgnoreCase("Authorization")).map(_.value)
+    headers.find(h => "Authorization".equalsIgnoreCase(h.name)).map(_.value)
 
   def this(r: HttpRequestBase) = {
     this(new RequestLineData(r.getRequestLine),
@@ -216,6 +219,11 @@ object HTTPRequestData extends SparkBindings[HTTPRequestData] {
 
   private[ml] def isFabricAuthMarker(headerName: String): Boolean =
     FabricAuthMarkerHeader.equalsIgnoreCase(headerName)
+
+  private def isCognitiveMwcAuthHeader(value: String): Boolean = {
+    val parts = Option(value).map(_.trim.split("\\s+", 2)).getOrElse(Array.empty)
+    parts.length == 2 && parts.head.equalsIgnoreCase("MwcToken") && parts.last.nonEmpty
+  }
 
   def fromHTTPExchange(httpEx: HttpExchange): HTTPRequestData = {
     val requestHeaders = httpEx.getRequestHeaders

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPSchema.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/io/http/HTTPSchema.scala
@@ -173,7 +173,7 @@ case class HTTPRequestData(requestLine: RequestLineData,
       authorizationHeader.exists(HTTPRequestData.isCognitiveMwcAuthHeader)
 
   private[ml] def authorizationHeader: Option[String] =
-    headers.find(h => "Authorization".equalsIgnoreCase(h.name)).map(_.value)
+    headers.find(h => "Authorization".equalsIgnoreCase(h.name)).flatMap(h => Option(h.value))
 
   def this(r: HttpRequestBase) = {
     this(new RequestLineData(r.getRequestLine),

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/fabric/VerifyTokenInvalidation.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/fabric/VerifyTokenInvalidation.scala
@@ -1,0 +1,42 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.fabric
+
+import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+
+import java.nio.file.Files
+
+class VerifyTokenInvalidation extends TestBase {
+
+  test("Spark MWC invalidation resolves the encoded NFS cache key") {
+    val tokenPath = Files.createTempFile("synapseml-mwc-token", ".cache")
+    val events = scala.collection.mutable.ArrayBuffer.empty[(String, String)]
+    val logicalCacheKey = "WorkspaceArtifact2SparkCore"
+
+    try {
+      TokenLibrary.invalidateSparkMwcTokenCaches(
+        logicalCacheKey,
+        cacheKey => {
+          events += ("encode" -> cacheKey)
+          "encoded-cache-key"
+        },
+        cacheKey => {
+          events += ("delete" -> cacheKey)
+          Files.deleteIfExists(tokenPath)
+        },
+        () => {
+          events += ("clear" -> "")
+          true
+        })
+
+      assert(events === Seq(
+        "encode" -> logicalCacheKey,
+        "delete" -> "encoded-cache-key",
+        "clear" -> ""))
+      assert(!Files.exists(tokenPath))
+    } finally {
+      Files.deleteIfExists(tokenPath)
+    }
+  }
+}

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/fabric/VerifyTokenInvalidation.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/fabric/VerifyTokenInvalidation.scala
@@ -75,6 +75,20 @@ class VerifyTokenInvalidation extends TestBase {
     assert(method.exists(_._1.getClass.getName.endsWith("WorkingReflectionCandidate$")))
   }
 
+  test("NFS token deletion reports filesystem failures without throwing") {
+    val directory = Files.createTempDirectory("synapseml-mwc-cache")
+    val child = Files.createFile(directory.resolve("token"))
+
+    try {
+      assert(!TokenLibrary.deleteTokenPath(directory))
+      assert(Files.exists(directory))
+      assert(Files.exists(child))
+    } finally {
+      Files.deleteIfExists(child)
+      Files.deleteIfExists(directory)
+    }
+  }
+
   test("concurrent refreshes invalidate a rejected MWC token once") {
     val workers = 8
     val executor = Executors.newFixedThreadPool(workers)

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/fabric/VerifyTokenInvalidation.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/fabric/VerifyTokenInvalidation.scala
@@ -6,6 +6,8 @@ package com.microsoft.azure.synapse.ml.fabric
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 
 import java.nio.file.Files
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.concurrent.{Callable, CountDownLatch, Executors, TimeUnit}
 
 class VerifyTokenInvalidation extends TestBase {
 
@@ -37,6 +39,51 @@ class VerifyTokenInvalidation extends TestBase {
       assert(!Files.exists(tokenPath))
     } finally {
       Files.deleteIfExists(tokenPath)
+    }
+  }
+
+  test("Spark MWC invalidation fails when the runtime exposes no supported cache API") {
+    val error = intercept[NoSuchMethodException] {
+      TokenLibrary.invalidateSparkMwcTokenCaches(
+        "cache-key",
+        identity,
+        _ => false,
+        () => false)
+    }
+
+    assert(error.getMessage.contains("does not expose MWC token cache invalidation"))
+  }
+
+  test("concurrent refreshes invalidate a rejected MWC token once") {
+    val workers = 8
+    val executor = Executors.newFixedThreadPool(workers)
+    val start = new CountDownLatch(1)
+    val currentAuth = new AtomicReference("MwcToken stale")
+    val invalidationCount = new AtomicInteger(0)
+    val refreshLock = new Object()
+
+    try {
+      val futures = (1 to workers).map { _ =>
+        executor.submit(new Callable[String] {
+          override def call(): String = {
+            start.await()
+            FabricClient.refreshAuthHeader(
+              "MwcToken stale",
+              refreshLock,
+              () => currentAuth.get(),
+              () => {
+                invalidationCount.incrementAndGet()
+                currentAuth.set("MwcToken fresh")
+              })
+          }
+        })
+      }
+      start.countDown()
+
+      assert(futures.map(_.get(10, TimeUnit.SECONDS)) === Seq.fill(workers)("MwcToken fresh"))
+      assert(invalidationCount.get() === 1)
+    } finally {
+      executor.shutdownNow()
     }
   }
 }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/fabric/VerifyTokenInvalidation.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/fabric/VerifyTokenInvalidation.scala
@@ -9,6 +9,16 @@ import java.nio.file.Files
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import java.util.concurrent.{Callable, CountDownLatch, Executors, TimeUnit}
 
+object BrokenReflectionCandidate {
+  val Initialize: Unit = throw new RuntimeException("simulated initialization failure")
+
+  def clear(): Unit = ()
+}
+
+object WorkingReflectionCandidate {
+  def clear(): Unit = ()
+}
+
 class VerifyTokenInvalidation extends TestBase {
 
   test("Spark MWC invalidation resolves the encoded NFS cache key") {
@@ -52,6 +62,17 @@ class VerifyTokenInvalidation extends TestBase {
     }
 
     assert(error.getMessage.contains("does not expose MWC token cache invalidation"))
+  }
+
+  test("runtime reflection skips a broken candidate and uses the next compatible class") {
+    val method = TokenLibrary.objectMethod(
+      Seq(
+        "com.microsoft.azure.synapse.ml.fabric.BrokenReflectionCandidate$",
+        "com.microsoft.azure.synapse.ml.fabric.WorkingReflectionCandidate$"),
+      "clear",
+      0)
+
+    assert(method.exists(_._1.getClass.getName.endsWith("WorkingReflectionCandidate$")))
   }
 
   test("concurrent refreshes invalidate a rejected MWC token once") {

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/io/split1/VerifyResponseBodyInspection.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/io/split1/VerifyResponseBodyInspection.scala
@@ -6,11 +6,12 @@ package com.microsoft.azure.synapse.ml.io.split1
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 import com.microsoft.azure.synapse.ml.io.http.HandlingUtils
 import org.apache.http.HttpVersion
-import org.apache.http.client.methods.CloseableHttpResponse
+import org.apache.http.client.methods.{CloseableHttpResponse, HttpPost}
 import org.apache.http.entity.BasicHttpEntity
 import org.apache.http.message.{BasicHttpResponse, BasicStatusLine}
 
-import java.io.{IOException, InputStream}
+import java.io.{ByteArrayInputStream, IOException, InputStream}
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.io.Source
 
 class VerifyResponseBodyInspection extends TestBase {
@@ -69,5 +70,31 @@ class VerifyResponseBodyInspection extends TestBase {
     }
 
     assert(replayedBody === new String(content, "UTF-8"))
+  }
+
+  test("request preview closes its entity stream and releases the request") {
+    val content = """{"prompt":"hello"}""".getBytes("UTF-8")
+    val streamClosed = new AtomicBoolean(false)
+    val requestReleased = new AtomicBoolean(false)
+    val input = new ByteArrayInputStream(content) {
+      override def close(): Unit = {
+        streamClosed.set(true)
+        super.close()
+      }
+    }
+    val entity = new BasicHttpEntity()
+    entity.setContent(input)
+    entity.setContentLength(content.length)
+    val request = new HttpPost("https://example.test/openai") {
+      override def releaseConnection(): Unit = {
+        requestReleased.set(true)
+        super.releaseConnection()
+      }
+    }
+    request.setEntity(entity)
+
+    assert(HandlingUtils.previewMessage(request) === new String(content, "UTF-8"))
+    assert(streamClosed.get())
+    assert(requestReleased.get())
   }
 }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/io/split1/VerifyResponseBodyInspection.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/io/split1/VerifyResponseBodyInspection.scala
@@ -72,6 +72,34 @@ class VerifyResponseBodyInspection extends TestBase {
     assert(replayedBody === new String(content, "UTF-8"))
   }
 
+  test("response inspection detects capacity errors in large bodies without consuming them") {
+    val content = ("""{"error":{"code":"CapacityLimitExceeded"}}""" +
+      ("x" * (1024 * 1024 + 128))).getBytes("UTF-8")
+
+    Seq(-1L, content.length.toLong).foreach { contentLength =>
+      val entity = new BasicHttpEntity()
+      entity.setContent(new ByteArrayInputStream(content))
+      entity.setContentLength(contentLength)
+      val response = new BasicHttpResponse(
+        new BasicStatusLine(HttpVersion.HTTP_1_1, 429, "Too Many Requests"))
+        with CloseableHttpResponse {
+        override def close(): Unit = ()
+      }
+      response.setEntity(entity)
+
+      val inspected = HandlingUtils.responseBodyForInspection(response)
+      assert(inspected.exists(_.contains("CapacityLimitExceeded")))
+      val replayed = Source.fromInputStream(response.getEntity.getContent, "UTF-8")
+      val replayedBody = try {
+        replayed.mkString
+      } finally {
+        replayed.close()
+      }
+
+      assert(replayedBody === new String(content, "UTF-8"))
+    }
+  }
+
   test("request preview closes its entity stream and releases the request") {
     val content = """{"prompt":"hello"}""".getBytes("UTF-8")
     val streamClosed = new AtomicBoolean(false)

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/io/split1/VerifyResponseBodyInspection.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/io/split1/VerifyResponseBodyInspection.scala
@@ -1,0 +1,73 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in project root for information.
+
+package com.microsoft.azure.synapse.ml.io.split1
+
+import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import com.microsoft.azure.synapse.ml.io.http.HandlingUtils
+import org.apache.http.HttpVersion
+import org.apache.http.client.methods.CloseableHttpResponse
+import org.apache.http.entity.BasicHttpEntity
+import org.apache.http.message.{BasicHttpResponse, BasicStatusLine}
+
+import java.io.{IOException, InputStream}
+import scala.io.Source
+
+class VerifyResponseBodyInspection extends TestBase {
+
+  test("response inspection replays bytes after an input failure") {
+    val content = """{"error":{"code":"RateLimitExceeded"}}""".getBytes("UTF-8")
+    val input = new InputStream {
+      private var index = 0
+      private var failed = false
+
+      override def read(): Int = {
+        if (index < content.length) {
+          val value = content(index) & 0xff
+          index += 1
+          value
+        } else {
+          failOrFinish()
+        }
+      }
+
+      override def read(buffer: Array[Byte], offset: Int, length: Int): Int = {
+        if (index < content.length) {
+          val count = math.min(length, content.length - index)
+          System.arraycopy(content, index, buffer, offset, count)
+          index += count
+          count
+        } else {
+          failOrFinish()
+        }
+      }
+
+      private def failOrFinish(): Int = {
+        if (!failed) {
+          failed = true
+          throw new IOException("simulated response read failure")
+        }
+        -1
+      }
+    }
+    val entity = new BasicHttpEntity()
+    entity.setContent(input)
+    entity.setContentLength(-1)
+    val response = new BasicHttpResponse(
+      new BasicStatusLine(HttpVersion.HTTP_1_1, 429, "Too Many Requests"))
+      with CloseableHttpResponse {
+      override def close(): Unit = ()
+    }
+    response.setEntity(entity)
+
+    assert(HandlingUtils.responseBodyForInspection(response).isEmpty)
+    val replayed = Source.fromInputStream(response.getEntity.getContent, "UTF-8")
+    val replayedBody = try {
+      replayed.mkString
+    } finally {
+      replayed.close()
+    }
+
+    assert(replayedBody === new String(content, "UTF-8"))
+  }
+}

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/io/split1/VerifySendWithRetries.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/io/split1/VerifySendWithRetries.scala
@@ -582,6 +582,107 @@ class VerifySendWithRetries extends TestBase {
     }
   }
 
+  test("implicit Fabric auth bounds 429 retries") {
+    val port = getFreePort
+    val requestCount = new AtomicInteger(0)
+    val server = startServer(port) { exchange =>
+      requestCount.incrementAndGet()
+      readRequestBody(exchange)
+      respond(exchange, 429, """{"error":{"code":"RateLimitExceeded"}}""",
+        headers = Map("Retry-After" -> "0"))
+    }
+    try {
+      val client = HttpClients.createDefault()
+      val (response, request) = HandlingUtils.sendWithFabricAuthRetries(
+        client,
+        fabricPost(port),
+        Array(0),
+        getAuthHeader = () => "MwcToken current",
+        refreshAuthHeader = _ => fail("401 refresh should not run for a 429"))
+      val code = response.getStatusLine.getStatusCode
+      response.close()
+      request.releaseConnection()
+      client.close()
+
+      assert(code === 429)
+      assert(requestCount.get() === 2, "Initial request plus one configured retry should be sent")
+    } finally {
+      server.stop(0)
+    }
+  }
+
+  test("unknown-length 429 response bodies remain readable") {
+    val port = getFreePort
+    val responseBody = """{"error":{"code":"RateLimitExceeded"}}"""
+    val server = startServer(port) { exchange =>
+      exchange.sendResponseHeaders(429, 0)
+      val output = exchange.getResponseBody
+      output.write(responseBody.getBytes("UTF-8"))
+      output.close()
+      exchange.close()
+    }
+    try {
+      val client = HttpClients.createDefault()
+      val request = new HttpGet(s"http://localhost:$port/test")
+      val response = HandlingUtils.sendWithRetries(client, request, Array.empty)
+      val body = Source.fromInputStream(response.getEntity.getContent, "UTF-8")
+      val actualBody = try {
+        body.mkString
+      } finally {
+        body.close()
+      }
+      response.close()
+      client.close()
+
+      assert(actualBody === responseBody)
+    } finally {
+      server.stop(0)
+    }
+  }
+
+  test("large unknown-length 429 response bodies remain readable") {
+    val port = getFreePort
+    val responseBody = "x" * (1024 * 1024 + 128)
+    val server = startServer(port) { exchange =>
+      exchange.sendResponseHeaders(429, 0)
+      val output = exchange.getResponseBody
+      output.write(responseBody.getBytes("UTF-8"))
+      output.close()
+      exchange.close()
+    }
+    try {
+      val client = HttpClients.createDefault()
+      val request = new HttpGet(s"http://localhost:$port/test")
+      val response = HandlingUtils.sendWithRetries(client, request, Array.empty)
+      val body = Source.fromInputStream(response.getEntity.getContent, "UTF-8")
+      val actualBody = try {
+        body.mkString
+      } finally {
+        body.close()
+      }
+      response.close()
+      client.close()
+
+      assert(actualBody === responseBody)
+    } finally {
+      server.stop(0)
+    }
+  }
+
+  test("Fabric auth marker requires an MWC authorization header") {
+    def requestData(markerValue: String, authHeader: String): HTTPRequestData = {
+      val request = new HttpGet("https://workspace.fabric.microsoft.com/cognitive/openai/chat")
+      request.setHeader(HTTPRequestData.FabricAuthMarkerHeader, markerValue)
+      request.setHeader("Authorization", authHeader)
+      new HTTPRequestData(request)
+    }
+
+    assert(requestData("true", "MwcToken token").usesFabricAuth)
+    assert(!requestData("false", "MwcToken token").usesFabricAuth)
+    assert(!requestData("true", "Bearer explicit").usesFabricAuth)
+    assert(!requestData("true", "MwcToken ").usesFabricAuth)
+  }
+
   test("untrusted marker does not replace explicit auth on a non-Fabric endpoint") {
     val port = getFreePort
     val authorization = new AtomicReference[String]()
@@ -628,6 +729,12 @@ class VerifySendWithRetries extends TestBase {
       endpointRoot))
     assert(!FabricClient.isEndpointUnder(
       "https://workspace.fabric.microsoft.com/cognitive/openai/%2e%2e/other",
+      endpointRoot))
+    assert(!FabricClient.isEndpointUnder(
+      "https://workspace.fabric.microsoft.com/cognitive/openai/%252e%252e/other",
+      endpointRoot))
+    assert(!FabricClient.isEndpointUnder(
+      "https://workspace.fabric.microsoft.com",
       endpointRoot))
   }
 }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/io/split1/VerifySendWithRetries.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/io/split1/VerifySendWithRetries.scala
@@ -683,6 +683,39 @@ class VerifySendWithRetries extends TestBase {
     assert(!requestData("true", "MwcToken ").usesFabricAuth)
   }
 
+  test("Fabric auth retries replace duplicate authorization headers") {
+    val port = getFreePort
+    val authorizationHeaders = new AtomicReference[Seq[String]]()
+    val server = startServer(port) { exchange =>
+      authorizationHeaders.set(exchange.getRequestHeaders.get("Authorization").asScala.toSeq)
+      readRequestBody(exchange)
+      respond(exchange, 200, """{"ok":true}""")
+    }
+    try {
+      val request = new HttpPost(s"http://localhost:$port/test")
+      request.setHeader(HTTPRequestData.FabricAuthMarkerHeader, "true")
+      request.addHeader("Authorization", "MwcToken stale")
+      request.addHeader("authorization", "Bearer duplicate")
+      request.setEntity(new StringEntity("""{"prompt":"hello"}""", "UTF-8"))
+
+      val client = HttpClients.createDefault()
+      val (response, replayedRequest) = HandlingUtils.sendWithFabricAuthRetries(
+        client,
+        new HTTPRequestData(request),
+        Array.empty,
+        getAuthHeader = () => "MwcToken current")
+      val code = response.getStatusLine.getStatusCode
+      response.close()
+      replayedRequest.releaseConnection()
+      client.close()
+
+      assert(code === 200)
+      assert(authorizationHeaders.get() === Seq("MwcToken current"))
+    } finally {
+      server.stop(0)
+    }
+  }
+
   test("untrusted marker does not replace explicit auth on a non-Fabric endpoint") {
     val port = getFreePort
     val authorization = new AtomicReference[String]()

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/io/split1/VerifySendWithRetries.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/io/split1/VerifySendWithRetries.scala
@@ -3,16 +3,20 @@
 
 package com.microsoft.azure.synapse.ml.io.split1
 
-import com.microsoft.azure.synapse.ml.io.http.HandlingUtils
+import com.microsoft.azure.synapse.ml.fabric.FabricClient
+import com.microsoft.azure.synapse.ml.io.http.{HTTPRequestData, HandlingUtils}
 
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 import com.sun.net.httpserver.{HttpExchange, HttpServer}
-import org.apache.http.client.methods.HttpGet
+import org.apache.http.client.methods.{HttpGet, HttpPost}
+import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.HttpClients
 
 import java.net.{InetSocketAddress, ServerSocket}
-import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{ConcurrentLinkedQueue, Executors}
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import scala.collection.JavaConverters._
+import scala.io.Source
 
 class VerifySendWithRetries extends TestBase {
 
@@ -42,6 +46,27 @@ class VerifySendWithRetries extends TestBase {
       os.close()
     }
     exchange.close()
+  }
+
+  private def readRequestBody(exchange: HttpExchange): String = {
+    val source = Source.fromInputStream(exchange.getRequestBody, "UTF-8")
+    try {
+      source.mkString
+    } finally {
+      source.close()
+    }
+  }
+
+  private def fabricPost(port: Int): HTTPRequestData = {
+    val request = new HttpPost(s"http://localhost:$port/test")
+    request.setHeader(HTTPRequestData.FabricAuthMarkerHeader, "true")
+    request.setHeader("X-Custom", "preserved")
+    request.setHeader("X-Taxonomy-TrafficType", "Background")
+    request.setHeader("X-Llm-Service-Tier", "flex")
+    request.setHeader("X-Taxonomy-ExtendedProperties", """{"feature":"synapseml"}""")
+    request.setHeader("x-ms-llm-feature-name", "SparkCodeFirst")
+    request.setEntity(new StringEntity("""{"prompt":"hello"}""", "UTF-8"))
+    new HTTPRequestData(request)
   }
 
   test("429 without Retry-After uses exponential backoff") {
@@ -426,5 +451,183 @@ class VerifySendWithRetries extends TestBase {
     } finally {
       server.stop(0)
     }
+  }
+
+  test("implicit Fabric auth refreshes and replays a request once after 401") {
+    val port = getFreePort
+    val requestCount = new AtomicInteger(0)
+    val refreshCount = new AtomicInteger(0)
+    val currentAuth = new AtomicReference("MwcToken stale")
+    val authHeaders = new ConcurrentLinkedQueue[String]()
+    val requestBodies = new ConcurrentLinkedQueue[String]()
+    val customHeaders = new ConcurrentLinkedQueue[String]()
+    val taxonomyHeaders = new ConcurrentLinkedQueue[String]()
+    val server = startServer(port) { exchange =>
+      authHeaders.add(exchange.getRequestHeaders.getFirst("Authorization"))
+      customHeaders.add(exchange.getRequestHeaders.getFirst("X-Custom"))
+      taxonomyHeaders.add(exchange.getRequestHeaders.getFirst("X-Taxonomy-TrafficType"))
+      requestBodies.add(readRequestBody(exchange))
+      if (requestCount.incrementAndGet() == 1) {
+        respond(exchange, 401, "expired")
+      } else {
+        respond(exchange, 200, """{"ok":true}""")
+      }
+    }
+    try {
+      val client = HttpClients.createDefault()
+      val requestData = fabricPost(port)
+      val (response, request) = HandlingUtils.sendWithFabricAuthRetries(
+        client,
+        requestData,
+        Array(10),
+        getAuthHeader = () => currentAuth.get(),
+        refreshAuthHeader = rejectedAuthHeader => {
+          assert(rejectedAuthHeader == "MwcToken stale")
+          refreshCount.incrementAndGet()
+          currentAuth.set("MwcToken fresh")
+          currentAuth.get()
+        })
+      val code = response.getStatusLine.getStatusCode
+      response.close()
+      request.releaseConnection()
+      client.close()
+
+      assert(code === 200)
+      assert(requestCount.get() === 2)
+      assert(refreshCount.get() === 1)
+      assert(authHeaders.asScala.toSeq === Seq("MwcToken stale", "MwcToken fresh"))
+      assert(requestBodies.asScala.toSeq === Seq("""{"prompt":"hello"}""", """{"prompt":"hello"}"""))
+      assert(customHeaders.asScala.toSeq === Seq("preserved", "preserved"))
+      assert(taxonomyHeaders.asScala.toSeq === Seq("Background", "Background"))
+      Seq(
+        "X-Taxonomy-TrafficType",
+        "X-Llm-Service-Tier",
+        "X-Taxonomy-ExtendedProperties",
+        "x-ms-llm-feature-name"
+      ).foreach { headerName =>
+        assert(requestData.headers.exists(_.name.equalsIgnoreCase(headerName)))
+      }
+    } finally {
+      server.stop(0)
+    }
+  }
+
+  test("implicit Fabric auth returns the second 401 without retrying again") {
+    val port = getFreePort
+    val requestCount = new AtomicInteger(0)
+    val refreshCount = new AtomicInteger(0)
+    val server = startServer(port) { exchange =>
+      requestCount.incrementAndGet()
+      readRequestBody(exchange)
+      respond(exchange, 401, "unauthorized")
+    }
+    try {
+      val client = HttpClients.createDefault()
+      val (response, request) = HandlingUtils.sendWithFabricAuthRetries(
+        client,
+        fabricPost(port),
+        Array(10, 10),
+        extraCodesToRetry = Set(401),
+        getAuthHeader = () => "MwcToken stale",
+        refreshAuthHeader = _ => {
+          refreshCount.incrementAndGet()
+          "MwcToken refreshed"
+        })
+      val code = response.getStatusLine.getStatusCode
+      response.close()
+      request.releaseConnection()
+      client.close()
+
+      assert(code === 401)
+      assert(requestCount.get() === 2)
+      assert(refreshCount.get() === 1)
+    } finally {
+      server.stop(0)
+    }
+  }
+
+  test("implicit Fabric auth is reacquired for a 429 retry") {
+    val port = getFreePort
+    val requestCount = new AtomicInteger(0)
+    val authCallCount = new AtomicInteger(0)
+    val authHeaders = new ConcurrentLinkedQueue[String]()
+    val server = startServer(port) { exchange =>
+      authHeaders.add(exchange.getRequestHeaders.getFirst("Authorization"))
+      readRequestBody(exchange)
+      if (requestCount.incrementAndGet() == 1) {
+        respond(exchange, 429, headers = Map("Retry-After" -> "0"))
+      } else {
+        respond(exchange, 200, """{"ok":true}""")
+      }
+    }
+    try {
+      val client = HttpClients.createDefault()
+      val (response, request) = HandlingUtils.sendWithFabricAuthRetries(
+        client,
+        fabricPost(port),
+        Array(10),
+        getAuthHeader = () => s"MwcToken token-${authCallCount.incrementAndGet()}",
+        refreshAuthHeader = _ => fail("401 refresh should not run for a 429"))
+      val code = response.getStatusLine.getStatusCode
+      response.close()
+      request.releaseConnection()
+      client.close()
+
+      assert(code === 200)
+      assert(requestCount.get() === 2)
+      assert(authCallCount.get() === 2)
+      assert(authHeaders.asScala.toSeq === Seq("MwcToken token-1", "MwcToken token-2"))
+    } finally {
+      server.stop(0)
+    }
+  }
+
+  test("untrusted marker does not replace explicit auth on a non-Fabric endpoint") {
+    val port = getFreePort
+    val authorization = new AtomicReference[String]()
+    val server = startServer(port) { exchange =>
+      authorization.set(exchange.getRequestHeaders.getFirst("Authorization"))
+      respond(exchange, 200, """{"ok":true}""")
+    }
+    try {
+      val client = HttpClients.createDefault()
+      val request = new HttpGet(s"http://localhost:$port/test")
+      request.setHeader(HTTPRequestData.FabricAuthMarkerHeader, "true")
+      request.setHeader("Authorization", "Bearer explicit")
+
+      val response = HandlingUtils.advanced(10)(client, new HTTPRequestData(request))
+
+      client.close()
+      assert(response.statusLine.statusCode === 200)
+      assert(authorization.get() === "Bearer explicit")
+    } finally {
+      server.stop(0)
+    }
+  }
+
+  test("Fabric endpoint validation requires HTTPS host and path containment") {
+    val endpointRoot = "https://workspace.fabric.microsoft.com/cognitive/openai/"
+
+    assert(FabricClient.isEndpointUnder(
+      "https://workspace.fabric.microsoft.com//cognitive/openai/chat",
+      endpointRoot))
+    assert(FabricClient.isEndpointUnder(
+      "https://workspace.fabric.microsoft.com:443/cognitive/openai/chat",
+      endpointRoot))
+    assert(!FabricClient.isEndpointUnder(
+      "http://workspace.fabric.microsoft.com/cognitive/openai/chat",
+      endpointRoot))
+    assert(!FabricClient.isEndpointUnder(
+      "https://attacker.example/cognitive/openai/chat",
+      endpointRoot))
+    assert(!FabricClient.isEndpointUnder(
+      "https://workspace.fabric.microsoft.com/other",
+      endpointRoot))
+    assert(!FabricClient.isEndpointUnder(
+      "https://workspace.fabric.microsoft.com/cognitive/openai/../other",
+      endpointRoot))
+    assert(!FabricClient.isEndpointUnder(
+      "https://workspace.fabric.microsoft.com/cognitive/openai/%2e%2e/other",
+      endpointRoot))
   }
 }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/io/split1/VerifySendWithRetries.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/io/split1/VerifySendWithRetries.scala
@@ -4,7 +4,7 @@
 package com.microsoft.azure.synapse.ml.io.split1
 
 import com.microsoft.azure.synapse.ml.fabric.FabricClient
-import com.microsoft.azure.synapse.ml.io.http.{HTTPRequestData, HandlingUtils}
+import com.microsoft.azure.synapse.ml.io.http.{HTTPRequestData, HandlingUtils, HeaderData, RequestLineData}
 
 import com.microsoft.azure.synapse.ml.core.test.base.TestBase
 import com.sun.net.httpserver.{HttpExchange, HttpServer}
@@ -681,6 +681,18 @@ class VerifySendWithRetries extends TestBase {
     assert(!requestData("false", "MwcToken token").usesFabricAuth)
     assert(!requestData("true", "Bearer explicit").usesFabricAuth)
     assert(!requestData("true", "MwcToken ").usesFabricAuth)
+  }
+
+  test("null authorization values are treated as absent") {
+    val requestData = HTTPRequestData(
+      RequestLineData("GET", "https://workspace.fabric.microsoft.com/cognitive/openai/chat", None),
+      Array(
+        HeaderData(HTTPRequestData.FabricAuthMarkerHeader, "true"),
+        HeaderData("Authorization", null)), //scalastyle:ignore null
+      None)
+
+    assert(requestData.authorizationHeader.isEmpty)
+    assert(!requestData.usesFabricAuth)
   }
 
   test("Fabric auth retries replace duplicate authorization headers") {


### PR DESCRIPTION
## Related Issues/PRs

- Companion pandas/session change: https://dev.azure.com/msdata/A365/_git/SynapseML-Internal/pullrequest/2280368
- Merged target CI repair: https://github.com/microsoft/SynapseML/pull/2691
- ADO work item: https://dev.azure.com/msdata/A365/_workitems/edit/5588216

## What changes are proposed in this pull request?

Refresh Fabric authentication safely during long-running AI Functions requests:

- Mark only implicit default Fabric OpenAI requests with a true-valued internal marker and MWC authorization as eligible for auth-aware retry; strip the marker before network transmission.
- Reconstruct requests from buffered bodies and original headers so a trusted 401 refreshes and replays once without losing caller state or duplicating authorization.
- Reacquire current Fabric authorization across bounded 429 retries while preserving readable unknown-length and partially inspected responses plus non-retryable capacity errors.
- Add workspace-scoped single-flight refresh, current-runtime token cache invalidation with short-circuiting runtime reflection, and null-safe, locale-stable Fabric OpenAI endpoint validation resistant to repeated percent encoding.
- Preserve explicit API keys, AAD/custom authorization, feature, taxonomy, service-tier, and user headers.

## How is this patch tested?

- [x] I have written tests and confirmed the proposed bug fix works.

Current-head local validation:

- `VerifySendWithRetries`: 24 passed
- `VerifyResponseBodyInspection`: 3 passed
- `VerifyTokenInvalidation`: 5 passed
- `OpenAIFabricHeadersSuite`: 7 passed
- `OpenAIFabricAuthRetrySuite`: 1 passed
- `AzureSearchAuthSuite`: 48 passed
- `AddDocumentsHeaderPersistenceSuite`: 1 passed
- Core/cognitive compile and test-compile passed with JDK 11
- Core/cognitive production and test scalastyle: 0 errors
- `sbt codegen` and `sbt packagePython` passed; generated OpenAI wrappers compiled and were present in the wheel
- Pinned Black 22.3.0: 202 files unchanged

## Does this PR change any dependencies?

- [x] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No. This is a reliability fix for existing Fabric AI Functions behavior.
- [ ] Yes. Make sure you have added samples following below steps.

## Current integration evidence

- Rebased onto upstream/master `25815741901ab8d9062c51eb3a7f06070550e607` after the target CI repair merged; final head `504c399c5a10b2aea0db69d6c7961b46c5a4ed54` is 10 commits ahead and 0 behind.
- Range-diff confirms the original nine feature commits remain patch-equivalent after the rebase.
- The tenth commit resolves the two final review findings: response inspection is bounded to 1 MiB plus one byte while preserving the complete response stream, and null `Authorization` header values are treated as absent.
- Current-head Copilot review reports `Findings: None`; all review threads are resolved.
- Exact PR-merge Azure build 234438806 ran against merge commit `fbbcad43035627fc53e4799428ef191af1043ba9` and passed all 65 jobs.
- GitHub reports no failed or pending checks on the current head.
- Current-head local compile, test-compile, production/test Scalastyle, targeted regression suites, codegen, packagePython, and pinned Black validation all pass with a clean tracked source tree.
