### PR TITLE
fix: propagate LightGBM iteration failures

### DIFF
--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/TrainUtils.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/TrainUtils.scala
@@ -107,10 +107,8 @@ private[lightgbm] object TrainUtils extends Serializable {
       }
     } catch {
       case e: java.lang.Exception =>
-        log.warn("LightGBM reached early termination on one task," +
-          " stopping training on task. This message should rarely occur." +
-          " Inner exception: " + e.toString)
-        state.isFinished = true
+        log.error(s"LightGBM task failed during iteration ${state.iteration}", e)
+        throw e
     }
   }
 

--- a/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/TrainUtilsSuite.scala
+++ b/lightgbm/src/test/scala/com/microsoft/azure/synapse/ml/lightgbm/split1/TrainUtilsSuite.scala
@@ -3,7 +3,13 @@
 
 package com.microsoft.azure.synapse.ml.lightgbm.split1
 
-import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMRegressor, NetworkManager, TrainUtils}
+import com.microsoft.azure.synapse.ml.io.http.SharedSingleton
+import com.microsoft.azure.synapse.ml.lightgbm.booster.LightGBMBooster
+import com.microsoft.azure.synapse.ml.lightgbm.{ColumnParams, LightGBMRegressor, NetworkManager, NetworkParams,
+  NetworkTopologyInfo, PartitionTaskContext, PartitionTaskTrainingState, SharedState, TaskInstrumentationMeasures,
+  TrainingContext, TrainUtils}
+import org.apache.spark.ml.linalg.SQLDataTypes
+import org.apache.spark.sql.types.{StructField, StructType}
 import org.scalatest.funsuite.AnyFunSuite
 import org.slf4j.LoggerFactory
 
@@ -42,6 +48,41 @@ class TrainUtilsSuite extends AnyFunSuite {
     "average_precision")
 
   private val tolerances = Seq(0.0, 0.25, 2.0, 25.0)
+
+  private def newTrainingState(booster: LightGBMBooster): PartitionTaskTrainingState = {
+    val featuresField = StructField("features", SQLDataTypes.VectorType)
+    val trainParams = new LightGBMRegressor().getTrainParams(
+      numTasks = 1,
+      featuresSchema = featuresField,
+      numTasksPerExec = 1)
+    val trainingContext = TrainingContext(
+      batchIndex = 0,
+      sharedStateSingleton = SharedSingleton(new SharedState(trainParams)),
+      schema = StructType(Seq(featuresField)),
+      numCols = 1,
+      numInitScoreClasses = 0,
+      trainingParams = trainParams,
+      networkParams = NetworkParams(12400, "127.0.0.1", 12400, barrierExecutionMode = false),
+      columnParams = ColumnParams("label", "features", None, None, None),
+      datasetParams = "",
+      featureNames = None,
+      numTasksPerExecutor = 1,
+      validationData = None,
+      serializedReferenceDataset = None,
+      partitionCounts = Some(Array(1L)))
+    val taskContext = PartitionTaskContext(
+      trainingCtx = trainingContext,
+      partitionId = 0,
+      taskId = 0L,
+      measures = new TaskInstrumentationMeasures(0),
+      networkTopologyInfo = NetworkTopologyInfo("127.0.0.1:12400", Array(0), 12400),
+      shouldExecuteTraining = true,
+      isEmptyPartition = false,
+      shouldReturnBooster = true,
+      shouldCalcValidationDataset = false)
+
+    PartitionTaskTrainingState(taskContext, booster)
+  }
 
   test("Improvement tolerance is symmetric across metrics and tolerance values") {
     val bestScore = 100.0
@@ -144,6 +185,21 @@ class TrainUtilsSuite extends AnyFunSuite {
     assert(!TrainUtils.shouldStopEarly(iteration = 4, bestIteration = 0, earlyStoppingRound = 5))
     assert(TrainUtils.shouldStopEarly(iteration = 5, bestIteration = 0, earlyStoppingRound = 5))
     assert(TrainUtils.shouldStopEarly(iteration = 10, bestIteration = 5, earlyStoppingRound = 5))
+  }
+
+  test("A native iteration failure is not reported as completed training") {
+    val nativeFailure = new RuntimeException("injected native iteration failure")
+    val booster = new LightGBMBooster() {
+      override def updateOneIteration(): Boolean = throw nativeFailure
+    }
+    val state = newTrainingState(booster)
+
+    val thrown = intercept[RuntimeException] {
+      TrainUtils.updateOneIteration(state, log)
+    }
+
+    assert(thrown eq nativeFailure)
+    assert(!state.isFinished)
   }
 
   test("Early stopping parameters accept valid values and reject invalid values") {


### PR DESCRIPTION
## Related issues and prior work

Supersedes #2684, which was closed because its author could not sign the CLA.
Related to #569 and #728.

This fixes the error-handling defect exposed by those reports. It does not claim
to fix every executor, native-library, resource, or network failure that can
produce a LightGBM socket error.

## What changed

`TrainUtils.updateOneIteration` previously caught a native iteration exception,
logged it as early termination, set `state.isFinished = true`, and allowed model
construction to continue.

The updated behavior:

- logs the failed iteration and rethrows the original exception;
- leaves the training state unfinished after failure;
- lets Spark fail the task or job instead of returning a partial model;
- keeps legitimate LightGBM completion and early stopping unchanged.

The regression test uses a booster that fails during its native update. Before
the fix, the test failed because no exception escaped. After the fix, it verifies
that the same exception object propagates and training is not marked complete.

## Validation

- `sbt scalastyle "Test / scalastyle" compile test:compile`
- `sbt "lightgbm/testOnly com.microsoft.azure.synapse.ml.lightgbm.split1.TrainUtilsSuite"`
- Fabric `lightgbm-streaming` scenario using jars built from this branch:
  - commit: `0df0110857334c4443be71b174a82bcbc2e8ca0b`
  - runtime: Spark `3.5.5.5.4.20260807.1`
  - fixed two-node Medium pool with autoscaling disabled
  - 100,000 rows, 8 partitions, 10 repeated distributed fits
  - exact core, `lightgbmlib-3.3.510`, and LightGBM jar provenance verified
  - application: `application_1788541423736_0001`
  - result: passed

Repository-wide Black currently reports 11 pre-existing formatting differences
in unchanged Python files. This PR does not modify Python.

## Broader LightGBM issue assessment

The customer-reported instability is genuine, but `Connection refused` and
native socket code 104 are usually secondary symptoms. Current `master` already
contains fixes for worker-port reservation, driver socket cleanup, retry
diagnostics, barrier topology handling, IPv6 endpoints, and validation-data
transfer.

Separate evidence points to a possible native `lightgbmlib-3.3.510` distributed
categorical crash family in #2302, #2438, #2467, and #2674. That needs its own
multi-executor native regression and should not be hidden inside this
error-propagation fix.
